### PR TITLE
[Bug] File uploads do not show in the activity log #5544

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -1292,7 +1292,7 @@ export const ProjectActivityLogTableMaps = {
       file_description: {
         icon: "",
         label: "Description",
-        data_type: "date",
+        data_type: "text",
       },
       file_size: {
         icon: "",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -1291,7 +1291,7 @@ export const ProjectActivityLogTableMaps = {
       },
       file_description: {
         icon: "",
-        label: "Day",
+        label: "Description",
         data_type: "date",
       },
       file_size: {
@@ -1384,6 +1384,21 @@ export const ProjectActivityLogOperationMaps = {
     },
   },
 
+  moped_project_files: {
+    DELETE: {
+      label: "Deleted",
+      icon: "close",
+    },
+    INSERT: {
+      label: "Added",
+      icon: "description",
+    },
+    UPDATE: {
+      label: "Updated",
+      icon: "create",
+    },
+  },
+
   generic: {
     DELETE: {
       label: "Deleted",
@@ -1427,6 +1442,9 @@ export const ProjectActivityLogCreateDescriptions = {
         .replace(/\w\S*/g, w => w.replace(/^\w/, c => c.toUpperCase()));
       return `'${phaseName}' as Project Phase with start date as '${recordData.phase_start}' and end date as '${recordData.phase_end}'`;
     },
+  },
+  moped_project_files: {
+    label: record => `New file '${record.record_data.event.data.new.file_name}'`,
   },
   generic: {
     label: () => "Added",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5544

Live Demo:
https://5544-sg-fileuploads-activitylog--atd-moped-main.netlify.app/moped/projects/164?tab=activity_log


Look! The file uploads are showing nicely:

<img width="1129" alt="2021-03-18_17-50-27" src="https://user-images.githubusercontent.com/5282430/111707754-a1c89c80-8812-11eb-937e-02ba3f2da547.png">
