### PR TITLE
Add project status to advanced filters

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -10,7 +10,7 @@ export const ProjectsListViewFiltersConf = {
   fields: [
     {
       name: "project_name",
-      label: "Project Name",
+      label: "Project name",
       placeholder: "Enter project name",
       type: "string",
       defaultOperator: "string_contains_case_insensitive",
@@ -24,7 +24,7 @@ export const ProjectsListViewFiltersConf = {
     },
     {
       name: "project_description",
-      label: "Project Description",
+      label: "Project description",
       placeholder: "Enter project description",
       type: "string",
       defaultOperator: "string_contains_case_insensitive",
@@ -48,7 +48,7 @@ export const ProjectsListViewFiltersConf = {
     },
     {
       name: "start_date",
-      label: "Start Date",
+      label: "Start date",
       placeholder: "Select date",
       type: "date",
       operators: [
@@ -56,8 +56,19 @@ export const ProjectsListViewFiltersConf = {
       ],
     },
     {
+      name: "current_status",
+      label: "Currrent status",
+      placeholder: "Current status",
+      type: "string",
+      operators: [
+        "string_contains_case_insensitive",
+        "string_begins_with_case_insensitive",
+        "string_ends_with_case_insensitive",
+      ],
+    },
+    {
       name: "current_phase",
-      label: "Currrent Phase",
+      label: "Currrent phase",
       placeholder: "Current phase",
       type: "string",
       operators: [
@@ -70,7 +81,7 @@ export const ProjectsListViewFiltersConf = {
     },
     {
       name: "project_team_members",
-      label: "Team Member",
+      label: "Team member",
       placeholder: "Team member",
       type: "string",
       operators: [


### PR DESCRIPTION
Add project status to advanced filters option. I also changed the labels to sentence case. 

Note, project statuses have spaces removed when displayed in the chip. For example, "on hold" is seen as "onhold". If you are searching for "onhold" you will not get any resuts. 

https://6272-add-status-to-filters--atd-moped-main.netlify.app/moped?filter=eyJiNDhlYTUwNi02YTc0LTQ1YjAtOTYwZC05MDI1NDNmNTA3ZDkiOnsiaWQiOiJiNDhlYTUwNi02YTc0LTQ1YjAtOTYwZC05MDI1NDNmNTA3ZDkiLCJmaWVsZCI6ImN1cnJlbnRfc3RhdHVzIiwib3BlcmF0b3IiOiJzdHJpbmdfY29udGFpbnNfY2FzZV9pbnNlbnNpdGl2ZSIsImF2YWlsYWJsZU9wZXJhdG9ycyI6W3sib3BlcmF0b3IiOiJfaWxpa2UiLCJsYWJlbCI6ImNvbnRhaW5zIiwiZGVzY3JpcHRpb24iOiJTdHJpbmcgaXMgY29udGFpbmVkIGluIGZpZWxkIChjYXNlLWluc2Vuc2l0aXZlKSIsImVudmVsb3BlIjoiJXtWQUxVRX0lIiwidHlwZSI6InN0cmluZyIsImlkIjoic3RyaW5nX2NvbnRhaW5zX2Nhc2VfaW5zZW5zaXRpdmUifSx7Im9wZXJhdG9yIjoiX2lsaWtlIiwibGFiZWwiOiJiZWdpbnMgd2l0aCIsImRlc2NyaXB0aW9uIjoiRmllbGQgY29udGVudCBiZWdpbnMgd2l0aCBzdHJpbmcgKGNhc2UtaW5zZW5zaXRpdmUpIiwiZW52ZWxvcGUiOiJ7VkFMVUV9JSIsInR5cGUiOiJzdHJpbmciLCJpZCI6InN0cmluZ19iZWdpbnNfd2l0aF9jYXNlX2luc2Vuc2l0aXZlIn0seyJvcGVyYXRvciI6Il9pbGlrZSIsImxhYmVsIjoiZW5kcyB3aXRoIiwiZGVzY3JpcHRpb24iOiJGaWVsZCBjb250ZW50IGVuZHMgd2l0aCBzdHJpbmcgKGNhc2UtaW5zZW5zaXRpdmUpIiwiZW52ZWxvcGUiOiIle1ZBTFVFfSIsInR5cGUiOiJzdHJpbmciLCJpZCI6InN0cmluZ19lbmRzX3dpdGhfY2FzZV9pbnNlbnNpdGl2ZSJ9XSwiZ3FsT3BlcmF0b3IiOiJfaWxpa2UiLCJlbnZlbG9wZSI6IiV7VkFMVUV9JSIsInBsYWNlaG9sZGVyIjoiQ3VycmVudCBzdGF0dXMiLCJ2YWx1ZSI6ImFjdGl2ZSIsInR5cGUiOiJzdHJpbmcifX0=