### PR TITLE
White screen when trying to download table with zero search results

### DIFF
--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -423,6 +423,7 @@ const GridTable = ({ title, query }) => {
         {/*Toolbar Space*/}
         <GridTableToolbar>
           <GridTableSearch
+            data={data}
             query={query}
             searchState={{
               searchParameters: search,

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -423,7 +423,7 @@ const GridTable = ({ title, query }) => {
         {/*Toolbar Space*/}
         <GridTableToolbar>
           <GridTableSearch
-            data={data}
+            projectsList={data}
             query={query}
             searchState={{
               searchParameters: search,

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -273,7 +273,7 @@ const GridTableSearch = ({
     // eslint-disable-next-line
     [dialogOpen, downloading, loading, query.limit, getExport]
   );
-  console.log(tableItems);
+
   return (
     <div>
       <GridTableExport query={query} />

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -57,7 +57,7 @@ const history = createBrowserHistory();
  * @constructor
  */
 const GridTableSearch = ({
-  data: tableItems,
+  projectsList,
   query,
   searchState,
   filterState,
@@ -324,8 +324,8 @@ const GridTableSearch = ({
               {query.config.showExport && (
                 <Button
                   disabled={
-                    tableItems &&
-                    !tableItems["project_list_view"].length &&
+                    projectsList &&
+                    !projectsList["project_list_view"].length &&
                     true
                   }
                   className={classes.downloadCsvButton}

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -57,6 +57,7 @@ const history = createBrowserHistory();
  * @constructor
  */
 const GridTableSearch = ({
+  data: tableItems,
   query,
   searchState,
   filterState,
@@ -272,7 +273,7 @@ const GridTableSearch = ({
     // eslint-disable-next-line
     [dialogOpen, downloading, loading, query.limit, getExport]
   );
-
+  console.log(tableItems);
   return (
     <div>
       <GridTableExport query={query} />
@@ -322,6 +323,11 @@ const GridTableSearch = ({
             >
               {query.config.showExport && (
                 <Button
+                  disabled={
+                    tableItems &&
+                    !tableItems["project_list_view"].length &&
+                    true
+                  }
                   className={classes.downloadCsvButton}
                   onClick={handleExportButtonClick}
                   startIcon={<Icon>save</Icon>}


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/6748
- Pass table items data as prop from GridTable to GridTableSearch components
- Use table items data prop to disable button if there are no table items

**How to test**
- Visit netlify preview and Log in to moped
- Visit projects page and search for something that doesn't return a list of projects
- See if download button is disabled