### PR TITLE
Project Staffing | Delete project team

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2628,6 +2628,34 @@
       - date_added
       filter: {}
       check: null
+  event_triggers:	
+  - name: activity_log_moped_proj_personnel	
+    definition:	
+      enable_manual: false	
+      insert:	
+        columns: '*'	
+      delete:	
+        columns: '*'	
+      update:	
+        columns:	
+        - added_by
+        - project_id
+        - project_personnel_id
+        - role_id
+        - status_id
+        - user_id
+        - notes
+        - date_added
+    retry_conf:	
+      num_retries: 0	
+      interval_sec: 10	
+      timeout_sec: 60	
+    webhook_from_env: MOPED_API_EVENTS_URL	
+    headers:	
+    - name: MOPED_API_APIKEY	
+      value_from_env: MOPED_API_APIKEY	
+    - value: activity_log	
+      name: MOPED_API_EVENT_NAME      
 - table:
     schema: public
     name: moped_proj_phases

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2542,7 +2542,6 @@
     permission:
       check: {}
       columns:
-      - status
       - project_id
       - project_personnel_id
       - date_added
@@ -2550,6 +2549,7 @@
       - notes
       - user_id
       - role_id
+      - status_id
       backend_only: false
   - role: moped-editor
     permission:
@@ -2559,9 +2559,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       backend_only: false
   select_permissions:
@@ -2572,9 +2572,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       filter: {}
   - role: moped-editor
@@ -2584,9 +2584,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       filter: {}
   - role: moped-viewer
@@ -2596,9 +2596,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       filter: {}
   update_permissions:
@@ -2609,9 +2609,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       filter: {}
       check: null
@@ -2622,9 +2622,9 @@
       - project_id
       - project_personnel_id
       - role_id
+      - status_id
       - user_id
       - notes
-      - status
       - date_added
       filter: {}
       check: null

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2542,13 +2542,9 @@
     permission:
       check: {}
       columns:
-      - join_date
-      - allocation
       - status
       - project_id
-      - project_personnel_user_id
       - project_personnel_id
-      - role_order
       - date_added
       - added_by
       - notes
@@ -2559,14 +2555,10 @@
     permission:
       check: {}
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
@@ -2576,14 +2568,10 @@
   - role: moped-admin
     permission:
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
@@ -2592,14 +2580,10 @@
   - role: moped-editor
     permission:
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
@@ -2608,14 +2592,10 @@
   - role: moped-viewer
     permission:
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
@@ -2625,14 +2605,10 @@
   - role: moped-admin
     permission:
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
@@ -2642,52 +2618,16 @@
   - role: moped-editor
     permission:
       columns:
-      - join_date
       - added_by
-      - allocation
       - project_id
       - project_personnel_id
-      - project_personnel_user_id
       - role_id
-      - role_order
       - user_id
       - notes
       - status
       - date_added
       filter: {}
       check: null
-  event_triggers:
-  - name: activity_log_moped_proj_personnel
-    definition:
-      enable_manual: false
-      insert:
-        columns: '*'
-      delete:
-        columns: '*'
-      update:
-        columns:
-        - join_date
-        - added_by
-        - allocation
-        - project_id
-        - project_personnel_id
-        - project_personnel_user_id
-        - role_id
-        - role_order
-        - user_id
-        - notes
-        - status
-        - date_added
-    retry_conf:
-      num_retries: 0
-      interval_sec: 10
-      timeout_sec: 60
-    webhook_from_env: MOPED_API_EVENTS_URL
-    headers:
-    - name: MOPED_API_APIKEY
-      value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
 - table:
     schema: public
     name: moped_proj_phases

--- a/moped-database/migrations/1613065498057_alter_table_public_moped_proj_personnel_drop_column_join_date/down.sql
+++ b/moped-database/migrations/1613065498057_alter_table_public_moped_proj_personnel_drop_column_join_date/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "join_date" date;
+ALTER TABLE "public"."moped_proj_personnel" ALTER COLUMN "join_date" DROP NOT NULL;

--- a/moped-database/migrations/1613065498057_alter_table_public_moped_proj_personnel_drop_column_join_date/up.sql
+++ b/moped-database/migrations/1613065498057_alter_table_public_moped_proj_personnel_drop_column_join_date/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "join_date" CASCADE;

--- a/moped-database/migrations/1613065535586_alter_table_public_moped_proj_personnel_drop_column_allocation/down.sql
+++ b/moped-database/migrations/1613065535586_alter_table_public_moped_proj_personnel_drop_column_allocation/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "allocation" int4;
+ALTER TABLE "public"."moped_proj_personnel" ALTER COLUMN "allocation" DROP NOT NULL;

--- a/moped-database/migrations/1613065535586_alter_table_public_moped_proj_personnel_drop_column_allocation/up.sql
+++ b/moped-database/migrations/1613065535586_alter_table_public_moped_proj_personnel_drop_column_allocation/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "allocation" CASCADE;

