### PR TITLE
Prevent saving Project Title and Project Description as blank strings

### DIFF
--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -216,9 +216,10 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
 
   const executeMutation = (field = null, value = null) => {
     const mutationField = field || editField;
-    const mutationValue = value !== null ? value : editValue;
+    const mutationValue = value !== null ? value : editValue; // where does editvalue come from? what is it initially
     // Execute mutation only if there is a new value selected, prevents user
     // from attempting to save initial value, which would be null
+    // this also prevents you from clicking yes when its not an initial value, just when its not updated
     if (mutationValue !== null) {
       updateField({
         mutation: generateUpdateQuery(mutationField, mutationValue),
@@ -429,14 +430,15 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
         <CircularProgress />
       ) : (
         <Grid container>
-          {Object.keys(fieldConfiguration.fields).map(field => {
+          { // map through fields from field configuration
+            Object.keys(fieldConfiguration.fields).map(field => {
             const fieldType =
               fieldConfiguration.fields[field]?.type ?? "string";
 
             return (
               <Grid
                 item
-                key={fieldConfiguration.fields[field]?.label}
+                key={fieldConfiguration.fields[field]?.label} // should there be a default fallback here?
                 className={classes.fieldGridItem}
                 xs={12}
                 sm={fieldConfiguration.fields[field]?.widthSmallAndLarger ?? 6}
@@ -449,6 +451,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                   )}
                   {(isEditing && editField === field) ||
                   fieldType === "boolean" ? (
+                    // boolean type fields are always rendered using function, regardless of editing status
                     <form onSubmit={e => handleAcceptClick(e)}>
                       <Grid container fullWidth>
                         <Grid item xs={12} sm={9}>
@@ -489,6 +492,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                       </Grid>
                     </form>
                   ) : (
+                    // if not currently editing field and field is not Boolean
                     <Typography
                       id={"label-" + field}
                       className={
@@ -507,7 +511,9 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                           <div>
                             <Icon
                               className={classes.editIcon}
-                              onClick={() => handleFieldEdit(field)}
+                              onClick={() => { 
+                                console.log("onclicked ", field)
+                                handleFieldEdit(field)}}
                             >
                               create
                             </Icon>

--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -96,6 +96,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
 
   const [editValue, setEditValue] = useState(null);
   const [editField, setEditField] = useState("");
+  // isEditing is True if any field is in edit state
   const [isEditing, setIsEditing] = useState(false);
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
 
@@ -159,7 +160,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
   };
 
   /**
-   * Retrieves the value for a field
+   * Retrieves the label/name for a field
    * @param {string} field - The value of the string
    * @returns {string}
    */
@@ -170,7 +171,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
   /**
    * Retrieves the value from the table object in memory
    * @param {string} field - The name of the field (column)
-   * @returns {*} - The value
+   * @returns {*} - The value or null if field not in table
    */
   const getValue = field => {
     const tableName = fieldConfiguration.table.name;
@@ -180,9 +181,9 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
   };
 
   /**
-   * Retrieves the format value and returns a printable formatted string or JSX
+   * Retrieves the field's value and returns a printable formatted string or JSX
+   * Used if field does not have a custom format function
    * @param {string} field - The name of the field (column)
-   * @param {boolean} raw - Retrieve the value only
    * @returns {string|JSX}
    */
   const formatValue = field => {
@@ -214,9 +215,15 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     return formattedValue;
   };
 
+  /**
+   * if editValue is not null, executes mutation, triggers Snackbar with mutation response and resets state
+   * @param field, optional. Provided when updating boolean field
+   * @param value, optional. Provided when updating boolean field
+   */
   const executeMutation = (field = null, value = null) => {
     const mutationField = field || editField;
     const mutationValue = value !== null ? value : editValue; // where does editvalue come from? what is it initially
+    console.log(editValue, value) // <-- need to check also about empty not just null
     // Execute mutation only if there is a new value selected, prevents user
     // from attempting to save initial value, which would be null
     // this also prevents you from clicking yes when its not an initial value, just when its not updated
@@ -413,6 +420,10 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     );
   };
 
+  /**
+   * Updates state with which field is being edited and sets isEditing to true
+   * @param {string} field
+   */
   const handleFieldEdit = field => {
     setIsEditing(true);
     setEditField(field);
@@ -438,7 +449,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
             return (
               <Grid
                 item
-                key={fieldConfiguration.fields[field]?.label} // should there be a default fallback here?
+                key={fieldConfiguration.fields[field]?.label}
                 className={classes.fieldGridItem}
                 xs={12}
                 sm={fieldConfiguration.fields[field]?.widthSmallAndLarger ?? 6}
@@ -469,6 +480,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                           )}
                         </Grid>
                         {fieldType !== "boolean" && (
+                          // show icons to accept or cancel edit
                           <Grid
                             item
                             xs={12}
@@ -506,8 +518,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                           )
                         : formatValue(field)}
                       {fieldConfiguration.fields[field].editable &&
-                        !isEditing &&
-                        fieldType !== "boolean" && (
+                        !isEditing && (
                           <div>
                             <Icon
                               className={classes.editIcon}

--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -231,6 +231,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     // Execute mutation only if there is a new value selected, prevents user
     // from attempting to save initial value, which would be null
     // Also prevents from executing migration if value has not changed
+    // And checks if field is allowed to be a blank string
     if (mutationValue !== null && (nullableField || mutationValue !== "")) {
       updateField({
         mutation: generateUpdateQuery(mutationField, mutationValue),

--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -94,7 +94,9 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     data: lookupTablesData,
   } = useQuery(LOOKUP_TABLE_QUERY);
 
+  // editValue, value of field being edited
   const [editValue, setEditValue] = useState(null);
+  // editField: string, name of field being edited
   const [editField, setEditField] = useState("");
   // isEditing is True if any field is in edit state
   const [isEditing, setIsEditing] = useState(false);
@@ -222,12 +224,12 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
    */
   const executeMutation = (field = null, value = null) => {
     const mutationField = field || editField;
-    const mutationValue = value !== null ? value : editValue; // where does editvalue come from? what is it initially
-    console.log(editValue, value) // <-- need to check also about empty not just null
+    const mutationValue = value !== null ? value : editValue;
+    const nullableField = fieldConfiguration.fields[mutationField].nullable ?? true;
     // Execute mutation only if there is a new value selected, prevents user
     // from attempting to save initial value, which would be null
-    // this also prevents you from clicking yes when its not an initial value, just when its not updated
-    if (mutationValue !== null) {
+    // Also prevents from executing migration if value has not changed
+    if (mutationValue !== null && (nullableField || mutationValue !== "")) {
       updateField({
         mutation: generateUpdateQuery(mutationField, mutationValue),
       })

--- a/moped-editor/src/components/DataTable/DataTable.js
+++ b/moped-editor/src/components/DataTable/DataTable.js
@@ -100,6 +100,8 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
   const [editField, setEditField] = useState("");
   // isEditing is True if any field is in edit state
   const [isEditing, setIsEditing] = useState(false);
+  // errorField, name of field that contains error
+  const [errorField, setErrorField] = useState("");
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
 
   const [updateField] = useMutation(INITIAL_MUTATION);
@@ -264,8 +266,13 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
           setEditValue(null);
           setEditField("");
           setIsEditing(false);
+          setErrorField("");
           setTimeout(() => setSnackbarState(DEFAULT_SNACKBAR_STATE), 3000);
         });
+    } else {
+      if (!nullableField && mutationValue === "") {
+        setErrorField(mutationField);
+      }
     }
   };
 
@@ -287,6 +294,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
     setEditValue(null);
     setEditField("");
     setIsEditing(false);
+    setErrorField("");
   };
 
   /**
@@ -294,6 +302,9 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
    * @param value
    */
   const handleFieldValueUpdate = value => {
+    if (errorField !== "") {
+      setErrorField("")
+    }
     setEditValue(value.target.value);
   };
 
@@ -344,8 +355,11 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
         label={fieldConfig.label}
         type="text"
         defaultValue={editValue ?? initialValue}
-        placeholder={fieldConfig?.placeholder}
+        placeholder={
+          errorField === field ? fieldConfig?.errorMessage : fieldConfig?.placeholder
+        }
         className={null}
+        error={errorField === field}
         multiline={fieldConfig?.multiline ?? false}
         rows={fieldConfig?.multilineRows ?? 1}
         onChange={e => handleFieldValueUpdate(e)}
@@ -524,9 +538,7 @@ const DataTable = ({ fieldConfiguration, data, loading, error, refetch }) => {
                           <div>
                             <Icon
                               className={classes.editIcon}
-                              onClick={() => { 
-                                console.log("onclicked ", field)
-                                handleFieldEdit(field)}}
+                              onClick={() => handleFieldEdit(field)}
                             >
                               create
                             </Icon>

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -47,6 +47,7 @@ const ProjectNameEditable = props => {
   );
   const [isEditing, setIsEditing] = useState(props?.isEditing ?? false);
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
+  const [titleError, setTitleError] = useState(false);
 
   if (props?.isEditing && !isEditing) {
     setIsEditing(true);
@@ -74,6 +75,9 @@ const ProjectNameEditable = props => {
   };
 
   const handleProjectNameChange = e => {
+    if (titleError) {
+      setTitleError(false)
+    }
     setProjectName(e.target.value);
   };
 
@@ -111,6 +115,8 @@ const ProjectNameEditable = props => {
         setIsEditing(false);
         setTimeout(() => setSnackbarState(DEFAULT_SNACKBAR_STATE), 3000);
       });
+    } else {
+      setTitleError(true);
     }
   };
 
@@ -141,7 +147,8 @@ const ProjectNameEditable = props => {
                 label={"Project Name"}
                 type="text"
                 defaultValue={projectName ?? props?.projectName}
-                placeholder={"Enter project name"}
+                error={titleError}
+                placeholder={titleError ? "Title cannot be blank" : "Enter project name"}
                 multiline={false}
                 rows={1}
                 onChange={e => handleProjectNameChange(e)}

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -82,6 +82,7 @@ const ProjectNameEditable = props => {
    */
   const handleAcceptClick = e => {
     e.preventDefault();
+    if (!projectName.trim()==="") {
     updateProjectName({
       variables: {
         projectId: props?.projectId,
@@ -110,6 +111,7 @@ const ProjectNameEditable = props => {
         setIsEditing(false);
         setTimeout(() => setSnackbarState(DEFAULT_SNACKBAR_STATE), 3000);
       });
+    }
   };
 
   /**
@@ -135,7 +137,7 @@ const ProjectNameEditable = props => {
             <Grid item xs={12} sm={9}>
               <TextField
                 fullWidth
-                id="date"
+                id="date" // id is date?
                 label={"Project Name"}
                 type="text"
                 defaultValue={projectName ?? props?.projectName}
@@ -170,7 +172,8 @@ const ProjectNameEditable = props => {
           </Grid>
         </form>
       )}
-      {!isEditing && (
+      { // if not Editing Project Name, show edit icon on mouse over of title
+        !isEditing && (
         <Typography
           color="textPrimary"
           variant="h2"

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -143,7 +143,7 @@ const ProjectNameEditable = props => {
             <Grid item xs={12} sm={9}>
               <TextField
                 fullWidth
-                id="date" // id is date?
+                id="project name"
                 label={"Project Name"}
                 type="text"
                 defaultValue={projectName ?? props?.projectName}

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
@@ -51,7 +51,8 @@ const ProjectSummaryTable = ({ data, loading, error, refetch }) => {
         editable: true,
         multiline: true,
         multilineRows: 4,
-        widthSmallAndLarger: 12
+        widthSmallAndLarger: 12,
+        nullable: false,
       },
       start_date: {
         label: "Start date",

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
@@ -53,6 +53,7 @@ const ProjectSummaryTable = ({ data, loading, error, refetch }) => {
         multilineRows: 4,
         widthSmallAndLarger: 12,
         nullable: false,
+        errorMessage: "Field cannot be blank",
       },
       start_date: {
         label: "Start date",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6582

To test: https://deploy-preview-361--atd-moped-main.netlify.app/moped/projects/276/
Try changing title or description to a blank/ empty string. 

I am also adding the field configuration to the gitbook https://app.gitbook.com/@atd-dts/s/moped/dev-guides/api/configuration-files