### PR TITLE
Miscellaneous color adjustments

### DIFF
--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -452,7 +452,7 @@ const GridTable = ({ title, query }) => {
               <Card className={classes.root}>
                 <TableContainer className={classes.container}>
                   <Table
-                    className={classes.stickyHeader}
+                    className={`hello ${classes.stickyHeader}`}
                     stickyHeader
                     aria-label="sticky table"
                   >

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -72,6 +72,9 @@ const useStyles = makeStyles(theme => ({
   tableChip: {
     "text-transform": "capitalize",
   },
+  stickyHeader: {
+    backgroundColor: theme.palette.background.paper,
+  },
 }));
 
 /**

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -451,7 +451,11 @@ const GridTable = ({ title, query }) => {
             ) : data ? (
               <Card className={classes.root}>
                 <TableContainer className={classes.container}>
-                  <Table stickyHeader aria-label="sticky table">
+                  <Table
+                    className={classes.stickyHeader}
+                    stickyHeader
+                    aria-label="sticky table"
+                  >
                     <GridTableListHeader
                       query={query}
                       sortOrder={sort.order}

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -72,9 +72,6 @@ const useStyles = makeStyles(theme => ({
   tableChip: {
     "text-transform": "capitalize",
   },
-  stickyHeader: {
-    backgroundColor: theme.palette.background.paper,
-  },
 }));
 
 /**
@@ -451,11 +448,7 @@ const GridTable = ({ title, query }) => {
             ) : data ? (
               <Card className={classes.root}>
                 <TableContainer className={classes.container}>
-                  <Table
-                    className={`hello ${classes.stickyHeader}`}
-                    stickyHeader
-                    aria-label="sticky table"
-                  >
+                  <Table stickyHeader aria-label="sticky table">
                     <GridTableListHeader
                       query={query}
                       sortOrder={sort.order}

--- a/moped-editor/src/components/GridTable/GridTableListHeader.js
+++ b/moped-editor/src/components/GridTable/GridTableListHeader.js
@@ -16,10 +16,12 @@ const useStyles = makeStyles(theme => ({
   },
   columnCell: {
     "user-select": "none",
+    backgroundColor: theme.palette.background.paper,
   },
   columnCellCursor: {
     cursor: "pointer",
     "user-select": "none",
+    backgroundColor: theme.palette.background.paper,
   },
 }));
 

--- a/moped-editor/src/layouts/MainLayout/MainLayout.js
+++ b/moped-editor/src/layouts/MainLayout/MainLayout.js
@@ -38,9 +38,7 @@ const MainLayout = () => {
   return user ? (
     <Navigate to="/moped" />
   ) : (
-    <div
-      className={classes.root}
-    >
+    <div className={classes.root}>
       <div className={classes.wrapper}>
         <div className={classes.contentContainer}>
           <div className={classes.content}>

--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -13,7 +13,7 @@ const theme = createMuiTheme({
     primary: {
       main: "#1276D1",
       dark: "#005cb2",
-      light: "#61b5ff",
+      light: "#55ACF8",
     },
     secondary: {
       main: "#ff6549",

--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -11,7 +11,7 @@ const theme = createMuiTheme({
       mapControlsHover: "#e6e6e6",
     },
     primary: {
-      main: "#1e88e5",
+      main: "#1276D1",
       dark: "#005cb2",
       light: "#61b5ff",
     },

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -82,6 +82,10 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.common.white,
     },
   },
+  appBar: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.header,
+  },
 }));
 
 function a11yProps(index) {

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -401,6 +401,7 @@ const ProjectView = () => {
                     {TABS.map((tab, i) => {
                       return (
                         <Tab
+                          className={classes.selectedTab}
                           key={tab.label}
                           label={tab.label}
                           {...a11yProps(i)}

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -91,6 +91,9 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.text.primary,
     },
   },
+  indicatorColor: {
+    backgroundColor: theme.palette.primary.light,
+  },
 }));
 
 function a11yProps(index) {

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -86,6 +86,11 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.header,
   },
+  selectedTab: {
+    "&.Mui-selected": {
+      color: theme.palette.text.primary,
+    },
+  },
 }));
 
 function a11yProps(index) {

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -397,6 +397,7 @@ const ProjectView = () => {
                 <Divider />
                 <AppBar className={classes.appBar} position="static">
                   <Tabs
+                    classes={{ indicator: classes.indicatorColor }}
                     value={activeTab}
                     onChange={handleChange}
                     aria-label="Project Details Tabs"

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -387,7 +387,7 @@ const ProjectView = () => {
                   </Grid>
                 </Box>
                 <Divider />
-                <AppBar position="static">
+                <AppBar className={classes.appBar} position="static">
                   <Tabs
                     value={activeTab}
                     onChange={handleChange}


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/6859
- Updated primary main and primary light colors in theme
- Set background color of Table row with `.MuiTableCell-stickyHeader`
- Set background color and text color to AppBar on project pages
- Set indicator color and text color of active tab on project pages

How to view changes
- Visit netlify preview and log in moped
- Go to projects section and look at the table
- Select a project and look at the tabs
- Select a tab and see the change there
- Go to staff section and look at the table