### PR TITLE
Replaces the ecapris_subproject_id unique constraint with an unconstrained index

### DIFF
--- a/moped-database/migrations/1619024083593_ecapris_replace_constraint_with_index/down.sql
+++ b/moped-database/migrations/1619024083593_ecapris_replace_constraint_with_index/down.sql
@@ -1,0 +1,6 @@
+-- Drop the unconstrained index
+DROP INDEX moped_project_ecapris_subproject_id_index;
+
+-- Create the unique index constraint
+CREATE UNIQUE INDEX moped_project_ecapris_subproject_id_uindex
+    ON moped_project (ecapris_subproject_id);

--- a/moped-database/migrations/1619024083593_ecapris_replace_constraint_with_index/up.sql
+++ b/moped-database/migrations/1619024083593_ecapris_replace_constraint_with_index/up.sql
@@ -1,0 +1,6 @@
+-- Drop the unique index constraint
+DROP INDEX moped_project_ecapris_subproject_id_uindex;
+
+-- Create a new unconstrained index
+CREATE INDEX moped_project_ecapris_subproject_id_index
+    ON moped_project (ecapris_subproject_id);

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -14,7 +14,7 @@ export const ADD_PROJECT = gql`
     $project_description: String! = ""
     $current_phase: String! = ""
     $current_status: String! = ""
-    $ecapris_subproject_id: numeric! = ""
+    $ecapris_subproject_id: numeric
     $fiscal_year: String! = ""
     $start_date: date = ""
     $capitally_funded: Boolean! = false

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -85,7 +85,7 @@ const NewProjectView = () => {
     start_date: moment().format("YYYY-MM-DD"),
     current_status: "",
     capitally_funded: false,
-    ecapris_subproject_id: "",
+    ecapris_subproject_id: null,
   });
   const [nameError, setNameError] = useState(false);
   const [descriptionError, setDescriptionError] = useState(false);


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5881

Replaces the ecapris_subproject_id unique constraint with an unconstrained index and allows ecapris_subproject_id to have no value.

To test, use [this deploy preview environment](https://deploy-preview-288--atd-moped-main.netlify.app/moped) rather than the one associated with this PR. The one I linked here includes a fix for an unrelated bug for a better testing experience. Not that you can't test whether you can put in the same ID twice (unique constraint) in the deploy preview environment. You would have to locally run the [code that establishes that environment](https://github.com/cityofaustin/atd-moped/pull/288).