### PR TITLE
removed unnecessary account management nav items

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -4570,7 +4570,7 @@
     },
     "atd-kickstand": {
       "version": "github:cityofaustin/atd-kickstand#b287a2190b1bf8c9d2f3c5fef5fe3c9d5df1323e",
-      "from": "github:cityofaustin/atd-kickstand#main"
+      "from": "github:cityofaustin/atd-kickstand#b287a2190b1bf8c9d2f3c5fef5fe3c9d5df1323e"
     },
     "atob": {
       "version": "2.1.2",

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavBar.js
@@ -5,9 +5,7 @@ import { Box, Drawer, Hidden, List, makeStyles } from "@material-ui/core";
 import { EmojiTransportation } from "@material-ui/icons";
 import {
   BarChart as BarChartIcon,
-  Settings as SettingsIcon,
   User as UserIcon,
-  UserPlus as UserPlusIcon,
   Users as UsersIcon,
   LogOut as LogOutIcon,
 } from "react-feather";
@@ -33,16 +31,6 @@ const items = [
     href: "/moped/account",
     icon: UserIcon,
     title: "Account",
-  },
-  {
-    href: "/moped/settings",
-    icon: SettingsIcon,
-    title: "Settings",
-  },
-  {
-    href: "/register",
-    icon: UserPlusIcon,
-    title: "Register",
   },
   {
     href: "/moped/logout",


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/4810

Removes "Settings" and "Register" options from user nav bar.

<img width="257" alt="Screen Shot 2021-01-19 at 5 34 30 PM" src="https://user-images.githubusercontent.com/35410637/105106963-9c520e80-5a7c-11eb-8164-fdfef7f3d403.png">
