### PR TITLE
Project Activity Feed | Improve fields displayed in activity log details from personnel table

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -280,5 +280,11 @@ export const PROJECT_ACTIVITY_LOG_DETAILS = gql`
         user_id
       }
     }
+    activity_log_lookup_tables: moped_activity_log(
+      where: { activity_id: { _eq: $activityId } }
+      distinct_on: record_type
+    ) {
+      record_type
+    }
   }
 `;

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -99,7 +99,7 @@ export function useActivityLogLookupTables() {
   const getLookups = (response, lookupDataKey) => {
     const recordTableNames = getActivityLogTableNames(response, lookupDataKey);
     const { query, areLookups, tablesMap } = buildLookupQuery(recordTableNames);
-    console.log(tablesMap);
+
     setLookupObject({ query, areLookups, tablesMap });
   };
 

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -97,6 +97,8 @@ export function useActivityLogLookupTables() {
    * @param {string} lookupDataKey - The key in the response whose values is the lookup data
    */
   const getLookups = (response, lookupDataKey) => {
+    debugger;
+
     const recordTableNames = getActivityLogTableNames(response, lookupDataKey);
     const { query, areLookups, tablesMap } = buildLookupQuery(recordTableNames);
 

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -97,8 +97,6 @@ export function useActivityLogLookupTables() {
    * @param {string} lookupDataKey - The key in the response whose values is the lookup data
    */
   const getLookups = (response, lookupDataKey) => {
-    debugger;
-
     const recordTableNames = getActivityLogTableNames(response, lookupDataKey);
     const { query, areLookups, tablesMap } = buildLookupQuery(recordTableNames);
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
@@ -116,6 +116,12 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
     }
   };
 
+  const generateLookupValue = (value, field, recordType) => {
+    const lookupValue = lookupMap?.[recordType]?.[field]?.[value];
+
+    return !!lookupValue ? <>{String(lookupValue)}</> : null;
+  };
+
   const generateValue = value => {
     return value === null || String(value).trim() === "" ? (
       <span className={classes.listColorGray}>Null</span>
@@ -160,7 +166,11 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
                         : classes.listColorBlack
                     }
                   >
-                    {generateValue(recordState[field])}
+                    {generateLookupValue(
+                      recordState[field],
+                      field,
+                      recordType
+                    ) || generateValue(recordState[field])}
                   </span>
                 }
                 secondary={

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
@@ -116,11 +116,15 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
     }
   };
 
-  const generateLookupValue = (value, field, recordType) => {
-    const lookupValue = lookupMap?.[recordType]?.[field]?.[value];
-
-    return !!lookupValue ? <>{String(lookupValue)}</> : null;
-  };
+  /**
+   * Get lookup value by table name, field, and primary key value from lookup map or return null
+   * @param {string} value - The primary key id from the lookup table
+   * @param {string} field - The name from the lookup table
+   * @param {string} recordType - The table name of the lookup table
+   * @return {string|null} The value translated through the lookup table or null if not found
+   */
+  const generateLookupValue = (value, field, recordType) =>
+    lookupMap?.[recordType]?.[field]?.[value] || null;
 
   const generateValue = value => {
     return value === null || String(value).trim() === "" ? (

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
+import { useActivityLogLookupTables } from "../../../utils/activityLogHelpers";
 
 import {
   AppBar,
@@ -69,10 +70,18 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
   const classes = useStyles();
 
+  const {
+    getLookups,
+    lookupLoading,
+    lookupError,
+    lookupMap,
+  } = useActivityLogLookupTables();
+
   const { loading, error, data } = useQuery(PROJECT_ACTIVITY_LOG_DETAILS, {
     variables: {
       activityId: activity_id,
     },
+    onCompleted: data => getLookups(data, "activity_log_lookup_tables"),
   });
 
   const [showDiffOnly, setShowDiffOnly] = useState(true);
@@ -108,7 +117,6 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
   };
 
   const generateValue = value => {
-
     return value === null || String(value).trim() === "" ? (
       <span className={classes.listColorGray}>Null</span>
     ) : (
@@ -204,7 +212,7 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
         </Toolbar>
       </AppBar>
       <div style={{ padding: "1rem" }}>
-        {loading ? (
+        {loading || lookupLoading ? (
           <CircularProgress />
         ) : (
           <Grid container spacing={3}>
@@ -322,6 +330,7 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
           </Grid>
         )}
         {error && <div>{error}</div>}
+        {lookupError && <div>{lookupError}</div>}
       </div>
     </Dialog>
   );


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5285

This PR updates the `PROJECT_ACTIVITY_LOG_DETAILS` query and adds a helper to the`ProjectActivityLogDialog` component to use lookup tables to translate values in the project activity log details view.

Example with some team member and team role changes: https://deploy-preview-242--atd-moped-main.netlify.app/moped/projects/183?tab=activity_log

### Details view with lookups
![Screen Shot 2021-03-12 at 3 17 10 PM](https://user-images.githubusercontent.com/37249039/111000379-90c9e800-8347-11eb-91ff-598a59d628fc.png)
