### PR TITLE
Remove password reset UI from account page #6220

### DIFF
--- a/moped-editor/src/views/account/AccountView/AccountView.js
+++ b/moped-editor/src/views/account/AccountView/AccountView.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Container, Grid, makeStyles } from "@material-ui/core";
 import Page from "src/components/Page";
 import Profile from "./Profile";
-import ProfileDetails from "./ProfileDetails";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -22,9 +21,6 @@ const Account = () => {
         <Grid container spacing={3}>
           <Grid item lg={4} md={6} xs={12}>
             <Profile />
-          </Grid>
-          <Grid item lg={8} md={6} xs={12}>
-            <ProfileDetails />
           </Grid>
         </Grid>
       </Container>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6620

Live demo:
https://deploy-preview-349--atd-moped-main.netlify.app/moped/account

** UI change only, Can be tested in Netlify, Moped-test, or locally

In the code we simply remove ProfileDetails component from AccountView 
<img width="1597" alt="2021-06-17_13-42-46" src="https://user-images.githubusercontent.com/5282430/122447680-9a2ba780-cf69-11eb-9a9c-c5def8e646bc.png">

