### PR TITLE
Configure activity feed timestamps to display to users in CDT #5543

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -14380,6 +14380,11 @@
         }
       }
     },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -58,6 +58,7 @@
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "lodash.toarray": "^4.4.0",
+    "luxon": "^1.26.0",
     "material-table": "^1.69.2",
     "moment": "^2.29.1",
     "nprogress": "^0.2.0",

--- a/moped-editor/src/config.js
+++ b/moped-editor/src/config.js
@@ -1,4 +1,7 @@
 export default {
+  user: {
+    timezoneOffset: new Date().getTimezoneOffset(),
+  },
   env: {
     APP_CLOUDFRONT: process.env.REACT_APP_AWS_CLOUDFRONT,
     APP_ENVIRONMENT: process.env.REACT_APP_HASURA_ENV,

--- a/moped-editor/src/utils/adjustedTimezoneDateTime.js
+++ b/moped-editor/src/utils/adjustedTimezoneDateTime.js
@@ -1,0 +1,9 @@
+import config from "../config";
+import { DateTime } from "luxon";
+
+/**
+ * Parses a SQL-Formatted date and adjusts for the current timezone offset in minutes
+ * @param {string} utcDate - The date being parsed
+ */
+export default utcDate =>
+  DateTime.fromISO(utcDate).minus({ minutes: config.user.timezoneOffset });

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
+import adjustedTimezoneDateTime from "../../../utils/adjustedTimezoneDateTime";
+import { DateTime } from "luxon";
 
 import {
   AppBar,
@@ -98,10 +100,10 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
   };
 
   const getDateTime = data => {
-    const date = data?.moped_activity_log[0]?.created_at;
+    const date = adjustedTimezoneDateTime(data?.moped_activity_log[0]?.created_at); // adjustedTimezoneDateTime(data?.moped_activity_log[0]?.created_at);
 
     try {
-      return new Date(date).toLocaleString();
+      return date.toLocaleString(DateTime.DATETIME_SHORT);
     } catch {
       return null;
     }


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5543

Live Demo:
https://deploy-preview-252--atd-moped-main.netlify.app/moped/projects/164?tab=activity_log

It works great now!

<img width="1392" alt="2021-03-19_11-19-25" src="https://user-images.githubusercontent.com/5282430/111811425-07fdff80-88a5-11eb-8fe0-5f3de4b526d2.png">
<img width="1467" alt="2021-03-19_11-19-13" src="https://user-images.githubusercontent.com/5282430/111811430-08969600-88a5-11eb-88fc-177a1940e49d.png">
