### PR TITLE
Moped Database: Rename staff table #4182

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -6,9 +6,6 @@
     name: moped_city_fiscal_years
 - table:
     schema: public
-    name: moped_coa_staff
-- table:
-    schema: public
     name: moped_components
 - table:
     schema: public
@@ -100,6 +97,9 @@
 - table:
     schema: public
     name: moped_status
+- table:
+    schema: public
+    name: moped_users
 - table:
     schema: public
     name: moped_workgroup

--- a/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/down.sql
+++ b/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/down.sql
@@ -1,1 +1,3 @@
 alter table "public"."moped_users" rename to "moped_coa_staff";
+
+alter sequence "public"."moped_users_staff_id_seq" rename to "moped_coa_staff_staff_id_seq";

--- a/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/down.sql
+++ b/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_users" rename to "moped_coa_staff";

--- a/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/up.sql
+++ b/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_coa_staff" rename to "moped_users";

--- a/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/up.sql
+++ b/moped-database/migrations/1602803091511_rename_table_public_moped_coa_staff/up.sql
@@ -1,1 +1,3 @@
 alter table "public"."moped_coa_staff" rename to "moped_users";
+
+alter sequence "public"."moped_coa_staff_staff_id_seq" rename to "moped_users_staff_id_seq";

--- a/moped-database/migrations/1602822189445_alter_table_public_moped_users_alter_column_staff_id/down.sql
+++ b/moped-database/migrations/1602822189445_alter_table_public_moped_users_alter_column_staff_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_users" rename column "user_id" to "staff_id";

--- a/moped-database/migrations/1602822189445_alter_table_public_moped_users_alter_column_staff_id/up.sql
+++ b/moped-database/migrations/1602822189445_alter_table_public_moped_users_alter_column_staff_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_users" rename column "staff_id" to "user_id";

--- a/moped-database/migrations/1602822304841_alter_table_public_moped_users_rename_keys/down.sql
+++ b/moped-database/migrations/1602822304841_alter_table_public_moped_users_rename_keys/down.sql
@@ -1,0 +1,18 @@
+/* Rename primary key */
+alter table "public"."moped_users"
+    rename constraint "moped_users_pkey"
+        to "moped_coa_staff_pkey";
+
+/* Rename foreign key */
+alter table "public"."moped_users"
+    rename constraint "moped_users_workgroup_id_fkey"
+        to "moped_coa_staff_workgroup_id_fkey";
+
+/* Rename unique key */
+alter table "public"."moped_users"
+    rename constraint "moped_users_user_id_key"
+        to "moped_coa_staff_staff_id_key";
+
+/* Rename sequence */
+alter sequence "public"."moped_users_user_id_seq"
+    rename to "moped_users_staff_id_seq";

--- a/moped-database/migrations/1602822304841_alter_table_public_moped_users_rename_keys/up.sql
+++ b/moped-database/migrations/1602822304841_alter_table_public_moped_users_rename_keys/up.sql
@@ -1,0 +1,18 @@
+/* Rename primary key */
+alter table "public"."moped_users"
+    rename constraint "moped_coa_staff_pkey"
+        to "moped_users_pkey";
+
+/* Rename foreign key */
+alter table "public"."moped_users"
+    rename constraint "moped_coa_staff_workgroup_id_fkey"
+        to "moped_users_workgroup_id_fkey";
+
+/* Rename unique key */
+alter table "public"."moped_users"
+    rename constraint "moped_coa_staff_staff_id_key"
+        to "moped_users_user_id_key";
+
+/* Rename sequence */
+alter sequence "public"."moped_users_staff_id_seq"
+    rename to "moped_users_user_id_seq";

--- a/moped-database/migrations/1602823000310_alter_table_public_moped_users_add_column_is_coa_staff/down.sql
+++ b/moped-database/migrations/1602823000310_alter_table_public_moped_users_add_column_is_coa_staff/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" DROP COLUMN "is_coa_staff";

--- a/moped-database/migrations/1602823000310_alter_table_public_moped_users_add_column_is_coa_staff/up.sql
+++ b/moped-database/migrations/1602823000310_alter_table_public_moped_users_add_column_is_coa_staff/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ADD COLUMN "is_coa_staff" boolean NOT NULL DEFAULT FALSE;

--- a/moped-database/migrations/1602823097162_alter_table_public_moped_users_alter_column_cognito_user_id/down.sql
+++ b/moped-database/migrations/1602823097162_alter_table_public_moped_users_alter_column_cognito_user_id/down.sql
@@ -1,0 +1,8 @@
+/* Type-cast into UUID */
+alter table "public"."moped_users"
+    alter column cognito_user_id type text using cognito_user_id::text;
+
+/* Creates unique constraint */
+alter table "public"."moped_users"
+    drop constraint "moped_users_cognito_user_id_key";
+

