### PR TITLE
Moped API | Handle CORS in the MOPED User Management API

### DIFF
--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -3,6 +3,7 @@ import boto3
 from botocore.exceptions import ClientError
 from flask import Blueprint, jsonify, abort, Response
 from flask_cognito import cognito_auth_required, current_cognito_jwt, request
+from flask_cors import CORS
 from config import api_config
 
 # Import our custom code
@@ -22,6 +23,7 @@ from users.helpers import (
 )
 
 users_blueprint = Blueprint("users_blueprint", __name__)
+CORS(users_blueprint)
 
 USER_POOL = api_config["COGNITO_USERPOOL_ID"]
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4583

This PR adds CORS setup to the users blueprint in the Flask app. CORS was already set up app-wide by Sergio 🙏 but it seems that blueprints require their own initialization.