### PR TITLE
Changes First Name and Last Name field type from Name to Text

### DIFF
--- a/moped-database/migrations/1609960117759_alter_table_public_moped_users_alter_column_first_name/down.sql
+++ b/moped-database/migrations/1609960117759_alter_table_public_moped_users_alter_column_first_name/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ALTER COLUMN "first_name" TYPE name;

--- a/moped-database/migrations/1609960117759_alter_table_public_moped_users_alter_column_first_name/up.sql
+++ b/moped-database/migrations/1609960117759_alter_table_public_moped_users_alter_column_first_name/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ALTER COLUMN "first_name" TYPE text;

--- a/moped-database/migrations/1609960123867_alter_table_public_moped_users_alter_column_last_name/down.sql
+++ b/moped-database/migrations/1609960123867_alter_table_public_moped_users_alter_column_last_name/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ALTER COLUMN "last_name" TYPE name;

--- a/moped-database/migrations/1609960123867_alter_table_public_moped_users_alter_column_last_name/up.sql
+++ b/moped-database/migrations/1609960123867_alter_table_public_moped_users_alter_column_last_name/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_users" ALTER COLUMN "last_name" TYPE text;


### PR DESCRIPTION
I noticed the First Name and Last Name fields in the database are of type Name, which was unknown to me, not to mention it lacks important string comparison operators we need. As it turns out "the name type exists only for the storage of identifiers in the internal system catalogs and **_is not intended for use by the general user_**".

https://www.postgresql.org/docs/current/datatype-character.html

This branch was created only for the migration, changes were cherry-picked from commit id: `3498946e118c995c8f82ff0ce19fe4e2ca5b9447`