### PR TITLE
Editor | Use error responses from User Management API for Add User form feedback

### DIFF
--- a/moped-editor/src/views/account/AccountView/ProfileDetails.js
+++ b/moped-editor/src/views/account/AccountView/ProfileDetails.js
@@ -38,7 +38,7 @@ const passwordValidationSchema = yup.object().shape({
 const ProfileDetails = () => {
   const classes = useStyles();
   const { user } = useUser();
-  const [userApiResult, userApiLoading, requestApi] = useUserApi();
+  const { result, loading, requestApi } = useUserApi();
 
   const { register, handleSubmit, errors, formState } = useForm({
     defaultValues: initialValues,
@@ -100,7 +100,7 @@ const ProfileDetails = () => {
               />
             </Grid>
             <Grid item xs={12} md={6}>
-              {userApiLoading || isSubmitting ? (
+              {loading || isSubmitting ? (
                 <CircularProgress />
               ) : (
                 <>
@@ -117,7 +117,7 @@ const ProfileDetails = () => {
               )}
             </Grid>
             <Grid item xs={12} md={6}>
-              {userApiResult?.success && (
+              {result?.success && (
                 <Alert severity="success">Password updated</Alert>
               )}
             </Grid>

--- a/moped-editor/src/views/staff/EditStaffView.js
+++ b/moped-editor/src/views/staff/EditStaffView.js
@@ -34,6 +34,7 @@ const GET_USER = gql`
       workgroup
       workgroup_id
       cognito_user_id
+      email
     }
   }
 `;

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -77,12 +77,6 @@ const statuses = [
   { value: "0", name: "Inactive" },
 ];
 
-// TODO: Display errors from the API
-// 1. Add catch to axios chain in useUserAPI hook
-// 2. export any errors as userErrors
-// 3. If userErrors, show in UI
-// 4. Nested as res.errors.email[0]
-
 // Pass editFormData to conditionally validate if adding or editing
 const staffValidationSchema = editFormData =>
   yup.object().shape({
@@ -218,8 +212,10 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
             }}
             variant="outlined"
             inputRef={register}
-            error={!!errors.last_name}
-            helperText={errors.last_name?.message}
+            error={!!errors.last_name || !!apiErrors?.last_name}
+            helperText={
+              errors.last_name?.message || formatApiErrors(apiErrors?.last_name)
+            }
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -233,8 +229,10 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
             }}
             variant="outlined"
             inputRef={register}
-            error={!!errors.title}
-            helperText={errors.title?.message}
+            error={!!errors.title || !!apiErrors?.title}
+            helperText={
+              errors.title?.message || formatApiErrors(apiErrors?.title)
+            }
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -248,8 +246,10 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
             }}
             variant="outlined"
             inputRef={register}
-            error={!!errors.email}
-            helperText={errors.email?.message}
+            error={!!errors.email || !!apiErrors?.email}
+            helperText={
+              errors.email?.message || formatApiErrors(apiErrors?.email)
+            }
           />
         </Grid>
         <Grid item xs={12} md={6}>
@@ -264,8 +264,10 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
             }}
             variant="outlined"
             inputRef={register}
-            error={!!errors.password}
-            helperText={errors.password?.message}
+            error={!!errors.password || !!apiErrors?.password}
+            helperText={
+              errors.password?.message || formatApiErrors(apiErrors?.password)
+            }
           />
         </Grid>
         <Grid item xs={12} md={6}>

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -105,7 +105,11 @@ const fieldParsers = {
 const StaffForm = ({ editFormData = null, userCognitoId }) => {
   const classes = useStyles();
   let navigate = useNavigate();
-  const { userApiLoading, requestApi, error: apiErrors } = useUserApi();
+  const {
+    loading: userApiLoading,
+    requestApi,
+    error: apiErrors,
+  } = useUserApi();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const {

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useUserApi } from "./helpers";
+import { formatApiErrors, useUserApi } from "./helpers";
 import { useForm, Controller } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
@@ -111,7 +111,7 @@ const fieldParsers = {
 const StaffForm = ({ editFormData = null, userCognitoId }) => {
   const classes = useStyles();
   let navigate = useNavigate();
-  const { userApiLoading, requestApi } = useUserApi();
+  const { userApiLoading, requestApi, error: apiErrors } = useUserApi();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const {
@@ -200,8 +200,11 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
             }}
             variant="outlined"
             inputRef={register}
-            error={!!errors.first_name}
-            helperText={errors.first_name?.message}
+            error={!!errors.first_name || !!apiErrors?.first_name}
+            helperText={
+              errors.first_name?.message ||
+              formatApiErrors(apiErrors?.first_name)
+            }
           />
         </Grid>
         <Grid item xs={12} md={6}>

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -170,7 +170,7 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
   };
 
   const handleDeleteConfirm = () => {
-    const requestPath = "/users/delete/" + userCognitoId;
+    const requestPath = "/users/" + userCognitoId;
     const deleteCallback = () => setIsDeleteModalOpen(false);
 
     requestApi({

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -77,6 +77,12 @@ const statuses = [
   { value: "0", name: "Inactive" },
 ];
 
+// TODO: Display errors from the API
+// 1. Add catch to axios chain in useUserAPI hook
+// 2. export any errors as userErrors
+// 3. If userErrors, show in UI
+// 4. Nested as res.errors.email[0]
+
 // Pass editFormData to conditionally validate if adding or editing
 const staffValidationSchema = editFormData =>
   yup.object().shape({
@@ -105,7 +111,7 @@ const fieldParsers = {
 const StaffForm = ({ editFormData = null, userCognitoId }) => {
   const classes = useStyles();
   let navigate = useNavigate();
-  const [userApiLoading, requestApi] = useUserApi();
+  const { userApiLoading, requestApi } = useUserApi();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const {

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -42,7 +42,9 @@ const GET_STAFF = gql`
 const StaffListView = () => {
   const classes = useStyles();
 
-  const { data, loading, error } = useQuery(GET_STAFF);
+  const { data, loading, error } = useQuery(GET_STAFF, {
+    fetchPolicy: "no-cache",
+  });
   if (error) {
     console.log(error);
   }

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -32,6 +32,7 @@ export function useUserApi() {
     axios(config)
       .then(res => {
         setResult(res.data);
+        setError(null); // Clear errors from previous attempts
         setLoading(false);
         !!callback && callback();
       })
@@ -53,4 +54,4 @@ const errorsToTranslate = {
 export const formatApiErrors = errorsArray =>
   errorsArray
     ? errorsArray.map(error => errorsToTranslate[error] || error).join(", ")
-    : false;
+    : null;

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -32,12 +32,37 @@ export function useUserApi() {
     axios(config)
       .then(res => {
         setResult(res.data);
-        console.log(res);
         setLoading(false);
         !!callback && callback();
       })
-      .catch(err => setError(err));
+      .catch(err => {
+        setError(err.response.data.error);
+      });
   };
 
   return { result, error, loading, requestApi };
 }
+
+const errorsToTranslate = {
+  "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'":
+    "not a valid email format",
+  "value does not match regex '^[a-zA-Z0-9_-!@%^*~?.:&*()[]$]*$'":
+    "password must only contain: a-z, A-Z, 0-9, and any of these special characters: _-!@%^~?.:&()[]$",
+};
+
+export const formatApiErrors = errorsArray =>
+  errorsArray
+    ? errorsArray.map(error => errorsToTranslate[error] || error).join(", ")
+    : false;
+// TODO: Handle email error ("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+// TODO: Handle password error ("^[a-zA-Z0-9_\-\!\@\%\^\*\~\?\.\:\&\*\(\)\[\]\$]*$")
+// {
+//   "error": {
+//     "email": [
+//       "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"
+//     ],
+//     "first_name": [
+//       "max length is 128"
+//     ]
+//   }
+// }

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -5,6 +5,7 @@ import axios from "axios";
 // Custom Hook for API calls
 export function useUserApi() {
   const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const { user, getToken } = useUser();
 
@@ -28,13 +29,15 @@ export function useUserApi() {
 
     setLoading(true);
 
-    axios(config).then(res => {
-      setResult(res.data);
-      console.log(res);
-      setLoading(false);
-      !!callback && callback();
-    });
+    axios(config)
+      .then(res => {
+        setResult(res.data);
+        console.log(res);
+        setLoading(false);
+        !!callback && callback();
+      })
+      .catch(err => setError(err));
   };
 
-  return { result, loading, requestApi };
+  return { result, error, loading, requestApi };
 }

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -54,15 +54,3 @@ export const formatApiErrors = errorsArray =>
   errorsArray
     ? errorsArray.map(error => errorsToTranslate[error] || error).join(", ")
     : false;
-// TODO: Handle email error ("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
-// TODO: Handle password error ("^[a-zA-Z0-9_\-\!\@\%\^\*\~\?\.\:\&\*\(\)\[\]\$]*$")
-// {
-//   "error": {
-//     "email": [
-//       "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"
-//     ],
-//     "first_name": [
-//       "max length is 128"
-//     ]
-//   }
-// }

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -36,5 +36,5 @@ export function useUserApi() {
     });
   };
 
-  return [result, loading, requestApi];
+  return { result, loading, requestApi };
 }


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4494

This PR updates the user add/edit forms to display errors return from the user API. I also fixed a bug that prevented these forms from submitting successfully in the current staging/production apps. Open to any feedback on whether we should make the API errors human-readable on the front-end or not. I definitely like the way the API returns the regex in the errors the way it does currently.

#### API errors in Add User form
<img width="798" alt="Screen Shot 2020-12-04 at 1 32 46 PM" src="https://user-images.githubusercontent.com/37249039/101208899-78f01300-3638-11eb-969d-60c633265c0f.png">
