### PR TITLE
Project Extent | Implement refinements to "Map project" step in new project workflow and "Project summary" page

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -8,6 +8,54 @@ export const PROJECT_NAME = gql`
   }
 `;
 
+export const ADD_PROJECT = gql`
+  mutation MyMutation(
+    $project_name: String! = ""
+    $project_description: String! = ""
+    $current_phase: String! = ""
+    $current_status: String! = ""
+    $eCapris_id: String! = ""
+    $fiscal_year: String! = ""
+    $start_date: date = ""
+    $capitally_funded: Boolean! = false
+    $project_priority: String! = ""
+    $project_extent_ids: jsonb = {}
+    $project_extent_geojson: jsonb = {}
+  ) {
+    insert_moped_project(
+      objects: {
+        project_name: $project_name
+        project_description: $project_description
+        current_phase: $current_phase
+        current_status: $current_status
+        eCapris_id: $eCapris_id
+        fiscal_year: $fiscal_year
+        start_date: $start_date
+        capitally_funded: $capitally_funded
+        project_priority: $project_priority
+        project_extent_ids: $project_extent_ids
+        project_extent_geojson: $project_extent_geojson
+      }
+    ) {
+      affected_rows
+      returning {
+        project_id
+        project_name
+        project_description
+        project_priority
+        current_phase
+        current_status
+        eCapris_id
+        fiscal_year
+        capitally_funded
+        start_date
+        project_extent_ids
+        project_extent_geojson
+      }
+    }
+  }
+`;
+
 export const SUMMARY_QUERY = gql`
   query ProjectSummary($projectId: Int) {
     moped_project(where: { project_id: { _eq: $projectId } }) {

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -318,7 +318,7 @@ export function useHoverLayer() {
  * Custom hook that initializes a map viewport and fits it to a provided feature collection
  * @param {object} mapRef - Ref object whose current property exposes the map instance
  * @param {object} featureCollection - A GeoJSON feature collection to fit the map bounds around
- * @param {boolean} shouldFitOnUpdate - Determines if map fits to featuresCollection if collection changes
+ * @param {boolean} shouldFitOnUpdate - Determines if map fits to featuresCollection if collection updates
  * @return {ViewportStateArray} Array that exposes the setter and getters for map viewport using useState hook
  */
 /**

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -316,19 +316,27 @@ export function useHoverLayer() {
 
 /**
  * Custom hook that initializes a map viewport and fits it to a provided feature collection
- * @param {Object} mapRef - Ref object whose current property exposes the map instance
- * @param {Object} featureCollection - A GeoJSON feature collection to fit the map bounds around
+ * @param {object} mapRef - Ref object whose current property exposes the map instance
+ * @param {object} featureCollection - A GeoJSON feature collection to fit the map bounds around
+ * @param {boolean} shouldFitOnUpdate - Determines if map fits to featuresCollection if collection changes
  * @return {ViewportStateArray} Array that exposes the setter and getters for map viewport using useState hook
  */
 /**
- * @typedef {Array} ViewportStateArray
- * @property {Object} StateArray[0] - A Mapbox viewport object
- * @property {Function} StateArray[1] - Setter for viewport state
+ * @typedef {array} ViewportStateArray
+ * @property {object} StateArray[0] - A Mapbox viewport object
+ * @property {function} StateArray[1] - Setter for viewport state
  */
-export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
+export function useFeatureCollectionToFitBounds(
+  mapRef,
+  featureCollection,
+  shouldFitOnFeatureUpdate = true
+) {
   const [viewport, setViewport] = useState(mapConfig.mapInit);
+  const [hasFitInitialized, setHasFitInitialized] = useState(false);
 
   useEffect(() => {
+    if (!shouldFitOnFeatureUpdate && hasFitInitialized) return;
+
     const mapBounds = createZoomBbox(featureCollection);
     const currentMap = mapRef.current;
 
@@ -360,7 +368,8 @@ export function useFeatureCollectionToFitBounds(mapRef, featureCollection) {
     };
 
     setViewport(prevViewport => fitViewportToBounds(prevViewport));
-  }, [featureCollection, mapRef]);
+    setHasFitInitialized(true);
+  }, [hasFitInitialized, shouldFitOnFeatureUpdate, featureCollection, mapRef]);
 
   return [viewport, setViewport];
 }

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -45,7 +45,7 @@ const NewProjectMap = ({
   const featureCount = sumFeaturesSelected(selectedLayerIds);
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
-  const { handleLayerHover, featureId, hoveredCoords } = useHoverLayer();
+  const { handleLayerHover, featureId } = useHoverLayer();
 
   /**
    * Adds or removes an interactive map feature from the project's feature collection and selected IDs array

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from "react";
+import React, { useRef, useCallback } from "react";
 import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import Geocoder from "react-map-gl-geocoder";
 import { Box, makeStyles } from "@material-ui/core";
@@ -17,6 +17,7 @@ import {
   mapConfig,
   mapStyles,
   sumFeaturesSelected,
+  useFeatureCollectionToFitBounds,
   useHoverLayer,
   renderFeatureCount,
 } from "../../../utils/mapHelpers";
@@ -44,7 +45,11 @@ const NewProjectMap = ({
   const mapRef = useRef();
   const featureCount = sumFeaturesSelected(selectedLayerIds);
 
-  const [viewport, setViewport] = useState(mapConfig.mapInit);
+  const [viewport, setViewport] = useFeatureCollectionToFitBounds(
+    mapRef,
+    featureCollection,
+    true
+  );
   const { handleLayerHover, featureId } = useHoverLayer();
 
   /**

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -16,7 +16,6 @@ import {
   MAPBOX_TOKEN,
   mapConfig,
   mapStyles,
-  renderTooltip,
   sumFeaturesSelected,
   useHoverLayer,
   renderFeatureCount,
@@ -151,7 +150,6 @@ const NewProjectMap = ({
             />
           </Source>
         ))}
-        {renderTooltip(featureId, hoveredCoords, classes.toolTip)}
       </ReactMapGL>
       {renderFeatureCount(featureCount)}
     </Box>

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from "react";
+import React, { useRef } from "react";
 import ReactMapGL, { Layer, NavigationControl, Source } from "react-map-gl";
 import Geocoder from "react-map-gl-geocoder";
 import { Box, makeStyles } from "@material-ui/core";
@@ -48,7 +48,7 @@ const NewProjectMap = ({
   const [viewport, setViewport] = useFeatureCollectionToFitBounds(
     mapRef,
     featureCollection,
-    true
+    false
   );
   const { handleLayerHover, featureId } = useHoverLayer();
 
@@ -106,14 +106,14 @@ const NewProjectMap = ({
    * Updates viewport on select of location from geocoder form
    * @param {Object} newViewport - Mapbox object that stores updated location for viewport
    */
-  const handleGeocoderViewportChange = useCallback(newViewport => {
+  const handleGeocoderViewportChange = newViewport => {
     const geocoderDefaultOverrides = { transitionDuration: 1000 };
 
     return handleViewportChange({
       ...newViewport,
       ...geocoderDefaultOverrides,
     });
-  }, []);
+  };
 
   return (
     <Box className={classes.mapBox}>

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -98,7 +98,7 @@ const NewProjectView = () => {
 
   const [areNoFeaturesSelected, setAreNoFeaturesSelected] = useState(false);
 
-  // Reset areNoFeatures once a feature is selected
+  // Reset areNoFeaturesSelected once a feature is selected to remove error message
   useEffect(() => {
     if (sumFeaturesSelected(selectedLayerIds) > 0) {
       setAreNoFeaturesSelected(false);
@@ -111,7 +111,7 @@ const NewProjectView = () => {
       { label: "Assign team" },
       {
         label: "Map project",
-        error: "Please select a location",
+        error: "Select a location to save project",
         isError: areNoFeaturesSelected,
       },
     ];

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -22,6 +22,7 @@ import Page from "src/components/Page";
 import { useMutation, gql } from "@apollo/client";
 import { ADD_PROJECT_PERSONNEL } from "../../../queries/project";
 import { filterObjectByKeys } from "../../../utils/materialTableHelpers";
+import { sumFeaturesSelected } from "../../../utils/mapHelpers";
 
 import ProjectSaveButton from "./ProjectSaveButton";
 
@@ -94,9 +95,10 @@ const NewProjectView = () => {
     type: "FeatureCollection",
     features: [],
   });
+  const [areNoFeaturesSelected, setAreNoFeaturesSelected] = useState(false);
 
   const getSteps = () => {
-    return ["Define Project", "Assign Team", "Map project"];
+    return ["Define project", "Assign team", "Map project"];
   };
 
   const getStepContent = step => {
@@ -228,6 +230,11 @@ const NewProjectView = () => {
   }, []);
 
   const handleSubmit = () => {
+    if (sumFeaturesSelected(selectedLayerIds) === 0) {
+      setAreNoFeaturesSelected(true);
+      return;
+    }
+
     // Change the initial state...
     setLoading(true);
 

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -96,7 +96,7 @@ const NewProjectView = () => {
   });
 
   const getSteps = () => {
-    return ["Define Project", "Assign Team", "Map Project"];
+    return ["Define Project", "Assign Team", "Map project"];
   };
 
   const getStepContent = step => {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -98,7 +98,15 @@ const NewProjectView = () => {
   const [areNoFeaturesSelected, setAreNoFeaturesSelected] = useState(false);
 
   const getSteps = () => {
-    return ["Define project", "Assign team", "Map project"];
+    return [
+      { label: "Define project" },
+      { label: "Assign team" },
+      {
+        label: "Map project",
+        error: "Please select a location",
+        isError: areNoFeaturesSelected,
+      },
+    ];
   };
 
   const getStepContent = step => {
@@ -233,6 +241,8 @@ const NewProjectView = () => {
     if (sumFeaturesSelected(selectedLayerIds) === 0) {
       setAreNoFeaturesSelected(true);
       return;
+    } else {
+      setAreNoFeaturesSelected(false);
     }
 
     // Change the initial state...
@@ -286,12 +296,16 @@ const NewProjectView = () => {
               <Divider />
               <CardContent>
                 <Stepper activeStep={activeStep}>
-                  {steps.map((label, index) => {
+                  {steps.map((step, index) => {
                     const stepProps = {};
                     const labelProps = {};
                     return (
-                      <Step key={label} {...stepProps}>
-                        <StepLabel {...labelProps}>{label}</StepLabel>
+                      <Step key={step.label} {...stepProps}>
+                        {step.isError ? (
+                          <StepLabel error={true}>{step.error}</StepLabel>
+                        ) : (
+                          <StepLabel {...labelProps}>{step.label}</StepLabel>
+                        )}
                       </Step>
                     );
                   })}

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -19,8 +19,8 @@ import DefineProjectForm from "./DefineProjectForm";
 import NewProjectTeam from "./NewProjectTeam";
 import NewProjectMap from "./NewProjectMap";
 import Page from "src/components/Page";
-import { useMutation, gql } from "@apollo/client";
-import { ADD_PROJECT_PERSONNEL } from "../../../queries/project";
+import { useMutation } from "@apollo/client";
+import { ADD_PROJECT, ADD_PROJECT_PERSONNEL } from "../../../queries/project";
 import { filterObjectByKeys } from "../../../utils/materialTableHelpers";
 import { sumFeaturesSelected } from "../../../utils/mapHelpers";
 
@@ -95,7 +95,15 @@ const NewProjectView = () => {
     type: "FeatureCollection",
     features: [],
   });
+
   const [areNoFeaturesSelected, setAreNoFeaturesSelected] = useState(false);
+
+  // Reset areNoFeatures once a feature is selected
+  useEffect(() => {
+    if (sumFeaturesSelected(selectedLayerIds) > 0) {
+      setAreNoFeaturesSelected(false);
+    }
+  }, [selectedLayerIds]);
 
   const getSteps = () => {
     return [
@@ -175,55 +183,7 @@ const NewProjectView = () => {
     setActiveStep(0);
   };
 
-  const addNewProject = gql`
-    mutation MyMutation(
-      $project_name: String! = ""
-      $project_description: String! = ""
-      $current_phase: String! = ""
-      $current_status: String! = ""
-      $eCapris_id: String! = ""
-      $fiscal_year: String! = ""
-      $start_date: date = ""
-      $capitally_funded: Boolean! = false
-      $project_priority: String! = ""
-      $project_extent_ids: jsonb = {}
-      $project_extent_geojson: jsonb = {}
-    ) {
-      insert_moped_project(
-        objects: {
-          project_name: $project_name
-          project_description: $project_description
-          current_phase: $current_phase
-          current_status: $current_status
-          eCapris_id: $eCapris_id
-          fiscal_year: $fiscal_year
-          start_date: $start_date
-          capitally_funded: $capitally_funded
-          project_priority: $project_priority
-          project_extent_ids: $project_extent_ids
-          project_extent_geojson: $project_extent_geojson
-        }
-      ) {
-        affected_rows
-        returning {
-          project_id
-          project_name
-          project_description
-          project_priority
-          current_phase
-          current_status
-          eCapris_id
-          fiscal_year
-          capitally_funded
-          start_date
-          project_extent_ids
-          project_extent_geojson
-        }
-      }
-    }
-  `;
-
-  const [addProject] = useMutation(addNewProject);
+  const [addProject] = useMutation(ADD_PROJECT);
 
   const [addStaff] = useMutation(ADD_PROJECT_PERSONNEL);
 

--- a/moped-editor/src/views/projects/newProjectView/ProjectSaveButton.js
+++ b/moped-editor/src/views/projects/newProjectView/ProjectSaveButton.js
@@ -56,6 +56,7 @@ export default function ProjectSaveButton({
   loading,
   success,
   handleButtonClick,
+  disabled,
 }) {
   const classes = useStyles();
 
@@ -69,7 +70,7 @@ export default function ProjectSaveButton({
         variant="contained"
         color="primary"
         className={buttonClassname}
-        disabled={loading && !success}
+        disabled={(loading && !success) || disabled}
         onClick={success ? null : handleButtonClick}
       >
         {success ? <Icon>check</Icon> : label}


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5376

This PR makes the following updates: 

1. Require at least one line selected (used this MUI pattern https://material-ui.com/components/steppers/#non-linear-error-step)
2. Sentence case in "Map project"
3. Remove "Polygon ID" hover
4. Set map extent to match to project extent when edit panel opens

### New Project stepper warns and disables submission if no features selected in map
![validateLocation](https://user-images.githubusercontent.com/37249039/110175519-8055c280-7dc7-11eb-8763-9246aec80ae9.gif)

### Map fits to feature collection on edit
![zoomOnEdit](https://user-images.githubusercontent.com/37249039/110175778-ecd0c180-7dc7-11eb-96c8-50badf24aa39.gif)

### Map fits to feature collection in new project stepper
![zoomInStepper](https://user-images.githubusercontent.com/37249039/110176094-6c5e9080-7dc8-11eb-9d06-8184518c4070.gif)

### Sentence case
<img width="340" alt="sentenceCaseMap" src="https://user-images.githubusercontent.com/37249039/110175607-aed39d80-7dc7-11eb-9c8a-85e794e83091.png">
