### PR TITLE
sets time zone to UTC when formatting for display

### DIFF
--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -188,7 +188,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
 
     switch (fieldType) {
       case "date":
-        formattedValue = new Date(formattedValue).toLocaleDateString();
+        formattedValue = new Date(formattedValue).toLocaleDateString('en-US', {timeZone: 'UTC'});
         break;
       case "boolean":
         formattedValue = formattedValue === true;
@@ -321,7 +321,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     return (
       <TextField
         fullWidth
-        id="date"
+        id="text"
         label={fieldConfig.label}
         type="text"
         defaultValue={editValue ?? initialValue}


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5682

Formatting display date using UTC fixes issue where incorrect date was rendered. Correct date is now rendered. @sergiogcx, can you please confirm this does not interfere with [this time zone-related PR you merged](https://github.com/cityofaustin/atd-moped/pull/254)?

https://user-images.githubusercontent.com/35410637/113343907-09441900-92f6-11eb-854f-7c66140c4170.mov