### PR TITLE
Prevent filter null failure when making new project

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -120,10 +120,11 @@ const ProjectView = () => {
   const { projectId } = useParams();
   let query = useQueryParams();
   const classes = useStyles();
-  const previousFilters = useLocation().state.filters;
-  const allProjectsLink = previousFilters
+  const previousFilters = useLocation()?.state?.filters;
+  const allProjectsLink = !!previousFilters
     ? `/moped/projects?filter=${previousFilters}`
     : "/moped/projects";
+
 
   // Get the tab query string value and associated tab index.
   // If there's no query string, default to first tab in TABS array


### PR DESCRIPTION
Fixes bug introduced by breadcrumbs update

In theory object returned by useLocation() should always include state, but using the optional chaining there too, because one never knows. 
<img width="1679" alt="2021-06-25_16-36-01" src="https://user-images.githubusercontent.com/12474808/123484684-61757900-d5ce-11eb-9451-226743067578.png">

