### PR TITLE
Moped API | File Uploads to S3

### DIFF
--- a/moped-api/app.py
+++ b/moped-api/app.py
@@ -12,6 +12,7 @@ MOPED_API_CURRENT_ENVIRONMENT = os.getenv("MOPED_API_CURRENT_ENVIRONMENT", "STAG
 from auth.auth import auth_blueprint
 from users.users import users_blueprint
 from events.events import events_blueprint
+from files.files import files_blueprint
 
 app = Flask(__name__)
 
@@ -21,6 +22,7 @@ app = Flask(__name__)
 app.register_blueprint(auth_blueprint, url_prefix="/auth")
 app.register_blueprint(users_blueprint, url_prefix="/users")
 app.register_blueprint(events_blueprint, url_prefix="/events")
+app.register_blueprint(files_blueprint, url_prefix="/files")
 
 #
 # Cognito

--- a/moped-api/files/files.py
+++ b/moped-api/files/files.py
@@ -1,16 +1,20 @@
-import datetime, boto3, os
+import datetime, boto3, os, json
 
 from flask import Blueprint, jsonify, request, redirect
 from flask_cognito import cognito_auth_required, current_cognito_jwt
 
-files_blueprint = Blueprint("auth_blueprint", __name__)
-aws_s3_client = boto3.client("s3", region_name=os.getenv("DEFALUT_REGION"))
-aws_bucket_name = os.getenv("S3_UPLOADS_BUCKET", None)
+from claims import *
 
-from helpers import (
+from files.helpers import (
     generate_clean_filename,
     generate_random_hash,
+    is_valid_filename,
+    is_valid_number,
 )
+
+files_blueprint = Blueprint("files_blueprint", __name__)
+aws_s3_client = boto3.client("s3", region_name=os.getenv("DEFALUT_REGION"))
+aws_bucket_name = os.getenv("S3_UPLOADS_BUCKET", None)
 
 
 @files_blueprint.route("/")
@@ -34,42 +38,81 @@ def auth_index() -> str:
 #
 @files_blueprint.route("/request-signature", methods=("GET",))
 @cognito_auth_required
-def files_request_signature() -> dict:
+@normalize_claims
+def files_request_signature(claims: list) -> dict:
     """
     Requests permission to upload a file directly to S3.
     If the request is valid, the response includes a temporary token.
     :return:
     """
-    # First, we need to retrieve the name of the file to be uploaded
+
+    # If not a valid user, then stop session...
+    if not is_valid_user(current_cognito_jwt):
+        jsonify({"status": "error", "message": "Not authorized"}), 403
+
+    # Load the user id from session
+    user_id = "123"
+    # If not a valid user, then stop session...
+    if not is_valid_number(user_id):
+        jsonify({"status": "error", "message": "Not authorized"}), 403
+
+    # Retrieve parameters:
     filename = request.args.get("file")
-    # Do we need to validate the file name? via regex?
-    # Do we care about the file name at all?
-    # Should the file name be hashed? Probably not
-    # Maybe not even require the file name, just a file extension?
+    project_id = request.args.get("project_id")
+
+    # Check our parameters
+    if not is_valid_number(project_id) or not is_valid_filename(filename):
+        jsonify({"status": "error", "message": "Invalid parameters"}), 403
+
+    #
+    # We have the basic requirements...
+    #
+    print("User Claims: ")
+    print(json.dumps(claims))
+    import pdb
+    pdb.set_trace()
 
     # Generate unique file name
     random_hash = generate_random_hash()
     file_new_unique_name = generate_clean_filename(filename)
-    file_s3_key = f"uploads/user_db_id/{file_new_unique_name}"
 
-    post = aws_s3_client.generate_presigned_post(
+    # Final Unique File Name:
+    file_s3_key = f"uploads/{project_id}/{user_id}_{file_new_unique_name}"
+
+    # Generate upload credentials
+    credentials = aws_s3_client.generate_presigned_post(
         Bucket=aws_bucket_name, Key=file_s3_key
     )
+
+    pdb.set_trace()
+
+    # Check for errors (not yet implemented)
 
     return jsonify(
         {
             "status": "success",
             "message": "permission granted",
             "uuid": random_hash,
-            "filename": filename,
-            "credentials": post,
+            "filename": file_s3_key,
+            "credentials": credentials,
         }
     )
 
 
 # Downloads a file from S3
 @files_blueprint.route("/download/<path:path>", methods=("GET",))
-def file_download(path) -> redirect:
+@cognito_auth_required
+@normalize_claims
+def file_download(path, claims: list) -> redirect:
+    """
+    Retrieves a download file url for the user
+    :param str path: The file name
+    :param list claims: The claims as loaded from the JWT token
+    :return redirect:
+    """
+    if not is_valid_user(current_cognito_jwt):
+        jsonify({"status": "error", "message": "not authorized"}), 403
+
     url = aws_s3_client.generate_presigned_url(
         ExpiresIn=60,  # seconds
         ClientMethod="get_object",

--- a/moped-api/files/files.py
+++ b/moped-api/files/files.py
@@ -1,0 +1,84 @@
+import datetime, boto3, os
+
+from flask import Blueprint, jsonify, request, redirect
+from flask_cognito import cognito_auth_required, current_cognito_jwt
+
+files_blueprint = Blueprint("auth_blueprint", __name__)
+aws_s3_client = boto3.client("s3", region_name=os.getenv("DEFALUT_REGION"))
+aws_bucket_name = os.getenv("S3_UPLOADS_BUCKET", None)
+
+from helpers import (
+    get_file_extension,
+    get_file_name,
+    generate_clean_filename,
+    is_valid_unique_id,
+    get_current_datetime,
+    filename_timestamp,
+    generate_random_hash,
+)
+
+
+@files_blueprint.route("/")
+def auth_index() -> str:
+    """
+    Returns a simple message.
+    :return str:
+    """
+    now = datetime.datetime.now()
+    return jsonify(
+        {
+            "message": "MOPED API Available - Files - Health Check - Available @ %s"
+            % now.strftime("%Y-%m-%d %H:%M:%S")
+        }
+    )
+
+
+#
+# In order to retrieve the current_cognito_jwt object,
+# we need to call the @cognito_auth_required decorator.
+#
+@files_blueprint.route("/request-signature", methods=("GET",))
+@cognito_auth_required
+def files_request_signature() -> dict:
+    """
+    Requests permission to upload a file directly to S3.
+    If the request is valid, the response includes a temporary token.
+    :return:
+    """
+    # First, we need to retrieve the name of the file to be uploaded
+    filename = request.args.get("file")
+    # Do we need to validate the file name? via regex?
+    # Do we care about the file name at all?
+    # Should the file name be hashed? Probably not
+    # Maybe not even require the file name, just a file extension?
+
+    # Generate unique file name
+    random_hash = generate_random_hash()
+    file_new_unique_name = generate_clean_filename(filename)
+    file_s3_key = f"uploads/user_db_id/{file_new_unique_name}"
+
+    post = aws_s3_client.generate_presigned_post(
+        Bucket=aws_bucket_name, Key=file_s3_key
+    )
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": "permission granted",
+            "uuid": random_hash,
+            "filename": filename,
+            "credentials": post,
+        }
+    )
+
+
+# Downloads a file from S3
+@files_blueprint.route("/download/<path:path>", methods=("GET",))
+def file_download(path) -> redirect:
+    url = aws_s3_client.generate_presigned_url(
+        ExpiresIn=60,  # seconds
+        ClientMethod="get_object",
+        Params={"Bucket": aws_bucket_name, "Key": path},
+    )
+
+    return redirect(url, code=302)

--- a/moped-api/files/files.py
+++ b/moped-api/files/files.py
@@ -8,12 +8,7 @@ aws_s3_client = boto3.client("s3", region_name=os.getenv("DEFALUT_REGION"))
 aws_bucket_name = os.getenv("S3_UPLOADS_BUCKET", None)
 
 from helpers import (
-    get_file_extension,
-    get_file_name,
     generate_clean_filename,
-    is_valid_unique_id,
-    get_current_datetime,
-    filename_timestamp,
     generate_random_hash,
 )
 

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -99,12 +99,15 @@ def generate_clean_filename(filename: str) -> str:
     :param str filename: Raw file name
     :return str:
     """
-    if isinstance(filename, str) is False:
-        raise Exception(f"Invalid file name: {filename}")
+    if isinstance(filename, str) is False or len(filename) == 0:
+        raise Exception(f"Invalid file name: '{filename}'")
 
     timestamp = filename_timestamp()
     file_extension = get_file_extension(filename)
     file_name = get_file_name(filename)
+
+    if timestamp is None or file_extension is None or filename is None:
+        raise Exception(f"Invalid file name: '{filename}'")
 
     clean_filename = "{0}.{1}".format(file_name, file_extension)
     unique_short_hash = generate_random_hash()[0:16]
@@ -117,6 +120,9 @@ def is_valid_unique_id(unique_id) -> bool:
     :param str unique_id: Unique ID string
     :return bool:
     """
+    if isinstance(unique_id, str) is False:
+        return False
+
     pattern = re.compile("^([a-z0-9]){64}$")
     return pattern.match(unique_id) is not None
 
@@ -144,7 +150,6 @@ def generate_random_hash() -> str:
     Generates a random hash
     :return str:
     """
-    if i
     rand_uuid_str = "{0}".format(uuid.uuid1()).encode()
     return str(hashlib.sha256(rand_uuid_str).hexdigest())
 

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -140,25 +140,28 @@ def is_valid_unique_id(unique_id) -> bool:
     return pattern.match(unique_id) is not None
 
 
-def is_valid_project_id(project_id: str) -> bool:
+def is_valid_number(number: str) -> bool:
     """
-    Returns True if the project_id is a valid number
-    :param str project_id: The project number as a string
+    Returns True if the integer string is a valid number
+    :param str number: The integer number as a string
     :return str:
     """
     # If not an instance of a string, false
-    if not isinstance(project_id, str):
+    if not isinstance(number, str):
         return False
 
     # Clean it up
-    clean_project_id = strip_non_numeric(project_id)
+    clean_number = strip_non_numeric(number)
 
     # If zero length, False
-    if len(clean_project_id) == 0:
+    if len(clean_number) == 0:
         return False
 
-    # Seems a good number
-    return True
+    try:
+        int(clean_number)
+        return True
+    except (ValueError, TypeError):
+        return False
 
 
 #####

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -194,3 +194,10 @@ def generate_random_hash() -> str:
 #
 # Retrieve user details
 #
+def get_user_id(claims: dict) -> str:
+    """
+    Retrieves the user id from the claims
+    :param dict claims: The claims dictionary
+    :return str: The users' database id as a string integer
+    """
+    return claims.get("https://hasura.io/jwt/claims", {}).get("x-hasura-user-db-id", None)

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -4,13 +4,26 @@ import re
 import uuid
 
 
+def strip_non_numeric(text: str) -> str:
+    """
+    Removes any non-numeric characters
+    :param str text: The input text
+    :return str:
+    """
+    if not isinstance(text, str):
+        return ""
+
+    pattern = re.compile("[^0-9]")
+    return re.sub(pattern, '', text)
+
+
 def strip_non_alpha(text: str) -> str:
     """
     Removes non-alphabetic characters from a string
     :param str text: The string in question
     :return str:
     """
-    if isinstance(text, str) is False:
+    if not isinstance(text, str):
         return ""
 
     pattern = re.compile("[^a-zA-Z]")
@@ -23,7 +36,7 @@ def strip_non_common(text: str) -> str:
     :param str text: The string in question
     :return str:
     """
-    if isinstance(text, str) is False:
+    if not isinstance(text, str):
         return ""
 
     pattern = re.compile("[^0-9a-zA-Z_-]")
@@ -36,7 +49,7 @@ def get_file_name(filename: str) -> str:
     :param str filename: The raw file name
     :return str:
     """
-    if isinstance(filename, str) is False:
+    if not isinstance(filename, str):
         return None
 
     if filename is None or filename == "":
@@ -56,7 +69,7 @@ def is_valid_filename(filename: str) -> bool:
     :return:
     """
 
-    if isinstance(filename, str) is False:
+    if not isinstance(filename, str):
         return False
 
     if filename is None or filename == "":
@@ -82,7 +95,7 @@ def get_file_extension(filename) -> str:
     :param str filename: The file name
     :return str:
     """
-    if is_valid_filename(filename) is False:
+    if not is_valid_filename(filename):
         return None
 
     file_extension = strip_non_alpha(filename.rsplit('.', 1)[1].lower().strip())
@@ -99,7 +112,7 @@ def generate_clean_filename(filename: str) -> str:
     :param str filename: Raw file name
     :return str:
     """
-    if isinstance(filename, str) is False or len(filename) == 0:
+    if not isinstance(filename, str) or len(filename) == 0:
         raise Exception(f"Invalid file name: '{filename}'")
 
     timestamp = filename_timestamp()
@@ -120,11 +133,32 @@ def is_valid_unique_id(unique_id) -> bool:
     :param str unique_id: Unique ID string
     :return bool:
     """
-    if isinstance(unique_id, str) is False:
+    if not isinstance(unique_id, str):
         return False
 
     pattern = re.compile("^([a-z0-9]){64}$")
     return pattern.match(unique_id) is not None
+
+
+def is_valid_project_id(project_id: str) -> bool:
+    """
+    Returns True if the project_id is a valid number
+    :param str project_id: The project number as a string
+    :return str:
+    """
+    # If not an instance of a string, false
+    if not isinstance(project_id, str):
+        return False
+
+    # Clean it up
+    clean_project_id = strip_non_numeric(project_id)
+
+    # If zero length, False
+    if len(clean_project_id) == 0:
+        return False
+
+    # Seems a good number
+    return True
 
 
 #####

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -1,0 +1,154 @@
+import datetime
+import hashlib
+import re
+import uuid
+
+
+def strip_non_alpha(text: str) -> str:
+    """
+    Removes non-alphabetic characters from a string
+    :param str text: The string in question
+    :return str:
+    """
+    if isinstance(text, str) is False:
+        return ""
+
+    pattern = re.compile("[^a-zA-Z]")
+    return re.sub(pattern, '', text).lower()
+
+
+def strip_non_common(text: str) -> str:
+    """
+    Removes characters that are not alphabetic, numbers, underscore and hyphens
+    :param str text: The string in question
+    :return str:
+    """
+    if isinstance(text, str) is False:
+        return ""
+
+    pattern = re.compile("[^0-9a-zA-Z_-]")
+    return re.sub(pattern, '', text).lower()
+
+
+def get_file_name(filename: str) -> str:
+    """
+    Returns the file name only without extension
+    :param str filename: The raw file name
+    :return str:
+    """
+    if isinstance(filename, str) is False:
+        return None
+
+    if filename is None or filename == "":
+        return None
+
+    if "." not in filename:
+        return None
+
+    filename_no_ext = filename.rsplit('.', 1)[0].lower()[:64]
+    return strip_non_common(filename_no_ext)
+
+
+def is_valid_filename(filename: str) -> bool:
+    """
+    Returns True if the filename is valid.
+    :param str filename: The raw file name
+    :return:
+    """
+
+    if isinstance(filename, str) is False:
+        return False
+
+    if filename is None or filename == "":
+        return False
+
+    if "." not in filename:
+        return False
+
+    file_name_clean = get_file_name(filename)
+
+    if len(filename) >= 130:
+        return False
+
+    if file_name_clean is None or file_name_clean == "":
+        return False
+
+    return True
+
+
+def get_file_extension(filename) -> str:
+    """
+    Returns the extension out of the file name
+    :param str filename: The file name
+    :return str:
+    """
+    if is_valid_filename(filename) is False:
+        return None
+
+    file_extension = strip_non_alpha(filename.rsplit('.', 1)[1].lower().strip())
+
+    if file_extension is None or file_extension == "":
+        return None
+
+    return file_extension
+
+
+def generate_clean_filename(filename: str) -> str:
+    """
+    Generates a safer, random and legible file name
+    :param str filename: Raw file name
+    :return str:
+    """
+    if isinstance(filename, str) is False:
+        raise Exception(f"Invalid file name: {filename}")
+
+    timestamp = filename_timestamp()
+    file_extension = get_file_extension(filename)
+    file_name = get_file_name(filename)
+
+    clean_filename = "{0}.{1}".format(file_name, file_extension)
+    unique_short_hash = generate_random_hash()[0:16]
+    return f"{timestamp}_{unique_short_hash}_{clean_filename}"
+
+
+def is_valid_unique_id(unique_id) -> bool:
+    """
+    Returns a valid unique id number
+    :param str unique_id: Unique ID string
+    :return bool:
+    """
+    pattern = re.compile("^([a-z0-9]){64}$")
+    return pattern.match(unique_id) is not None
+
+
+#####
+# Time
+#####
+def get_current_datetime() -> str:
+    """
+    Returns the current date time as a string
+    :return str:
+    """
+    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+
+def filename_timestamp():
+    return datetime.datetime.now().strftime("%m%d%Y%H%M%S")
+
+
+#####
+# Random Number Generator
+#####
+def generate_random_hash() -> str:
+    """
+    Generates a random hash
+    :return str:
+    """
+    if i
+    rand_uuid_str = "{0}".format(uuid.uuid1()).encode()
+    return str(hashlib.sha256(rand_uuid_str).hexdigest())
+
+
+#
+# Retrieve user details
+#

--- a/moped-api/files/helpers.py
+++ b/moped-api/files/helpers.py
@@ -14,7 +14,7 @@ def strip_non_numeric(text: str) -> str:
         return ""
 
     pattern = re.compile("[^0-9]")
-    return re.sub(pattern, '', text)
+    return re.sub(pattern, "", text)
 
 
 def strip_non_alpha(text: str) -> str:
@@ -27,7 +27,7 @@ def strip_non_alpha(text: str) -> str:
         return ""
 
     pattern = re.compile("[^a-zA-Z]")
-    return re.sub(pattern, '', text).lower()
+    return re.sub(pattern, "", text).lower()
 
 
 def strip_non_common(text: str) -> str:
@@ -40,7 +40,7 @@ def strip_non_common(text: str) -> str:
         return ""
 
     pattern = re.compile("[^0-9a-zA-Z_-]")
-    return re.sub(pattern, '', text).lower()
+    return re.sub(pattern, "", text).lower()
 
 
 def get_file_name(filename: str) -> str:
@@ -58,7 +58,7 @@ def get_file_name(filename: str) -> str:
     if "." not in filename:
         return None
 
-    filename_no_ext = filename.rsplit('.', 1)[0].lower()[:64]
+    filename_no_ext = filename.rsplit(".", 1)[0].lower()[:64]
     return strip_non_common(filename_no_ext)
 
 
@@ -80,6 +80,9 @@ def is_valid_filename(filename: str) -> bool:
 
     file_name_clean = get_file_name(filename)
 
+    if get_file_extension(filename) is None:
+        return False
+
     if len(filename) >= 130:
         return False
 
@@ -95,10 +98,16 @@ def get_file_extension(filename) -> str:
     :param str filename: The file name
     :return str:
     """
-    if not is_valid_filename(filename):
+    if not isinstance(filename, str):
         return None
 
-    file_extension = strip_non_alpha(filename.rsplit('.', 1)[1].lower().strip())
+    if filename is None or filename == "":
+        return None
+
+    if "." not in filename:
+        return None
+
+    file_extension = strip_non_alpha(filename.rsplit(".", 1)[1].lower().strip())
 
     if file_extension is None or file_extension == "":
         return None
@@ -116,10 +125,16 @@ def generate_clean_filename(filename: str) -> str:
         raise Exception(f"Invalid file name: '{filename}'")
 
     timestamp = filename_timestamp()
-    file_extension = get_file_extension(filename)
-    file_name = get_file_name(filename)
+    file_extension = get_file_extension(filename).strip()
+    file_name = get_file_name(filename).strip()
 
-    if timestamp is None or file_extension is None or filename is None:
+    if (
+        timestamp is None
+        or file_extension is None
+        or file_extension == ""
+        or file_name is None
+        or file_name == ""
+    ):
         raise Exception(f"Invalid file name: '{filename}'")
 
     clean_filename = "{0}.{1}".format(file_name, file_extension)
@@ -172,7 +187,7 @@ def get_current_datetime() -> str:
     Returns the current date time as a string
     :return str:
     """
-    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
 def filename_timestamp():
@@ -200,4 +215,6 @@ def get_user_id(claims: dict) -> str:
     :param dict claims: The claims dictionary
     :return str: The users' database id as a string integer
     """
-    return claims.get("https://hasura.io/jwt/claims", {}).get("x-hasura-user-db-id", None)
+    return claims.get("https://hasura.io/jwt/claims", {}).get(
+        "x-hasura-user-db-id", None
+    )

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -1,5 +1,4 @@
 import unittest
-import pdb
 
 
 from files.helpers import (

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -1,4 +1,6 @@
+import unittest
 import pdb
+
 
 from files.helpers import (
     get_file_extension,
@@ -13,7 +15,7 @@ from files.helpers import (
 )
 
 
-class TestFilesHelpers:
+class TestFilesHelpers(unittest.TestCase):
 
     def test_strip_non_alpha(self):
         assert strip_non_alpha(None) == ""
@@ -54,3 +56,11 @@ class TestFilesHelpers:
 
     def test_is_valid_unique_id(self):
         assert is_valid_unique_id(generate_random_hash())
+
+    def test_generate_clean_filename(self):
+        self.assertRaises(Exception, generate_clean_filename, None)
+        self.assertRaises(Exception, generate_clean_filename, "")
+        self.assertRaises(Exception, generate_clean_filename, ".png")
+        self.assertRaises(Exception, generate_clean_filename, "naathing")
+
+        assert generate_clean_filename("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz").endswith("crazy6filetyuimovtar.gz")

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -13,7 +13,7 @@ from files.helpers import (
     strip_non_alpha,
     strip_non_common,
     strip_non_numeric,
-    is_valid_project_id
+    is_valid_number
 )
 
 
@@ -26,6 +26,7 @@ class TestFilesHelpers(unittest.TestCase):
         assert strip_non_numeric("     ") == ""
         assert strip_non_numeric("\n") == ""
         assert strip_non_numeric("123456789") == "123456789"
+        assert strip_non_numeric("0") == "0"
 
     def test_strip_non_alpha(self):
         assert strip_non_alpha(None) == ""
@@ -75,9 +76,9 @@ class TestFilesHelpers(unittest.TestCase):
 
         assert generate_clean_filename("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz").endswith("crazy6filetyuimovtar.gz")
 
-    def test_is_valid_project_id(self):
-        assert is_valid_project_id(123) is False
-        assert is_valid_project_id(None) is False
-        assert is_valid_project_id("") is False
-        assert is_valid_project_id("ABC") is False
-        assert is_valid_project_id("123")
+    def test_is_valid_number(self):
+        assert is_valid_number(123) is False
+        assert is_valid_number(None) is False
+        assert is_valid_number("") is False
+        assert is_valid_number("ABC") is False
+        assert is_valid_number("123")

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -12,10 +12,20 @@ from files.helpers import (
     generate_random_hash,
     strip_non_alpha,
     strip_non_common,
+    strip_non_numeric,
+    is_valid_project_id
 )
 
 
 class TestFilesHelpers(unittest.TestCase):
+
+    def test_strip_non_numeric(self):
+        assert strip_non_numeric(None) == ""
+        assert strip_non_numeric(1234) == ""
+        assert strip_non_numeric(False) == ""
+        assert strip_non_numeric("     ") == ""
+        assert strip_non_numeric("\n") == ""
+        assert strip_non_numeric("123456789") == "123456789"
 
     def test_strip_non_alpha(self):
         assert strip_non_alpha(None) == ""
@@ -64,3 +74,10 @@ class TestFilesHelpers(unittest.TestCase):
         self.assertRaises(Exception, generate_clean_filename, "naathing")
 
         assert generate_clean_filename("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz").endswith("crazy6filetyuimovtar.gz")
+
+    def test_is_valid_project_id(self):
+        assert is_valid_project_id(123) is False
+        assert is_valid_project_id(None) is False
+        assert is_valid_project_id("") is False
+        assert is_valid_project_id("ABC") is False
+        assert is_valid_project_id("123")

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -1,0 +1,56 @@
+import pdb
+
+from files.helpers import (
+    get_file_extension,
+    get_file_name,
+    generate_clean_filename,
+    is_valid_unique_id,
+    get_current_datetime,
+    filename_timestamp,
+    generate_random_hash,
+    strip_non_alpha,
+    strip_non_common,
+)
+
+
+class TestFilesHelpers:
+
+    def test_strip_non_alpha(self):
+        assert strip_non_alpha(None) == ""
+        assert strip_non_alpha(1234) == ""
+        assert strip_non_alpha(False) == ""
+        assert strip_non_alpha("@#$%^&*(") == ""
+        assert strip_non_alpha("     ") == ""
+        assert strip_non_alpha("123456789") == ""
+        assert strip_non_alpha("\n") == ""
+
+    def test_strip_non_common(self):
+        assert strip_non_common(None) == ""
+        assert strip_non_common("      ") == ""
+        assert strip_non_common("hello()world") == "helloworld"
+        assert strip_non_common("\n") == ""
+        assert strip_non_common("crazy6^filE!@#$%T^Y&U*I<>???") == "crazy6filetyui"
+        assert strip_non_common("'<($-Hello_World-$)>.png") == "-hello_world-png"
+
+    def test_get_file_name(self):
+        assert get_file_name(None) is None
+        assert get_file_name("noext") is None
+        assert get_file_name("n1230098123091209812039812308.png") == "n1230098123091209812039812308"
+
+    def test_get_file_extension(self):
+        assert get_file_extension(None) is None
+        assert get_file_extension("") is None
+        assert get_file_extension("noext") is None
+        assert get_file_extension("    .png") is None
+        assert get_file_extension("           ") is None
+        assert get_file_extension(".png") is None
+        assert get_file_extension("1.^^^") is None
+        assert get_file_extension("1.   ") is None
+        assert get_file_extension(".   ") is None
+
+        assert get_file_extension("a675ffad8f7df7d217e7028b342e0b38e2f2996ab0463645e24021ec366f873b2a.pdf") == "pdf"
+        assert get_file_extension("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz") == "gz"
+        assert get_file_extension("filename.png") == "png"
+
+    def test_is_valid_unique_id(self):
+        assert is_valid_unique_id(generate_random_hash())

--- a/moped-api/tests/test_files_helpers.py
+++ b/moped-api/tests/test_files_helpers.py
@@ -12,7 +12,8 @@ from files.helpers import (
     strip_non_alpha,
     strip_non_common,
     strip_non_numeric,
-    is_valid_number
+    is_valid_number,
+    is_valid_filename,
 )
 
 
@@ -53,9 +54,7 @@ class TestFilesHelpers(unittest.TestCase):
         assert get_file_extension(None) is None
         assert get_file_extension("") is None
         assert get_file_extension("noext") is None
-        assert get_file_extension("    .png") is None
         assert get_file_extension("           ") is None
-        assert get_file_extension(".png") is None
         assert get_file_extension("1.^^^") is None
         assert get_file_extension("1.   ") is None
         assert get_file_extension(".   ") is None
@@ -63,6 +62,10 @@ class TestFilesHelpers(unittest.TestCase):
         assert get_file_extension("a675ffad8f7df7d217e7028b342e0b38e2f2996ab0463645e24021ec366f873b2a.pdf") == "pdf"
         assert get_file_extension("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz") == "gz"
         assert get_file_extension("filename.png") == "png"
+        assert get_file_extension("    .png") == "png"
+        assert get_file_extension(".pdf") == "pdf"
+
+
 
     def test_is_valid_unique_id(self):
         assert is_valid_unique_id(generate_random_hash())
@@ -72,6 +75,7 @@ class TestFilesHelpers(unittest.TestCase):
         self.assertRaises(Exception, generate_clean_filename, "")
         self.assertRaises(Exception, generate_clean_filename, ".png")
         self.assertRaises(Exception, generate_clean_filename, "naathing")
+        self.assertRaises(Exception, generate_clean_filename, "naathing.")
 
         assert generate_clean_filename("crazy6^filE!@#$%T^Y&U*I<>???.mov.tar.gz").endswith("crazy6filetyuimovtar.gz")
 
@@ -81,3 +85,14 @@ class TestFilesHelpers(unittest.TestCase):
         assert is_valid_number("") is False
         assert is_valid_number("ABC") is False
         assert is_valid_number("123")
+
+    def test_is_valid_filename(self):
+        assert is_valid_filename(123) is False
+        assert is_valid_filename("123") is False
+        assert is_valid_filename(None) is False
+        assert is_valid_filename("None") is False
+        assert is_valid_filename({}) is False
+        assert is_valid_filename(".png") is False
+        assert is_valid_filename(".") is False
+        assert is_valid_filename("file.") is False
+


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5298

Basically, this branch extends the moped API to allow for uploads and downloads from S3. This allows us to use a react component to upload files directly from the UI into S3.

- Route `/files/download/<file-path>`:  This route will attempt to find the file in the pre-configured bucket name, and if it is found it will return a signed url that makes the file temporarily public (up to 60 seconds).
- Route `/files/request-signature?file=<file-path>`: This route will attempt to request permission to upload a file to s3. If the request is successful, the user is allowed to upload a file to that specific file path only.

This implements the file upload API, unfortunately this cannot be tested without Postman and AWS Creds, but here are the screenshots:

<img width="1680" alt="2021-03-03_11-57-50" src="https://user-images.githubusercontent.com/5282430/109851036-ccaed000-7c18-11eb-9dd5-1ac2f451853a.png">
<img width="1680" alt="2021-03-03_11-57-26" src="https://user-images.githubusercontent.com/5282430/109851039-cd476680-7c18-11eb-8a8d-e66d5c8e175a.png">
