### PR TITLE
Capitally Funded  ➡️ Capital Funding

### DIFF
--- a/moped-editor/src/views/projects/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/DefineProjectForm.js
@@ -198,7 +198,7 @@ const DefineProjectForm = ({ projectDetails, setProjectDetails }) => {
           </Select>
         </Grid>
         <Grid item xs={4}>
-          <InputLabel>Capitally Funded?</InputLabel>
+          <InputLabel>Capital Funding?</InputLabel>
           <Switch
             type="checkbox"
             checked={projectDetails.capitally_funded}

--- a/moped-editor/src/views/projects/ProjectSummary.js
+++ b/moped-editor/src/views/projects/ProjectSummary.js
@@ -52,6 +52,7 @@ const SUMMARY_QUERY = gql`
       start_date
       current_phase
       current_status
+      capitally_funded
       eCapris_id
       fiscal_year
       project_priority

--- a/moped-editor/src/views/projects/ProjectSummaryDetails.js
+++ b/moped-editor/src/views/projects/ProjectSummaryDetails.js
@@ -63,7 +63,6 @@ const ProjectSummaryDetails = details => {
         formattedValue = value.field === true ? "Yes" : "No";
         break;
       case "string":
-        console.log(value.field);
         formattedValue =
           value.field === "" ? (
             <Box color="text.disabled">
@@ -76,7 +75,6 @@ const ProjectSummaryDetails = details => {
       default:
         break;
     }
-    console.log(formattedValue);
     return formattedValue;
   };
 

--- a/moped-editor/src/views/projects/ProjectSummaryDetails.js
+++ b/moped-editor/src/views/projects/ProjectSummaryDetails.js
@@ -9,6 +9,7 @@ const ProjectSummaryDetails = details => {
     start_date,
     fiscal_year,
     project_priority,
+    capitally_funded,
     eCapris_id,
   } = details.details;
 
@@ -16,32 +17,68 @@ const ProjectSummaryDetails = details => {
     {
       field: current_status,
       label: "Current Status",
+      type: "string",
     },
     {
       field: current_phase,
       label: "Current Phase",
+      type: "string",
     },
     {
       field: project_description,
       label: "Description",
+      type: "string",
     },
     {
       field: start_date,
       label: "Start Date",
+      type: "string",
     },
     {
       field: fiscal_year,
       label: "Fiscal Year",
+      type: "string",
     },
     {
       field: project_priority,
       label: "Priority",
+      type: "string",
+    },
+    {
+      field: capitally_funded,
+      label: "Capital Funding",
+      type: "boolean",
     },
     {
       field: eCapris_id,
       label: "eCapris ID",
+      type: "string",
     },
   ];
+
+  const formatValue = value => {
+    let formattedValue = value.field;
+    switch (value.type) {
+      case "boolean":
+        formattedValue = value.field === true ? "Yes" : "No";
+        break;
+      case "string":
+        console.log(value.field);
+        formattedValue =
+          value.field === "" ? (
+            <Box color="text.disabled">
+              <p>No data</p>
+            </Box>
+          ) : (
+            value.field
+          );
+        break;
+      default:
+        break;
+    }
+    console.log(formattedValue);
+    return formattedValue;
+  };
 
   return (
     <Grid container spacing={2}>
@@ -49,13 +86,7 @@ const ProjectSummaryDetails = details => {
         <Grid item xs={6}>
           <Box mb={2}>
             <h4>{detail.label}</h4>
-            {detail.field ? (
-              <p>{detail.field}</p>
-            ) : (
-              <Box color="text.disabled">
-                <p>No data</p>
-              </Box>
-            )}
+            <p>{formatValue(detail)}</p>
           </Box>
         </Grid>
       ))}

--- a/moped-editor/src/views/projects/ProjectsListView.js
+++ b/moped-editor/src/views/projects/ProjectsListView.js
@@ -73,7 +73,7 @@ const projectsQueryConf = {
       searchable: false,
       sortable: false,
       label_search: null,
-      label_table: "Capitally Funded",
+      label_table: "Capital Funding",
       type: "String",
     },
   },

--- a/moped-editor/src/views/projects/ProjectsTable.js
+++ b/moped-editor/src/views/projects/ProjectsTable.js
@@ -80,7 +80,7 @@ const ProjectsTable = ({ projects }) => {
                 <TableCell>Status</TableCell>
                 <TableCell>Date Added</TableCell>
                 <TableCell>Start Date</TableCell>
-                <TableCell>Capitally Funded</TableCell>
+                <TableCell>Capital Funding</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4745

This pull request updates the labeling for "Capital Funding" fields. It does not change the database schema or table attributes. If that change is necessary in the DB, I can work on those migrations as a follow-up task.

In the process of adding the Capital Funding field to the Project Summary page, I encountered a bug where a record that had Capital Funding set as `false` was being displayed as "No data". I changed the ternary logic in a way that was quick for me in the moment but allows for some expanded type checking based on field in the future.

![Screen Shot 2020-12-18 at 5 26 58 PM](https://user-images.githubusercontent.com/5697474/102672915-d10a3780-4157-11eb-9475-e1854f459bc5.jpg)

![Screen Shot 2020-12-18 at 5 26 42 PM](https://user-images.githubusercontent.com/5697474/102672923-d5365500-4157-11eb-84a9-80a3615145de.jpg)

![Screen Shot 2020-12-18 at 5 26 35 PM](https://user-images.githubusercontent.com/5697474/102672926-d6678200-4157-11eb-944b-39e39122a838.jpg)

![Screen Shot 2020-12-18 at 5 26 11 PM](https://user-images.githubusercontent.com/5697474/102672927-d7001880-4157-11eb-89db-2f1890600eb3.jpg)

