### PR TITLE
Add additional workgroups to Moped #6768

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -287,6 +287,9 @@
       check: {}
 - table:
     schema: public
+    name: moped_department
+- table:
+    schema: public
     name: moped_entity
   insert_permissions:
   - role: moped-admin
@@ -4463,6 +4466,10 @@
 - table:
     schema: public
     name: moped_users
+  object_relationships:
+  - name: moped_workgroup
+    using:
+      foreign_key_constraint_on: workgroup_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -4586,6 +4593,10 @@
 - table:
     schema: public
     name: moped_workgroup
+  object_relationships:
+  - name: moped_department
+    using:
+      foreign_key_constraint_on: department_id
   insert_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/migrations/1627672459000_create_table_public_moped_department/down.sql
+++ b/moped-database/migrations/1627672459000_create_table_public_moped_department/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."moped_department";

--- a/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
+++ b/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
@@ -4,4 +4,5 @@ INSERT INTO "public"."moped_department"(department_id, department_name)
 VALUES (0, 'None'),
        (1, 'Austin Transportation'),
        (2, 'Corridor Program Office'),
-       (3, 'Public Works');
+       (3, 'Public Works'),
+       (4, 'Other');

--- a/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
+++ b/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "public"."moped_department"("department_id" serial NOT NULL, "department_name" text NOT NULL, "date_added" Timestamp NOT NULL DEFAULT now(), PRIMARY KEY ("department_id") );
+
+INSERT INTO "public"."moped_department"(department_id, department_name)
+VALUES (0, 'None'),
+       (1, 'Austin Transporation'),
+       (2, 'Corridor Program Office'),
+       (3, 'Public Works');

--- a/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
+++ b/moped-database/migrations/1627672459000_create_table_public_moped_department/up.sql
@@ -2,6 +2,6 @@ CREATE TABLE "public"."moped_department"("department_id" serial NOT NULL, "depar
 
 INSERT INTO "public"."moped_department"(department_id, department_name)
 VALUES (0, 'None'),
-       (1, 'Austin Transporation'),
+       (1, 'Austin Transportation'),
        (2, 'Corridor Program Office'),
        (3, 'Public Works');

--- a/moped-database/migrations/1627672511597_alter_table_public_moped_workgroup_add_column_department_id/down.sql
+++ b/moped-database/migrations/1627672511597_alter_table_public_moped_workgroup_add_column_department_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_workgroup" DROP COLUMN "department_id";

--- a/moped-database/migrations/1627672511597_alter_table_public_moped_workgroup_add_column_department_id/up.sql
+++ b/moped-database/migrations/1627672511597_alter_table_public_moped_workgroup_add_column_department_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_workgroup" ADD COLUMN "department_id" integer NULL;

--- a/moped-database/migrations/1627672550424_set_fk_public_moped_workgroup_department_id/down.sql
+++ b/moped-database/migrations/1627672550424_set_fk_public_moped_workgroup_department_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_workgroup" drop constraint "moped_workgroup_department_id_fkey";

--- a/moped-database/migrations/1627672550424_set_fk_public_moped_workgroup_department_id/up.sql
+++ b/moped-database/migrations/1627672550424_set_fk_public_moped_workgroup_department_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_workgroup"
+           add constraint "moped_workgroup_department_id_fkey"
+           foreign key ("department_id")
+           references "public"."moped_department"
+           ("department_id") on update no action on delete no action;

--- a/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/down.sql
+++ b/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/down.sql
@@ -1,0 +1,6 @@
+/*
+ DELETES NEW VALUES FOR THE WORKGROUP TABLE
+*/
+
+DELETE FROM public.moped_workgroup
+    WHERE workgroup_id IN (19,20,21,22,23);

--- a/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/down.sql
+++ b/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/down.sql
@@ -3,4 +3,4 @@
 */
 
 DELETE FROM public.moped_workgroup
-    WHERE workgroup_id IN (19,20,21,22,23);
+    WHERE workgroup_id IN (19,20,21,22,23,24);

--- a/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
+++ b/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
@@ -1,0 +1,8 @@
+/*
+ INSERTS NEW VALUES FOR THE WORKGROUP TABLE
+*/
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Urban Trails', 19, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Safe Routes to School', 20, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Corridor Program Office', 21, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Sidewalks', 22, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Engineering Services Division', 23, 3);

--- a/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
+++ b/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
@@ -3,6 +3,7 @@
 */
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Urban Trails', 19, 3);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Safe Routes to School', 20, 3);
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Corridor Program Office', 21, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Corridor Program Office', 21, 2);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Sidewalks', 22, 3);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Engineering Services Division', 23, 3);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Other', 24, 4);

