### PR TITLE
Make "Project name" editable on Project summary page #5378

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -1,0 +1,194 @@
+import React, { useState } from "react";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import { Grid, Icon, Snackbar, TextField, Typography } from "@material-ui/core";
+import { gql, useMutation } from "@apollo/client";
+import { Alert } from "@material-ui/lab";
+
+/**
+ * GridTable Style
+ */
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: "100%",
+  },
+  paper: {
+    width: "100%",
+    marginBottom: theme.spacing(2),
+  },
+  editIcon: {
+    cursor: "pointer",
+    marginLeft: "8px",
+  },
+  editIconConfirm: {
+    cursor: "pointer",
+    marginTop: "16px",
+    fontSize: "2rem",
+  },
+  titleEditField: {
+    "font-size": "1.5rem",
+    "font-weight": "bold",
+  },
+}));
+
+const ProjectNameEditable = props => {
+  const classes = useStyles();
+
+  const DEFAULT_SNACKBAR_STATE = {
+    open: false,
+    message: null,
+    severity: "success",
+  };
+
+  const initialProjectName = props?.projectName;
+  const [showEditIcon, setShowEditIcon] = useState(false);
+  const [projectName, setProjectName] = useState(initialProjectName);
+  const [isEditing, setIsEditing] = useState(false);
+  const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
+
+  const updateProjectNameQuery = gql`
+    mutation UpdateProjectName($projectId: Int!, $projectName: String!) {
+      update_moped_project(
+        where: { project_id: { _eq: $projectId } }
+        _set: { project_name: $projectName }
+      ) {
+        affected_rows
+      }
+    }
+  `;
+
+  const [updateProjectName] = useMutation(updateProjectNameQuery);
+
+  const handleMouseEnter = () => {
+    setShowEditIcon(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowEditIcon(false);
+  };
+
+  const handleProjectNameChange = e => {
+    setProjectName(e.target.value);
+  };
+
+  /**
+   * Makes the update via GraphQL
+   */
+  const handleAcceptClick = e => {
+    e.preventDefault();
+    updateProjectName({
+      variables: {
+        projectId: props?.projectId,
+        projectName: projectName,
+      },
+    })
+      .then(res => {
+        setSnackbarState({
+          open: true,
+          message: <span>Success! the project name has been updated!</span>,
+          severity: "success",
+        });
+      })
+      .catch(err => {
+        setSnackbarState({
+          open: true,
+          message: <span>There was a problem updating the project name.</span>,
+          severity: "error",
+        });
+        setProjectName(initialProjectName);
+      })
+      .finally(() => {
+        setIsEditing(false);
+        setTimeout(() => setSnackbarState(DEFAULT_SNACKBAR_STATE), 3000);
+      });
+  };
+
+  /**
+   * Handles closing the edit mode
+   * @param {ChangeEvent} e - HTML DOM Event
+   */
+  const handleCancelClick = e => {
+    e.preventDefault();
+    setIsEditing(false);
+    setProjectName(initialProjectName);
+  };
+
+  const handleSnackbarClose = () => {
+    setSnackbarState(DEFAULT_SNACKBAR_STATE);
+  };
+
+  return (
+    <>
+      {isEditing && (
+        <form onSubmit={e => handleAcceptClick(e)}>
+          <Grid container fullWidth>
+            <Grid item xs={12} sm={9}>
+              <TextField
+                fullWidth
+                id="date"
+                label={"Project Name"}
+                type="text"
+                defaultValue={projectName ?? props?.projectName}
+                placeholder={"Enter project name"}
+                multiline={false}
+                rows={1}
+                onChange={e => handleProjectNameChange(e)}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                InputProps={{
+                  classes: {
+                    input: classes.titleEditField,
+                  },
+                }}
+              />
+            </Grid>
+            <Grid item xs={12} sm={3} className={classes.fieldGridItemButtons}>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={handleAcceptClick}
+              >
+                check
+              </Icon>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={e => handleCancelClick(e)}
+              >
+                close
+              </Icon>
+            </Grid>
+          </Grid>
+        </form>
+      )}
+      {!isEditing && (
+        <Typography
+          color="textPrimary"
+          variant="h2"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          {projectName}
+          {showEditIcon && props?.editable && (
+            <Icon
+              className={classes.editIcon}
+              onClick={() => setIsEditing(true)}
+            >
+              create
+            </Icon>
+          )}
+        </Typography>
+      )}
+      <Snackbar
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
+        open={snackbarState.open}
+        onClose={handleSnackbarClose}
+        key={"datatable-snackbar"}
+      >
+        <Alert onClose={handleSnackbarClose} severity={snackbarState.severity}>
+          {snackbarState.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default ProjectNameEditable;

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -42,6 +42,7 @@ const ProjectNameEditable = props => {
   const initialProjectName = props?.projectName;
   const [showEditIcon, setShowEditIcon] = useState(false);
   const [projectName, setProjectName] = useState(initialProjectName);
+  const [projectNameBeforeEdit, setProjectNameBeforeEdit] = useState(projectName);
   const [isEditing, setIsEditing] = useState(false);
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
 
@@ -82,6 +83,7 @@ const ProjectNameEditable = props => {
       },
     })
       .then(res => {
+        setProjectNameBeforeEdit(projectName);
         setSnackbarState({
           open: true,
           message: <span>Success! the project name has been updated!</span>,
@@ -89,6 +91,7 @@ const ProjectNameEditable = props => {
         });
       })
       .catch(err => {
+        setProjectName(projectNameBeforeEdit);
         setSnackbarState({
           open: true,
           message: <span>There was a problem updating the project name.</span>,
@@ -109,7 +112,7 @@ const ProjectNameEditable = props => {
   const handleCancelClick = e => {
     e.preventDefault();
     setIsEditing(false);
-    setProjectName(initialProjectName);
+    setProjectName(projectNameBeforeEdit);
   };
 
   const handleSnackbarClose = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -14,7 +14,6 @@ import {
   AppBar,
   Tab,
   Tabs,
-  Typography,
   CardActions,
 } from "@material-ui/core";
 
@@ -27,6 +26,7 @@ import TabPanel from "./TabPanel";
 import { PROJECT_NAME } from "../../../queries/project";
 import ProjectActivityLog from "./ProjectActivityLog";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
+import ProjectNameEditable from "./ProjectNameEditable";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -103,9 +103,11 @@ const ProjectView = () => {
             ) : (
               <div className={classes.root}>
                 <Box p={4} pb={2}>
-                  <Typography color="textPrimary" variant="h2">
-                    {data.moped_project[0].project_name}
-                  </Typography>
+                  <ProjectNameEditable
+                    projectName={data.moped_project[0].project_name}
+                    projectId={projectId}
+                    editable={true}
+                  />
                 </Box>
                 <Divider />
                 <AppBar position="static">


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5378

Live Demo:
https://deploy-preview-233--atd-moped-main.netlify.app/moped/session/signin

What to expect:
- Mouse hover shows edit icon
- User can accept or cancel the operation
- The user can use the mouse to save, or hit the Enter button in the keyboard.


![2021-03-07_22-36-27 (1)](https://user-images.githubusercontent.com/5282430/110274946-ad57d000-7f95-11eb-82d9-08616a30a5f7.gif)
