### PR TITLE
Allow spaces in workgroup name

### DIFF
--- a/moped-api/users/validation.py
+++ b/moped-api/users/validation.py
@@ -64,7 +64,7 @@ USER_VALIDATION_SCHEMA = {
         "empty": False,
         "minlength": 3,
         "maxlength": 128,
-        "regex": "^[a-zA-Z0-9_\-\!\@\%\^\*\~\?\.\:\&\*\(\)\[\]\$]*$",
+        "regex": "^[a-zA-Z0-9_\-\!\@\%\^\*\~\?\.\:\&\*\(\)\[\]\$\ ]*$",
     },
     "workgroup_id": {
         "type": "number",


### PR DESCRIPTION
This PR updates the regex for `workgroup` validation in the API to allow spaces so we can use the full workgroup names in the database.