### PR TITLE
Resolves follow-up tasks to signal-based component editing

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -586,6 +586,17 @@ export const COMPONENT_DETAILS_QUERY = gql`
   }
 `;
 
+export const SIGNAL_COMPONENTS_QUERY = gql`
+  query GetSignalComponents {
+    moped_components(where: {component_name: {_ilike: "signal"}}) {
+      component_name
+      component_subtype
+      component_id
+      line_representation
+    }
+  }
+`;
+
 export const UPDATE_MOPED_COMPONENT = gql`
   mutation UpdateMopedComponent(
     $objects: [moped_proj_components_insert_input!]!

--- a/moped-editor/src/utils/mapHelpers.js
+++ b/moped-editor/src/utils/mapHelpers.js
@@ -14,7 +14,6 @@ import {
   withStyles,
 } from "@material-ui/core";
 import { KeyboardArrowDown, KeyboardArrowUp } from "@material-ui/icons";
-import { v4 as uuidv4 } from "uuid";
 import {
   mapSaveActionReducer,
   mapSaveActionInitialState,
@@ -1054,39 +1053,4 @@ export const queryCtnFeatureService = async function(projectExtentId) {
       console.log("Error fetching geometry: " + JSON.stringify(err));
       return null;
     });
-};
-
-/**
- * Immitate a "drawn point" feature from a traffic signal goejosn feature. Sets required
- * fields so that featureCollection can be used in the DB mutation on submit
- * @param {Object} signal - A GeoJSON feature or a falsey object (e.g. "" from empty input)
- * @return {Object} A geojson feature collection with the signal feature or 0 features
- */
-export const signalToFeatureCollection = signal => {
-  let featureCollection = {
-    type: "FeatureCollection",
-    features: [],
-  };
-  if (signal) {
-    /* 
-    / preserves the feature's previous UUID if it's being edited. we are **not** preserving
-    / any other feature properties when the feature is edited. so, for example, if the user
-    / edits a signal component and the signal geometry in socrata has since changed, the new
-    / geometry will be saved.
-    */
-    const featureUUID = signal.id || uuidv4();
-    const feature = {
-      type: "Feature",
-      properties: {
-        ...signal.properties,
-        renderType: "Point",
-        PROJECT_EXTENT_ID: featureUUID,
-        sourceLayer: "drawnByUser",
-      },
-      geometry: signal.geometry,
-      id: featureUUID,
-    };
-    featureCollection.features.push(feature);
-  }
-  return featureCollection;
 };

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -7,23 +7,23 @@ import { v4 as uuidv4 } from "uuid";
  * @param {Object} signal - A GeoJSON feature or a falsey object (e.g. "" from empty input)
  * @return {Object} A geojson feature collection with the signal feature or 0 features
  */
- export const signalToFeatureCollection = signal => {
+export const signalToFeatureCollection = signal => {
   let featureCollection = {
     type: "FeatureCollection",
     features: [],
   };
-  if (signal) {
+  if (signal && signal?.properties && signal?.geometry) {
     /* 
     / preserves the feature's previous UUID if it's being edited. we are **not** preserving
     / any other feature properties when the feature is edited. so, for example, if the user
     / edits a signal component and the signal geometry in socrata has since changed, the new
     / geometry will be saved.
     */
-    const featureUUID = signal.id || uuidv4();
+    const featureUUID = signal?.id || uuidv4();
     const feature = {
       type: "Feature",
       properties: {
-        ...signal.properties,
+        ...signal?.properties,
         renderType: "Point",
         PROJECT_EXTENT_ID: featureUUID,
         sourceLayer: "drawnByUser",
@@ -36,7 +36,10 @@ import { v4 as uuidv4 } from "uuid";
   return featureCollection;
 };
 
-export const useInitialSignalComponentValue = (editFeatureCollection, setSignal) => {
+export const useInitialSignalComponentValue = (
+  editFeatureCollection,
+  setSignal
+) => {
   /*
   / initializes the selected signal value - handles case of editing existing component
   / tests for signal_id prop to ensure we're not handing a non-signal component (which happens

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -2,6 +2,40 @@ import { useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 /**
+ * Function to pass to MUI Autocomplete `filterOptions` prop which filters signal select
+ * options.
+ */
+export const filterSignalOptions = (
+  options,
+  { inputValue, getOptionLabel }
+) => {
+  // limits options to ensure fast rendering
+  const limit = 40;
+  // applies the default autcomplete matching behavior plus our limit filter
+  const filteredOptions = options.filter(option =>
+    getOptionLabel(option)
+      .toLowerCase()
+      .includes(inputValue.toLowerCase())
+  );
+  return filteredOptions.slice(0, limit);
+};
+
+/**
+ * MUI autocomplete getOptionSelected function to which matches input signal value to
+ * select options.
+ */
+export const getSignalOptionSelected = (option, value) =>
+  option.properties?.signal_id === value.properties?.signal_id;
+
+/**
+ * MUI autocomplete getOptionLabel function to which formats the value rendered in
+ * the select option menu
+ */
+export const getSignalOptionLabel = option =>
+  // this label formatting mirrors the Data Tracker formatting
+  `${option.properties.signal_id}: ${option.properties.location_name}`;
+
+/**
  * Immitate a "drawn point" feature from a traffic signal goejosn feature. Sets required
  * fields so that featureCollection can be used in the DB mutation on submit
  * @param {Object} signal - A GeoJSON feature or a falsey object (e.g. "" from empty input)

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -123,11 +123,14 @@ export const useSignalChangeEffect = (
 /*
 / Defines text input to render in MUI autocomplete
 */
-export const renderSignalInput = params => (
+export const renderSignalInput = (params, signalError = false) => (
   <TextField
     {...params}
-    helperText="Required"
+    error={signalError}
+    InputLabelProps={{ required: false }}
     label="Signal"
+    required
+    helperText="Required"
     variant="outlined"
   />
 );

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Immitate a "drawn point" feature from a traffic signal goejosn feature. Sets required
+ * fields so that featureCollection can be used in the DB mutation on submit
+ * @param {Object} signal - A GeoJSON feature or a falsey object (e.g. "" from empty input)
+ * @return {Object} A geojson feature collection with the signal feature or 0 features
+ */
+ export const signalToFeatureCollection = signal => {
+  let featureCollection = {
+    type: "FeatureCollection",
+    features: [],
+  };
+  if (signal) {
+    /* 
+    / preserves the feature's previous UUID if it's being edited. we are **not** preserving
+    / any other feature properties when the feature is edited. so, for example, if the user
+    / edits a signal component and the signal geometry in socrata has since changed, the new
+    / geometry will be saved.
+    */
+    const featureUUID = signal.id || uuidv4();
+    const feature = {
+      type: "Feature",
+      properties: {
+        ...signal.properties,
+        renderType: "Point",
+        PROJECT_EXTENT_ID: featureUUID,
+        sourceLayer: "drawnByUser",
+      },
+      geometry: signal.geometry,
+      id: featureUUID,
+    };
+    featureCollection.features.push(feature);
+  }
+  return featureCollection;
+};

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 /**
@@ -33,4 +34,51 @@ import { v4 as uuidv4 } from "uuid";
     featureCollection.features.push(feature);
   }
   return featureCollection;
+};
+
+export const useInitialSignalComponentValue = (editFeatureCollection, setSignal) => {
+  /*
+  / initializes the selected signal value - handles case of editing existing component
+  / tests for signal_id prop to ensure we're not handing a non-signal component (which happens
+  / e.g. when an existing component's type is changed)
+  */
+  useEffect(() => {
+    if (
+      !editFeatureCollection ||
+      editFeatureCollection.features.length === 0 ||
+      !editFeatureCollection.features[0].properties.signal_id
+    ) {
+      setSignal(null);
+      return;
+    } else if (editFeatureCollection.features.length > 1) {
+      /*
+      / If a non-signal component is edited, all previously-defined feature geometries
+      / will be dropped.
+      */
+      console.warn(
+        "Found signal component with multiple feature geometries. All but one feature will be removed."
+      );
+    }
+    setSignal(editFeatureCollection.features[0]);
+    // only fire on init
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+/*
+/ Hook which updates the component editor state based on the selected signal
+*/
+export const useSignalChangeEffect = (
+  signal,
+  setSelectedComponentSubtype,
+  setEditFeatureCollection
+) => {
+  useEffect(() => {
+    const signalSubtype = signal
+      ? signal.properties.signal_type.toLowerCase()
+      : "";
+    const featureCollection = signalToFeatureCollection(signal);
+    setSelectedComponentSubtype(signalSubtype);
+    setEditFeatureCollection(featureCollection);
+  }, [signal, setSelectedComponentSubtype, setEditFeatureCollection]);
 };

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -123,17 +123,19 @@ export const useSignalChangeEffect = (
 /*
 / Defines text input to render in MUI autocomplete
 */
-export const renderSignalInput = (params, signalError = false) => (
-  <TextField
-    {...params}
-    error={signalError}
-    InputLabelProps={{ required: false }}
-    label="Signal"
-    required
-    helperText="Required"
-    variant="outlined"
-  />
-);
+export const renderSignalInput = (params, signalError = false, variant="standard") => {
+  return (
+    <TextField
+      {...params}
+      error={signalError}
+      InputLabelProps={{ required: false }}
+      label="Signal"
+      required
+      helperText="Required"
+      variant={variant}
+    />
+  );
+};
 
 /**
  * Get's the correct COMPONENT_DEFIINITION property based on the presence of a signal feature

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
+import { TextField } from "@material-ui/core";
 
-/**
- * Function to pass to MUI Autocomplete `filterOptions` prop which filters signal select
- * options.
- */
+/*
+/ MUI autocomplete filter function which limits number of options rendered in select menu
+*/
 export const filterSignalOptions = (
   options,
   { inputValue, getOptionLabel }
@@ -119,3 +119,15 @@ export const useSignalChangeEffect = (
     setEditFeatureCollection(featureCollection);
   }, [signal, setSelectedComponentSubtype, setEditFeatureCollection]);
 };
+
+/*
+/ Defines text input to render in MUI autocomplete
+*/
+export const renderSignalInput = params => (
+  <TextField
+    {...params}
+    helperText="Required"
+    label="Signal"
+    variant="outlined"
+  />
+);

--- a/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectMap.js
@@ -455,7 +455,7 @@ const NewProjectMap = ({
         width="100%"
         height="60vh"
         interactiveLayerIds={
-          !isDrawing && !isSignalComponent && getEditMapInteractiveIds()
+          !isDrawing && !isSignalComponent ? getEditMapInteractiveIds() : []
         }
         onHover={!isDrawing && !isSignalComponent ? handleLayerHover : null}
         onClick={!isDrawing && !isSignalComponent ? handleLayerClick : null}

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -35,6 +35,11 @@ import {
 
 import ProjectSaveButton from "./ProjectSaveButton";
 
+import {
+  useSignalStateManager,
+  generateProjectComponent,
+} from "src/utils/signalComponentHelpers";
+
 /**
  * Styles
  */
@@ -50,89 +55,6 @@ const useStyles = makeStyles(theme => ({
     marginLeft: theme.spacing(1),
   },
 }));
-
-/**
- * Component definitions. The component_id must match a valid component in the
- * moped_components DB lookup table.
- */
-const COMPONENT_DEFINITIONS = {
-  generic: {
-    name: "Extent",
-    description: "New Project Feature Extent",
-    component_id: 0,
-  },
-  phb: {
-    name: "PHB",
-    description: "Pedestrian ssignal",
-    component_id: 16,
-  },
-  traffic: {
-    name: "Traffic signal",
-    description: "Traffic signal",
-    component_id: 18,
-  },
-};
-
-/**
- * Get's the correct COMPONENT_DEFIINITION property based on the presence of a signal feature
- * @param {Boolean} fromSignalAsset - if signal autocomplete switch is active
- * @param {Object} featureCollection - The final GeoJSON to be inserted into a component
- * @return {Object} - The component definition pboject
- */
-const getComponentDef = (featureCollection, fromSignalAsset) => {
-  const signalType = fromSignalAsset
-    ? featureCollection.features[0].properties?.signal_type?.toLowerCase()
-    : null;
-  return signalType
-    ? COMPONENT_DEFINITIONS[signalType]
-    : COMPONENT_DEFINITIONS.generic;
-};
-
-/**
- * Generates a project component object that can be used in mutation.
- * @param {Boolean} fromSignalAsset - if signal autocomplete switch is active
- * @param {Object} featureCollection - The final GeoJSON to be inserted into a component
- * @return {Object} - The component mutation object
- */
-const generateProjectComponent = (featureCollection, fromSignalAsset) => {
-  const componentDef = getComponentDef(featureCollection, fromSignalAsset);
-  return {
-    name: "Extent",
-    description: "Project full extent",
-    component_id: componentDef.component_id,
-    status_id: 1,
-    moped_proj_features_components: {
-      data: featureCollection.features.map(feature => ({
-        name: componentDef.name,
-        description: componentDef.description,
-        status_id: 1,
-        moped_proj_feature_object: {
-          data: {
-            status_id: 1,
-            location: feature,
-          },
-        },
-      })),
-    },
-  };
-};
-
-/**
- * Resets featureCollection and signal when fromSignalAsset toggle changes. Ensures we keep
- * form state clean.
- * @param {Boolean} fromSignalAsset - if signal autocomplete switch is active
- * @param {func} setSignal - signal state setter
- * @param {Object} setFeatureCollection - featureCollection state setter
- */
-const useSignalStateManager = (fromSignal, setSignal, setFeatureCollection) => {
-  useEffect(() => {
-    setFeatureCollection({
-      type: "FeatureCollection",
-      features: [],
-    });
-    setSignal("");
-  }, [setFeatureCollection, fromSignal, setSignal]);
-};
 
 /**
  * New Project View
@@ -499,7 +421,9 @@ const NewProjectView = () => {
           <Container>
             <Card className={classes.cardWrapper}>
               <Box pt={2} pl={2}>
-                <CardHeader title={projectDetails.project_name || "Project name"} />
+                <CardHeader
+                  title={projectDetails.project_name || "Project name"}
+                />
               </Box>
               <Divider />
               <CardContent>

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import {
   Button,
   Box,
+  CircularProgress,
   Container,
   Card,
   CardHeader,
@@ -20,7 +21,9 @@ import NewProjectTeam from "./NewProjectTeam";
 import NewProjectMap from "./NewProjectMap";
 import ProjectSummaryMap from "../projectView/ProjectSummaryMap";
 import Page from "src/components/Page";
-import { useMutation } from "@apollo/client";
+import { useQuery, useMutation } from "@apollo/client";
+import { SIGNAL_COMPONENTS_QUERY } from "../../../queries/project";
+
 import {
   ADD_PROJECT,
   UPDATE_NEW_PROJ_FEATURES,
@@ -34,7 +37,6 @@ import {
 } from "../../../utils/mapHelpers";
 
 import ProjectSaveButton from "./ProjectSaveButton";
-
 import {
   useSignalStateManager,
   generateProjectComponent,
@@ -96,6 +98,12 @@ const NewProjectView = () => {
     ecapris_subproject_id: null,
   });
 
+  const {
+    error: componentQueryError,
+    loading: componentQueryloading,
+    data: componentData,
+  } = useQuery(SIGNAL_COMPONENTS_QUERY);
+
   const [nameError, setNameError] = useState(false);
   const [descriptionError, setDescriptionError] = useState(false);
   const [personnel, setPersonnel] = useState([]);
@@ -104,6 +112,10 @@ const NewProjectView = () => {
     features: [],
   });
   const [areNoFeaturesSelected, setAreNoFeaturesSelected] = useState(false);
+
+  /**
+   * Signal component state management
+   */
   const [signal, setSignal] = useState("");
   const [fromSignalAsset, setFromSignalAsset] = useState(false);
   useSignalStateManager(fromSignalAsset, setSignal, setFeatureCollection);
@@ -326,7 +338,13 @@ const NewProjectView = () => {
         ...projectDetails,
         // Next we generate the project extent component
         moped_proj_components: {
-          data: [generateProjectComponent(featureCollection, fromSignalAsset)],
+          data: [
+            generateProjectComponent(
+              featureCollection,
+              fromSignalAsset,
+              componentData["moped_components"]
+            ),
+          ],
         },
         // Finally we provide the project personnel
         moped_proj_personnel: { data: cleanedPersonnel },
@@ -413,6 +431,11 @@ const NewProjectView = () => {
     // handleSubmit changes on every render, cannot be a dependency
     // eslint-disable-next-line
   }, [saveActionState]);
+
+  if (componentQueryloading) {
+    return <CircularProgress />;
+  }
+  if (componentQueryError) return `Error! ${componentQueryError.message}`;
 
   return (
     <>

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -40,8 +40,6 @@ const SignalAutocomplete = ({
 
   const { features, loading, error } = useSocrataGeojson(SOCRATA_ENDPOINT);
 
-  const options = features ? [...features, ""] : [""];
-
   if (loading) {
     // we don't want to render the autocomplete without options, because getOptionSelected
     // will error if we're editing an existing component
@@ -66,24 +64,18 @@ const SignalAutocomplete = ({
         );
         return filteredOptions.slice(0, limit);
       }}
-      getOptionSelected={(option, value) => {
-        // todo: i had to use optional chaning here, but i'm not sure why. the `value` test was
-        // seemingly calling the first condition when value was ""
-        return value
-          ? option.properties?.signal_id === value.properties?.signal_id
-          : option === "";
-      }}
-      // this label formatting mirrors the Data Tracker formatting
+      getOptionSelected={(option, value) =>
+        option.properties?.signal_id === value.properties?.signal_id
+      }
       getOptionLabel={option =>
-        option
-          ? `${option.properties.signal_id}: ${option.properties.location_name}`
-          : ""
+        // this label formatting mirrors the Data Tracker formatting
+        `${option.properties.signal_id}: ${option.properties.location_name}`
       }
       onChange={(e, signal) => {
         handleFieldChange(signal);
       }}
       loading={loading}
-      options={options}
+      options={features}
       renderInput={params => (
         <TextField
           {...params}
@@ -105,7 +97,7 @@ const SignalAutocomplete = ({
           variant="standard"
         />
       )}
-      value={signal}
+      value={signal || null}
     />
   );
 };

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -2,7 +2,7 @@ import React from "react";
 import { TextField, CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
-import { signalToFeatureCollection } from "src/utils/mapHelpers";
+import { signalToFeatureCollection } from "src/utils/signalComponentHelpers";
 
 const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -4,10 +4,10 @@ import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
 import {
   filterSignalOptions,
+  signalToFeatureCollection,
   getSignalOptionLabel,
   getSignalOptionSelected,
   renderSignalInput,
-  signalToFeatureCollection,
 } from "src/utils/signalComponentHelpers";
 
 const SOCRATA_ENDPOINT =

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -67,7 +67,7 @@ const SignalAutocomplete = ({
       }}
       loading={loading}
       options={features}
-      renderInput={renderSignalInput}
+      renderInput={params => renderSignalInput(params, signalError)}
       value={signal || null}
     />
   );

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -11,11 +11,11 @@ const SOCRATA_ENDPOINT =
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a
  * Socrata dataset. Data is fetched once when the component mounts.
  * @param {Object} signal - A GeoJSON feature or a falsey object (e.g. "" from empty input)
- * * @param {func} setSignal - signal state setter
- * * @param {Object} projectDetails - The parent view's project details object
- * * @param {Object} setProjectDetails - The projectDetails state setter
- * * @param {Object} setFeatureCollection - The parent view's featureCollection state setter
- * * @param {Boolean} signalError - If the current signal value is in validation error
+ * @param {func} setSignal - signal state setter
+ * @param {Object} projectDetails - The parent view's project details object
+ * @param {Object} setProjectDetails - The projectDetails state setter
+ * @param {Object} setFeatureCollection - The parent view's featureCollection state setter
+ * @param {Boolean} signalError - If the current signal value is in validation error
  *  @return {JSX.Element}
  */
 const SignalAutocomplete = ({

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -2,7 +2,11 @@ import React from "react";
 import { TextField, CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
-import { signalToFeatureCollection } from "src/utils/signalComponentHelpers";
+import {
+  signalToFeatureCollection,
+  getSignalOptionLabel,
+  getSignalOptionSelected,
+} from "src/utils/signalComponentHelpers";
 
 const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
@@ -64,13 +68,8 @@ const SignalAutocomplete = ({
         );
         return filteredOptions.slice(0, limit);
       }}
-      getOptionSelected={(option, value) =>
-        option.properties?.signal_id === value.properties?.signal_id
-      }
-      getOptionLabel={option =>
-        // this label formatting mirrors the Data Tracker formatting
-        `${option.properties.signal_id}: ${option.properties.location_name}`
-      }
+      getOptionSelected={getSignalOptionSelected}
+      getOptionLabel={getSignalOptionLabel}
       onChange={(e, signal) => {
         handleFieldChange(signal);
       }}

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -1,11 +1,13 @@
 import React from "react";
-import { TextField, CircularProgress } from "@material-ui/core";
+import { CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
 import {
-  signalToFeatureCollection,
+  filterSignalOptions,
   getSignalOptionLabel,
   getSignalOptionSelected,
+  renderSignalInput,
+  signalToFeatureCollection,
 } from "src/utils/signalComponentHelpers";
 
 const SOCRATA_ENDPOINT =
@@ -57,17 +59,7 @@ const SignalAutocomplete = ({
   return (
     <Autocomplete
       id="signal-id"
-      filterOptions={(options, { inputValue, getOptionLabel }) => {
-        // limits options to ensure fast rendering
-        const limit = 40;
-        // applies the default autcomplete matching behavior plus our limit filter
-        const filteredOptions = options.filter(option =>
-          getOptionLabel(option)
-            .toLowerCase()
-            .includes(inputValue.toLowerCase())
-        );
-        return filteredOptions.slice(0, limit);
-      }}
+      filterOptions={filterSignalOptions}
       getOptionSelected={getSignalOptionSelected}
       getOptionLabel={getSignalOptionLabel}
       onChange={(e, signal) => {
@@ -75,27 +67,7 @@ const SignalAutocomplete = ({
       }}
       loading={loading}
       options={features}
-      renderInput={params => (
-        <TextField
-          {...params}
-          error={signalError}
-          helperText="Required"
-          InputProps={{
-            ...params.InputProps,
-            endAdornment: (
-              <>
-                {loading ? (
-                  <CircularProgress color="primary" size={20} />
-                ) : null}
-              </>
-            ),
-          }}
-          InputLabelProps={{ required: false }}
-          label="Signal"
-          required
-          variant="standard"
-        />
-      )}
+      renderInput={renderSignalInput}
       value={signal || null}
     />
   );

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -242,8 +242,8 @@ const ProjectComponentsMapView = ({
       >
         <Grid>
           <Grid className={classes.layerSelectBox}>{children}</Grid>
-          <Grid xs={12}>
-            <Divider fullWidth className={classes.mapToolsDivider} />
+          <Grid item xs={12}>
+            <Divider className={classes.mapToolsDivider} />
             <Button
               onClick={() => setEditPanelCollapsed(false)}
               startIcon={<KeyboardArrowUp />}

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -41,7 +41,7 @@ const SignalComponentAutocomplete = ({
       <Alert severity="error">{`Unable to load signal list: ${error}`}</Alert>
     );
   }
-
+  
   return (
     <Autocomplete
       className={classes}
@@ -77,7 +77,7 @@ const SignalComponentAutocomplete = ({
           variant="outlined"
         />
       )}
-      value={signal}
+      value={signal || null}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -20,7 +20,7 @@ const useInitialComponentValue = (editFeatureCollection, setSignal) => {
       editFeatureCollection.features.length === 0 ||
       !editFeatureCollection.features[0].properties.signal_id
     ) {
-      setSignal("");
+      setSignal(null);
       return;
     } else if (editFeatureCollection.features.length > 1) {
       /*
@@ -70,9 +70,8 @@ const SignalComponentAutocomplete = ({
   setEditFeatureCollection,
   editFeatureCollection,
 }) => {
-  const [signal, setSignal] = useState("");
+  const [signal, setSignal] = useState(null);
   const { features, loading, error } = useSocrataGeojson(SOCRATA_ENDPOINT);
-  const options = features ? [...features, ""] : [""];
 
   useInitialComponentValue(editFeatureCollection, setSignal);
 
@@ -105,22 +104,18 @@ const SignalComponentAutocomplete = ({
         );
         return filteredOptions.slice(0, limit);
       }}
-      getOptionSelected={(option, value) => {
-        return value
-          ? option.properties?.signal_id === value.properties?.signal_id
-          : option === "";
-      }}
+      getOptionSelected={(option, value) =>
+        option.properties?.signal_id === value.properties?.signal_id
+      }
       // this label formatting mirrors the Data Tracker formatting
       getOptionLabel={option =>
-        option
-          ? `${option.properties.signal_id}: ${option.properties.location_name}`
-          : ""
+        `${option.properties.signal_id}: ${option.properties.location_name}`
       }
       onChange={(e, signal) => {
-        setSignal(signal);
+        setSignal(signal ? signal : null);
       }}
       loading={loading}
-      options={options}
+      options={features}
       renderInput={params => (
         <TextField
           {...params}
@@ -129,7 +124,7 @@ const SignalComponentAutocomplete = ({
           variant="outlined"
         />
       )}
-      value={signal || ""}
+      value={signal}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -61,7 +61,7 @@ const SignalComponentAutocomplete = ({
       }}
       loading={loading}
       options={features}
-      renderInput={renderSignalInput}
+      renderInput={params => renderSignalInput(params, null, "outlined")}
       value={signal || null}
     />
   );

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -3,10 +3,14 @@ import { useState } from "react";
 import { TextField, CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
-import { useSignalChangeEffect, useInitialSignalComponentValue } from "src/utils/signalComponentHelpers";
+import {
+  useSignalChangeEffect,
+  useInitialSignalComponentValue,
+  getSignalOptionLabel,
+  getSignalOptionSelected,
+} from "src/utils/signalComponentHelpers";
 const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
-
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a
@@ -41,7 +45,7 @@ const SignalComponentAutocomplete = ({
       <Alert severity="error">{`Unable to load signal list: ${error}`}</Alert>
     );
   }
-  
+
   return (
     <Autocomplete
       className={classes}
@@ -57,13 +61,9 @@ const SignalComponentAutocomplete = ({
         );
         return filteredOptions.slice(0, limit);
       }}
-      getOptionSelected={(option, value) =>
-        option.properties?.signal_id === value.properties?.signal_id
-      }
+      getOptionSelected={getSignalOptionSelected}
       // this label formatting mirrors the Data Tracker formatting
-      getOptionLabel={option =>
-        `${option.properties.signal_id}: ${option.properties.location_name}`
-      }
+      getOptionLabel={getSignalOptionLabel}
       onChange={(e, signal) => {
         setSignal(signal ? signal : null);
       }}

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -1,59 +1,12 @@
 import React from "react";
+import { useState } from "react";
 import { TextField, CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
-import { useEffect, useState } from "react";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
-import { signalToFeatureCollection } from "src/utils/mapHelpers";
-
+import { useSignalChangeEffect, useInitialSignalComponentValue } from "src/utils/signalComponentHelpers";
 const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
 
-const useInitialComponentValue = (editFeatureCollection, setSignal) => {
-  /*
-  / initializes the selected signal value - handles case of editing existing component
-  / tests for signal_id prop to ensure we're not handing a non-signal component (which happens
-  / e.g. when an existing component's type is changed)
-  */
-  useEffect(() => {
-    if (
-      !editFeatureCollection ||
-      editFeatureCollection.features.length === 0 ||
-      !editFeatureCollection.features[0].properties.signal_id
-    ) {
-      setSignal(null);
-      return;
-    } else if (editFeatureCollection.features.length > 1) {
-      /*
-      / If a non-signal component is edited, all previously-defined feature geometries
-      / will be dropped.
-      */
-      console.warn(
-        "Found signal component with multiple feature geometries. All but one feature will be removed."
-      );
-    }
-    setSignal(editFeatureCollection.features[0]);
-    // only fire on init
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-};
-
-/*
-/ Hook which updates the component editor state based on the selected signal
-*/
-const useSignalChangeEffect = (
-  signal,
-  setSelectedComponentSubtype,
-  setEditFeatureCollection
-) => {
-  useEffect(() => {
-    const signalSubtype = signal
-      ? signal.properties.signal_type.toLowerCase()
-      : "";
-    const featureCollection = signalToFeatureCollection(signal);
-    setSelectedComponentSubtype(signalSubtype);
-    setEditFeatureCollection(featureCollection);
-  }, [signal, setSelectedComponentSubtype, setEditFeatureCollection]);
-};
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a
@@ -73,7 +26,7 @@ const SignalComponentAutocomplete = ({
   const [signal, setSignal] = useState(null);
   const { features, loading, error } = useSocrataGeojson(SOCRATA_ENDPOINT);
 
-  useInitialComponentValue(editFeatureCollection, setSignal);
+  useInitialSignalComponentValue(editFeatureCollection, setSignal);
 
   useSignalChangeEffect(
     signal,

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -1,13 +1,15 @@
 import React from "react";
 import { useState } from "react";
-import { TextField, CircularProgress } from "@material-ui/core";
+import { CircularProgress } from "@material-ui/core";
 import { Autocomplete, Alert } from "@material-ui/lab";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
 import {
+  filterSignalOptions,
   useSignalChangeEffect,
-  useInitialSignalComponentValue,
   getSignalOptionLabel,
   getSignalOptionSelected,
+  useInitialSignalComponentValue,
+  renderSignalInput,
 } from "src/utils/signalComponentHelpers";
 const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
@@ -50,17 +52,7 @@ const SignalComponentAutocomplete = ({
     <Autocomplete
       className={classes}
       id="signal-id"
-      filterOptions={(options, { inputValue, getOptionLabel }) => {
-        // limits options to ensure fast rendering
-        const limit = 40;
-        // applies the default autcomplete matching behavior plus our limit filter
-        const filteredOptions = options.filter(option =>
-          getOptionLabel(option)
-            .toLowerCase()
-            .includes(inputValue.toLowerCase())
-        );
-        return filteredOptions.slice(0, limit);
-      }}
+      filterOptions={filterSignalOptions}
       getOptionSelected={getSignalOptionSelected}
       // this label formatting mirrors the Data Tracker formatting
       getOptionLabel={getSignalOptionLabel}
@@ -69,14 +61,7 @@ const SignalComponentAutocomplete = ({
       }}
       loading={loading}
       options={features}
-      renderInput={params => (
-        <TextField
-          {...params}
-          helperText="Required"
-          label="Signal"
-          variant="outlined"
-        />
-      )}
+      renderInput={renderSignalInput}
       value={signal || null}
     />
   );


### PR DESCRIPTION
Fixes [#7136](https://github.com/cityofaustin/atd-data-tech/issues/7136).

- Source signal component definitions from Moped DB
-  Unifies input props for SignalAutoComplete and SignalComponentAutocomplete components
- Addresses a few linter warnings