--- a/moped-database/migrations/1602823097162_alter_table_public_moped_users_alter_column_cognito_user_id/up.sql
+++ b/moped-database/migrations/1602823097162_alter_table_public_moped_users_alter_column_cognito_user_id/up.sql
@@ -1,0 +1,8 @@
+/* Type-cast into UUID */
+alter table "public"."moped_users"
+    alter column cognito_user_id type uuid using cognito_user_id::uuid;
+
+/* Creates unique constraint */
+alter table "public"."moped_users"
+    add constraint "moped_users_cognito_user_id_key"
+        unique ("cognito_user_id");

--- a/moped-database/migrations/1602823426327_alter_table_public_moped_users_add_column_status_id/down.sql
+++ b/moped-database/migrations/1602823426327_alter_table_public_moped_users_add_column_status_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" DROP COLUMN "status_id";

--- a/moped-database/migrations/1602823426327_alter_table_public_moped_users_add_column_status_id/up.sql
+++ b/moped-database/migrations/1602823426327_alter_table_public_moped_users_add_column_status_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ADD COLUMN "status_id" integer NOT NULL DEFAULT 0;

--- a/moped-database/seeds/1602292389297_initial_seed.sql
+++ b/moped-database/seeds/1602292389297_initial_seed.sql
@@ -13,9 +13,9 @@ INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start
 INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start_date, fiscal_year_end_date, active_fy) VALUES ('2021', NULL, NULL, true);
 INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start_date, fiscal_year_end_date, active_fy) VALUES ('2020', NULL, NULL, false);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('ATSD', 1, '2020-10-09 14:53:02.752811+00');
