### PR TITLE
DB | Update workgroup migration

### DIFF
--- a/moped-database/migrations/1607538472784_insert_workgroups/up.sql
+++ b/moped-database/migrations/1607538472784_insert_workgroups/up.sql
@@ -1,3 +1,4 @@
+DELETE FROM public.moped_workgroup WHERE workgroup_id = 1;
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Active Transportation & Street Design', 1, '2020-12-04 16:53:02.752811+00');
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Arterial Management', 2, '2020-12-04 16:53:02.752811+00');
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Data & Technology Services', 3, '2020-12-04 16:53:02.752811+00');


### PR DESCRIPTION
This PR updates the previous workgroup migration that failed its GH Action run. The problem was a single workgroup already present in the `moped_workgroup` table conflicting with the 1st insert statement.