### PR TITLE
Data Migration | Transform IMPD data to fit moped_proj_personnel table in Moped #5602

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2537,6 +2537,10 @@
 - table:
     schema: public
     name: moped_proj_personnel
+  object_relationships:
+  - name: moped_user
+    using:
+      foreign_key_constraint_on: user_id
   insert_permissions:
   - role: moped-admin
     permission:

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -88,6 +88,12 @@ export const TEAM_QUERY = gql`
       project_personnel_id
       date_added
       added_by
+      moped_user {
+        first_name
+        last_name
+        workgroup_id
+        user_id
+      }
     }
     moped_workgroup {
       workgroup_id
@@ -96,15 +102,6 @@ export const TEAM_QUERY = gql`
     moped_project_roles {
       project_role_id
       project_role_name
-    }
-    moped_users(
-      order_by: { last_name: asc }
-      where: { status_id: { _eq: 1 } }
-    ) {
-      first_name
-      last_name
-      workgroup_id
-      user_id
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -46,7 +46,6 @@ const ProjectTeamTable = ({
   if (loading || !data) return <CircularProgress />;
 
   // Get data from the team query payload
-  const users = data.moped_users;
   const personnel = {};
 
   // For each personnel entry...
@@ -88,14 +87,14 @@ const ProjectTeamTable = ({
   );
 
   // Options for Autocomplete form elements
-  const userIds = users.map(user => user.user_id);
+  const userIds = data.moped_proj_personnel.map(user => user.moped_user.user_id);
 
   /**
    * Get a user object from the users array
    * @param {number} id - User id from the moped project personnel row
    * @return {object} Object containing user data
    */
-  const getUserById = id => users.find(user => user.user_id === id);
+  const getUserById = id => data.moped_proj_personnel.find(user => user.moped_user.user_id === id)?.moped_user;
 
   /**
    * Get personnel name from their user ID


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5602

What this branch does is a necessary refactor for the actual migration happening in a different PR. Once the personnel is migrated, they are imported as inactive; however, this presents the projects team page with a problem because the graphql query excludes any inactive users causing the code to a WSOD. Also, I noticed this query gathers the entire list of active users, even if there is no personnel associated to a project, which is not performant or necessary.

** Tried renaming the branch name to have the same github issue number but GitHub it keeps nagging **