--- a/moped-database/migrations/1613065579652_alter_table_public_moped_proj_personnel_drop_column_role_order/down.sql
+++ b/moped-database/migrations/1613065579652_alter_table_public_moped_proj_personnel_drop_column_role_order/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "role_order" int4;
+ALTER TABLE "public"."moped_proj_personnel" ALTER COLUMN "role_order" DROP NOT NULL;

--- a/moped-database/migrations/1613065579652_alter_table_public_moped_proj_personnel_drop_column_role_order/up.sql
+++ b/moped-database/migrations/1613065579652_alter_table_public_moped_proj_personnel_drop_column_role_order/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "role_order" CASCADE;

--- a/moped-database/migrations/1613065672692_alter_table_public_moped_proj_personnel_drop_column_project_personnel_user_id/down.sql
+++ b/moped-database/migrations/1613065672692_alter_table_public_moped_proj_personnel_drop_column_project_personnel_user_id/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "project_personnel_user_id" int4;
+ALTER TABLE "public"."moped_proj_personnel" ALTER COLUMN "project_personnel_user_id" DROP NOT NULL;

--- a/moped-database/migrations/1613065672692_alter_table_public_moped_proj_personnel_drop_column_project_personnel_user_id/up.sql
+++ b/moped-database/migrations/1613065672692_alter_table_public_moped_proj_personnel_drop_column_project_personnel_user_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "project_personnel_user_id" CASCADE;

--- a/moped-database/migrations/1613066369582_alter_table_public_moped_proj_personnel_drop_column_status/down.sql
+++ b/moped-database/migrations/1613066369582_alter_table_public_moped_proj_personnel_drop_column_status/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "status" text;
+ALTER TABLE "public"."moped_proj_personnel" ALTER COLUMN "status" DROP NOT NULL;

--- a/moped-database/migrations/1613066369582_alter_table_public_moped_proj_personnel_drop_column_status/up.sql
+++ b/moped-database/migrations/1613066369582_alter_table_public_moped_proj_personnel_drop_column_status/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "status" CASCADE;

--- a/moped-database/migrations/1613066457765_alter_table_public_moped_proj_personnel_add_column_status_id/down.sql
+++ b/moped-database/migrations/1613066457765_alter_table_public_moped_proj_personnel_add_column_status_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" DROP COLUMN "status_id";

--- a/moped-database/migrations/1613066457765_alter_table_public_moped_proj_personnel_add_column_status_id/up.sql
+++ b/moped-database/migrations/1613066457765_alter_table_public_moped_proj_personnel_add_column_status_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_personnel" ADD COLUMN "status_id" integer NOT NULL DEFAULT 0;

