### PR TITLE
JWT Token: Clean-up

### DIFF
--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -174,18 +174,6 @@ export const getJwt = user => user.idToken.jwtToken;
 export const isUserSSO = user =>
   user.idToken.payload["cognito:username"].startsWith("azuread_");
 
-export const availableSessionTime = user => {
-  try {
-    return (
-      user.idToken.getExpiration() - Math.round(new Date().getTime() / 1000)
-    );
-  } catch {
-    return 0;
-  }
-};
-
-export const isSessionExpired = user => availableSessionTime(user) > 0;
-
 // This function takes a CognitoUser Object and returns the role with the
 // highest permissions level within their allowed roles.
 export const getHighestRole = user => {

--- a/moped-editor/src/components/ApolloErrorHandler.js
+++ b/moped-editor/src/components/ApolloErrorHandler.js
@@ -30,7 +30,7 @@ const ApolloErrorHandler = props => {
   if (jwtError) {
     setTimeout(() => {
       window.location.reload();
-    }, 1500);
+    }, 5000);
   }
 
   return (


### PR DESCRIPTION
These are two small changes:
- Removes unused functions
- Allows more time (5 seconds) for AWS Amplify to refresh token