### PR TITLE
Project Extent | Zoom to project extent in Project Summary view

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -3529,6 +3529,28 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@turf/bbox": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.3.0.tgz",
+      "integrity": "sha512-N4ue5Xopu1qieSHP2MA/CJGWHPKaTrVXQJjzHRNcY1vtsO126xbSaJhWUrFc5x5vVkXp0dcucGryO0r5m4o/KA==",
+      "requires": {
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+    },
+    "@turf/meta": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
+      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+      "requires": {
+        "@turf/helpers": "^6.3.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -40,6 +40,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",
+    "@turf/bbox": "^6.3.0",
     "apollo-boost": "^0.4.9",
     "atd-kickstand": "github:cityofaustin/atd-kickstand#b287a2190b1bf8c9d2f3c5fef5fe3c9d5df1323e",
     "aws-amplify": "^3.3.4",

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import bbox from "@turf/bbox";
 import theme from "../theme/index";
 import { Typography } from "@material-ui/core";
 import { isEqual } from "lodash";
@@ -89,6 +90,8 @@ export const mapConfig = {
     },
   },
 };
+
+export const createZoomBbox = featureCollection => bbox(featureCollection);
 
 /**
  * Get the IDs from the layerConfigs object to set as interactive in the map components

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -91,7 +91,7 @@ export const mapConfig = {
 };
 
 /**
- * Create a Mapbox LngLatBounds object from a bbox feature collection
+ * Create a Mapbox LngLatBounds object from a bbox generated from a feature collection
  * @param {Object} featureCollection - A GeoJSON feature collection
  * @return {Array} A nested array that fits the LngLatBounds Mapbox object format
  */

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -315,7 +315,7 @@ export function useHoverLayer() {
 }
 
 /**
- * Custom hook that returns a vector tile layer hover event handler and the details to place and populate a tooltip
+ * Custom hook that initializes a map viewport and fits it to a provided feature collection
  * @param {Object} mapRef - Ref object whose current property exposes the map instance
  * @param {Object} featureCollection - A GeoJSON feature collection to fit the map bounds around
  * @return {ViewportStateArray} Array that exposes the setter and getters for map viewport using useState hook

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -314,6 +314,17 @@ export function useHoverLayer() {
   return { handleLayerHover, featureId, hoveredCoords };
 }
 
+/**
+ * Custom hook that returns a vector tile layer hover event handler and the details to place and populate a tooltip
+ * @param {Object} mapRef - Ref object whose current property exposes the map instance
+ * @param {Object} featureCollection - A GeoJSON feature collection to fit the map bounds around
+ * @return {ViewportStateArray} Array that exposes the setter and getters for map viewport using useState hook
+ */
+/**
+ * @typedef {Array} ViewportStateArray
+ * @property {Object} StateArray[0] - A Mapbox viewport object
+ * @property {Function} StateArray[1] - Setter for viewport state
+ */
 export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
   const [viewport, setViewport] = useState(mapConfig.mapInit);
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -90,6 +90,11 @@ export const mapConfig = {
   },
 };
 
