### PR TITLE
Update map hover tooltip styles

### DIFF
--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -94,7 +94,7 @@ export const mapStyles = {
     zIndex: 9,
     pointerEvents: "none",
     borderRadius: 6,
-    boxShadow: "0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)"
+    boxShadow: "0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)",
   },
 };
 
@@ -567,8 +567,8 @@ export const createProjectViewLayerConfig = (
  * @param {Object} className - Styles from the classes object
  * @return {JSX} The populated tooltip JSX
  */
-export const renderTooltip = (tooltipText, hoveredCoords, className) => {
-  return (tooltipText && (
+export const renderTooltip = (tooltipText, hoveredCoords, className) =>
+  tooltipText && (
     <div
       className={className}
       style={{
@@ -578,7 +578,7 @@ export const renderTooltip = (tooltipText, hoveredCoords, className) => {
     >
       <div>{stringToTitleCase(tooltipText)}</div>
     </div>
-  ))};
+  );
 
 /**
  * Build the JSX for the map feature count subtext

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -11,6 +11,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import { get } from "lodash";
+import stringToTitleCase from "./stringToTitleCase";
 
 export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 export const NEARMAP_KEY = process.env.REACT_APP_NEARMAP_TOKEN;
@@ -567,7 +568,6 @@ export const createProjectViewLayerConfig = (
  * @return {JSX} The populated tooltip JSX
  */
 export const renderTooltip = (tooltipText, hoveredCoords, className) => {
-  console.log(tooltipText)
   return (tooltipText && (
     <div
       className={className}
@@ -576,7 +576,7 @@ export const renderTooltip = (tooltipText, hoveredCoords, className) => {
         top: hoveredCoords?.y,
       }}
     >
-      <div>{tooltipText}</div>
+      <div>{stringToTitleCase(tooltipText)}</div>
     </div>
   ))};
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -11,7 +11,6 @@ import {
   Typography,
 } from "@material-ui/core";
 import { get } from "lodash";
-import stringToTitleCase from "./stringToTitleCase";
 
 export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 export const NEARMAP_KEY = process.env.REACT_APP_NEARMAP_TOKEN;
@@ -95,6 +94,7 @@ export const mapStyles = {
     pointerEvents: "none",
     borderRadius: 6,
     boxShadow: "0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)",
+    textTransform: "capitalize",
   },
 };
 
@@ -576,7 +576,7 @@ export const renderTooltip = (tooltipText, hoveredCoords, className) =>
         top: hoveredCoords?.y,
       }}
     >
-      <div>{stringToTitleCase(tooltipText)}</div>
+      <div>{tooltipText.toLowerCase()}</div>
     </div>
   );
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -93,7 +93,7 @@ export const mapStyles = {
     zIndex: 9,
     pointerEvents: "none",
     borderRadius: 6,
-    // boxShadow: 0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)
+    boxShadow: "0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)"
   },
 };
 

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -84,14 +84,16 @@ export const mapStyles = {
   toolTipStyles: {
     position: "absolute",
     margin: 8,
-    padding: 4,
-    background: theme.palette.text.primary,
+    padding: 6,
+    background: theme.palette.primary.main,
     color: theme.palette.background.default,
     maxWidth: 300,
     fontSize: "0.875rem",
     fontWeight: 500,
     zIndex: 9,
     pointerEvents: "none",
+    borderRadius: 6,
+    // boxShadow: 0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)
   },
 };
 
@@ -528,7 +530,6 @@ export const createSummaryMapLayers = geoJSON => {
       })
   );
 };
-
 /**
  * Create a configuration to set the Mapbox spec styles for persisted layer features
  * @summary The fill color key's value below is a Mapbox "case" expression whose cases are
@@ -565,8 +566,9 @@ export const createProjectViewLayerConfig = (
  * @param {Object} className - Styles from the classes object
  * @return {JSX} The populated tooltip JSX
  */
-export const renderTooltip = (tooltipText, hoveredCoords, className) =>
-  tooltipText && (
+export const renderTooltip = (tooltipText, hoveredCoords, className) => {
+  console.log(tooltipText)
+  return (tooltipText && (
     <div
       className={className}
       style={{
@@ -576,7 +578,7 @@ export const renderTooltip = (tooltipText, hoveredCoords, className) =>
     >
       <div>{tooltipText}</div>
     </div>
-  );
+  ))};
 
 /**
  * Build the JSX for the map feature count subtext

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -95,6 +95,7 @@ export const mapStyles = {
     borderRadius: 6,
     boxShadow: "0 0 1px 0 rgb(0 0 0 / 31%), 0 2px 2px -2px rgb(0 0 0 / 25%)",
     textTransform: "capitalize",
+    fontFamily: 'Roboto',
   },
 };
 

--- a/moped-editor/src/utils/stringToTitleCase.js
+++ b/moped-editor/src/utils/stringToTitleCase.js
@@ -1,7 +1,7 @@
- export default str => {
+export default str => {
   let lowerStr = str.toLowerCase();
   // uppercase first character
   lowerStr = lowerStr.charAt(0).toUpperCase() + lowerStr.slice(1);
   // uppercase characters after spaces
-  return lowerStr.replace(/\W\S/g, t=> t.toUpperCase());
- }
+  return lowerStr.replace(/\W\S/g, t => t.toUpperCase());
+};

--- a/moped-editor/src/utils/stringToTitleCase.js
+++ b/moped-editor/src/utils/stringToTitleCase.js
@@ -1,7 +1,0 @@
-export default str => {
-  let lowerStr = str.toLowerCase();
-  // uppercase first character
-  lowerStr = lowerStr.charAt(0).toUpperCase() + lowerStr.slice(1);
-  // uppercase characters after spaces
-  return lowerStr.replace(/\W\S/g, t => t.toUpperCase());
-};

--- a/moped-editor/src/utils/stringToTitleCase.js
+++ b/moped-editor/src/utils/stringToTitleCase.js
@@ -1,0 +1,7 @@
+ export default str => {
+  let lowerStr = str.toLowerCase();
+  // uppercase first character
+  lowerStr = lowerStr.charAt(0).toUpperCase() + lowerStr.slice(1);
+  // uppercase characters after spaces
+  return lowerStr.replace(/\W\S/g, t=> t.toUpperCase());
+ }

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -69,7 +69,7 @@ export const useStyles = makeStyles({
  * @param {Object} projectFeatureCollection - A helper state containing a secondary feature collection (optional)
  * @param {function} refetchProjectDetails - A callback function to re-fetch the project's details  (optional)
  * @param {boolean} noPadding - Set to True if you wish for the map to have no padding (optional)
- * @param {boolean} newFeature - Set to True if this is a new feature for a project (optional
+ * @param {boolean} newFeature - Set to True if this is a new feature for a project (optional)
  * @return {JSX.Element}
  * @constructor
  */


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6253

To test:
https://deploy-preview-365--atd-moped-main.netlify.app/moped/projects/276?tab=summary

hover over street names to bring up tooltip
