### PR TITLE
Redirect /moped to /moped/projects

### DIFF
--- a/moped-editor/src/routes.js
+++ b/moped-editor/src/routes.js
@@ -31,7 +31,11 @@ export const routes = [
     action: "moped:visit",
     element: <DashboardLayout />,
     children: [
-      { path: "/", action: "moped:visit", element: <ProjectsListView /> },
+      {
+        path: "/",
+        action: "moped:visit",
+        element: <Navigate to="/moped/projects" />,
+      },
       {
         path: "dashboard",
         action: "dashboard:visit",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6774
and should also handle https://github.com/cityofaustin/atd-data-tech/issues/6550 since a user can no longer go to `/moped/?filter=eyJhY2JiZmM0Ni0xNjhlLTRlNDItYWIwZC0yYzFhNz[…]lbnQgcGhhc2UiLCJ2YWx1ZSI6InBvdCIsInR5cGUiOiJzdHJpbmcifX0=` and instead will always be at `/moped/proejcts/?filter=foobarfooetc`

https://6774-redirect-moped--atd-moped-main.netlify.app/

To test: click moped icon, projects tab should be highlighted as active. 
