### PR TITLE
Bug | Handle saving a project when no team members are added

### DIFF
--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -228,23 +228,27 @@ const NewProjectView = () => {
       .then(response => {
         const { project_id } = response.data.insert_moped_project.returning[0];
 
-        const cleanedPersonnel = personnel
-          // We need to flatten (reverse the nesting) for role_ids
-          .map(item => {
-            // For every personnel, iterate through role_ids
-            return item.role_id.map(role_id => {
-              // build a new object with specific values
-              return {
-                role_id: role_id,
-                user_id: item.user_id,
-              };
-            });
-          })[0] // The array should be single
-          // Now we proceed as normal...
-          .map(row => ({
-            ...filterObjectByKeys(row, ["tableData"]),
-            project_id,
-          }));
+        // If personnel are added to the project, handle roles and remove unneeded data
+        const cleanedPersonnel =
+          personnel.length > 0
+            ? personnel
+                // We need to flatten (reverse the nesting) for role_ids
+                .map(item => {
+                  // For every personnel, iterate through role_ids
+                  return item.role_id.map(role_id => {
+                    // build a new object with specific values
+                    return {
+                      role_id: role_id,
+                      user_id: item.user_id,
+                    };
+                  });
+                })[0] // The array should be single
+                // Now we proceed as normal...
+                .map(row => ({
+                  ...filterObjectByKeys(row, ["tableData"]),
+                  project_id,
+                }))
+            : [];
 
         addStaff({
           variables: {


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5879

This PR updates the handling of project personnel records when saving a project through the new project stepper. Previously, if a project contained no personnel, the code tried to map over an `undefined` returned from referencing an invalid index of an empty array. Ex. [][0] => undefined => undefined.map() => `Uncaught TypeError: Cannot read property 'map' of undefined`. We probably haven't run into this bug before since we always add team members when demoing/testing.

To test:
1. Created a new project and be sure to add be sure to eCapris ID (to avoid the [eCapris ID error](https://github.com/cityofaustin/atd-data-tech/issues/5881))
2. Don't add any personnel
3. Select a feature
4. Save the project