### PR TITLE
Reroute user to moped staff page after a staff member is deleted

### DIFF
--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -196,7 +196,10 @@ const StaffForm = ({ editFormData = null, userCognitoId }) => {
    */
   const handleDeleteConfirm = () => {
     const requestPath = "/users/" + userCognitoId;
-    const deleteCallback = () => setIsDeleteModalOpen(false);
+    const deleteCallback = () => {
+      setIsDeleteModalOpen(false);
+      navigate("/moped/staff/");
+    };
 
     requestApi({
       method: "delete",


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/6475
- Add navigate to callback after user is deleted in staff view
- User is redirected to '/moped/staff/' 

**How to test**
- Visit website using the netlify build preview.
- Make sure your moped account has the ability to delete users.
- Visit staff page and select a user you want to delete.
- Afterwards click the delete user button and then confirm.