### PR TITLE
[Bug] Map error handler not rendering on projects without locations #6228

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -49,10 +49,20 @@ const ProjectSummaryMap = ({ projectExtentGeoJSON, setIsEditing }) => {
 
   /**
    * Updates viewport on zoom, scroll, and other events
-   * @param {Object} viewport - Mapbox object that stores properties of the map view
+   * @param {Object} updatedViewPort - Mapbox object that stores properties of the map view
    */
-  const handleViewportChange = viewport => setViewport(viewport);
+  const handleViewportChange = updatedViewPort => setViewport(updatedViewPort);
 
+  /**
+   * Let's throw an error intentionally if there are no features for a project.
+   */
+  if(featureCount < 1) {
+    throw Error("Map error: Cannot render or edit maps with no features");
+  }
+
+  /**
+   * If we do have features, proceed to render map.
+   */
   return (
     <Box>
       <ReactMapGL


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6228

Forces the component to throw an error if there are no features to render.

** Test with moped-test or local environment, which include projects without features.