--- a/moped-database/seeds/1602292389297_initial_seed.sql
+++ b/moped-database/seeds/1602292389297_initial_seed.sql
@@ -83,7 +83,7 @@ INSERT INTO public.moped_project_roles (project_role_id, project_role_name, acti
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (11, 'Project Sponsor', true, 11, '2020-10-09 14:43:03.859547+00');
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (12, 'Unknown Role', true, 100, '2020-10-09 14:43:03.859548+00');
 INSERT INTO public.moped_project_roles (project_role_id, project_role_name, active_role, role_order, date_added) VALUES (2, 'Street Designer', true, 2, '2020-10-09 14:44:51.2889+00');
-INSERT INTO public.moped_proj_personnel (project_id, user_id, role_id, join_date, notes) VALUES (1, 1, 1, '2020-12-04 16:53:02.752811+00', 'This is a note');
+INSERT INTO public.moped_proj_personnel (project_id, user_id, role_id, date_added, notes, status_id) VALUES (1, 1, 1, '2020-12-04 16:53:02.752811+00', 'This is a note', 1);
 SELECT pg_catalog.setval('public.moped_categories_category_id_seq', 8, true);
 SELECT pg_catalog.setval('public.moped_users_user_id_seq', 3, true);
 SELECT pg_catalog.setval('public.moped_components_component_id_seq', 1, false);

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -32,13 +32,9 @@ export const TEAM_QUERY = gql`
       user_id
       role_id
       notes
-      join_date
-      allocation
-      status
+      status_id
       project_id
-      project_personnel_user_id
       project_personnel_id
-      role_order
       date_added
       added_by
     }
@@ -77,12 +73,8 @@ export const UPDATE_PROJECT_PERSONNEL = gql`
     $user_id: Int
     $notes: String
     $project_id: Int
-    $join_date: date
-    $allocation: Int
-    $status: String
-    $project_personnel_user_id: Int
+    $status_id: Int
     $project_personnel_id: Int!
-    $role_order: Int
     $date_added: timestamptz
     $added_by: Int
     $role_id: Int
@@ -93,12 +85,8 @@ export const UPDATE_PROJECT_PERSONNEL = gql`
         user_id: $user_id
         notes: $notes
         project_id: $project_id
-        join_date: $join_date
-        allocation: $allocation
-        status: $status
-        project_personnel_user_id: $project_personnel_user_id
+        status_id: $status_id
         project_personnel_id: $project_personnel_id
-        role_order: $role_order
         date_added: $date_added
         added_by: $added_by
         role_id: $role_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -28,7 +28,9 @@ export const SUMMARY_QUERY = gql`
 
 export const TEAM_QUERY = gql`
   query TeamSummary($projectId: Int) {
-    moped_proj_personnel(where: { project_id: { _eq: $projectId } }) {
+    moped_proj_personnel(
+      where: { project_id: { _eq: $projectId }, status_id: { _eq: 1 } }
+    ) {
       user_id
       role_id
       notes

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -236,7 +236,10 @@ const ProjectTeamTable = ({
                   updatedPersonnelData,
                   ["__typename", "tableData"]
                 );
-                debugger;
+
+                updateProjectPersonnel({
+                  variables: cleanedPersonnelData,
+                });
               }
 
               setTimeout(() => refetch(), 501);

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -3,6 +3,7 @@ import { useQuery, useMutation } from "@apollo/client";
 
 // Material
 import { CircularProgress, TextField } from "@material-ui/core";
+import { Clear as ClearIcon } from "@material-ui/icons";
 import MaterialTable from "material-table";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 
@@ -152,7 +153,6 @@ const ProjectTeamTable = ({
           name="notes"
           multiline
           inputProps={{ maxLength: 125 }}
-          variant="outlined"
           helperText="125 character max"
           value={props.value}
           onChange={e => props.onChange(e.target.value)}
@@ -169,6 +169,7 @@ const ProjectTeamTable = ({
       options={{
         search: false,
       }}
+      icons={{ Delete: ClearIcon }}
       editable={{
         onRowAdd: newData =>
           new Promise((resolve, reject) => {

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -178,7 +178,11 @@ const ProjectTeamTable = ({
                 console.log("Add to new project");
               } else {
                 // Insert personnel and associate with project
-                const personnelData = { ...newData, project_id: projectId };
+                const personnelData = {
+                  ...newData,
+                  project_id: projectId,
+                  status_id: 1,
+                };
 
                 addProjectPersonnel({
                   variables: {
@@ -195,7 +199,7 @@ const ProjectTeamTable = ({
           new Promise((resolve, reject) => {
             setTimeout(() => {
               if (isNewProject) {
-                // Add personnel to state
+                // Update personnel in state
                 console.log("Update in new project");
               } else {
                 // Mutate personnel
@@ -212,6 +216,27 @@ const ProjectTeamTable = ({
                 updateProjectPersonnel({
                   variables: cleanedPersonnelData,
                 });
+              }
+
+              setTimeout(() => refetch(), 501);
+              resolve();
+            }, 500);
+          }),
+        onRowDelete: oldData =>
+          new Promise((resolve, reject) => {
+            setTimeout(() => {
+              if (isNewProject) {
+                // Remove personnel from state
+                console.log("Update in new project");
+              } else {
+                // Update status to inactive (0) to soft delete
+                const updatedPersonnelData = { ...oldData, status_id: 0 };
+
+                const cleanedPersonnelData = filterObjectByKeys(
+                  updatedPersonnelData,
+                  ["__typename", "tableData"]
+                );
+                debugger;
               }
 
               setTimeout(() => refetch(), 501);


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/4913

This PR adds the ability to soft delete personnel from a project in the Project Summary Team tab. The table in this tab is filtered to `status_id` of 1. Personnel are "removed" from a project by switching that field to 0. There are also some DB changes summarized below. Replacing the existing table in the New Project workflow is the next PR.

This is also includes a few UI improvements from https://github.com/cityofaustin/atd-data-tech/issues/4834 (X icon instead of trash can icon to remove personnel, notes edit field is now standard MUI style instead of outlined, and increased notes character count to 125).

####  Changes to `moped_proj_personnel`

**Removed**
- `join_date` (captured in `date_added`)
- `allocation` (no longer in scope)
- `role_order` (stored in roles table)
- `project_personnel_user_id` (duplicate of `user_id`)

**Updated**
- Change `status_id` to integer that defaults to 0 (active/inactive)

#### Original (note that the trash can icons are now X icons in the preview)
![Screen Shot 2021-02-11 at 2 28 11 PM](https://user-images.githubusercontent.com/37249039/107694857-7a137100-6c75-11eb-90e3-eaf85f5e2c7e.png)

#### Confirm dialog
![Screen Shot 2021-02-11 at 2 28 15 PM](https://user-images.githubusercontent.com/37249039/107694865-7e3f8e80-6c75-11eb-8605-703d7cd746f3.png)

#### Removed
![Screen Shot 2021-02-11 at 2 28 19 PM](https://user-images.githubusercontent.com/37249039/107694880-81d31580-6c75-11eb-948e-bdb50ebc2bde.png)
