### PR TITLE
Include moped version number in footer

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "licence": "CC0 1.0 Universal",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "homepage": "/moped",
   "private": false,
   "scripts": {

--- a/moped-editor/src/components/ExternalLink.js
+++ b/moped-editor/src/components/ExternalLink.js
@@ -2,11 +2,16 @@ import React from "react";
 import Link from "@material-ui/core/Link";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 
-const ExternalLink = ({ url, text }) => {
+const ExternalLink = ({ url, text, linkColor }) => {
   return (
     <span>
       {!!text ? (
-        <Link href={url} target="_blank" rel="noopener noreferrer">
+        <Link
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          color={linkColor ?? "primary"}
+        >
           {text}
           <OpenInNewIcon style={{ fontSize: 16 }} />
         </Link>

--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
-import { makeStyles } from "@material-ui/core";
+import { makeStyles, Typography } from "@material-ui/core";
 import NavBar from "./NavBar/NavBar";
 import TopBar from "./TopBar";
 import { useUser } from "../../auth/user";
+import ExternalLink from "../../components/ExternalLink";
+var pckg = require("../../../package.json");
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -29,7 +31,29 @@ const useStyles = makeStyles(theme => ({
     height: "100%",
     overflow: "auto",
   },
+  footer: {
+    paddingLeft: theme.spacing(4),
+    paddingBottom: theme.spacing(2),
+    color: "#1492ff",
+  },
 }));
+
+const Footer = () => {
+  const classes = useStyles();
+  console.log(pckg);
+  return (
+    <div className={classes.footer}>
+      <Typography variant="caption" color="textSecondary">
+        Moped{" "}
+        <ExternalLink
+          text={`v${pckg.version}`}
+          url={`https://github.com/cityofaustin/atd-moped/releases/tag/v${pckg.version}`}
+          linkColor="inherit"
+        />
+      </Typography>
+    </div>
+  );
+};
 
 const DashboardLayout = () => {
   const classes = useStyles();
@@ -41,14 +65,12 @@ const DashboardLayout = () => {
   return user ? (
     <div className={classes.root}>
       <TopBar onOpen={() => setOpen(true)} />
-      <NavBar
-        onClose={() => setOpen(false)}
-        isOpen={isOpen}
-      />
+      <NavBar onClose={() => setOpen(false)} isOpen={isOpen} />
       <div className={classes.wrapper}>
         <div className={classes.contentContainer}>
           <div className={classes.content}>
             <Outlet />
+            <Footer />
           </div>
         </div>
       </div>

--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -30,11 +30,6 @@ const useStyles = makeStyles(theme => ({
     height: "100%",
     overflow: "auto",
   },
-  footer: {
-    paddingLeft: theme.spacing(4),
-    paddingBottom: theme.spacing(2),
-    color: "#1492ff",
-  },
 }));
 
 const DashboardLayout = () => {

--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
-import { makeStyles, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core";
 import NavBar from "./NavBar/NavBar";
 import TopBar from "./TopBar";
 import { useUser } from "../../auth/user";
-import ExternalLink from "../../components/ExternalLink";
-var pckg = require("../../../package.json");
+import Footer from "./Footer"
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -37,23 +36,6 @@ const useStyles = makeStyles(theme => ({
     color: "#1492ff",
   },
 }));
-
-const Footer = () => {
-  const classes = useStyles();
-  console.log(pckg);
-  return (
-    <div className={classes.footer}>
-      <Typography variant="caption" color="textSecondary">
-        Moped{" "}
-        <ExternalLink
-          text={`v${pckg.version}`}
-          url={`https://github.com/cityofaustin/atd-moped/releases/tag/v${pckg.version}`}
-          linkColor="inherit"
-        />
-      </Typography>
-    </div>
-  );
-};
 
 const DashboardLayout = () => {
   const classes = useStyles();

--- a/moped-editor/src/layouts/DashboardLayout/Footer.js
+++ b/moped-editor/src/layouts/DashboardLayout/Footer.js
@@ -5,6 +5,7 @@ var pckg = require("../../../package.json");
 
 const useStyles = makeStyles(theme => ({
   root: {
+    paddingTop: theme.spacing(1),
     paddingLeft: theme.spacing(4),
     paddingBottom: theme.spacing(2),
   },

--- a/moped-editor/src/layouts/DashboardLayout/Footer.js
+++ b/moped-editor/src/layouts/DashboardLayout/Footer.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { makeStyles, Typography } from "@material-ui/core";
+import ExternalLink from "../../components/ExternalLink";
+var pckg = require("../../../package.json");
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    paddingLeft: theme.spacing(4),
+    paddingBottom: theme.spacing(2),
+  },
+}));
+
+const Footer = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <Typography variant="caption" color="textSecondary">
+        Moped {" "}
+        <ExternalLink
+          text={`v${pckg.version}`}
+          url={`https://github.com/cityofaustin/atd-moped/releases/tag/v${pckg.version}`}
+          linkColor="inherit"
+        />
+      </Typography>
+    </div>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
closes https://github.com/cityofaustin/atd-data-tech/issues/6520

https://deploy-preview-358--atd-moped-main.netlify.app/moped

the netlify sidebar icon slightly covers the footer. What do yall think of the color of the text and the size? Margin/padding? 

