### PR TITLE
Renders user avatar images in activity feed #4809

### DIFF
--- a/moped-editor/src/components/CDN/Avatar.js
+++ b/moped-editor/src/components/CDN/Avatar.js
@@ -1,35 +1,63 @@
 import React from "react";
 import { Avatar, Icon, makeStyles, Typography } from "@material-ui/core";
-import { useUser } from "../../auth/user";
 
 import config from "../../config";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   root: {},
   avatar: {
     height: 100,
     width: 100,
     marginBottom: 8,
+    backgroundColor: theme.palette.grey["300"],
   },
   userInitials: {
     fontSize: "2rem",
   },
 }));
 
-const CDNAvatar = props => {
-  const classes = useStyles();
-  const { user } = useUser();
 
-  const imageSrc = props?.src ? `${config.env.APP_CLOUDFRONT}/${props.src}` : null
+/**
+ * A wrapper for Material's Avatar component.
+ * @param {Object} className - The class name override
+ * @param {String} src - The image in the CDN
+ * @param {String} initials - The initials to render within the avatar (when no image is present).
+ * @param {boolean} largeInitials - If true, it makes the initials a little larger.
+ * @param {String} userColor - The background color to render under the initials.
+ * @return {JSX.Element}
+ * @constructor
+ */
+const CDNAvatar = ({className, src, initials, largeInitials, userColor}) => {
+  const classes = useStyles();
+
+  /**
+   * The image source from CloudFront CDN
+   * @type {string|null}
+   */
+  const imageSource = src
+    ? `${config.env.APP_CLOUDFRONT}/${src}`
+    : null; // If src is null, the avatar will default to initials
+
+  /**
+   * Overrides the default background color if provided.
+   * @type {{backgroundColor: (string)}|null}
+   */
+  const imageStyleOverride = userColor
+    ? {
+        backgroundColor: userColor,
+      }
+    : null;
 
   return (
     <Avatar
-      className={props?.className ? props.className : classes.avatar}
-      src={imageSrc}
-      style={{ backgroundColor: imageSrc ? "white" : user?.userColor }}
+      className={className ? className : classes.avatar}
+      src={imageSource}
+      style={imageStyleOverride}
     >
-      <Typography className={props?.largeInitials ? classes.userInitials : null}>
-        {props?.initials ? props.initials : <Icon>user</Icon>}
+      <Typography
+        className={largeInitials ? classes.userInitials : null}
+      >
+        {initials ? initials : <Icon>user</Icon>}
       </Typography>
     </Avatar>
   );

--- a/moped-editor/src/components/CDN/Avatar.js
+++ b/moped-editor/src/components/CDN/Avatar.js
@@ -16,7 +16,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-
 /**
  * A wrapper for Material's Avatar component.
  * @param {Object} className - The class name override
@@ -24,25 +23,31 @@ const useStyles = makeStyles(theme => ({
  * @param {String} initials - The initials to render within the avatar (when no image is present).
  * @param {boolean} largeInitials - If true, it makes the initials a little larger.
  * @param {String} userColor - The background color to render under the initials.
+ * @param {boolean} useGenericAvatar - If true, whenever src is not provided it uses a generic avatar as opposed to initials.
  * @return {JSX.Element}
  * @constructor
  */
-const CDNAvatar = ({className, src, initials, largeInitials, userColor}) => {
+const CDNAvatar = ({
+  className,
+  src,
+  initials,
+  largeInitials,
+  userColor,
+  useGenericAvatar,
+}) => {
   const classes = useStyles();
 
   /**
    * The image source from CloudFront CDN
    * @type {string|null}
    */
-  const imageSource = src
-    ? `${config.env.APP_CLOUDFRONT}/${src}`
-    : null; // If src is null, the avatar will default to initials
+  const imageSource = !!src ? `${config.env.APP_CLOUDFRONT}/${src}` : null;
 
   /**
    * Overrides the default background color if provided.
    * @type {{backgroundColor: (string)}|null}
    */
-  const imageStyleOverride = userColor
+  const imageStyleOverride = !!userColor
     ? {
         backgroundColor: userColor,
       }
@@ -50,15 +55,18 @@ const CDNAvatar = ({className, src, initials, largeInitials, userColor}) => {
 
   return (
     <Avatar
+      alt={initials}
       className={className ? className : classes.avatar}
       src={imageSource}
       style={imageStyleOverride}
     >
-      <Typography
-        className={largeInitials ? classes.userInitials : null}
-      >
-        {initials ? initials : <Icon>user</Icon>}
-      </Typography>
+      {!!!useGenericAvatar && initials && initials.length > 0 ? (
+        <Typography className={largeInitials ? classes.userInitials : null}>
+          {initials}
+        </Typography>
+      ) : (
+        <Icon>person</Icon>
+      )}
     </Avatar>
   );
 };

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -131,6 +131,7 @@ const TopBar = ({ className, onOpen, ...rest }) => {
               className={classes.avatar}
               src={userDbData.picture}
               initials={userInitials}
+              userColor={user?.userColor}
             />
           </Button>
           <Menu

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -352,6 +352,8 @@ export const PROJECT_ACTIVITY_LOG = gql`
       moped_user {
         first_name
         last_name
+        picture
+        email
         user_id
       }
     }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -36,6 +36,7 @@ import { PROJECT_ACTIVITY_LOG } from "../../../queries/project";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { Alert } from "@material-ui/lab";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
+import CDNAvatar from "../../../components/CDN/Avatar";
 
 const useStyles = makeStyles(theme => ({
   table: {
@@ -232,13 +233,13 @@ const ProjectActivityLog = () => {
                       >
                         <Box display="flex" p={0}>
                           <Box p={0}>
-                            <Avatar
-                              alt={getInitials(change?.moped_user)}
-                              src="/moped/static/images/avatars/userAvatar.jpg"
+                            <CDNAvatar
                               className={classes.avatarSmall}
-                            >
-                              {getInitials(change?.moped_user)}
-                            </Avatar>
+                              src={change?.moped_user?.picture}
+                              initials={getInitials(change?.moped_user)}
+                              userColor={null}
+                              useGenericAvatar={true}
+                            />
                           </Box>
                           <Box
                             p={0}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -16,7 +16,6 @@ import {
 import ProjectActivityLogDialog from "./ProjectActivityLogDialog";
 
 import {
-  Avatar,
   Box,
   Button,
   CardContent,


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/4809

* Front-end change only:
Live Demo: https://363-sg-avatars--atd-moped-main.netlify.app/moped/projects/273?tab=activity_log

Refactors the CDNAvatar component and it is applied to the activity log.


<img width="946" alt="2021-08-04_20-40-24" src="https://user-images.githubusercontent.com/5282430/128273403-76509ad7-37a5-47e7-89a7-312e9bacaba0.png">
