### PR TITLE
[Bug] Prevent map from zooming in too close #6821

### DIFF
--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -328,7 +328,7 @@ const NewProjectMap = ({
       <ReactMapGL
         {...viewport}
         ref={mapRef}
-        maxZoom={18}
+        maxZoom={20}
         width="100%"
         height="60vh"
         interactiveLayerIds={!isDrawing && getEditMapInteractiveIds()}

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -328,6 +328,7 @@ const NewProjectMap = ({
       <ReactMapGL
         {...viewport}
         ref={mapRef}
+        maxZoom={18}
         width="100%"
         height="60vh"
         interactiveLayerIds={!isDrawing && getEditMapInteractiveIds()}

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -262,7 +262,7 @@ const ProjectComponentsMapView = ({
         {...viewport}
         /* Object reference to this object */
         ref={mapRef}
-        maxZoom={18}
+        maxZoom={20}
         width="100%"
         height="60vh"
         /* Access Key */

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -262,6 +262,7 @@ const ProjectComponentsMapView = ({
         {...viewport}
         /* Object reference to this object */
         ref={mapRef}
+        maxZoom={18}
         width="100%"
         height="60vh"
         /* Access Key */

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -86,7 +86,7 @@ const ProjectSummaryMap = ({
         {...viewport}
         /* Object reference to this object */
         ref={mapRef}
-        maxZoom={18}
+        maxZoom={20}
         width="100%"
         height="60vh"
         /* Access Key */

--- a/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummaryMap.js
@@ -86,6 +86,7 @@ const ProjectSummaryMap = ({
         {...viewport}
         /* Object reference to this object */
         ref={mapRef}
+        maxZoom={18}
         width="100%"
         height="60vh"
         /* Access Key */


### PR DESCRIPTION
Updates MaxZoom across all instances of `<ReactMapGL/>`

### Live Demo:
https://deploy-preview-397--atd-moped-main.netlify.app/

<img width="1648" alt="2021-08-16_18-02-04" src="https://user-images.githubusercontent.com/5282430/129634949-ebd2a8e9-fa74-402d-9ee6-e50f5c1b292d.png">
