### PR TITLE
7473: Don't show the edit icon if there there isn't a status

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary.js
@@ -225,7 +225,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   </Box>
                 )}
                 {/*Edit Button*/}
-                {!statusUpdateEditable && (
+                {!statusUpdateEditable && statusUpdate && (
                   <Icon
                     className={classes.editIcon}
                     onClick={handleStatusUpdateEdit}


### PR DESCRIPTION
This PR intended to close cityofaustin/atd-data-tech/issues/7473.

- [x] Don't show the edit icon when there isn't a status

It's a one-liner; it just checks that the status is existing as a condition of showing the edit icon. 

PR deployment for testing: https://deploy-preview-437--atd-moped-main.netlify.app/moped/projects/176/