### PR TITLE
Moped Database | Permissions for Activity Log

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -10,6 +10,43 @@
           name: moped_users
         column_mapping:
           updated_by: cognito_user_id
+  select_permissions:
+  - role: moped-admin
+    permission:
+      columns:
+      - activity_id
+      - record_id
+      - record_type
+      - record_data
+      - description
+      - created_at
+      - updated_by
+      filter: {}
+      allow_aggregations: true
+  - role: moped-editor
+    permission:
+      columns:
+      - created_at
+      - description
+      - record_id
+      - record_data
+      - updated_by
+      - record_type
+      - activity_id
+      filter: {}
+      allow_aggregations: true
+  - role: moped-viewer
+    permission:
+      columns:
+      - created_at
+      - description
+      - record_id
+      - record_data
+      - updated_by
+      - record_type
+      - activity_id
+      filter: {}
+      allow_aggregations: true
 - table:
     schema: public
     name: moped_categories


### PR DESCRIPTION
Creates access permissions for the activity log for all users:

![image](https://user-images.githubusercontent.com/5282430/106068676-8a98e880-60c6-11eb-8618-4abd1ae491f9.png)
