### PR TITLE
[Project Components] Zoom to extent of all components when creating new component #6574

### DIFF
--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -695,6 +695,7 @@ export function useFeatureCollectionToFitBounds(
 
       const newViewport = featureViewport.fitBounds(mapBounds, {
         padding: 100,
+        maxZoom: 16,
       });
 
       const { longitude, latitude, zoom } = newViewport;

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -686,7 +686,8 @@ export function useFeatureCollectionToFitBounds(
      * @return {Object} Viewport object with updated attributes based on project's features
      */
     const fitViewportToBounds = viewport => {
-      if (featureCollection.features.length === 0) return viewport;
+      // Let's check if we have any features are all, otherwise return the state of viewport...
+      if ((featureCollection?.features?.length ?? 0) === 0) return viewport;
       const featureViewport = new WebMercatorViewport({
         viewport,
         width: currentMap?._width ?? window.innerWidth * 0.45,

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -61,12 +61,26 @@ export const useStyles = makeStyles({
   ...layerSelectStyles,
 });
 
+/**
+ * This the new project map editor component
+ * @param {Object} featureCollection - A feature collection GeoJSON object (state)
+ * @param {function} setFeatureCollection - The function to change the feature collection state
+ * @param {Number} projectId - The current project id (optional)
+ * @param {Object} projectFeatureCollection - A helper state containing a secondary feature collection (optional)
+ * @param {function} refetchProjectDetails - A callback function to re-fetch the project's details  (optional)
+ * @param {boolean} noPadding - Set to True if you wish for the map to have no padding (optional)
+ * @param {boolean} newFeature - Set to True if this is a new feature for a project (optional
+ * @return {JSX.Element}
+ * @constructor
+ */
 const NewProjectMap = ({
   featureCollection,
   setFeatureCollection,
   projectId = null,
+  projectFeatureCollection = null,
   refetchProjectDetails = null,
   noPadding = false,
+  newFeature = false,
 }) => {
   const classes = useStyles();
   const mapRef = useRef();
@@ -76,9 +90,13 @@ const NewProjectMap = ({
   );
   const mapControlContainerRef = useRef();
 
+  /**
+   * Generate a viewport configuration object
+   */
   const [viewport, setViewport] = useFeatureCollectionToFitBounds(
     mapRef,
-    featureCollection,
+    // If this is a new feature, use the project feature collection to retrieve the area
+    newFeature ? projectFeatureCollection : featureCollection,
     false
   );
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
@@ -58,6 +58,7 @@ const useStyles = makeStyles(theme => ({
  * @param {Number} componentId - The moped_proj_component id being edited
  * @param {function} handleCancelEdit - The function to call if we need to cancel editing
  * @param {function} projectRefetchFeatures - Reload parent component's features
+ * @param {Object} projectFeatureCollection - The entire project's feature collection GeoJSON (optional)
  * @return {JSX.Element}
  * @constructor
  */
@@ -65,9 +66,12 @@ const ProjectComponentEdit = ({
   componentId,
   handleCancelEdit,
   projectRefetchFeatures,
+  projectFeatureCollection = null,
 }) => {
   const { projectId } = useParams();
   const classes = useStyles();
+
+  // Template that should keep all features for this component
   const emptyFeatureCollection = {
     type: "FeatureCollection",
     features: [],
@@ -775,6 +779,8 @@ const ProjectComponentEdit = ({
           projectId={null}
           refetchProjectDetails={null}
           noPadding={true}
+          newFeature={componentId === 0}
+          projectFeatureCollection={projectFeatureCollection}
         />
         {error && (
           <Alert className={classes.mapAlert} severity="error">

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -36,6 +36,14 @@ const useStyles = makeStyles({
   },
 });
 
+/**
+ * THe project component map viewer
+ * @param {Object} projectFeatureCollection - The features collection GeoJSON
+ * @param {function} setIsEditing - A callback to change the state to edit mode
+ * @param {boolean} editEnabled - Ture when we are editing
+ * @return {JSX.Element}
+ * @constructor
+ */
 const ProjectComponentsMapView = ({
   projectFeatureCollection,
   setIsEditing,


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6574

** Front-end changes only, you can use Netlify, moped-test or locally.

Live Preview:
https://deploy-preview-359--atd-moped-main.netlify.app/moped/session/signin

This PR updates the components editor so that whenever a new component is added, it initializes the map to start in the same area as the rest of the project.