### PR TITLE
Replace moment with date-fns throughout moped

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -16340,9 +16340,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -17634,9 +17634,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -20789,9 +20789,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -21189,8 +21189,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
@@ -21886,9 +21885,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -10446,9 +10446,9 @@
       }
     },
     "date-fns": {
-      "version": "2.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.27.tgz",
-      "integrity": "sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg=="
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
     },
     "debounce": {
       "version": "1.2.0",
@@ -15047,6 +15047,11 @@
         "react-double-scrollbar": "0.0.15"
       },
       "dependencies": {
+        "date-fns": {
+          "version": "2.0.0-alpha.27",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.27.tgz",
+          "integrity": "sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg=="
+        },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -51,6 +51,7 @@
     "axios": "^0.21.1",
     "chart.js": "^2.9.4",
     "clsx": "^1.1.1",
+    "date-fns": "^2.23.0",
     "dompurify": "^2.2.8",
     "env-cmd": "^10.1.0",
     "filepond": "^3.6.0",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -64,7 +64,6 @@
     "lodash.get": "^4.4.2",
     "lodash.toarray": "^4.4.0",
     "material-table": "^1.69.2",
-    "moment": "^2.29.1",
     "nprogress": "^0.2.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -25,7 +25,7 @@ import GridTableExport from "./GridTableExport";
 import TabPanel from "../../views/projects/projectView/TabPanel";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useLazyQuery } from "@apollo/client";
