### PR TITLE
Remove CORS config in Users blueprint

### DIFF
--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -3,7 +3,6 @@ import boto3
 from botocore.exceptions import ClientError
 from flask import Blueprint, jsonify, abort, Response
 from flask_cognito import cognito_auth_required, current_cognito_jwt, request
-from flask_cors import CORS
 from config import api_config
 
 # Import our custom code
@@ -23,7 +22,6 @@ from users.helpers import (
 )
 
 users_blueprint = Blueprint("users_blueprint", __name__)
-CORS(users_blueprint)
 
 USER_POOL = api_config["COGNITO_USERPOOL_ID"]
 


### PR DESCRIPTION
This PR removes some extra config for the users blueprint so we can update the Moped API.