### PR TITLE
Update Cognito account-creation emails to users #6219

### DIFF
--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -99,7 +99,7 @@ def user_create_user(claims: list) -> (Response, int):
                 UserPoolId=USER_POOL,
                 Username=email,
                 TemporaryPassword=password,
-                MessageAction="SUPPRESS"
+                MessageAction="SUPPRESS",
                 UserAttributes=[
                     {"Name": "email", "Value": email},
                     {"Name": "email_verified", "Value": "true"},

--- a/moped-api/users/users.py
+++ b/moped-api/users/users.py
@@ -99,6 +99,7 @@ def user_create_user(claims: list) -> (Response, int):
                 UserPoolId=USER_POOL,
                 Username=email,
                 TemporaryPassword=password,
+                MessageAction="SUPPRESS"
                 UserAttributes=[
                     {"Name": "email", "Value": email},
                     {"Name": "email_verified", "Value": "true"},


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6219

** Can only be tested locally with postman, API change only.

From the [boto documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.admin_create_user): 

>MessageAction (string) -- Set to "RESEND" to resend the invitation message to a user that already exists and reset the expiration limit on the user's account. Set to "SUPPRESS" to suppress sending the message. Only one value can be specified.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.admin_create_user