+/**
+ * Create a Mapbox LngLatBounds object from a bbox feature collection
+ * @param {Object} featureCollection - A GeoJSON feature collection
+ * @return {Array} A nested array that fits the LngLatBounds Mapbox object format
+ */
 export const createZoomBbox = featureCollection => {
   const [minLng, minLat, maxLng, maxLat] = bbox(featureCollection);
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import bbox from "@turf/bbox";
 import theme from "../theme/index";
 import { Typography } from "@material-ui/core";
-import { isEqual } from "lodash";
 
 export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 
@@ -53,8 +52,6 @@ export const mapConfig = {
     latitude: 30.268039,
     longitude: -97.742828,
     zoom: 12,
-    bearing: 0,
-    pitch: 0,
   },
   mapboxDefaultMaxZoom: 18,
   geocoderBbox: austinFullPurposeJurisdictionFeatureCollection.bbox,
@@ -150,10 +147,14 @@ export const getGeoJSON = e =>
  * Determine if a feature is present/absent from the feature collection state
  * @param {Object} selectedFeature - Feature selected
  * @param {Array} features - Array of GeoJSON features
+ * @param {String} idField - Key for id field in feature properties
  * @return {Boolean} Is feature present in features of feature collection in state
  */
-export const isFeaturePresent = (selectedFeature, features) =>
-  features.some(feature => isEqual(selectedFeature, feature));
+export const isFeaturePresent = (selectedFeature, features, idField) =>
+  features.some(
+    feature =>
+      selectedFeature.properties[idField] === feature.properties[idField]
+  );
 
 /**
  * Create a configuration to set the Mapbox spec styles for selected/unselected/hovered layer features

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -91,7 +91,13 @@ export const mapConfig = {
   },
 };
 
-export const createZoomBbox = featureCollection => bbox(featureCollection);
+export const createZoomBbox = featureCollection => {
+  const [p1, p2, p3, p4] = bbox(featureCollection);
+  return [
+    [p1, p2],
+    [p3, p4],
+  ];
+};
 
 /**
  * Get the IDs from the layerConfigs object to set as interactive in the map components

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -329,8 +329,8 @@ export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
   const [viewport, setViewport] = useState(mapConfig.mapInit);
 
   useEffect(() => {
-    const currentMap = mapRef.current;
     const mapBounds = createZoomBbox(featureCollection);
+    const currentMap = mapRef.current;
 
     /**
      * Takes the existing viewport and transforms it to fit the project's features
@@ -338,6 +338,8 @@ export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
      * @return {Object} Viewport object with updated attributes based on project's features
      */
     const fitViewportToBounds = viewport => {
+      if (featureCollection.features.length === 0) return viewport;
+
       const featureViewport = new WebMercatorViewport({
         viewport,
         width: currentMap._width,
@@ -358,7 +360,7 @@ export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
     };
 
     setViewport(prevViewport => fitViewportToBounds(prevViewport));
-  }, [featureCollection]);
+  }, [featureCollection, mapRef]);
 
   return [viewport, setViewport];
 }

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -53,6 +53,8 @@ export const mapConfig = {
     latitude: 30.268039,
     longitude: -97.742828,
     zoom: 12,
+    bearing: 0,
+    pitch: 0,
   },
   mapboxDefaultMaxZoom: 18,
   geocoderBbox: austinFullPurposeJurisdictionFeatureCollection.bbox,
@@ -92,10 +94,11 @@ export const mapConfig = {
 };
 
 export const createZoomBbox = featureCollection => {
-  const [p1, p2, p3, p4] = bbox(featureCollection);
+  const [minLng, minLat, maxLng, maxLat] = bbox(featureCollection);
+
   return [
-    [p1, p2],
-    [p3, p4],
+    [minLng, minLat],
+    [maxLng, maxLat],
   ];
 };
 

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useMemo } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import Geocoder from "react-map-gl-geocoder";
 import { Box, makeStyles } from "@material-ui/core";
