### PR TITLE
Fixes the activity log label for project extend and geojson

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -6,6 +6,7 @@ import {
   getChangeIcon,
   getRecordTypeLabel,
   getHumanReadableField,
+  ProjectActivityLogGenericDescriptions,
 } from "./ProjectActivityLogTableMaps";
 
 import ProjectActivityLogDialog from "./ProjectActivityLogDialog";
@@ -29,7 +30,7 @@ import {
 
 import { PROJECT_ACTIVITY_LOG } from "../../../queries/project";
 import makeStyles from "@material-ui/core/styles/makeStyles";
-import {Alert} from "@material-ui/lab";
+import { Alert } from "@material-ui/lab";
 
 const useStyles = makeStyles(theme => ({
   table: {
@@ -128,11 +129,14 @@ const ProjectActivityLog = () => {
     return data?.moped_activity_log?.length ?? 0;
   };
 
+  const isFieldGeneric = field =>
+    field in ProjectActivityLogGenericDescriptions;
+
   return (
     <CardContent>
       <h2 style={{ padding: "0rem 0 2rem 0" }}>Activity feed</h2>
       {getTotalItems() === 0 ? (
-          <Alert severity="info">There aren't any items for this project.</Alert>
+        <Alert severity="info">There aren't any items for this project.</Alert>
       ) : (
         <TableContainer component={Paper}>
           <Table className={classes.table} aria-label="simple table">
@@ -215,15 +219,29 @@ const ProjectActivityLog = () => {
                           {change.description.map(changeItem => {
                             return (
                               <Grid item className={classes.tableChangeItem}>
-                                <b>
-                                  {getRecordTypeLabel(change.record_type)}{" "}
-                                  {getHumanReadableField(
-                                    change.record_type,
-                                    changeItem.field
-                                  )}
-                                </b>{" "}
-                                from <b>&quot;{changeItem.old}&quot;</b> to{" "}
-                                <b>&quot;{changeItem.new}&quot;</b>
+                                {isFieldGeneric(changeItem.field) ? (
+                                  <b>
+                                    {
+                                      ProjectActivityLogGenericDescriptions[
+                                        changeItem.field
+                                      ]?.label
+                                    }
+                                  </b>
+                                ) : (
+                                  <>
+                                    <b>
+                                      {getRecordTypeLabel(change.record_type)}{" "}
+                                      {getHumanReadableField(
+                                        change.record_type,
+                                        changeItem.field
+                                      )}
+                                    </b>{" "}
+                                    from{" "}
+                                    <b>&quot;{String(changeItem.old)}&quot;</b>{" "}
+                                    to{" "}
+                                    <b>&quot;{String(changeItem.new)}&quot;</b>
+                                  </>
+                                )}
                               </Grid>
                             );
                           })}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -129,6 +129,11 @@ const ProjectActivityLog = () => {
     return data?.moped_activity_log?.length ?? 0;
   };
 
+  /**
+   * Returns True if the field should be a generic type (i.e., maps, objects)
+   * @param {string} field - The field name (column name)
+   * @return {boolean} - True if the field is contained in the ProjectActivityLogGenericDescriptions object
+   */
   const isFieldGeneric = field =>
     field in ProjectActivityLogGenericDescriptions;
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -1310,7 +1310,7 @@ export const ProjectActivityLogGenericDescriptions = {
     label: "Project extent updated",
   },
   project_extent_geojson: {
-    label: "Project geo-json updated",
+    label: "Project GeoJSON updated",
   }
 }
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -1305,6 +1305,15 @@ export const ProjectActivityLogOperationMaps = {
   },
 };
 
+export const ProjectActivityLogGenericDescriptions = {
+  project_extent_ids: {
+    label: "Project extent updated",
+  },
+  project_extent_geojson: {
+    label: "Project geo-json updated",
+  }
+}
+
 /**
  * Returns a human-readable field name (translates the column into a readable label)
  * @param {string} type - The table name


### PR DESCRIPTION
Preview:
https://deploy-preview-214--atd-moped-main.netlify.app/


The problem:
<img width="886" alt="2021-02-10_11-41-49" src="https://user-images.githubusercontent.com/5282430/107552315-f2f0cb00-6b98-11eb-9517-aa95dfcc507a.png">

The fix:
<img width="886" alt="2021-02-10_12-09-23" src="https://user-images.githubusercontent.com/5282430/107552338-fe43f680-6b98-11eb-8778-78f315616c8c.png">


To test, run locally with `$ npm run start:staging`