### PR TITLE
Prevent edit/delete comment icons from appearing if not comment creator

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2549,6 +2549,7 @@
       - comm_id
       - project_id
       - status_id
+      - added_by_user_id
       backend_only: false
   - role: moped-editor
     permission:
@@ -2561,6 +2562,7 @@
       - status_id
       - comm_id
       - project_id
+      - added_by_user_id
       backend_only: false
   select_permissions:
   - role: moped-admin
@@ -2573,6 +2575,7 @@
       - project_note
       - date_created
       - status_id
+      - added_by_user_id
       filter: {}
       allow_aggregations: true
   - role: moped-editor
@@ -2585,6 +2588,7 @@
       - project_note
       - date_created
       - status_id
+      - added_by_user_id
       filter: {}
       allow_aggregations: true
   - role: moped-viewer
@@ -2597,6 +2601,7 @@
       - comm_id
       - project_id
       - status_id
+      - added_by_user_id
       filter: {}
       allow_aggregations: true
   update_permissions:
@@ -2610,6 +2615,7 @@
       - project_note
       - date_created
       - status_id
+      - added_by_user_id
       filter: {}
       check: null
   - role: moped-editor
@@ -2622,6 +2628,7 @@
       - project_note
       - date_created
       - status_id
+      - added_by_user_id
       filter: {}
       check: null
   event_triggers:

--- a/moped-database/migrations/1624984081574_alter_table_public_moped_proj_notes_add_column_added_by_user_id/down.sql
+++ b/moped-database/migrations/1624984081574_alter_table_public_moped_proj_notes_add_column_added_by_user_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_notes" DROP COLUMN "added_by_user_id";

--- a/moped-database/migrations/1624984081574_alter_table_public_moped_proj_notes_add_column_added_by_user_id/up.sql
+++ b/moped-database/migrations/1624984081574_alter_table_public_moped_proj_notes_add_column_added_by_user_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_proj_notes" ADD COLUMN "added_by_user_id" integer NOT NULL DEFAULT 1;

--- a/moped-editor/src/queries/comments.js
+++ b/moped-editor/src/queries/comments.js
@@ -7,6 +7,7 @@ export const COMMENTS_QUERY = gql`
       order_by: { date_created: asc }
     ) {
       added_by
+      added_by_user_id
       project_note
       project_id
       date_created

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -112,6 +112,7 @@ const ProjectComments = () => {
             project_note: DOMPurify.sanitize(noteText),
             project_id: projectId,
             status_id: 1,
+            added_by_user_id: Number(userSessionData.user_id),
           },
         ],
       },
@@ -203,28 +204,31 @@ const ProjectComments = () => {
                               )
                             }
                           />
-                          <ListItemSecondaryAction>
-                            {commentId !== item.project_note_id && (
+                          {userSessionData.user_id ===
+                            item.added_by_user_id && (
+                            <ListItemSecondaryAction>
+                              {commentId !== item.project_note_id && (
+                                <IconButton
+                                  edge="end"
+                                  aria-label="edit"
+                                  onClick={() =>
+                                    editComment(i, item.project_note_id)
+                                  }
+                                >
+                                  <EditIcon />
+                                </IconButton>
+                              )}
                               <IconButton
                                 edge="end"
-                                aria-label="edit"
+                                aria-label="delete"
                                 onClick={() =>
-                                  editComment(i, item.project_note_id)
+                                  submitDeleteComment(item.project_note_id)
                                 }
                               >
-                                <EditIcon />
+                                <DeleteIcon />
                               </IconButton>
-                            )}
-                            <IconButton
-                              edge="end"
-                              aria-label="delete"
-                              onClick={() =>
-                                submitDeleteComment(item.project_note_id)
-                              }
-                            >
-                              <DeleteIcon />
-                            </IconButton>
-                          </ListItemSecondaryAction>
+                            </ListItemSecondaryAction>
+                          )}
                         </ListItem>
                         {isNotLastItem && <Divider component="li" />}
                       </>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -19,7 +19,7 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import EditIcon from "@material-ui/icons/Edit";
 
 import { makeStyles } from "@material-ui/core/styles";
-import { getSessionDatabaseData } from "src/auth/user";
+import { getSessionDatabaseData, getHighestRole, useUser } from "src/auth/user";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import parse from "html-react-parser";
@@ -53,6 +53,8 @@ const useStyles = makeStyles(theme => ({
 
 const ProjectComments = () => {
   const { projectId } = useParams();
+  const { user } = useUser();
+  const userHighestRole = getHighestRole(user);
   const classes = useStyles();
   const userSessionData = getSessionDatabaseData();
   const [noteText, setNoteText] = useState("");
@@ -204,8 +206,10 @@ const ProjectComments = () => {
                               )
                             }
                           />
-                          {userSessionData.user_id ===
-                            item.added_by_user_id && (
+                          {// show edit/delete icons if comment authored by logged in user
+                          // or user is admin
+                          (userSessionData.user_id === item.added_by_user_id ||
+                            userHighestRole === "moped-admin") && (
                             <ListItemSecondaryAction>
                               {commentId !== item.project_note_id && (
                                 <IconButton


### PR DESCRIPTION
Database updates, so need to test on moped test or locally. 

Testing locally takes a bit of effort. I signed in and made some comments, signing in locally we are all JD. I changed the user_id in `src/auth/user.js` Line 104 to a different userid (ex, Mike Dilley is 8, Nathan Wilkes is 2). Sign out and sign back in and see the comments.  In this screenshot the user is Nathan. 

![Screen Shot 2021-06-29 at 3 49 51 PM](https://user-images.githubusercontent.com/12474808/123865583-b4626f80-d8f1-11eb-8e51-da3230006fcf.png)

I thought we had a similar issue in moped-test since when I logged in it says I am Patrick, but I see John has been able to leave comments as himself. 


edit -- now that I check for moped-admin status as well as who authored the comments, you have to sign in as the test-viewer (creds in 1password) to see if the icons are hidden. The user's highest role is based on whose password signed in, so changing the user_id in line 104 doesn't affect the role. 