### PR TITLE
add form validation and disable default enter key behavior

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -4,7 +4,7 @@ import { useQuery, useMutation } from "@apollo/client";
 // Material
 import { CircularProgress, TextField, Typography } from "@material-ui/core";
 import { Clear as ClearIcon } from "@material-ui/icons";
-import MaterialTable from "material-table";
+import MaterialTable, { MTableEditRow } from "material-table";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { filterObjectByKeys } from "../../../utils/materialTableHelpers";
 import typography from "../../../theme/typography";
@@ -93,6 +93,7 @@ const ProjectTeamTable = ({
       title: "Name",
       field: "user_id",
       render: personnel => getPersonnelName(personnel.user_id),
+      validate: rowData => !!rowData.user_id,
       editComponent: props => (
         <Autocomplete
           id="user_id"
@@ -116,6 +117,7 @@ const ProjectTeamTable = ({
       title: "Role",
       field: "role_id",
       render: personnel => roles[personnel.role_id],
+      validate: rowData => !!rowData.role_id,
       editComponent: props => (
         <Autocomplete
           id="role_id"
@@ -216,6 +218,13 @@ const ProjectTeamTable = ({
     <ApolloErrorHandler errors={error}>
       <MaterialTable
         columns={columns}
+        components={{
+          EditRow: (props, rowData) => <MTableEditRow {...props} onKeyDown={(e) => {
+              if (e.keyCode === 13) {
+                // Bypass default MaterialTable behavior of submitting the entire form when a user hits enter
+              }
+          }} />
+        }}
         data={isNewProject ? personnelState : personnel}
         title="Project team"
         options={{


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5452

- Adds form validation so a user can't submit a new team member without a username or role
- Disables default MaterialTable enter key behavior so hitting enter on a single field doesn't submit the whole form (this had to be done because MaterialTable's form validation is overridden when a user hits enter)

There's still a minor UX bump in that without being able to submit a form with the enter key, the user has to click the "save" button. Still better than a nasty error! Solution would be to reenable default enter key behavior when user_id and role_id are populated. Haven't had a chance to figure that out yet but wanted to get this submitted in time for the release! Happy to take a crack at it if there's more time.