### PR TITLE
Patch Heroku Deployment Script

### DIFF
--- a/.github/workflows/aws-heroku-helper.sh
+++ b/.github/workflows/aws-heroku-helper.sh
@@ -126,6 +126,11 @@ function run_database_migration() {
   echo "Endpoint: ${HASURA_SERVER_ENDPOINT}";
   sleep 5;
 
+  # For the time being, we need to remove PostGIS from Heroku, it's not helping
+  print_header "Removing PostGIS from extensions";
+  sed --in-place '/create extension if not exists postgis/d' ./migrations/1599856186244_init/up.sql;
+  grep -rIno "create extension if not exists postgis" ./migrations/1599856186244_init/up.sql
+
   print_header "Checking the server is online";
   wait_server_ready;
 

--- a/.github/workflows/aws-heroku-helper.sh
+++ b/.github/workflows/aws-heroku-helper.sh
@@ -129,7 +129,11 @@ function run_database_migration() {
   # For the time being, we need to remove PostGIS from Heroku, it's not helping
   print_header "Removing PostGIS from extensions";
   sed --in-place '/create extension if not exists postgis/d' ./migrations/1599856186244_init/up.sql;
-  grep -rIno "create extension if not exists postgis" ./migrations/1599856186244_init/up.sql
+  {
+    grep -rIno "create extension if not exists postgis" ./migrations/1599856186244_init/up.sql;
+  } || {
+    echo "PostGIS removed successfully.";
+  }
 
   print_header "Checking the server is online";
   wait_server_ready;


### PR DESCRIPTION
This patch should prevent PostGIS from being installed in moped-test. This is only a problem in Heroku, because PostGIS comes with +5,000 rows, which puts us close to the 10k limit on the free tier and makes us get a bunch of annoying emails.

Tested to work, now the total amount of rows is 1500 (down from 7000+):

<img width="453" alt="2021-08-12_12-45-28" src="https://user-images.githubusercontent.com/5282430/129236981-7c6111f4-f419-44df-89c9-2b9716842413.png">
 