--- a/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
+++ b/moped-database/migrations/1627672560000_update_table_moped_workgroup_additional_workgroups/up.sql
@@ -6,4 +6,9 @@ INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id)
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Corridor Program Office', 21, 2);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Sidewalks', 22, 3);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Engineering Services Division', 23, 3);
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, department_id) VALUES ('Other', 24, 4);
+
+-- Other already exists, we are going to update its department
+UPDATE public.moped_workgroup
+    SET department_id = 4
+        WHERE workgroup_id = 18   -- Other
+;

--- a/moped-database/migrations/1627673512978_update_table_moped_workgroup_add_department_existing_workgroups/down.sql
+++ b/moped-database/migrations/1627673512978_update_table_moped_workgroup_add_department_existing_workgroups/down.sql
@@ -1,0 +1,6 @@
+/*
+ DISASSOCIATE THE DEPARTMENT ID FOR ANY EXISTING RECORDS
+*/
+UPDATE public.moped_workgroup
+    SET department_id = NULL
+    WHERE workgroup_id < 19;

--- a/moped-database/migrations/1627673512978_update_table_moped_workgroup_add_department_existing_workgroups/up.sql
+++ b/moped-database/migrations/1627673512978_update_table_moped_workgroup_add_department_existing_workgroups/up.sql
@@ -1,0 +1,6 @@
+/*
+    UPDATES ALL EXISTING VALUES IN WORKGROUP TABLE
+*/
+UPDATE public.moped_workgroup
+    SET department_id = 1
+    WHERE workgroup_id < 19;

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -829,24 +829,24 @@ INSERT INTO public.moped_project (project_uuid, project_name, project_descriptio
 -- Data for Name: moped_workgroup; Type: TABLE DATA; Schema: public; Owner: atd_moped
 --
 
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Active Transportation & Street Design', 1, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Arterial Management', 2, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Data & Technology Services', 3, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Finance', 4, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Human Resources', 5, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Office of Special Events', 6, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Office of the Director', 7, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Parking Enterprise', 8, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Parking Meters', 9, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Public Information Office', 10, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Right-of-Way', 11, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Signs & Markings', 12, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Smart Mobility', 13, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Systems Development', 14, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Transportation Engineering', 15, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Transportation Development Services', 16, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Vision Zero', 17, '2020-12-04 16:53:02.752811+00');
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added) VALUES ('Other', 18, '2020-12-04 16:53:02.752811+00');
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Active Transportation & Street Design', 1, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Arterial Management', 2, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Data & Technology Services', 3, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Finance', 4, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Human Resources', 5, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Office of Special Events', 6, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Office of the Director', 7, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Parking Enterprise', 8, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Parking Meters', 9, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Public Information Office', 10, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Right-of-Way', 11, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Signs & Markings', 12, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Smart Mobility', 13, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Systems Development', 14, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Transportation Engineering', 15, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Transportation Development Services', 16, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Vision Zero', 17, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Other', 18, '2020-12-04 16:53:02.752811+00', 1);
 
 
 --

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -846,7 +846,7 @@ INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, de
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Transportation Engineering', 15, '2020-12-04 16:53:02.752811+00', 1);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Transportation Development Services', 16, '2020-12-04 16:53:02.752811+00', 1);
 INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Vision Zero', 17, '2020-12-04 16:53:02.752811+00', 1);
-INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Other', 18, '2020-12-04 16:53:02.752811+00', 1);
+INSERT INTO public.moped_workgroup (workgroup_name, workgroup_id, date_added, department_id) VALUES ('Other', 18, '2020-12-04 16:53:02.752811+00', 4);
 
 
 --


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/6768

** MIGRATIONS ONLY:  These can only be tested in **moped-test** or local.


Changes:

Additional workgroups to moped_workgroup table

For Public Works:
- Urban Trails
- Safe Routes to School
- Corridor Program Office
- Sidewalks
- Engineering Services Division

New table, moped_department:
- Austin Transporation
- Corridor Program Office
- Public Works

- Moped Workgroup has a new column department_id, and it has associated relationships


A user can be filtered or grouped by department:

<img width="1518" alt="2021-07-30_16-02-53" src="https://user-images.githubusercontent.com/5282430/127706374-ddb4ae1a-369e-4f37-8f14-5199dc6a6c53.png">
