### PR TITLE
Moped Editor | Make The Project Search Feature Great Again #5830

### DIFF
--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -146,8 +146,35 @@ const GridTable = ({ title, query }) => {
   query.offset = pagination.offset;
   query.cleanWhere();
 
+  /**
+   * Attempts to retrieve a valid graphql search value, for example when searching on an
+   * integer/float field but providing it a string, this function returns the value configured
+   * in the invalidValueDefault field in the search object, or null.
+   * @param {string} column - The name of the column to search
+   * @param {*} value - The value in question
+   * @returns {*} - The value output
+   */
+  const getSearchValue = (column, value) => {
+    // Retrieve the type of field (string, float, int, etc)
+    const type = query.config.columns[column].type;
+    // Get the invalidValueDefault in the search config object
+    const invalidValueDefault = query.config.columns[column].search?.invalidValueDefault ?? null;
+
+    // If the type is number of float, attempt to parse as such
+    if(type === "number" || type === "float" || type === "double") {
+      value = Number.parseFloat(value) || invalidValueDefault;
+    }
+    // If integer, attempt to parse as integer
+    if(type === "int" || type === "integer") {
+      value = Number.parseInt(value)  || invalidValueDefault;
+    }
+    // Any other value types are pass-through for now
+    return value;
+  }
+
   // If we have a search, use the terms...
   if (search.value && search.value !== "") {
+
     /**
      * Iterate through all column keys, if they are searchable
      * add the to the Or list.
@@ -158,10 +185,12 @@ const GridTable = ({ title, query }) => {
         const { operator, quoted, envelope } = query.config.columns[
           column
         ].search;
-        const value = quoted
-          ? `"${envelope.replace("{VALUE}", search.value)}"`
-          : search.value;
-        query.setOr(column, `${operator}: ${value}`);
+        const searchValue = getSearchValue(column, search.value);
+        const graphqlSearchValue = quoted
+          ? `"${envelope.replace("{VALUE}", searchValue)}"`
+          : searchValue;
+
+        query.setOr(column, `${operator}: ${graphqlSearchValue}`);
       });
   }
 

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -156,16 +156,15 @@ const GridTable = ({ title, query }) => {
    */
   const getSearchValue = (column, value) => {
     // Retrieve the type of field (string, float, int, etc)
-    const type = query.config.columns[column].type;
+    const type = query.config.columns[column].type.toLowerCase();
     // Get the invalidValueDefault in the search config object
     const invalidValueDefault = query.config.columns[column].search?.invalidValueDefault ?? null;
-
     // If the type is number of float, attempt to parse as such
-    if(type === "number" || type === "float" || type === "double") {
+    if(["number", "float", "double"].includes(type)) {
       value = Number.parseFloat(value) || invalidValueDefault;
     }
     // If integer, attempt to parse as integer
-    if(type === "int" || type === "integer") {
+    if(["int", "integer"].includes(type)) {
       value = Number.parseInt(value)  || invalidValueDefault;
     }
     // Any other value types are pass-through for now

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -98,7 +98,7 @@ export const ProjectsListViewQueryConf = {
     ecapris_subproject_id: {
       hidden: false,
       searchable: true,
-      sortable: false,
+      sortable: true,
       label: "eCapris Subp.",
       filter: value => (
         <ExternalLink
@@ -106,12 +106,13 @@ export const ProjectsListViewQueryConf = {
           url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${value}`}
         />
       ),
-      type: "string",
+      type: "number",
       search: {
         label: "Search by eCapris subproject id",
         operator: "_eq",
-        quoted: true,
+        quoted: false,
         envelope: "%{VALUE}%",
+        invalidValueDefault: 0
       },
     },
   },


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5830

It appears that switching the ecapris_subproject_id type from string to number is breaking the code. This PR refactors the code so that whenever there is an unavoidable situation whenever we pass a string to a numeric field in a search it assumes a safe default value.

![2021-04-17_13-40-23 (1)](https://user-images.githubusercontent.com/5282430/115123419-93d97900-9f82-11eb-86b3-87a64e706f59.gif)
