### PR TITLE
[Bug] Previous 'Subtype' stays in text box after selecting new 'Type' #6616

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
@@ -262,11 +262,11 @@ const ProjectComponentEdit = ({
     const selectedType = (newValue ?? e.target.value ?? "").toLowerCase();
 
     // Generates a list of available component subtypes given a component type
-    const availableSubTypes = getAvailableSubtypes(selectedType);
+    const newAvailableSubTypes = getAvailableSubtypes(selectedType);
 
     // Set The selected component type
     setSelectedComponentType(selectedType);
-    setAvailableSubtypes(availableSubTypes);
+    setAvailableSubtypes(newAvailableSubTypes);
     setSelectedComponentSubtype(null);
   };
 
@@ -606,8 +606,8 @@ const ProjectComponentEdit = ({
     // If there is a componentId, then get subtypes
     if (componentId > 0) {
       // Now get the available subtypes
-      const availableSubTypes = getAvailableSubtypes(componentTypeDB);
-      setAvailableSubtypes(availableSubTypes);
+      const newStateAvailableSubTypes = getAvailableSubtypes(componentTypeDB);
+      setAvailableSubtypes(newStateAvailableSubTypes);
       // If the component type has subtypes, then fetch those and update state
       if (initialTypeCounts[componentTypeDB].count > 1) {
         const subtypeDB = (databaseComponent?.component_subtype ?? "")
@@ -694,10 +694,12 @@ const ProjectComponentEdit = ({
                 <Autocomplete
                   id="moped-project-subtype-select"
                   className={classes.formSelect}
-                  value={availableSubtypes.find(
-                    subtype =>
-                      subtype.toLowerCase() === selectedComponentSubtype
-                  )}
+                  value={
+                    availableSubtypes.find(
+                      subtype =>
+                        subtype.toLowerCase() === selectedComponentSubtype
+                    ) ?? null
+                  }
                   options={[...new Set(availableSubtypes)].sort()}
                   getOptionLabel={component => component}
                   renderInput={params => (


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6616

Description:
  Refactors subtype & subcomponent logic and removes duplicates

** Front-end change only, test with Netlify

Live Demo:
https://deploy-preview-364--atd-moped-main.netlify.app/moped/session/signin
