### PR TITLE
[Bug] Fix moped-test API deployment #424

### DIFF
--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -135,7 +135,7 @@ jobs:
       - name: "Install AWS Cli"
         run: |
           sudo apt-get install python3-setuptools
-          pip3 install --upgrade setuptools
+          pip3 install --upgrade setuptools==57.5.0
           pip3 install awscli boto3 zappa virtualenv
       # Run the shell commands using the AWS environment variables
       - name: "Build"

--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -135,6 +135,7 @@ jobs:
       - name: "Install AWS Cli"
         run: |
           sudo apt-get install python3-setuptools
+          pip3 install --upgrade setuptools
           pip3 install awscli boto3 zappa virtualenv
       # Run the shell commands using the AWS environment variables
       - name: "Build"

--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -135,7 +135,6 @@ jobs:
       - name: "Install AWS Cli"
         run: |
           sudo apt-get install python3-setuptools
-          pip3 install --upgrade setuptools==57.5.0
           pip3 install awscli boto3 zappa virtualenv
       # Run the shell commands using the AWS environment variables
       - name: "Build"

--- a/.github/workflows/aws-moped-api-helper.sh
+++ b/.github/workflows/aws-moped-api-helper.sh
@@ -43,8 +43,9 @@ function initialize_virtualenv() {
 # First, we need to create the python package by installing requirements
 #
 function install_requirements() {
-  echo "Installing requirements..."
-  pip install -r "./requirements/${WORKING_STAGE}.txt"
+  echo "Installing requirements...";
+  pip install --upgrade setuptools==57.5.0;
+  pip install -r "./requirements/${WORKING_STAGE}.txt";
 }
 
 

--- a/moped-api/requirements/development.txt
+++ b/moped-api/requirements/development.txt
@@ -46,7 +46,6 @@ PyYAML==5.4
 requests==2.25.1
 responses==0.12.0
 rsa==4.7
-setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/development.txt
+++ b/moped-api/requirements/development.txt
@@ -46,6 +46,7 @@ PyYAML==5.4
 requests==2.25.1
 responses==0.12.0
 rsa==4.7
+setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/development.txt
+++ b/moped-api/requirements/development.txt
@@ -56,5 +56,5 @@ urllib3==1.26.6
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
 xmltodict==0.12.0
-zappa==0.52.0
+zappa==0.53.0
 zipp==3.4.0

--- a/moped-api/requirements/moped_test.txt
+++ b/moped-api/requirements/moped_test.txt
@@ -35,7 +35,6 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
-setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/moped_test.txt
+++ b/moped-api/requirements/moped_test.txt
@@ -44,4 +44,4 @@ troposphere==2.6.2
 urllib3==1.26.6
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
-zappa==0.52.0
+zappa==0.53.0

--- a/moped-api/requirements/moped_test.txt
+++ b/moped-api/requirements/moped_test.txt
@@ -35,6 +35,7 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
+setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/production.txt
+++ b/moped-api/requirements/production.txt
@@ -35,7 +35,6 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
-setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/production.txt
+++ b/moped-api/requirements/production.txt
@@ -44,4 +44,4 @@ troposphere==2.6.2
 urllib3==1.26.6
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
-zappa==0.52.0
+zappa==0.53.0

--- a/moped-api/requirements/production.txt
+++ b/moped-api/requirements/production.txt
@@ -35,6 +35,7 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
+setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/staging.txt
+++ b/moped-api/requirements/staging.txt
@@ -35,7 +35,6 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
-setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3

--- a/moped-api/requirements/staging.txt
+++ b/moped-api/requirements/staging.txt
@@ -44,4 +44,4 @@ troposphere==2.6.2
 urllib3==1.26.6
 Werkzeug==0.16.1
 wsgi-request-logger==0.4.6
-zappa==0.52.0
+zappa==0.53.0

--- a/moped-api/requirements/staging.txt
+++ b/moped-api/requirements/staging.txt
@@ -35,6 +35,7 @@ pytz==2020.1
 PyYAML==5.4
 requests==2.25.1
 rsa==4.7
+setuptools==57.5.0
 s3transfer==0.4.2
 six==1.15.0
 text-unidecode==1.3


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-moped/issues/424

Downgrades setuptools to v 57.5.0 as per breaking changes in newest version:

https://setuptools.pypa.io/en/latest/history.html#v58-0-0

## Result

![2021-09-28_14-57-45](https://user-images.githubusercontent.com/5282430/135157067-e02d588b-37a3-4e99-a8b3-6b54cce3b30a.png)

