### PR TITLE
Add .prettierignore to database subfolder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore DB code
+moped-database/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore DB code
-moped-database/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore DB config code
+moped-database/*

--- a/moped-database/.prettierignore
+++ b/moped-database/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore DB code
+*


### PR DESCRIPTION
This PR adds a `.prettierignore` file to the DB subfolder to prevent auto-formatting that creates conflicts with changes that Hasura generates.

I tested in `/moped-database/metadata/tables.yaml` with my VSCode setup and was able to verify that format-on-save did not create any changes after this update, but this could use some testing on other machines.