-import moment from "moment";
+import { format } from "date-fns";
 import { get } from "lodash";
 
 const useStyles = makeStyles(theme => ({
@@ -150,7 +150,8 @@ const GridTableSearch = ({
    * @param {string} fileContents
    */
   const downloadFile = fileContents => {
-    const exportFileName = query.table + moment(Date.now()).format();
+    const exportFileName =
+      query.table + format(Date.now(), "yyyy-MM-dd'T'HH:mm:ssxxx");
     const blob = new Blob([fileContents], { type: "text/csv;charset=utf-8;" });
     const link = document.createElement("a");
     if (link.download !== undefined) {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -14,7 +14,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import moment from "moment";
+import { format } from "date-fns";
 import DefineProjectForm from "./DefineProjectForm";
 import NewProjectTeam from "./NewProjectTeam";
 import NewProjectMap from "./NewProjectMap";
@@ -95,7 +95,7 @@ const NewProjectView = () => {
     current_phase: "",
     project_description: "",
     project_name: "",
-    start_date: moment().format("YYYY-MM-DD"),
+    start_date: format(Date.now(), "yyyy-MM-dd"),
     current_status: "",
     capitally_funded: false,
     ecapris_subproject_id: null,

--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -32,7 +32,8 @@ import { PAGING_DEFAULT_COUNT } from "../../../constants/tables";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
-import moment from "moment";
+import { format } from "date-fns";
+import parseISO from "date-fns/parseISO";
 
 /**
  * ProjectTimeline Component - renders the view displayed when the "Timeline"
@@ -312,7 +313,10 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
     {
       title: "Start date",
       field: "phase_start",
-      render: rowData => moment(rowData.phase_start).format("MM/DD/YYYY"),
+      render: rowData =>
+        rowData.phase_start
+          ? format(parseISO(rowData.phase_start), "MM/dd/yyyy")
+          : undefined,
       editComponent: props => (
         <DateFieldEditComponent
           {...props}
@@ -324,7 +328,10 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
     {
       title: "End date",
       field: "phase_end",
-      render: rowData => moment(rowData.phase_end).format("MM/DD/YYYY"),
+      render: rowData =>
+        rowData.phase_end
+          ? format(parseISO(rowData.phase_end), "MM/dd/yyyy")
+          : undefined,
       editComponent: props => (
         <DateFieldEditComponent {...props} name="phase_end" label="End Date" />
       ),
@@ -356,7 +363,9 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
       title: "Completion estimate",
       field: "milestone_estimate",
       render: rowData =>
-        moment(rowData.milestone_estimate).format("MM/DD/YYYY"),
+        rowData.milestone_estimate
+          ? format(parseISO(rowData.milestone_estimate), "MM/dd/yyyy")
+          : undefined,
       editComponent: props => (
         <DateFieldEditComponent
           {...props}
@@ -368,7 +377,10 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
     {
       title: "Date completed",
       field: "milestone_end",
-      render: rowData => moment(rowData.milestone_end).format("MM/DD/YYYY"),
+      render: rowData =>
+        rowData.milestone_end
+          ? format(parseISO(rowData.milestone_end), "MM/dd/yyyy")
+          : undefined,
       editComponent: props => (
         <DateFieldEditComponent
           {...props}
@@ -526,7 +538,8 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
                   </Typography>
                 }
                 options={{
-                  ...(data.moped_proj_phases.length < PAGING_DEFAULT_COUNT + 1 && {
+                  ...(data.moped_proj_phases.length <
+                    PAGING_DEFAULT_COUNT + 1 && {
                     paging: false,
                   }),
                   search: false,
@@ -666,7 +679,8 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
                   </Typography>
                 }
                 options={{
-                  ...(data.moped_proj_milestones.length < PAGING_DEFAULT_COUNT + 1 && {
+                  ...(data.moped_proj_milestones.length <
+                    PAGING_DEFAULT_COUNT + 1 && {
                     paging: false,
                   }),
                   search: false,

--- a/moped-editor/src/views/reports/DashboardView/LatestOrders.js
+++ b/moped-editor/src/views/reports/DashboardView/LatestOrders.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import clsx from "clsx";
-import moment from "moment";
 import { v4 as uuid } from "uuid";
 import PerfectScrollbar from "react-perfect-scrollbar";
 import PropTypes from "prop-types";
@@ -21,6 +20,7 @@ import {
   makeStyles,
 } from "@material-ui/core";
 import ArrowRightIcon from "@material-ui/icons/ArrowRight";
+import { format } from "date-fns";
 
 const data = [
   {
@@ -122,9 +122,7 @@ const LatestOrders = ({ className, ...rest }) => {
                 <TableRow hover key={order.id}>
                   <TableCell>{order.ref}</TableCell>
                   <TableCell>{order.customer.name}</TableCell>
-                  <TableCell>
-                    {moment(order.createdAt).format("DD/MM/YYYY")}
-                  </TableCell>
+                  <TableCell>{format(order.createdAt, "dd/MM/yyyy")}</TableCell>
                   <TableCell>
                     <Chip color="primary" label={order.status} size="small" />
                   </TableCell>

--- a/moped-editor/src/views/reports/DashboardView/LatestProducts.js
+++ b/moped-editor/src/views/reports/DashboardView/LatestProducts.js
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import { v4 as uuid } from "uuid";
-import moment from "moment";
+import subHours from "date-fns/subHours";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import {
   Box,
   Button,
@@ -27,32 +28,32 @@ const data = [
   {
     id: uuid(),
     name: "Finance Data",
-    updatedAt: moment().subtract(2, "hours"),
+    updatedAt: subHours(Date.now(), 2),
     imageUrl: <MonetizationOnIcon />,
   },
   {
     id: uuid(),
     name: "ATD Data Tracker",
     imageUrl: <StorageIcon />,
-    updatedAt: moment().subtract(2, "hours"),
+    updatedAt: subHours(Date.now(), 2),
   },
   {
     id: uuid(),
     name: "TXDOT Systems",
     imageUrl: <BusinessIcon />,
-    updatedAt: moment().subtract(3, "hours"),
+    updatedAt: subHours(Date.now(), 3),
   },
   {
     id: uuid(),
     name: "Finance Data",
     imageUrl: <MonetizationOnIcon />,
-    updatedAt: moment().subtract(5, "hours"),
+    updatedAt: subHours(Date.now(), 5),
   },
   {
     id: uuid(),
     name: "eCapris Project Reporting",
     imageUrl: <BuildIcon />,
-    updatedAt: moment().subtract(9, "hours"),
+    updatedAt: subHours(Date.now(), 9),
   },
 ];
 
@@ -78,18 +79,25 @@ const LatestProducts = ({ className, ...rest }) => {
       />
       <Divider />
       <List>
-        {products.map((product, i) => (
-          <ListItem divider={i < products.length - 1} key={product.id}>
-            <ListItemAvatar>{product.imageUrl}</ListItemAvatar>
-            <ListItemText
-              primary={product.name}
-              secondary={`Updated ${product.updatedAt.fromNow()}`}
-            />
-            <IconButton edge="end" size="small">
-              <MoreVertIcon />
-            </IconButton>
-          </ListItem>
-        ))}
+        {products.map((product, i) => {
+          return (
+            <ListItem divider={i < products.length - 1} key={product.id}>
+              <ListItemAvatar>{product.imageUrl}</ListItemAvatar>
+              <ListItemText
+                primary={product.name}
+                secondary={`Updated ${formatDistanceToNow(
+                  new Date(product.updatedAt),
+                  {
+                    addSufix: true,
+                  }
+                )} ago`}
+              />
+              <IconButton edge="end" size="small">
+                <MoreVertIcon />
+              </IconButton>
+            </ListItem>
+          );
+        })}
       </List>
       <Divider />
       <Box display="flex" justifyContent="flex-end" p={2}>


### PR DESCRIPTION
- Closes https://github.com/cityofaustin/atd-data-tech/issues/5447
- Replaced moment functions with date-fns functions
- Moment was replaced in LatestProducts, LatestOrders, ProjectTimeline, NewProjectView, GridTableSearch components

How to view changes
- Go to dashboard and scroll down to data syncs. Look at last updated.
- Go to dashboard and scroll down to latest staff updates. Look at the date column.
- Go to projects and click on the new project button. Look at start date.
- Go to projects and click on the download button (make sure there are search results). Look at file name.
- Go to projects and select an existing project. Go to timeline and look at start date, end date, date completed, completion estimate columns.