### PR TITLE
Moped | Single Sign On | Refactor Claims Structure in DynamoDB #4422

### DIFF
--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -186,18 +186,18 @@ def format_claims(user_id: str, roles: list) -> dict:
     }
 
 
-def put_claims(user_id: str, claims: dict):
+def put_claims(user_email: str, user_claims: dict):
     """
     Sets claims in DynamoDB
-    :param str user_id: The user id to set the claims for
-    :param dict claims: The claims object to be persisted in DynamoDB
+    :param str user_email: The user email to set the claims for
+    :param dict user_claims: The claims object to be persisted in DynamoDB
     """
-    claims_str = json.dumps(claims)
+    claims_str = json.dumps(user_claims)
     encrypted_claims = encrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims_str)
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.put_item(
         TableName=AWS_COGNITO_DYNAMO_TABLE_NAME,
-        Item={"user_id": {"S": user_id}, "claims": {"S": encrypted_claims}},
+        Item={"user_id": {"S": user_email}, "claims": {"S": encrypted_claims}},
     )
 
 

--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -152,16 +152,15 @@ def retrieve_claims(user_id: str) -> Optional[str]:
     )["Item"]["claims"]["S"]
 
 
-def load_claims(user_id: str) -> dict:
+def load_claims(user_email: str) -> dict:
     """
     Loads claims from DynamoDB
-    :param str user_id: The user id to retrieve the claims for
+    :param str user_email: The user email to retrieve the claims for
     :return dict: The claims JSON
     """
-    claims = retrieve_claims(user_id=user_id)
+    claims = retrieve_claims(user_id=user_email)
     decrypted_claims = decrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims)
     claims = json.loads(decrypted_claims)
-    claims["x-hasura-user-id"] = user_id
     return claims
 
 

--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -201,6 +201,18 @@ def put_claims(user_email: str, user_claims: dict):
     )
 
 
+def delete_claims(user_email: str):
+    """
+    Deletes claims in DynamoDB
+    :param str user_email: The user email to set the claims for
+    """
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    dynamodb.delete_item(
+        TableName=AWS_COGNITO_DYNAMO_TABLE_NAME,
+        Key={"user_id": {"S": user_email}},
+    )
+
+
 def encrypt(fernet_key: str, content: str) -> Optional[str]:
     """
     Converts a dictionary into an encrypted string.

--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -152,15 +152,18 @@ def retrieve_claims(user_id: str) -> Optional[str]:
     )["Item"]["claims"]["S"]
 
 
-def load_claims(user_email: str) -> dict:
+def load_claims(user_email: str, user_id: str = None) -> dict:
     """
     Loads claims from DynamoDB
     :param str user_email: The user email to retrieve the claims for
+    :param str user_id: The user id (uuid, if missing it wont render x-hasura-user-id)
     :return dict: The claims JSON
     """
     claims = retrieve_claims(user_id=user_email)
     decrypted_claims = decrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims)
     claims = json.loads(decrypted_claims)
+    if user_id is not None:
+        claims["x-hasura-user-id"] = user_id
     return claims
 
 

--- a/moped-api/users/helpers.py
+++ b/moped-api/users/helpers.py
@@ -151,3 +151,16 @@ def db_deactivate_user(user_cognito_id: str) -> dict:
         }
     )
     return response.json()
+
+
+def get_user_email_from_attr(user_attr: object) -> str:
+    """
+    Returns the user email from a user attributes object as provided by the admin_get_user method
+    :param object user_attr: The user attributes object
+    :return str:
+    """
+    email = list(
+        filter(lambda attr: attr["Name"] == "email", user_attr["UserAttributes"])
+    )[0]["Value"]
+
+    return email.replace("azuread_", "")

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -196,7 +196,7 @@ def user_update_user(id: str, claims: list) -> (Response, int):
 
         if roles:
             user_claims = format_claims(id, roles)
-            put_claims(id, user_claims)
+            put_claims(user_email=user_profile["email"], user_claims=user_claims)
 
         response = {
             "success": {

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -118,7 +118,7 @@ def user_create_user(claims: list) -> (Response, int):
         # Encrypt and set Hasura metadata in DynamoDB
         roles = json_data["roles"]
         user_claims = format_claims(cognito_username, roles)
-        put_claims(cognito_username, user_claims)
+        put_claims(user_email=email, user_claims=user_claims)
 
         # Generate the user profile for the database
         user_profile = generate_user_profile(

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -35,7 +35,7 @@ def user_list_users() -> (Response, int):
         cognito_client = boto3.client("cognito-idp")
 
         user_response = cognito_client.list_users(UserPoolId=USER_POOL)
-        user_list = user_response["Users"]
+        user_list = list(filter(lambda user: "azuread_" not in user["Username"], user_response["Users"]))
         return jsonify(user_list)
     else:
         abort(403)

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -11,6 +11,7 @@ from claims import *
 from users.helpers import (
     generate_user_profile,
     generate_cognito_attributes,
+    get_user_email_from_attr,
     is_valid_user_profile,
     is_valid_uuid,
     db_create_user,
@@ -53,8 +54,8 @@ def user_get_user(id: str) -> (Response, int):
         user_dict = {}
 
         user_info = cognito_client.admin_get_user(UserPoolId=USER_POOL, Username=id)
-        user_roles = load_claims(id)
-
+        user_email = get_user_email_from_attr(user_attr=user_info)
+        user_roles = load_claims(user_email=user_email, user_id=id)
         user_dict.update(user_info)
         user_dict.update(user_roles)
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4422

Keeps the functionality of the API the same, but it switches the claims to use email identifiers as opposed to Cognito UUIDs, that way we can have two or more cognito accounts (Cognito and AzureAD) both pointing to the same record in DynamoDB where we get our claims.