### PR TITLE
Fix bug preventing changing project name

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -86,7 +86,7 @@ const ProjectNameEditable = props => {
    */
   const handleAcceptClick = e => {
     e.preventDefault();
-    if (!projectName.trim()==="") {
+    if (!(projectName.trim()==="")) {
     updateProjectName({
       variables: {
         projectId: props?.projectId,


### PR DESCRIPTION
Closes cityofaustin/atd-data-tech#7010

In a PEMDAS-type code error, I was incorrectly checking if a title update was empty. 
I wanted to check that `projectName.trim()===""` was not true. But `!projectName.trim()===""` was evaluating as `!projectName.trim()` equals `""`

Test here: https://7010-change-project-name--atd-moped-main.netlify.app/ by changing a project's name and saving. 