### PR TITLE
User Management | Replace "Login" in side drawer with "Log out"

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
@@ -3,13 +3,13 @@ import { useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import { Box, Drawer, Hidden, List, makeStyles } from "@material-ui/core";
 import { EmojiTransportation } from "@material-ui/icons";
-import InputIcon from "@material-ui/icons/Input";
 import {
   BarChart as BarChartIcon,
   Settings as SettingsIcon,
   User as UserIcon,
   UserPlus as UserPlusIcon,
   Users as UsersIcon,
+  LogOut as LogOutIcon,
 } from "react-feather";
 import NavItem from "./NavItem";
 
@@ -46,7 +46,7 @@ const items = [
   },
   {
     href: "/moped/logout",
-    icon: InputIcon,
+    icon: LogOutIcon,
     title: "Logout",
   },
 ];

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
@@ -3,9 +3,9 @@ import { useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import { Box, Drawer, Hidden, List, makeStyles } from "@material-ui/core";
 import { EmojiTransportation } from "@material-ui/icons";
+import InputIcon from "@material-ui/icons/Input";
 import {
   BarChart as BarChartIcon,
-  Lock as LockIcon,
   Settings as SettingsIcon,
   User as UserIcon,
   UserPlus as UserPlusIcon,
@@ -40,20 +40,15 @@ const items = [
     title: "Settings",
   },
   {
-    href: "/login",
-    icon: LockIcon,
-    title: "Login",
-  },
-  {
     href: "/register",
     icon: UserPlusIcon,
     title: "Register",
   },
-  // {
-  //   href: '/404',
-  //   icon: AlertCircleIcon,
-  //   title: 'Error'
-  // }
+  {
+    href: "/login",
+    icon: InputIcon,
+    title: "Logout",
+  },
 ];
 
 const useStyles = makeStyles(() => ({

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { useUser } from "../../../auth/user";
 import PropTypes from "prop-types";
 import { Box, Drawer, Hidden, List, makeStyles } from "@material-ui/core";
 import { EmojiTransportation } from "@material-ui/icons";

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useUser } from "../../../auth/user";
 import PropTypes from "prop-types";
 import { Box, Drawer, Hidden, List, makeStyles } from "@material-ui/core";
 import { EmojiTransportation } from "@material-ui/icons";
@@ -45,7 +46,7 @@ const items = [
     title: "Register",
   },
   {
-    href: "/login",
+    href: "/moped/logout",
     icon: InputIcon,
     title: "Logout",
   },

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -12,7 +12,7 @@ import {
   makeStyles,
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
-import InputIcon from "@material-ui/icons/Input";
+import { LogOut as LogOutIcon } from "react-feather";
 import Logo from "src/components/Logo";
 import { useUser } from "../../auth/user";
 import { defaultUser } from "../../views/account/AccountView/Profile";
@@ -45,7 +45,7 @@ const TopBar = ({ className, onMobileNavOpen, ...rest }) => {
         </Box>
         <Hidden mdDown>
           <IconButton color="inherit" onClick={logout}>
-            <InputIcon />
+            <LogOutIcon />
           </IconButton>
         </Hidden>
         <Hidden lgUp>

--- a/moped-editor/src/routes.js
+++ b/moped-editor/src/routes.js
@@ -8,6 +8,7 @@ import NewStaffView from "src/views/staff/NewStaffView";
 import EditStaffView from "src/views/staff/EditStaffView";
 import DashboardView from "src/views/reports/DashboardView/DashboardView";
 import LoginView from "src/views/auth/LoginView";
+import Logout from "src/views/auth/Logout";
 import NotFoundView from "src/views/errors/NotFoundView";
 import NewProjectView from "src/views/projects/newProjectView/NewProjectView";
 import ProjectSummary from "src/views/projects/projectView/ProjectView";
@@ -42,6 +43,7 @@ const routes = [
         path: "projects/:projectId",
         element: <ProjectSummary />,
       },
+      { path: "logout", element: <Logout /> },
       { path: "settings", element: <SettingsView /> },
       { path: "404", element: <NotFoundView /> },
       { path: "*", element: <Navigate to="/moped/404" /> },

--- a/moped-editor/src/views/auth/Logout.js
+++ b/moped-editor/src/views/auth/Logout.js
@@ -1,9 +1,16 @@
+import React from "react";
 import { useUser } from "../../auth/user";
+import { Navigate } from "react-router-dom";
 
 const Logout = () => {
   const { logout } = useUser();
 
-  return logout();
+  const logoutAndRedirect = () => {
+    logout();
+    return <Navigate to="/" />;
+  };
+
+  return logoutAndRedirect();
 };
 
 export default Logout;

--- a/moped-editor/src/views/auth/Logout.js
+++ b/moped-editor/src/views/auth/Logout.js
@@ -1,0 +1,9 @@
+import { useUser } from "../../auth/user";
+
+const Logout = () => {
+  const { logout } = useUser();
+
+  return logout();
+};
+
+export default Logout;


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4758

This PR updates the logout button icon and adds a logout link to the sidebar for logging out in mobile viewports.

### Updated icons and new sidebar link
<img width="1499" alt="Screen Shot 2021-01-14 at 12 16 58 PM" src="https://user-images.githubusercontent.com/37249039/104660072-7a771700-568b-11eb-921b-70f42a2d35dc.png">