-INSERT INTO public.moped_coa_staff (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9699d49f-c5ba-4dad-b286-510a5e178aa7', 'JD', 'Maccombs', 'Developer', 'DTS', 1, 1, NULL, '2020-10-09 13:44:02.159095+00');
-INSERT INTO public.moped_coa_staff (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9972fa62-1bbd-4f58-9b7d-80b9bc73a537', 'Mike', 'Schofield', 'Engineer', 'ATSD', 3, 1, NULL, '2020-10-09 13:44:02.15918+00');
-INSERT INTO public.moped_coa_staff (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('e6bb053b-d6bf-4460-b9a5-c5cb7021958d', 'Nathan', 'Wilkes', 'Engineer', 'ATSD', 2, 1, NULL, '2020-10-09 13:44:02.159184+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9699d49f-c5ba-4dad-b286-510a5e178aa7', 'JD', 'Maccombs', 'Developer', 'DTS', 1, 1, NULL, '2020-10-09 13:44:02.159095+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9972fa62-1bbd-4f58-9b7d-80b9bc73a537', 'Mike', 'Schofield', 'Engineer', 'ATSD', 3, 1, NULL, '2020-10-09 13:44:02.15918+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('e6bb053b-d6bf-4460-b9a5-c5cb7021958d', 'Nathan', 'Wilkes', 'Engineer', 'ATSD', 2, 1, NULL, '2020-10-09 13:44:02.159184+00');
 INSERT INTO public.moped_entity (entity_uuid, workgroup_name, abbreviated_name, entity_id, affiliated_workgroup, date_added) VALUES ('f30415c5-0b5d-4d92-bb04-7c4f0ea13288', 'Capital Metro', 'CapMetro', 1, NULL, '2020-10-09 13:44:36.783377+00');
 INSERT INTO public.moped_milestones (milestone_name, milestone_description, milestone_order, required_milestone, milestone_id) VALUES ('actual construction start date', '', 7, true, 3);
 INSERT INTO public.moped_milestones (milestone_name, milestone_description, milestone_order, required_milestone, milestone_id) VALUES ('actual end date', '', 1, true, 4);
@@ -65,7 +65,7 @@ INSERT INTO public.moped_project_roles (project_role_id, project_role_name, acti
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (12, 'Unknown Role', true, 100, '2020-10-09 14:43:03.859548+00');
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (2, 'Street Designer', true, 2, '2020-10-09 14:44:51.2889+00');
 SELECT pg_catalog.setval('public.moped_categories_category_id_seq', 8, true);
-SELECT pg_catalog.setval('public.moped_coa_staff_staff_id_seq', 3, true);
+SELECT pg_catalog.setval('public.moped_users_staff_id_seq', 3, true);
 SELECT pg_catalog.setval('public.moped_components_component_id_seq', 1, false);
 SELECT pg_catalog.setval('public.moped_entities_entity_id_seq', 1, true);
 SELECT pg_catalog.setval('public.moped_financials_financials_id_seq', 1, false);

--- a/moped-database/seeds/1602292389297_initial_seed.sql
+++ b/moped-database/seeds/1602292389297_initial_seed.sql
@@ -13,9 +13,9 @@ INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start
 INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start_date, fiscal_year_end_date, active_fy) VALUES ('2021', NULL, NULL, true);
 INSERT INTO public.moped_city_fiscal_years (fiscal_year_value, fiscal_year_start_date, fiscal_year_end_date, active_fy) VALUES ('2020', NULL, NULL, false);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('ATSD', 1, '2020-10-09 14:53:02.752811+00');
-INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9699d49f-c5ba-4dad-b286-510a5e178aa7', 'JD', 'Maccombs', 'Developer', 'DTS', 1, 1, NULL, '2020-10-09 13:44:02.159095+00');
-INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('9972fa62-1bbd-4f58-9b7d-80b9bc73a537', 'Mike', 'Schofield', 'Engineer', 'ATSD', 3, 1, NULL, '2020-10-09 13:44:02.15918+00');
-INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, staff_id, workgroup_id, cognito_user_id, date_added) VALUES ('e6bb053b-d6bf-4460-b9a5-c5cb7021958d', 'Nathan', 'Wilkes', 'Engineer', 'ATSD', 2, 1, NULL, '2020-10-09 13:44:02.159184+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, user_id, workgroup_id, cognito_user_id, date_added) VALUES ('9699d49f-c5ba-4dad-b286-510a5e178aa7', 'JD', 'Maccombs', 'Developer', 'DTS', 1, 1, NULL, '2020-10-09 13:44:02.159095+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, user_id, workgroup_id, cognito_user_id, date_added) VALUES ('9972fa62-1bbd-4f58-9b7d-80b9bc73a537', 'Mike', 'Schofield', 'Engineer', 'ATSD', 3, 1, NULL, '2020-10-09 13:44:02.15918+00');
+INSERT INTO public.moped_users (staff_uuid, first_name, last_name, title, workgroup, user_id, workgroup_id, cognito_user_id, date_added) VALUES ('e6bb053b-d6bf-4460-b9a5-c5cb7021958d', 'Nathan', 'Wilkes', 'Engineer', 'ATSD', 2, 1, NULL, '2020-10-09 13:44:02.159184+00');
 INSERT INTO public.moped_entity (entity_uuid, workgroup_name, abbreviated_name, entity_id, affiliated_workgroup, date_added) VALUES ('f30415c5-0b5d-4d92-bb04-7c4f0ea13288', 'Capital Metro', 'CapMetro', 1, NULL, '2020-10-09 13:44:36.783377+00');
 INSERT INTO public.moped_milestones (milestone_name, milestone_description, milestone_order, required_milestone, milestone_id) VALUES ('actual construction start date', '', 7, true, 3);
 INSERT INTO public.moped_milestones (milestone_name, milestone_description, milestone_order, required_milestone, milestone_id) VALUES ('actual end date', '', 1, true, 4);
@@ -65,7 +65,7 @@ INSERT INTO public.moped_project_roles (project_role_id, project_role_name, acti
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (12, 'Unknown Role', true, 100, '2020-10-09 14:43:03.859548+00');
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (2, 'Street Designer', true, 2, '2020-10-09 14:44:51.2889+00');
 SELECT pg_catalog.setval('public.moped_categories_category_id_seq', 8, true);
-SELECT pg_catalog.setval('public.moped_users_staff_id_seq', 3, true);
+SELECT pg_catalog.setval('public.moped_users_user_id_seq', 3, true);
 SELECT pg_catalog.setval('public.moped_components_component_id_seq', 1, false);
 SELECT pg_catalog.setval('public.moped_entities_entity_id_seq', 1, true);
 SELECT pg_catalog.setval('public.moped_financials_financials_id_seq', 1, false);


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4182

## Changes
- [x] Renames table moped_coa_staff to moped_users.
- [x] Renames column staff_id to user_id, and renames unique keys
- [x] Changes type of cognito_id column to UUID
- [x] Creates column  is_coa_staff (type: bool)
- [x] Creates column status_id (type: integer)
- [x] Updates seed data for new data structure.


## To run:

```
# Be sure to have docker, docker-compose & hasura CLI installed.

# Start the hasura cluster:
$ ./hasura-cluster start

# Run the hasura console:
$ hasura console 
```