### PR TITLE
Move actions column index to the right on MaterialTable instances

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -231,6 +231,7 @@ const ProjectTeamTable = ({
         options={{
           search: false,
           rowStyle: { fontFamily: typography.fontFamily },
+          actionsColumnIndex: -1
         }}
         icons={{ Delete: ClearIcon }}
         editable={{

--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -263,6 +263,9 @@ const ProjectTimeline = () => {
                       }, 500);
                     }),
                 }}
+                options={{
+                  actionsColumnIndex: -1
+                }}
               />
             </div>
             <Box pt={2}>


### PR DESCRIPTION
PR that would move the actions column to the right when adding to the Project Team and Timeline tables

Associated with https://github.com/cityofaustin/atd-data-tech/issues/5375

Example:
<img width="1139" alt="Screen Shot 2021-04-08 at 4 54 27 PM" src="https://user-images.githubusercontent.com/35410637/114105158-e388b800-9891-11eb-8080-64254b9e38ae.png">
