### PR TITLE
Moped | Single Sign On | Make API Populate Cognito UUID in DynamoDB #4455

### DIFF
--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -186,18 +186,23 @@ def format_claims(user_id: str, roles: list) -> dict:
     }
 
 
-def put_claims(user_email: str, user_claims: dict):
+def put_claims(user_email: str, user_claims: dict, cognito_uuid: str = None):
     """
     Sets claims in DynamoDB
     :param str user_email: The user email to set the claims for
     :param dict user_claims: The claims object to be persisted in DynamoDB
+    :param str cognito_uuid: The Cognito UUID
     """
     claims_str = json.dumps(user_claims)
     encrypted_claims = encrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims_str)
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.put_item(
         TableName=AWS_COGNITO_DYNAMO_TABLE_NAME,
-        Item={"user_id": {"S": user_email}, "claims": {"S": encrypted_claims}},
+        Item={
+            "user_id": {"S": user_email},
+            "claims": {"S": encrypted_claims},
+            "cognito_uuid": {"S": cognito_uuid},
+        },
     )
 
 

--- a/moped-api/claims.py
+++ b/moped-api/claims.py
@@ -137,38 +137,38 @@ def has_user_role(role, claims) -> bool:
     return False
 
 
-def retrieve_claims(user_email: str) -> Optional[str]:
+def retrieve_user_profile(user_email: str) -> dict:
     """
-    Retrieves the encrypted claims from DynamoDB
+    Retrieves the user profile from the claims table(including encrypted claims and the cognito uuid)
     :param str user_email: The user email
-    :return Optional[str]: The claims string (encrypted)
+    :return dict: The user profile as a dictionary
     """
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-    user_claims = dynamodb.get_item(
+    user_profile = dynamodb.get_item(
         TableName=AWS_COGNITO_DYNAMO_TABLE_NAME,
         Key={
             "user_id": {"S": user_email},
         },
     )
 
-    if "Item" not in user_claims:
-        raise RuntimeError(f"Unable to find claims with given user_id.")
+    if "Item" not in user_profile:
+        raise RuntimeError(f"Unable to find user_profile with given user_id.")
 
-    return user_claims["Item"]["claims"]["S"]
+    return user_profile["Item"]
 
 
-def load_claims(user_email: str, user_id: str = None) -> dict:
+def load_claims(user_email: str) -> dict:
     """
     Loads claims from DynamoDB
     :param str user_email: The user email to retrieve the claims for
-    :param str user_id: The user id (uuid, if missing it wont render x-hasura-user-id)
     :return dict: The claims JSON
     """
-    claims = retrieve_claims(user_email=user_email)
-    decrypted_claims = decrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims)
+    profile = retrieve_user_profile(user_email=user_email)
+    claims_encrypted = profile["claims"]["S"]
+    cognito_uuid = profile["cognito_uuid"]["S"]
+    decrypted_claims = decrypt(fernet_key=AWS_COGNITO_DYNAMO_SECRET_KEY, content=claims_encrypted)
     claims = json.loads(decrypted_claims)
-    if user_id is not None:
-        claims["x-hasura-user-id"] = user_id
+    claims["x-hasura-user-id"] = cognito_uuid
     return claims
 
 

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -118,7 +118,7 @@ def user_create_user(claims: list) -> (Response, int):
         # Encrypt and set Hasura metadata in DynamoDB
         roles = json_data["roles"]
         user_claims = format_claims(cognito_username, roles)
-        put_claims(user_email=email, user_claims=user_claims)
+        put_claims(user_email=email, user_claims=user_claims, cognito_uuid=cognito_username)
 
         # Generate the user profile for the database
         user_profile = generate_user_profile(

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -55,7 +55,7 @@ def user_get_user(id: str) -> (Response, int):
 
         user_info = cognito_client.admin_get_user(UserPoolId=USER_POOL, Username=id)
         user_email = get_user_email_from_attr(user_attr=user_info)
-        user_roles = load_claims(user_email=user_email, user_id=id)
+        user_roles = load_claims(user_email=user_email)
         user_dict.update(user_info)
         user_dict.update(user_roles)
 

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -35,7 +35,11 @@ def user_list_users() -> (Response, int):
         cognito_client = boto3.client("cognito-idp")
 
         user_response = cognito_client.list_users(UserPoolId=USER_POOL)
-        user_list = list(filter(lambda user: "azuread_" not in user["Username"], user_response["Users"]))
+        user_list = list(
+            filter(
+                lambda user: "azuread_" not in user["Username"], user_response["Users"]
+            )
+        )
         return jsonify(user_list)
     else:
         abort(403)
@@ -118,7 +122,9 @@ def user_create_user(claims: list) -> (Response, int):
         # Encrypt and set Hasura metadata in DynamoDB
         roles = json_data["roles"]
         user_claims = format_claims(cognito_username, roles)
-        put_claims(user_email=email, user_claims=user_claims, cognito_uuid=cognito_username)
+        put_claims(
+            user_email=email, user_claims=user_claims, cognito_uuid=cognito_username
+        )
 
         # Generate the user profile for the database
         user_profile = generate_user_profile(
@@ -128,7 +134,9 @@ def user_create_user(claims: list) -> (Response, int):
         db_response = db_create_user(user_profile=user_profile)
 
         if "errors" in db_response:
-            cognito_response = cognito_client.admin_delete_user(UserPoolId=USER_POOL, Username=cognito_username)
+            cognito_response = cognito_client.admin_delete_user(
+                UserPoolId=USER_POOL, Username=cognito_username
+            )
             final_response = {
                 "error": {
                     "message": "Error in the database, user deleted from cognito",
@@ -175,9 +183,7 @@ def user_update_user(id: str, claims: list) -> (Response, int):
         json_data = request.json
         roles = json_data.get("roles", None)
 
-        user_profile = generate_user_profile(
-            cognito_id=id, json_data=request.json
-        )
+        user_profile = generate_user_profile(cognito_id=id, json_data=request.json)
 
         db_response = db_update_user(user_profile=user_profile)
 
@@ -204,7 +210,11 @@ def user_update_user(id: str, claims: list) -> (Response, int):
 
         if roles:
             user_claims = format_claims(id, roles)
-            put_claims(user_email=user_profile["email"], user_claims=user_claims)
+            put_claims(
+                user_email=user_profile["email"],
+                user_claims=user_claims,
+                cognito_uuid=id,
+            )
 
         response = {
             "success": {
@@ -243,7 +253,9 @@ def user_delete_user(id: str, claims: list) -> (Response, int):
         user_info = cognito_client.admin_get_user(UserPoolId=USER_POOL, Username=id)
         user_email = get_user_email_from_attr(user_attr=user_info)
 
-        cognito_response = cognito_client.admin_delete_user(UserPoolId=USER_POOL, Username=id)
+        cognito_response = cognito_client.admin_delete_user(
+            UserPoolId=USER_POOL, Username=id
+        )
         delete_claims(user_email=user_email)
 
         response = {


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4455

This PR adds the cognito_uuid column in the users table in DynamoDB, it lives right along with the claims and the user email. We need the cognito_uuid to be provided when searching with an email, as opposed to browsing through the entire Cognito list of users.

The Lambda that generates tokens for AzureAD needs that Cognito UUID, and it passes it to Hasura. Normal cognito accounts are not affected at all.