### PR TITLE
Project Extent | Fix drawn layer select checkbox

### DIFF
--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -359,7 +359,7 @@ export const createProjectViewLayerConfig = (sourceName, visibleLayerIds) => {
   let layerStyleSpec =
     mapConfig.layerConfigs[sourceName]?.layerStyleSpec() ?? null;
 
-  if (!!visibleLayerIds) {
+  if (layerStyleSpec !== null && !!visibleLayerIds) {
     layerStyleSpec = {
       ...layerStyleSpec,
       layout: {

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -281,6 +281,7 @@ export const isFeaturePresent = (selectedFeature, features, layerName) => {
  * @param {String} hoveredId - The ID of the feature hovered
  * @param {String} sourceName - Source name to get config properties for layer styles
  * @param {Array} selectedLayerIds - Array of string IDs that a user has selected
+ * @param {Array} visibleLayerIds - Array of layer names that are visible and have checked boxes in the useLayerSelect UI
  * @return {Object} Mapbox layer style object
  */
 export const createProjectSelectLayerConfig = (
@@ -353,13 +354,18 @@ export const createSummaryMapLayers = geoJSON => {
  * @summary The fill color key's value below is a Mapbox "case" expression whose cases are
  * built in fillColorCases above. These cases use the sourceLayer and color values set in
  * layerConfigs to set colors of features in the projectExtent feature collection layer on the map.
- * @return {Object} Mapbox layer style object
+ * @param {string} sourceName - Source name to get config properties for layer styles
+ * @param {Array} visibleLayerIds - Array of layer names that are visible and have checked boxes in the useLayerSelect UI
+ * @return {object} Mapbox layer style object
  */
-export const createProjectViewLayerConfig = (sourceName, visibleLayerIds) => {
+export const createProjectViewLayerConfig = (
+  sourceName,
+  visibleLayerIds = null
+) => {
   let layerStyleSpec =
     mapConfig.layerConfigs[sourceName]?.layerStyleSpec() ?? null;
 
-  if (layerStyleSpec !== null && !!visibleLayerIds) {
+  if (!!layerStyleSpec && !!visibleLayerIds) {
     layerStyleSpec = {
       ...layerStyleSpec,
       layout: {

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -355,8 +355,22 @@ export const createSummaryMapLayers = geoJSON => {
  * layerConfigs to set colors of features in the projectExtent feature collection layer on the map.
  * @return {Object} Mapbox layer style object
  */
-export const createProjectViewLayerConfig = id =>
-  mapConfig.layerConfigs[id]?.layerStyleSpec() ?? null;
+export const createProjectViewLayerConfig = (sourceName, visibleLayerIds) => {
+  let layerStyleSpec =
+    mapConfig.layerConfigs[sourceName]?.layerStyleSpec() ?? null;
+
+  if (!!visibleLayerIds) {
+    layerStyleSpec = {
+      ...layerStyleSpec,
+      layout: {
+        ...layerStyleSpec.layout,
+        visibility: visibleLayerIds.includes(sourceName) ? "visible" : "none",
+      },
+    };
+  }
+
+  return layerStyleSpec;
+};
 
 /**
  * Build the JSX of the hover tooltip on map

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -222,7 +222,10 @@ const NewProjectMap = ({
             >
               <Layer
                 key={config.layerIdName}
-                {...createProjectViewLayerConfig(config.layerIdName)}
+                {...createProjectViewLayerConfig(
+                  config.layerIdName,
+                  visibleLayerIds
+                )}
               />
             </Source>
           )


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/5862

This PR updates the `createProjectViewLayerConfig` helper to consider the `visibleLayerIds` array of layer ID names exposed by `useLayerSelect`. If a layer name is in the array, the `visibility` property of the layer's style spec is set to `visible`. Oppositely, the `visibility` property is set to `none` if the layer name is not present in the array. The checkbox UI adds and removes the layer ID names from the `visibleLayerIds` when a user toggles the checkboxes.

This can be tested on https://deploy-preview-291--atd-moped-main.netlify.app/moped/projects/159 by clicking on the Edit button on the map and then toggling the "Drawn" checkbox.

#### Toggle drawn point layer
![toggleDrawnPoints](https://user-images.githubusercontent.com/37249039/115920722-32148580-a440-11eb-8a38-94ac137be0cb.gif)
