### PR TITLE
Remove certain instances of fiscal year and current status fields in the UI

### DIFF
--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -33,31 +33,16 @@ const DefineProjectForm = ({
     }
   `;
 
-  const FISCAL_QUERY = gql`
-    query Fiscal {
-      moped_city_fiscal_years(order_by: { fiscal_year_value: asc }) {
-        fiscal_year_value
-      }
-    }
-  `;
-
   const {
     loading: statusLoading,
     error: statusError,
     data: statuses,
   } = useQuery(STATUS_QUERY);
 
-  const { loading: fiscalLoading, error: fiscalError, data: fiscal } = useQuery(
-    FISCAL_QUERY
-  );
-
   const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1);
 
   if (statusLoading) return <CircularProgress />;
   if (statusError) return `Error! ${statusError.message}`;
-
-  if (fiscalLoading) return <CircularProgress />;
-  if (fiscalError) return `Error! ${fiscalError.message}`;
 
   return (
     <form style={{ padding: 25 }}>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -114,25 +114,6 @@ const DefineProjectForm = ({
         </Grid>
 
         <Grid item xs={3}>
-          <InputLabel>Fiscal year</InputLabel>
-          <Select
-            name="fiscal_year"
-            style={{ width: 150, paddingLeft: 10 }}
-            value={projectDetails.fiscal_year}
-            onChange={e => handleFieldChange(e.target.value, e.target.name)}
-          >
-            {fiscal.moped_city_fiscal_years.map(fiscal => (
-              <MenuItem
-                key={fiscal.fiscal_year_value}
-                value={fiscal.fiscal_year_value}
-              >
-                {fiscal.fiscal_year_value}
-              </MenuItem>
-            ))}
-          </Select>
-        </Grid>
-
-        <Grid item xs={3}>
           <InputLabel>Current status</InputLabel>
           <Select
             name="current_status"

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -22,27 +22,7 @@ const DefineProjectForm = ({
     setProjectDetails(updatedProjectDetails);
   };
 
-  const STATUS_QUERY = gql`
-    query Status {
-      moped_status(
-        order_by: { status_order: asc }
-        where: { status_id: { _gt: 0 } }
-      ) {
-        status_name
-      }
-    }
-  `;
-
-  const {
-    loading: statusLoading,
-    error: statusError,
-    data: statuses,
-  } = useQuery(STATUS_QUERY);
-
   const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1);
-
-  if (statusLoading) return <CircularProgress />;
-  if (statusError) return `Error! ${statusError.message}`;
 
   return (
     <form style={{ padding: 25 }}>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -1,14 +1,5 @@
 import React from "react";
-import {
-  TextField,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  Switch,
-  CircularProgress,
-} from "@material-ui/core";
-import { useQuery, gql } from "@apollo/client";
+import { TextField, Grid, InputLabel, Switch } from "@material-ui/core";
 
 const DefineProjectForm = ({
   projectDetails,
@@ -21,8 +12,6 @@ const DefineProjectForm = ({
 
     setProjectDetails(updatedProjectDetails);
   };
-
-  const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1);
 
   return (
     <form style={{ padding: 25 }}>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -97,22 +97,6 @@ const DefineProjectForm = ({
             }}
           />
         </Grid>
-
-        <Grid item xs={3}>
-          <InputLabel>Current status</InputLabel>
-          <Select
-            name="current_status"
-            style={{ width: 150, paddingLeft: 10 }}
-            value={projectDetails.current_status}
-            onChange={e => handleFieldChange(e.target.value, e.target.name)}
-          >
-            {statuses.moped_status.map(status => (
-              <MenuItem key={status.status_name} value={status.status_name}>
-                {capitalize(status.status_name)}
-              </MenuItem>
-            ))}
-          </Select>
-        </Grid>
       </Grid>
 
       <Grid container spacing={3} style={{ margin: 20 }}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryTable.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import DataTable from "../../../components/DataTable/DataTable";
 import makeStyles from "@material-ui/core/styles/makeStyles";
-import { Box, Grid } from '@material-ui/core';
+import { Box, Grid } from "@material-ui/core";
 
 import ExternalLink from "../../../components/ExternalLink";
 
@@ -38,7 +38,8 @@ const ProjectSummaryTable = ({ data, loading, error, refetch }) => {
           table: "moped_status",
           fieldLabel: "status_name",
           fieldValue: "status_name",
-          relationship: "where: {status_id: {_gt: 0}}, order_by: {status_order: asc}",
+          relationship:
+            "where: {status_id: {_gt: 0}}, order_by: {status_order: asc}",
           style: classes.fieldSelectCapitalize,
           format: value => String(value).toLowerCase(),
         },
@@ -61,23 +62,12 @@ const ProjectSummaryTable = ({ data, loading, error, refetch }) => {
         placeholder: "Select date",
         editable: true,
       },
-      fiscal_year: {
-        label: "Fiscal year",
-        type: "select",
-        placeholder: "Select fiscal year",
-        lookup: {
-          table: "moped_city_fiscal_years",
-          fieldLabel: "fiscal_year_value",
-          fieldValue: "fiscal_year_value",
-        },
-        editable: true,
-      },
       capitally_funded: {
         label: "Capital funding",
         type: "boolean",
         placeholder: "Select capitally funded",
         editable: true,
-        dependentField: "ecapris_subproject_id"
+        dependentField: "ecapris_subproject_id",
       },
       ...(capitallyFunded && {
         ecapris_subproject_id: {
@@ -112,7 +102,8 @@ const ProjectSummaryTable = ({ data, loading, error, refetch }) => {
           table: "moped_phases",
           fieldLabel: "phase_name",
           fieldValue: "phase_name",
-          relationship: "where: {phase_id: {_gt: 0}}, order_by: {phase_order: asc}",
+          relationship:
+            "where: {phase_id: {_gt: 0}}, order_by: {phase_order: asc}",
           style: classes.fieldSelectCapitalize,
           format: value => String(value).toLowerCase(),
         },


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/6719
- Remove fiscal year field from define new project and project summary views
- Remove fiscal year query and error/loading handlers
- Remove current status from define new project view
- Remove current status query and error/loading handlers
- Remove unneeded imports in DefineProjectForm component