@@ -20,7 +20,6 @@ import {
   sumFeaturesSelected,
   useHoverLayer,
   renderFeatureCount,
-  createZoomBbox,
 } from "../../../utils/mapHelpers";
 
 export const useStyles = makeStyles({
@@ -45,9 +44,6 @@ const NewProjectMap = ({
   const classes = useStyles();
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
-  const mapZoomBbox = useMemo(() => {
-    createZoomBbox(featureCollection);
-  }, [featureCollection]);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -49,7 +49,7 @@ const NewProjectMap = ({
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
 
   /**
-   * Adds or removes an interactive map feature from the project's feature collection
+   * Adds or removes an interactive map feature from the project's feature collection and selected IDs array
    * @param {Object} e - Event object for click
    */
   const handleLayerClick = e => {
@@ -61,37 +61,35 @@ const NewProjectMap = ({
     const clickedFeatureId = getFeatureId(e, layerIdField);
     const selectedFeature = getGeoJSON(e);
 
-    if (!!clickedFeatureId && !!layerSource) {
-      const layerIds = selectedLayerIds[layerSource] || [];
+    const layerIds = selectedLayerIds[layerSource] || [];
 
-      const updatedLayerIds = !layerIds.includes(clickedFeatureId)
-        ? [...layerIds, clickedFeatureId]
-        : layerIds.filter(id => id !== clickedFeatureId);
+    const updatedLayerIds = !layerIds.includes(clickedFeatureId)
+      ? [...layerIds, clickedFeatureId]
+      : layerIds.filter(id => id !== clickedFeatureId);
 
-      const updatedSelectedIds = {
-        ...selectedLayerIds,
-        [layerSource]: updatedLayerIds,
-      };
+    const updatedSelectedIds = {
+      ...selectedLayerIds,
+      [layerSource]: updatedLayerIds,
+    };
 
-      const updatedFeatureCollection = isFeaturePresent(
-        selectedFeature,
-        featureCollection.features,
-        layerIdField
-      )
-        ? {
-            ...featureCollection,
-            features: featureCollection.features.filter(
-              feature => !isEqual(feature, selectedFeature)
-            ),
-          }
-        : {
-            ...featureCollection,
-            features: [...featureCollection.features, selectedFeature],
-          };
+    const updatedFeatureCollection = isFeaturePresent(
+      selectedFeature,
+      featureCollection.features,
+      layerIdField
+    )
+      ? {
+          ...featureCollection,
+          features: featureCollection.features.filter(
+            feature => !isEqual(feature, selectedFeature)
+          ),
+        }
+      : {
+          ...featureCollection,
+          features: [...featureCollection.features, selectedFeature],
+        };
 
-      setSelectedLayerIds(updatedSelectedIds);
-      setFeatureCollection(updatedFeatureCollection);
-    }
+    setSelectedLayerIds(updatedSelectedIds);
+    setFeatureCollection(updatedFeatureCollection);
   };
 
   /**

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -57,10 +57,8 @@ const NewProjectMap = ({
 
     if (!layerSource) return;
 
-    const clickedFeatureId = getFeatureId(
-      e,
-      mapConfig.layerConfigs[layerSource].layerIdField
-    );
+    const { layerIdField } = mapConfig.layerConfigs[layerSource];
+    const clickedFeatureId = getFeatureId(e, layerIdField);
     const selectedFeature = getGeoJSON(e);
 
     if (!!clickedFeatureId && !!layerSource) {
@@ -77,7 +75,8 @@ const NewProjectMap = ({
 
       const updatedFeatureCollection = isFeaturePresent(
         selectedFeature,
-        featureCollection.features
+        featureCollection.features,
+        layerIdField
       )
         ? {
             ...featureCollection,

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback, useMemo } from "react";
 import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import Geocoder from "react-map-gl-geocoder";
 import { Box, makeStyles } from "@material-ui/core";
@@ -20,6 +20,7 @@ import {
   sumFeaturesSelected,
   useHoverLayer,
   renderFeatureCount,
+  createZoomBbox,
 } from "../../../utils/mapHelpers";
 
 export const useStyles = makeStyles({
@@ -44,6 +45,9 @@ const NewProjectMap = ({
   const classes = useStyles();
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
+  const mapZoomBbox = useMemo(() => {
+    createZoomBbox(featureCollection);
+  }, [featureCollection]);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -88,7 +88,7 @@ const ProjectSummaryMap = ({
       };
     };
 
-    setViewport(viewport => fitViewportToBounds(viewport));
+    setViewport(prevViewport => fitViewportToBounds(prevViewport));
   }, [projectExtentGeoJSON]);
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -63,13 +63,20 @@ const ProjectSummaryMap = ({
     const currentMap = mapRef.current;
     const mapBounds = createZoomBbox(projectExtentGeoJSON);
 
-    setViewport(viewport => {
-      const vp = new WebMercatorViewport({
+    /**
+     * Takes the existing viewport and transforms it to fit the project's features
+     * @param {Object} viewport - Describes the map view
+     * @return {Object} Viewport object with updated attributes based on project's features
+     */
+    const fitViewportToBounds = viewport => {
+      const featureViewport = new WebMercatorViewport({
         viewport,
         width: currentMap._width,
         height: currentMap._height,
       });
-      const newViewport = vp.fitBounds(mapBounds, { padding: 100 });
+      const newViewport = featureViewport.fitBounds(mapBounds, {
+        padding: 100,
+      });
 
       const { longitude, latitude, zoom } = newViewport;
 
@@ -79,7 +86,9 @@ const ProjectSummaryMap = ({
         latitude,
         zoom,
       };
-    });
+    };
+
+    setViewport(viewport => fitViewportToBounds(viewport));
   }, [projectExtentGeoJSON]);
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -5,7 +5,6 @@ import ReactMapGL, {
   Source,
   WebMercatorViewport,
 } from "react-map-gl";
-import { AutoSizer } from "react-virtualized";
 import { Box, Button, makeStyles } from "@material-ui/core";
 import { EditLocation as EditLocationIcon } from "@material-ui/icons";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -51,7 +50,6 @@ const ProjectSummaryMap = ({
   const classes = useStyles();
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
-  const mapBounds = createZoomBbox(projectExtentGeoJSON);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
@@ -63,23 +61,27 @@ const ProjectSummaryMap = ({
   const handleViewportChange = viewport => setViewport(viewport);
 
   useEffect(() => {
-    // if (projectExtentGeoJSON.features.length === 0) return;
-    const vp = new WebMercatorViewport({
-      viewport,
-      width: 500,
-      height: 500,
-    });
+    const currentMap = mapRef.current;
+    const mapBounds = createZoomBbox(projectExtentGeoJSON);
 
-    const newViewport = vp.fitBounds(mapBounds, { padding: 40 });
-    console.log(newViewport);
-    const { longitude, latitude, zoom } = newViewport;
-    setViewport({
-      ...viewport,
-      longitude,
-      latitude,
-      zoom,
+    setViewport(viewport => {
+      const vp = new WebMercatorViewport({
+        viewport,
+        width: currentMap._width,
+        height: currentMap._height,
+      });
+      const newViewport = vp.fitBounds(mapBounds, { padding: 100 });
+
+      const { longitude, latitude, zoom } = newViewport;
+
+      return {
+        ...viewport,
+        longitude,
+        latitude,
+        zoom,
+      };
     });
-  }, []);
+  }, [projectExtentGeoJSON]);
 
   return (
     <Box className={classes.mapBox}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -5,6 +5,7 @@ import ReactMapGL, {
   Source,
   WebMercatorViewport,
 } from "react-map-gl";
+import { AutoSizer } from "react-virtualized";
 import { Box, Button, makeStyles } from "@material-ui/core";
 import { EditLocation as EditLocationIcon } from "@material-ui/icons";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -23,6 +24,7 @@ import {
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({
+  mapBox: { width: "100%", height: "60vh" },
   locationCountText: {
     fontSize: "0.875rem",
     fontWeight: 500,
@@ -50,7 +52,6 @@ const ProjectSummaryMap = ({
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
   const mapBounds = createZoomBbox(projectExtentGeoJSON);
-  console.log(mapBounds);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
@@ -62,29 +63,31 @@ const ProjectSummaryMap = ({
   const handleViewportChange = viewport => setViewport(viewport);
 
   useEffect(() => {
-    if (projectExtentGeoJSON.features.length === 0) return;
-
-    const vp = new WebMercatorViewport(viewport);
-    debugger;
-    const { longitude, latitude, zoom } = vp.fitBounds(mapBounds, {
-      padding: 0,
+    // if (projectExtentGeoJSON.features.length === 0) return;
+    const vp = new WebMercatorViewport({
+      viewport,
+      width: 500,
+      height: 500,
     });
 
+    const newViewport = vp.fitBounds(mapBounds, { padding: 40 });
+    console.log(newViewport);
+    const { longitude, latitude, zoom } = newViewport;
     setViewport({
       ...viewport,
       longitude,
       latitude,
       zoom,
     });
-  }, [viewport, projectExtentGeoJSON, mapBounds]);
+  }, []);
 
   return (
-    <Box>
+    <Box className={classes.mapBox}>
       <ReactMapGL
         {...viewport}
         ref={mapRef}
-        width="100%"
-        height="60vh"
+        width={"100%"}
+        height={"100%"}
         interactiveLayerIds={["projectExtent"]}
         onHover={handleLayerHover}
         mapboxApiAccessToken={MAPBOX_TOKEN}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -23,7 +23,6 @@ import {
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({
-  mapBox: { width: "100%", height: "60vh" },
   locationCountText: {
     fontSize: "0.875rem",
     fontWeight: 500,
@@ -84,12 +83,12 @@ const ProjectSummaryMap = ({
   }, [projectExtentGeoJSON]);
 
   return (
-    <Box className={classes.mapBox}>
+    <Box>
       <ReactMapGL
         {...viewport}
         ref={mapRef}
         width={"100%"}
-        height={"100%"}
+        height={"60vh"}
         interactiveLayerIds={["projectExtent"]}
         onHover={handleLayerHover}
         mapboxApiAccessToken={MAPBOX_TOKEN}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -1,5 +1,10 @@
-import React, { useState, useRef } from "react";
-import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
+import React, { useState, useRef, useEffect } from "react";
+import ReactMapGL, {
+  Layer,
+  NavigationControl,
+  Source,
+  WebMercatorViewport,
+} from "react-map-gl";
 import { Box, Button, makeStyles } from "@material-ui/core";
 import { EditLocation as EditLocationIcon } from "@material-ui/icons";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -55,6 +60,23 @@ const ProjectSummaryMap = ({
    * @param {Object} viewport - Mapbox object that stores properties of the map view
    */
   const handleViewportChange = viewport => setViewport(viewport);
+
+  useEffect(() => {
+    if (projectExtentGeoJSON.features.length === 0) return;
+
+    const vp = new WebMercatorViewport(viewport);
+    debugger;
+    const { longitude, latitude, zoom } = vp.fitBounds(mapBounds, {
+      padding: 0,
+    });
+
+    setViewport({
+      ...viewport,
+      longitude,
+      latitude,
+      zoom,
+    });
+  }, [viewport, projectExtentGeoJSON, mapBounds]);
 
   return (
     <Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -1,10 +1,5 @@
-import React, { useState, useRef, useEffect } from "react";
-import ReactMapGL, {
-  Layer,
-  NavigationControl,
-  Source,
-  WebMercatorViewport,
-} from "react-map-gl";
+import React, { useRef } from "react";
+import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import { Box, Button, makeStyles } from "@material-ui/core";
 import { EditLocation as EditLocationIcon } from "@material-ui/icons";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -13,13 +8,12 @@ import "react-map-gl-geocoder/dist/mapbox-gl-geocoder.css";
 import {
   createProjectViewLayerConfig,
   MAPBOX_TOKEN,
-  mapConfig,
   mapStyles,
   renderTooltip,
   renderFeatureCount,
   sumFeaturesSelected,
   useHoverLayer,
-  createZoomBbox,
+  useFeatureCollectionToFitBounds,
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({
@@ -50,46 +44,17 @@ const ProjectSummaryMap = ({
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
 
-  const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
+  const [viewport, setViewport] = useFeatureCollectionToFitBounds(
+    mapRef,
+    projectExtentGeoJSON
+  );
 
   /**
    * Updates viewport on zoom, scroll, and other events
    * @param {Object} viewport - Mapbox object that stores properties of the map view
    */
   const handleViewportChange = viewport => setViewport(viewport);
-
-  useEffect(() => {
-    const currentMap = mapRef.current;
-    const mapBounds = createZoomBbox(projectExtentGeoJSON);
-
-    /**
-     * Takes the existing viewport and transforms it to fit the project's features
-     * @param {Object} viewport - Describes the map view
-     * @return {Object} Viewport object with updated attributes based on project's features
-     */
-    const fitViewportToBounds = viewport => {
-      const featureViewport = new WebMercatorViewport({
-        viewport,
-        width: currentMap._width,
-        height: currentMap._height,
-      });
-      const newViewport = featureViewport.fitBounds(mapBounds, {
-        padding: 100,
-      });
-
-      const { longitude, latitude, zoom } = newViewport;
-
-      return {
-        ...viewport,
-        longitude,
-        latitude,
-        zoom,
-      };
-    };
-
-    setViewport(prevViewport => fitViewportToBounds(prevViewport));
-  }, [projectExtentGeoJSON]);
 
   return (
     <Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -61,8 +61,8 @@ const ProjectSummaryMap = ({
       <ReactMapGL
         {...viewport}
         ref={mapRef}
-        width={"100%"}
-        height={"60vh"}
+        width="100%"
+        height="60vh"
         interactiveLayerIds={["projectExtent"]}
         onHover={handleLayerHover}
         mapboxApiAccessToken={MAPBOX_TOKEN}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -14,6 +14,7 @@ import {
   renderFeatureCount,
   sumFeaturesSelected,
   useHoverLayer,
+  createZoomBbox,
 } from "../../../utils/mapHelpers";
 
 const useStyles = makeStyles({
@@ -43,6 +44,8 @@ const ProjectSummaryMap = ({
   const classes = useStyles();
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
+  const mapBounds = createZoomBbox(projectExtentGeoJSON);
+  console.log(mapBounds);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4819

This PR adds a custom hook that handles fit the project summary map to a bbox created from its existing feature collection. 

@amenity I think that this feature would be great for the edit map too, but, with the current code, it will zoom to the current features each time a new line is selected. I could refactor to add the option to only zoom on initial load but could use some feedback before investing time on that route.

### Edit and then update fit
![editAndZoom](https://user-images.githubusercontent.com/37249039/106655976-ae917980-655f-11eb-93ff-481a446ab503.gif)

### Create a project
![Screen Shot 2021-02-02 at 1 56 17 PM](https://user-images.githubusercontent.com/37249039/106656085-d2ed5600-655f-11eb-97b0-a90d9257885b.png)

### and then redirect to summary view with map zoomed to selection
![Screen Shot 2021-02-02 at 1 56 22 PM](https://user-images.githubusercontent.com/37249039/106656152-e993ad00-655f-11eb-9e3e-f52de33d48a9.png)

