### PR TITLE
Project Extent | Restrict geocoder and restore unselected polygon outlines

### DIFF
--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -22,6 +22,7 @@ const theme = createMuiTheme({
     map: {
       selected: "#00AAB1",
       transparent: "rgba(0,0,0,0)",
+      outline: "#000000",
     },
   },
   shadows,

--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -20,9 +20,9 @@ const theme = createMuiTheme({
       secondary: "#000000",
     },
     map: {
-      selected: "#00AAB1",
+      selected: "#1e88e5",
       transparent: "rgba(0,0,0,0)",
-      outline: "#000000",
+      outline: "#1e88e5",
     },
   },
   shadows,

--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -20,9 +20,7 @@ const theme = createMuiTheme({
       secondary: "#000000",
     },
     map: {
-      selected: "#1e88e5",
       transparent: "rgba(0,0,0,0)",
-      outline: "#1e88e5",
     },
   },
   shadows,

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -122,7 +122,7 @@ export const createProjectSelectLayerConfig = (
         theme.palette.map.selected,
         ["in", ["get", "polygon_id"], ["literal", layerIds]],
         config.layerColor,
-        theme.palette.map.transparent,
+        theme.palette.map.outline,
       ],
       "fill-opacity": 0.4,
     },

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -41,6 +41,12 @@ export const layerConfigs = [
   },
 ];
 
+const fillOpacities = {
+  selected: 0.75,
+  hovered: 0.5,
+  unselected: 0.25,
+};
+
 /**
  * Get the IDs from the layerConfigs object to set as interactive in the map components
  * @return {Array} List of layer IDs to be set as interactive (hover, click) in map
@@ -115,15 +121,15 @@ export const createProjectSelectLayerConfig = (
     },
     "source-layer": config.layerSourceName,
     paint: {
-      "fill-color": [
+      "fill-color": config.layerColor,
+      "fill-opacity": [
         "case",
         ["==", ["get", "polygon_id"], hoveredId],
-        theme.palette.map.selected,
+        fillOpacities.hovered,
         ["in", ["get", "polygon_id"], ["literal", layerIds]],
-        config.layerColor,
-        theme.palette.map.outline,
+        fillOpacities.selected,
+        fillOpacities.unselected,
       ],
-      "fill-opacity": 0.4,
     },
   };
 };
@@ -148,7 +154,7 @@ export const createProjectViewLayerConfig = () => ({
   type: "fill",
   paint: {
     "fill-color": ["case", ...fillColorCases, theme.palette.map.transparent],
-    "fill-opacity": 0.5,
+    "fill-opacity": fillOpacities.selected,
   },
 });
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -10,6 +10,27 @@ export const mapInit = {
   zoom: 12,
 };
 
+// Query that returns feature collection with bbox for Austin Full Purpose Jurisdiction\
+// https://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/BOUNDARIES_jurisdiction_1231_1951/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=&returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=true&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token=
+const austinFullPurposeJurisdictionFeatureCollection = {
+  type: "FeatureCollection",
+  crs: {
+    type: "name",
+    properties: {
+      name: "EPSG:4326",
+    },
+  },
+  bbox: [
+    -97.940377028014,
+    30.1337172258415,
+    -97.578205982277,
+    30.4648268798927,
+  ],
+  features: [],
+};
+
+export const geocoderBbox = austinFullPurposeJurisdictionFeatureCollection.bbox;
+
 // Set the layer attributes to render on map
 export const layerConfigs = [
   {

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -10,8 +10,7 @@ export const mapInit = {
   zoom: 12,
 };
 
-// Query that returns feature collection with bbox for Austin Full Purpose Jurisdiction\
-// https://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/BOUNDARIES_jurisdiction_1231_1951/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=&returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=true&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token=
+// See MOPED Technical Docs > User Interface > Map > react-map-gl-geocoder
 const austinFullPurposeJurisdictionFeatureCollection = {
   type: "FeatureCollection",
   crs: {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -8,6 +8,7 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
 import {
   createProjectSelectLayerConfig,
+  geocoderBbox,
   getGeoJSON,
   getInteractiveIds,
   getLayerSource,
@@ -135,6 +136,7 @@ const NewProjectMap = ({
           mapRef={mapRef}
           onViewportChange={handleGeocoderViewportChange}
           mapboxApiAccessToken={MAPBOX_TOKEN}
+          bbox={geocoderBbox}
           position="top-right"
         />
         {layerConfigs.map(config => (


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4821
Closes https://github.com/cityofaustin/atd-data-tech/issues/4715

This PR updates the New Project map geocoder with a bounding box to keep search results within the Austin area. It also restores the polygon outlines in the map to allow users to see selectable polygons.

Updated technical docs for geocoder: https://app.gitbook.com/@atd-dts/s/moped-technical-docs/infrastructure/user-interface/maps

### Filtered geocoder results and outlines/fill for unselected polygons
<img width="1266" alt="Screen Shot 2021-01-04 at 11 40 18 AM" src="https://user-images.githubusercontent.com/37249039/103563095-cc48c180-4e81-11eb-9bcb-6bbcc72a2d8a.png">