### PR TITLE
Project Extent | Implement extent definition using CTN segments

### DIFF
--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -118,7 +118,15 @@ export const createProjectSelectLayerConfig = (
     },
     paint: {
       "line-color": config.layerColor,
-      "line-width": 2,
+      "line-width": {
+        base: 1,
+        stops: [
+          [10, 1],
+          [13, 2],
+          [16, 5],
+          [18, 10],
+        ],
+      },
       "line-opacity": [
         "case",
         ["==", ["get", "PROJECT_EXTENT_ID"], hoveredId],

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -120,14 +120,19 @@ export const createProjectSelectLayerConfig = (
   return {
     id: config.layerId,
     type: config.type,
-    source: {
-      type: "vector",
-      tiles: [config.layerUrl],
-    },
+    // source: {
+    //   type: "vector",
+    //   tiles: [config.layerUrl],
+    // },
     "source-layer": config.layerSourceName,
+    layout: {
+      "line-cap": "round",
+      "line-join": "round",
+    },
     paint: {
+      "line-blur": 0,
       "line-color": config.layerColor,
-      "line-width": 5,
+      "line-width": 2,
       "line-opacity": [
         "case",
         ["==", ["get", "PROJECT_EXTENT_ID"], hoveredId],

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -27,14 +27,6 @@ export const geocoderBbox = austinFullPurposeJurisdictionFeatureCollection.bbox;
 
 // Set the layer attributes to render on map
 export const layerConfigs = [
-  // {
-  //   layerId: "location-polygons",
-  //   type: "fill",
-  //   layerSourceName: "asmp_polygons",
-  //   layerColor: theme.palette.primary.main,
-  //   layerUrl:
-  //     "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/location_polygons_vector_tiles_w_IDs/VectorTileServer/tile/{z}/{y}/{x}.pbf",
-  // },
   {
     layerId: "ctn-lines",
     type: "line",
@@ -120,17 +112,11 @@ export const createProjectSelectLayerConfig = (
   return {
     id: config.layerId,
     type: config.type,
-    // source: {
-    //   type: "vector",
-    //   tiles: [config.layerUrl],
-    // },
     "source-layer": config.layerSourceName,
     layout: {
-      "line-cap": "round",
       "line-join": "round",
     },
     paint: {
-      "line-blur": 0,
       "line-color": config.layerColor,
       "line-width": 2,
       "line-opacity": [

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -52,6 +52,7 @@ export const mapConfig = {
     longitude: -97.742828,
     zoom: 12,
   },
+  mapboxDefaultMaxZoom: 18,
   geocoderBbox: austinFullPurposeJurisdictionFeatureCollection.bbox,
   layerConfigs: {
     CTN: {
@@ -60,6 +61,7 @@ export const mapConfig = {
       layerColor: theme.palette.primary.main,
       layerUrl:
         "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/CTN_Project_Extent_Vector_Tiles/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+      layerMaxLOD: 14,
       get layerStyleSpec() {
         return function(hoveredId, layerIds) {
           return {

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -17,23 +17,7 @@ const austinFullPurposeJurisdictionFeatureCollection = {
   features: [],
 };
 
-export const mapConfig = {
-  mapInit: {
-    latitude: 30.268039,
-    longitude: -97.742828,
-    zoom: 12,
-  },
-  geocoderBbox: austinFullPurposeJurisdictionFeatureCollection.bbox,
-  layerConfigs: {
-    CTN: {
-      layerIdName: "ctn-lines",
-      layerIdField: "PROJECT_EXTENT_ID",
-      type: "line",
-      layerColor: theme.palette.primary.main,
-      layerUrl:
-        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/CTN_Project_Extent_Vector_Tiles/VectorTileServer/tile/{z}/{y}/{x}.pbf",
-    },
-  },
+export const mapStyles = {
   statusOpacities: {
     selected: 0.75,
     hovered: 0.5,
@@ -62,12 +46,31 @@ export const mapConfig = {
   },
 };
 
+export const mapConfig = {
+  mapInit: {
+    latitude: 30.268039,
+    longitude: -97.742828,
+    zoom: 12,
+  },
+  geocoderBbox: austinFullPurposeJurisdictionFeatureCollection.bbox,
+  layerConfigs: {
+    CTN: {
+      layerIdName: "ctn-lines",
+      layerIdField: "PROJECT_EXTENT_ID",
+      type: "line",
+      layerColor: theme.palette.primary.main,
+      layerUrl:
+        "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/CTN_Project_Extent_Vector_Tiles/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+    },
+  },
+};
+
 /**
  * Get the IDs from the layerConfigs object to set as interactive in the map components
  * @return {Array} List of layer IDs to be set as interactive (hover, click) in map
  */
 export const getInteractiveIds = () =>
-  Object.values(mapConfig.layerConfigs).map(config => config.layerId);
+  Object.values(mapConfig.layerConfigs).map(config => config.layerIdName);
 
 /**
  * Get a feature's ID attribute from a Mapbox map click or hover event
@@ -130,7 +133,7 @@ export const createProjectSelectLayerConfig = (
 
   // https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/
   return {
-    id: config.layerId,
+    id: config.layerIdName,
     type: config.type,
     "source-layer": sourceName,
     layout: {
@@ -138,14 +141,14 @@ export const createProjectSelectLayerConfig = (
     },
     paint: {
       "line-color": config.layerColor,
-      "line-width": mapConfig.lineWidthStops,
+      "line-width": mapStyles.lineWidthStops,
       "line-opacity": [
         "case",
         ["==", ["get", "PROJECT_EXTENT_ID"], hoveredId],
-        mapConfig.statusOpacities.hovered,
+        mapStyles.statusOpacities.hovered,
         ["in", ["get", "PROJECT_EXTENT_ID"], ["literal", layerIds]],
-        mapConfig.statusOpacities.selected,
-        mapConfig.statusOpacities.unselected,
+        mapStyles.statusOpacities.selected,
+        mapStyles.statusOpacities.unselected,
       ],
     },
   };
@@ -153,9 +156,9 @@ export const createProjectSelectLayerConfig = (
 
 // Builds cases to match GeoJSON features with corresponding colors set for their layer
 // https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#case
-const fillColorCases = Object.values(mapConfig.layerConfigs).reduce(
-  (acc, config) => {
-    acc.push(["==", ["get", "sourceLayer"], config.layerSourceName]);
+const fillColorCases = Object.entries(mapConfig.layerConfigs).reduce(
+  (acc, [sourceName, config]) => {
+    acc.push(["==", ["get", "sourceLayer"], sourceName]);
     acc.push(config.layerColor);
     return acc;
   },
@@ -173,9 +176,9 @@ export const createProjectViewLayerConfig = () => ({
   id: "projectExtent",
   type: "line",
   paint: {
-    "line-width": mapConfig.lineWidthStops,
+    "line-width": mapStyles.lineWidthStops,
     "line-color": ["case", ...fillColorCases, theme.palette.map.transparent],
-    "line-opacity": mapConfig.statusOpacities.selected,
+    "line-opacity": mapStyles.statusOpacities.selected,
   },
 });
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -158,7 +158,15 @@ export const createProjectViewLayerConfig = () => ({
   id: "projectExtent",
   type: "line",
   paint: {
-    "line-width": 5,
+    "line-width": {
+      base: 1,
+      stops: [
+        [10, 1],
+        [13, 2],
+        [16, 5],
+        [18, 10],
+      ],
+    },
     "line-color": ["case", ...fillColorCases, theme.palette.map.transparent],
     "line-opacity": fillOpacities.selected,
   },

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -108,7 +108,10 @@ export const getFeatureId = (e, idKey) =>
  * @return {String} The name of the source layer
  */
 export const getLayerSource = e =>
-  e.features && e.features.length > 0 && e.features[0].layer["source-layer"];
+  e.features &&
+  e.features.length > 0 &&
+  (e.features[0].layer["source-layer"] ||
+    e.features[0].properties["sourceLayer"]);
 
 /**
  * Get a feature's GeoJSON from a Mapbox map click or hover event
@@ -120,7 +123,6 @@ export const getGeoJSON = e =>
   e.features.length > 0 && {
     geometry: e.features[0].geometry,
     id: e.features[0].id,
-    sourceLayer: e.features[0].sourceLayer,
     source: e.features[0].source,
     properties: {
       ...e.features[0].properties,
@@ -233,7 +235,7 @@ export function useHoverLayer() {
       setFeature(null);
       return;
     }
-    // debugger;
+
     // Otherwise, get details for tooltip
     const {
       srcEvent: { offsetX, offsetY },

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -64,7 +64,7 @@ export const getInteractiveIds = () =>
  * @param {String} idKey - Key that exposes the id of the polygon in the layer
  * @return {String} The ID of the polygon clicked or hovered
  */
-export const getFeaturePolygonId = (e, idKey) =>
+export const getFeatureId = (e, idKey) =>
   e.features && e.features.length > 0 && e.features[0].properties[idKey];
 
 /**
@@ -157,10 +157,11 @@ const fillColorCases = layerConfigs.reduce((acc, config) => {
  */
 export const createProjectViewLayerConfig = () => ({
   id: "projectExtent",
-  type: "fill",
+  type: "line",
   paint: {
-    "fill-color": ["case", ...fillColorCases, theme.palette.map.transparent],
-    "fill-opacity": fillOpacities.selected,
+    "line-width": 5,
+    "line-color": ["case", ...fillColorCases, theme.palette.map.transparent],
+    "line-opacity": fillOpacities.selected,
   },
 });
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -27,12 +27,21 @@ export const geocoderBbox = austinFullPurposeJurisdictionFeatureCollection.bbox;
 
 // Set the layer attributes to render on map
 export const layerConfigs = [
+  // {
+  //   layerId: "location-polygons",
+  //   type: "fill",
+  //   layerSourceName: "asmp_polygons",
+  //   layerColor: theme.palette.primary.main,
+  //   layerUrl:
+  //     "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/location_polygons_vector_tiles_w_IDs/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+  // },
   {
-    layerId: "location-polygons",
-    layerSourceName: "asmp_polygons",
+    layerId: "ctn-lines",
+    type: "line",
+    layerSourceName: "CTN",
     layerColor: theme.palette.primary.main,
     layerUrl:
-      "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/location_polygons_vector_tiles_w_IDs/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+      "https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/CTN_Project_Extent_Vector_Tiles/VectorTileServer/tile/{z}/{y}/{x}.pbf",
   },
 ];
 
@@ -52,10 +61,11 @@ export const getInteractiveIds = () =>
 /**
  * Get a feature's ID attribute from a Mapbox map click or hover event
  * @param {Object} e - Event object for click or hover on map
+ * @param {String} idKey - Key that exposes the id of the polygon in the layer
  * @return {String} The ID of the polygon clicked or hovered
  */
-export const getFeaturePolygonId = e =>
-  e.features && e.features.length > 0 && e.features[0].properties.polygon_id;
+export const getFeaturePolygonId = (e, idKey) =>
+  e.features && e.features.length > 0 && e.features[0].properties[idKey];
 
 /**
  * Get a feature's layer source from a Mapbox map click or hover event
@@ -109,19 +119,20 @@ export const createProjectSelectLayerConfig = (
   // https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/
   return {
     id: config.layerId,
-    type: "fill",
+    type: config.type,
     source: {
       type: "vector",
       tiles: [config.layerUrl],
     },
     "source-layer": config.layerSourceName,
     paint: {
-      "fill-color": config.layerColor,
-      "fill-opacity": [
+      "line-color": config.layerColor,
+      "line-width": 5,
+      "line-opacity": [
         "case",
-        ["==", ["get", "polygon_id"], hoveredId],
+        ["==", ["get", "PROJECT_EXTENT_ID"], hoveredId],
         fillOpacities.hovered,
-        ["in", ["get", "polygon_id"], ["literal", layerIds]],
+        ["in", ["get", "PROJECT_EXTENT_ID"], ["literal", layerIds]],
         fillOpacities.selected,
         fillOpacities.unselected,
       ],

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -66,6 +66,7 @@ export const mapConfig = {
             type: "line",
             layout: {
               "line-join": "round",
+              "line-cap": "round",
             },
             paint: {
               "line-color": this.layerColor,
@@ -184,6 +185,10 @@ const fillColorCases = Object.entries(mapConfig.layerConfigs).reduce(
 export const createProjectViewLayerConfig = () => ({
   id: "projectExtent",
   type: "line",
+  layout: {
+    "line-join": "round",
+    "line-cap": "round",
+  },
   paint: {
     "line-width": mapStyles.lineWidthStops,
     "line-color": ["case", ...fillColorCases, theme.palette.map.transparent],

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -196,7 +196,7 @@ export const createProjectViewLayerConfig = () => ({
  * @param {String} hoveredFeature - The ID of the feature hovered
  * @param {Object} hoveredCoords - Object with keys x and y that describe position of cursor
  * @param {Object} className - Styles from the classes object
- * @return {JSX} Mapbox layer style object
+ * @return {JSX} The populated tooltip JSX
  */
 export const renderTooltip = (hoveredFeature, hoveredCoords, className) =>
   hoveredFeature && (
@@ -222,11 +222,31 @@ export const sumFeaturesSelected = selectedLayerIds =>
     0
   );
 
+/**
+ * Custom hook that returns a vector tile layer hover event handler and the details to place and populate a tooltip
+ * @return {{handleLayerHover:Function, featuredId:String, hoveredCoords:Object}}
+ * @return {HoverObject} Object that exposes the setter and getters for a hovered feature
+ */
+/**
+ * @typedef {Object} HoverObject
+ * @property {Function} handleLayerHover - Function that get and sets featureId and Point for tooltip
+ * @property {String} featuredId - The ID of the hovered feature
+ * @property {Point} hoveredCoords - The coordinates used to place the tooltip
+ */
+/**
+ * @typedef {Object} Point
+ * @property {Number} x - The x coordinate to the place the tooltip
+ * @property {Number} y - The y coordinate to the place the tooltip
+ */
 export function useHoverLayer() {
   const [featureId, setFeature] = useState(null);
   const [hoveredCoords, setHoveredCoords] = useState(null);
 
-  const handleHover = e => {
+  /**
+   * Gets and sets data from a map feature used to populate and place a tooltip
+   * @param {Object} e - Mouse hover event that supplies the feature details and hover coordinates
+   */
+  const handleLayerHover = e => {
     const layerSource = getLayerSource(e);
 
     // If a layer isn't hovered, reset state and don't proceed
@@ -249,5 +269,5 @@ export function useHoverLayer() {
     setHoveredCoords({ x: offsetX, y: offsetY });
   };
 
-  return { handleHover, featureId, hoveredCoords };
+  return { handleLayerHover, featureId, hoveredCoords };
 }

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import ReactMapGL, { Layer, NavigationControl } from "react-map-gl";
+import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import Geocoder from "react-map-gl-geocoder";
 import { Box, Typography, makeStyles } from "@material-ui/core";
 import { isEqual } from "lodash";
@@ -140,14 +140,16 @@ const NewProjectMap = ({
           position="top-right"
         />
         {layerConfigs.map(config => (
-          <Layer
-            key={config.layerId}
-            {...createProjectSelectLayerConfig(
-              vectorTilePolygonId,
-              config,
-              selectedLayerIds
-            )}
-          />
+          <Source key={config.layerId} type="vector" tiles={[config.layerUrl]}>
+            <Layer
+              key={config.layerId}
+              {...createProjectSelectLayerConfig(
+                vectorTilePolygonId,
+                config,
+                selectedLayerIds
+              )}
+            />
+          </Source>
         ))}
         {renderTooltip(vectorTilePolygonId, hoveredCoords, classes.toolTip)}
       </ReactMapGL>

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -48,11 +48,7 @@ const NewProjectMap = ({
   const mapRef = useRef();
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
-  const { handleHover, featureId, hoveredCoords } = useHoverLayer();
-
-  const handleLayerHover = e => {
-    handleHover(e);
-  };
+  const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
 
   const handleLayerClick = e => {
     const layerSource = getLayerSource(e);

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -50,14 +50,21 @@ const NewProjectMap = ({
   const [hoveredCoords, setHoveredCoords] = useState(null);
 
   const handleLayerHover = e => {
+    const layerSource = getLayerSource(e);
+
+    if (!layerSource) return;
+
     const {
       srcEvent: { offsetX, offsetY },
     } = e;
 
-    const vectorTilePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
+    const hoveredFeatureId = getFeatureId(
+      e,
+      mapConfig.layerConfigs[layerSource].layerIdField
+    );
 
-    if (!!vectorTilePolygonId) {
-      setVectorTilePolygonId(vectorTilePolygonId);
+    if (!!hoveredFeatureId) {
+      setVectorTilePolygonId(hoveredFeatureId);
       setHoveredCoords({ x: offsetX, y: offsetY });
     } else {
       setHoveredCoords(null);
@@ -66,8 +73,14 @@ const NewProjectMap = ({
   };
 
   const handleLayerClick = e => {
-    const vectorTilePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
     const layerSource = getLayerSource(e);
+
+    if (!layerSource) return;
+
+    const vectorTilePolygonId = getFeatureId(
+      e,
+      mapConfig.layerConfigs[layerSource].layerIdField
+    );
     const selectedFeature = getGeoJSON(e);
 
     if (!!vectorTilePolygonId && !!layerSource) {
@@ -136,13 +149,13 @@ const NewProjectMap = ({
           bbox={mapConfig.geocoderBbox}
           position="top-right"
         />
-        {mapConfig.layerConfigs.map(config => (
-          <Source key={config.layerId} type="vector" tiles={[config.layerUrl]}>
+        {Object.entries(mapConfig.layerConfigs).map(([sourceName, config]) => (
+          <Source key={sourceName} type="vector" tiles={[config.layerUrl]}>
             <Layer
               key={config.layerId}
               {...createProjectSelectLayerConfig(
                 vectorTilePolygonId,
-                config,
+                sourceName,
                 selectedLayerIds
               )}
             />

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -132,7 +132,7 @@ const NewProjectMap = ({
             key={config.layerIdName}
             type="vector"
             tiles={[config.layerUrl]}
-            maxzoom={14} // This value comes from the maxLOD from the vector tile layer metadata
+            maxzoom={config.layerMaxLOD || mapConfig.mapboxDefaultMaxZoom} // maxLOD found in vector tile layer metadata
           >
             <Layer
               key={config.layerIdName}

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -18,6 +18,7 @@ import {
   mapStyles,
   renderTooltip,
   sumFeaturesSelected,
+  useHoverLayer,
 } from "../../../utils/mapHelpers";
 
 export const useStyles = makeStyles({
@@ -47,30 +48,10 @@ const NewProjectMap = ({
   const mapRef = useRef();
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
-  const [featureId, setFeature] = useState(null);
-  const [hoveredCoords, setHoveredCoords] = useState(null);
+  const { handleHover, featureId, hoveredCoords } = useHoverLayer();
 
   const handleLayerHover = e => {
-    const layerSource = getLayerSource(e);
-
-    // If a layer isn't hovered, reset state and don't proceed
-    if (!layerSource) {
-      setHoveredCoords(null);
-      setFeature(null);
-      return;
-    }
-
-    // Otherwise, get details for tooltip
-    const {
-      srcEvent: { offsetX, offsetY },
-    } = e;
-    const hoveredFeatureId = getFeatureId(
-      e,
-      mapConfig.layerConfigs[layerSource].layerIdField
-    );
-
-    setFeature(hoveredFeatureId);
-    setHoveredCoords({ x: offsetX, y: offsetY });
+    handleHover(e);
   };
 
   const handleLayerClick = e => {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -12,7 +12,7 @@ import {
   getGeoJSON,
   getInteractiveIds,
   getLayerSource,
-  getFeaturePolygonId,
+  getFeatureId,
   isFeaturePresent,
   layerConfigs,
   MAPBOX_TOKEN,
@@ -57,7 +57,7 @@ const NewProjectMap = ({
       srcEvent: { offsetX, offsetY },
     } = e;
 
-    const vectorTilePolygonId = getFeaturePolygonId(e, "PROJECT_EXTENT_ID");
+    const vectorTilePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
 
     if (!!vectorTilePolygonId) {
       setVectorTilePolygonId(vectorTilePolygonId);
@@ -69,7 +69,7 @@ const NewProjectMap = ({
   };
 
   const handleLayerClick = e => {
-    const vectorTilePolygonId = getFeaturePolygonId(e, "PROJECT_EXTENT_ID");
+    const vectorTilePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
     const layerSource = getLayerSource(e);
     const selectedFeature = getGeoJSON(e);
 

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -8,18 +8,15 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
 import {
   createProjectSelectLayerConfig,
-  geocoderBbox,
   getGeoJSON,
   getInteractiveIds,
   getLayerSource,
   getFeatureId,
   isFeaturePresent,
-  layerConfigs,
   MAPBOX_TOKEN,
-  mapInit,
+  mapConfig,
   renderTooltip,
   sumFeaturesSelected,
-  toolTipStyles,
 } from "../../../utils/mapHelpers";
 
 export const useStyles = makeStyles({
@@ -27,7 +24,7 @@ export const useStyles = makeStyles({
     fontSize: "0.875rem",
     fontWeight: 500,
   },
-  toolTip: toolTipStyles,
+  toolTip: mapConfig.toolTipStyles,
   navStyle: {
     position: "absolute",
     top: 0,
@@ -48,7 +45,7 @@ const NewProjectMap = ({
   const classes = useStyles();
   const mapRef = useRef();
 
-  const [viewport, setViewport] = useState(mapInit);
+  const [viewport, setViewport] = useState(mapConfig.mapInit);
   const [vectorTilePolygonId, setVectorTilePolygonId] = useState(null);
   const [hoveredCoords, setHoveredCoords] = useState(null);
 
@@ -136,10 +133,10 @@ const NewProjectMap = ({
           mapRef={mapRef}
           onViewportChange={handleGeocoderViewportChange}
           mapboxApiAccessToken={MAPBOX_TOKEN}
-          bbox={geocoderBbox}
+          bbox={mapConfig.geocoderBbox}
           position="top-right"
         />
-        {layerConfigs.map(config => (
+        {mapConfig.layerConfigs.map(config => (
           <Source key={config.layerId} type="vector" tiles={[config.layerUrl]}>
             <Layer
               key={config.layerId}

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -57,7 +57,7 @@ const NewProjectMap = ({
       srcEvent: { offsetX, offsetY },
     } = e;
 
-    const vectorTilePolygonId = getFeaturePolygonId(e);
+    const vectorTilePolygonId = getFeaturePolygonId(e, "PROJECT_EXTENT_ID");
 
     if (!!vectorTilePolygonId) {
       setVectorTilePolygonId(vectorTilePolygonId);
@@ -69,7 +69,7 @@ const NewProjectMap = ({
   };
 
   const handleLayerClick = e => {
-    const vectorTilePolygonId = getFeaturePolygonId(e);
+    const vectorTilePolygonId = getFeaturePolygonId(e, "PROJECT_EXTENT_ID");
     const layerSource = getLayerSource(e);
     const selectedFeature = getGeoJSON(e);
 

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -132,6 +132,7 @@ const NewProjectMap = ({
             key={config.layerIdName}
             type="vector"
             tiles={[config.layerUrl]}
+            maxzoom={14} // This value comes from the maxLOD from the vector tile layer metadata
           >
             <Layer
               key={config.layerIdName}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -6,7 +6,7 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
 import {
   createProjectViewLayerConfig,
-  getFeaturePolygonId,
+  getFeatureId,
   MAPBOX_TOKEN,
   mapInit,
   renderTooltip,
@@ -44,7 +44,7 @@ const ProjectSummaryDetailsMap = ({
       srcEvent: { offsetX, offsetY },
     } = e;
 
-    const featurePolygonId = getFeaturePolygonId(e);
+    const featurePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
 
     if (!!featurePolygonId) {
       setHoveredFeature(featurePolygonId);

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -8,7 +8,7 @@ import {
   createProjectViewLayerConfig,
   getFeatureId,
   MAPBOX_TOKEN,
-  mapInit,
+  mapConfig,
   renderTooltip,
   sumFeaturesSelected,
   toolTipStyles,
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
     fontSize: "0.875rem",
     fontWeight: 500,
   },
-  toolTip: toolTipStyles,
+  toolTip: mapConfig.toolTipStyles,
   navStyle: {
     position: "absolute",
     top: 0,
@@ -35,7 +35,7 @@ const ProjectSummaryDetailsMap = ({
   const classes = useStyles();
   const mapRef = useRef();
 
-  const [viewport, setViewport] = useState(mapInit);
+  const [viewport, setViewport] = useState(mapConfig.mapInit);
   const [hoveredFeature, setHoveredFeature] = useState(null);
   const [hoveredCoords, setHoveredCoords] = useState(null);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -36,11 +36,7 @@ const ProjectSummaryDetailsMap = ({
   const mapRef = useRef();
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
-  const { handleHover, featureId, hoveredCoords } = useHoverLayer();
-
-  const handleLayerHover = e => {
-    handleHover(e);
-  };
+  const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
 
   const handleViewportChange = viewport => setViewport(viewport);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -6,7 +6,6 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
 import {
   createProjectViewLayerConfig,
-  getInteractiveIds,
   MAPBOX_TOKEN,
   mapConfig,
   mapStyles,
@@ -52,7 +51,7 @@ const ProjectSummaryDetailsMap = ({
         ref={mapRef}
         width="100%"
         height={500}
-        interactiveLayerIds={getInteractiveIds()}
+        interactiveLayerIds={["projectExtent"]}
         onHover={handleLayerHover}
         mapboxApiAccessToken={MAPBOX_TOKEN}
         onViewportChange={handleViewportChange}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -6,11 +6,13 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
 import {
   createProjectViewLayerConfig,
-  getFeatureId,
+  getInteractiveIds,
   MAPBOX_TOKEN,
   mapConfig,
+  mapStyles,
   renderTooltip,
   sumFeaturesSelected,
+  useHoverLayer,
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({
@@ -18,7 +20,7 @@ const useStyles = makeStyles({
     fontSize: "0.875rem",
     fontWeight: 500,
   },
-  toolTip: mapConfig.toolTipStyles,
+  toolTip: mapStyles.toolTipStyles,
   navStyle: {
     position: "absolute",
     top: 0,
@@ -35,23 +37,10 @@ const ProjectSummaryDetailsMap = ({
   const mapRef = useRef();
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
-  const [hoveredFeature, setHoveredFeature] = useState(null);
-  const [hoveredCoords, setHoveredCoords] = useState(null);
+  const { handleHover, featureId, hoveredCoords } = useHoverLayer();
 
   const handleLayerHover = e => {
-    const {
-      srcEvent: { offsetX, offsetY },
-    } = e;
-
-    const featurePolygonId = getFeatureId(e, "PROJECT_EXTENT_ID");
-
-    if (!!featurePolygonId) {
-      setHoveredFeature(featurePolygonId);
-      setHoveredCoords({ x: offsetX, y: offsetY });
-    } else {
-      setHoveredFeature(null);
-      setHoveredCoords(null);
-    }
+    handleHover(e);
   };
 
   const handleViewportChange = viewport => setViewport(viewport);
@@ -63,7 +52,7 @@ const ProjectSummaryDetailsMap = ({
         ref={mapRef}
         width="100%"
         height={500}
-        interactiveLayerIds={["projectExtent"]}
+        interactiveLayerIds={getInteractiveIds()}
         onHover={handleLayerHover}
         mapboxApiAccessToken={MAPBOX_TOKEN}
         onViewportChange={handleViewportChange}
@@ -76,7 +65,7 @@ const ProjectSummaryDetailsMap = ({
             <Layer {...createProjectViewLayerConfig()} />
           </Source>
         )}
-        {renderTooltip(hoveredFeature, hoveredCoords, classes.toolTip)}
+        {renderTooltip(featureId, hoveredCoords, classes.toolTip)}
       </ReactMapGL>
       <Typography className={classes.locationCountText}>
         {sumFeaturesSelected(selectedLayerIds)} locations in this project

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryDetailsMap.js
@@ -11,7 +11,6 @@ import {
   mapConfig,
   renderTooltip,
   sumFeaturesSelected,
-  toolTipStyles,
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4892

This PR updates the vector tile layer used to define the project extent with the [CTN layer](https://tiles.arcgis.com/tiles/0L95CJ0VTaxqcmED/arcgis/rest/services/CTN_Project_Extent_Vector_Tiles/VectorTileServer). I also updated the way styles are defined with a map config object to make switching out or adding layers more straightforward in the future. I also consolidated some common logic between the `NewProjectMap` and `ProjectSummaryDetailsMap` components into a custom hook called `useHoverLayer`.

Found out about the [`get` syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) which I used to expose `this` in the map layer configs so that I could introspect the object outside of the `layerStyleSpec` and get the values for color and field ID.

#### Updated New Project map
<img width="1226" alt="Screen Shot 2021-01-22 at 2 22 59 PM" src="https://user-images.githubusercontent.com/37249039/105551154-feeb1a80-5cc7-11eb-89a4-472c5cca029e.png">

#### Selecting from the layer
<img width="1226" alt="Screen Shot 2021-01-22 at 2 23 17 PM" src="https://user-images.githubusercontent.com/37249039/105551199-09a5af80-5cc8-11eb-8aab-f0c7b74a13b6.png">

#### Project Summary view
<img width="1008" alt="Screen Shot 2021-01-25 at 5 11 36 PM" src="https://user-images.githubusercontent.com/37249039/105777667-673c3500-5f30-11eb-8182-d4ce9532990d.png">

#### A longer feature
![Screen Shot 2021-01-25 at 5 15 54 PM](https://user-images.githubusercontent.com/37249039/105777991-0bbe7700-5f31-11eb-955d-f71ac8a2b627.png)
