### PR TITLE
Moped Database | Add column to easily retrieve the operation type #5205

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -17,6 +17,7 @@
       - activity_id
       - created_at
       - description
+      - operation_type
       - record_data
       - record_id
       - record_project_id
@@ -30,6 +31,7 @@
       - activity_id
       - created_at
       - description
+      - operation_type
       - record_data
       - record_id
       - record_project_id
@@ -43,6 +45,7 @@
       - activity_id
       - created_at
       - description
+      - operation_type
       - record_data
       - record_id
       - record_project_id

--- a/moped-database/migrations/1612468574956_alter_table_public_moped_activity_log_add_column_operation_type/down.sql
+++ b/moped-database/migrations/1612468574956_alter_table_public_moped_activity_log_add_column_operation_type/down.sql
@@ -1,0 +1,3 @@
+COMMENT ON COLUMN "public"."moped_activity_log"."operation_type" IS E'';
+ALTER TABLE "public"."moped_activity_log" DROP COLUMN "operation_type";
+DROP INDEX moped_activity_log_operation_type_index;

--- a/moped-database/migrations/1612468574956_alter_table_public_moped_activity_log_add_column_operation_type/up.sql
+++ b/moped-database/migrations/1612468574956_alter_table_public_moped_activity_log_add_column_operation_type/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."moped_activity_log" ADD COLUMN "operation_type" varchar(8) NULL;
+COMMENT ON COLUMN "public"."moped_activity_log"."operation_type" IS E'The operation type as provided by Hasura: INSERT, UPDATE, DELETE';
+CREATE INDEX moped_activity_log_operation_type_index ON moped_activity_log (operation_type);


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5205
Closes https://github.com/cityofaustin/atd-data-tech/issues/5206

This PR basically creates a new column in the activity_log table, allows us to quickly retrieve the operation type: INSERT, UPDATE, DELETE. It will be a nullable varchar(8) and it will be indexed (since we are not expecting more than those 3 entries)

Also, it will be null by default, this field will be populated by the Lambda in SQS as it processes new events from Hasura