### PR TITLE
7471: Status updates not showing when filtering by status type

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -103,6 +103,7 @@ const ProjectComments = () => {
         ...noteTypeConditions,
       },
     },
+    fetchPolicy: "no-cache",
   });
 
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {


### PR DESCRIPTION
Reproducing this bug is subtle. 

Here's what I think is happening: Essentially, Apollo has an (aggressive?) [caching behavior](https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies) which aims to reduce back-and-forth between the app and the graphql endpoint. When you first visit the comments tab, a query to pull comments is run, the data is provided to the component which renders the entire set of comments. If you then (without refreshing the page) return to the summary tab, add a new status, and then return to the comments page, the data object returned and maintained by `useQuery` will have the the results previously returned which are now out of date. The caching behavior essentially creates a "pocket of state" with stale data. This PR configures Apollo to disable the cache on this query. 

I am not entirely rock solid however on why the cache isn't invalidated by Apollo, as one is able to inspect the payload returned by Hasura (as a result of invocation of the `refetch()` method) which invariably contains the correct, up-to-date data. I would expect to be able to:

1) View the comments (to populate the cache)
1) Visit summary and make a new status (to make the cache out-of-date)
1) Return to the comments and see that status missing (using the stale cached data)
1) Toggle between "All" and "Status Updates" to cause `refetch` to be invoked
1) And see the updated content (as Apollo has seen new data from Hasura and recognized its cached data to be stale)

`refetch` is causing a query to hasura to be made, but it's as if the cache is not being invalidated even when updated data comes back to populate `data`. This is what I would expect Apollo to be doing, which leads me to think that I may be barking up the wrong tree. 

However, this fixes the behavior, for better or worse.

This PR _hopes_ to close cityofaustin/atd-data-tech/issues/7471.

The link to the PR deployment is here: https://deploy-preview-440--atd-moped-main.netlify.app.