### PR TITLE
Sets project name as HTML page title rather than "Project Summary Page"

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -272,7 +272,11 @@ const ProjectView = () => {
 
   return (
     <ApolloErrorHandler error={error}>
-      <Page title={loading ? "Project Summary Page" : data.moped_project[0].project_name}>
+      <Page
+        title={
+          loading ? "Project Summary Page" : data.moped_project[0].project_name
+        }
+      >
         <Container maxWidth="xl">
           <Card className={classes.cardWrapper}>
             {loading ? (

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -272,7 +272,7 @@ const ProjectView = () => {
 
   return (
     <ApolloErrorHandler error={error}>
-      <Page title="Project Summary Page">
+      <Page title={loading ? "Project Summary Page" : data.moped_project[0].project_name}>
         <Container maxWidth="xl">
           <Card className={classes.cardWrapper}>
             {loading ? (


### PR DESCRIPTION
- Fixes https://github.com/cityofaustin/atd-data-tech/issues/5355
- Fully testable in the Netlify deploy preview environment

<img width="1440" alt="Screen Shot 2021-06-03 at 5 09 44 PM" src="https://user-images.githubusercontent.com/35410637/120718216-8cb4ee80-c48e-11eb-94c6-6cf5021e779e.png">
