### PR TITLE
API | Add update password route test and update existing tests

### DIFF
--- a/moped-api/tests/test_users.py
+++ b/moped-api/tests/test_users.py
@@ -129,7 +129,7 @@ class TestUsers(TestApp):
     @patch("flask_cognito._cognito_auth_required")
     @patch("users.users.is_valid_user")
     def test_gets_users(
-        self, mock_cognito_auth_required, mock_is_valid_user, create_user_pool
+        self, mock_is_valid_user, mock_cognito_auth_required, create_user_pool
     ):
         """Test get users route."""
         mock_is_valid_user.return_value = True
@@ -173,9 +173,9 @@ class TestUsers(TestApp):
     @patch("users.users.load_claims")
     def test_gets_user(
         self,
-        mock_cognito_auth_required,
-        mock_is_valid_user,
         mock_load_claims,
+        mock_is_valid_user,
+        mock_cognito_auth_required,
         create_user_pool,
     ):
         """Test get user route."""

--- a/moped-api/tests/test_users.py
+++ b/moped-api/tests/test_users.py
@@ -231,19 +231,29 @@ class TestUsers(TestApp):
     @patch("flask_cognito._cognito_auth_required")
     @patch("users.users.is_valid_user")
     @patch("users.users.has_user_role")
+    @patch("users.users.is_valid_user_profile")
+    @patch("users.users.format_claims")
     @patch("users.users.put_claims")
+    @patch("users.users.generate_user_profile")
+    @patch("users.users.db_create_user")
     def test_creates_user_success(
         self,
-        mock_cognito_auth_required,
-        mock_is_valid_user,
-        mock_has_user_role,
+        mock_db_create_user,
+        mock_generate_user_profile,
         mock_put_claims,
+        mock_format_claims,
+        mock_is_valid_user_profile,
+        mock_has_user_role,
+        mock_is_valid_user,
+        mock_cognito_auth_required,
         create_user_pool,
     ):
         """Test create user route."""
         # Mock valid user check and claims loaded from DynamoDB
         mock_is_valid_user.return_value = True
         mock_has_user_role.return_value = True
+        mock_is_valid_user_profile.return_value = True, None
+        mock_db_create_user.return_value = {}
 
         # Patch normalize claims
         claims = create_user_claims()

--- a/moped-api/tests/test_users.py
+++ b/moped-api/tests/test_users.py
@@ -286,19 +286,22 @@ class TestUsers(TestApp):
     @patch("flask_cognito._cognito_auth_required")
     @patch("users.users.is_valid_user")
     @patch("users.users.has_user_role")
+    @patch("users.users.is_valid_user_profile")
     @patch("users.users.put_claims")
     def test_creates_user_already_exists(
         self,
-        mock_cognito_auth_required,
-        mock_is_valid_user,
-        mock_has_user_role,
         mock_put_claims,
+        mock_is_valid_user_profile,
+        mock_has_user_role,
+        mock_is_valid_user,
+        mock_cognito_auth_required,
         create_user_pool,
     ):
         """Test create user route when user already exists."""
         # Mock valid user check and claims loaded from DynamoDB
         mock_is_valid_user.return_value = True
         mock_has_user_role.return_value = True
+        mock_is_valid_user_profile.return_value = True, None
 
         # Patch normalize claims
         claims = create_user_claims()
@@ -331,7 +334,7 @@ class TestUsers(TestApp):
         fail_response_dict = self.parse_response(fail_response.data)
 
         assert isinstance(fail_response_dict, dict)
-        assert fail_response_dict["ResponseMetadata"]["HTTPStatusCode"] == 400
+        assert isinstance(fail_response_dict.get("Error", None), dict)
         assert fail_response_dict["Error"]["Code"] == "UsernameExistsException"
 
     @mock_cognitoidp


### PR DESCRIPTION
This PR updates the User API test coverage to work with the latest improvements and also adds a test for the new password update route. I also fixed the order of nested `@patch` decorators in the test methods to pass in arguments in the right order. https://docs.python.org/3/library/unittest.mock.html#quick-guide

<img width="1657" alt="Screen Shot 2020-11-27 at 4 36 41 PM" src="https://user-images.githubusercontent.com/37249039/100521806-966e3a00-316b-11eb-85c7-674ade29e7c0.png">
