### PR TITLE
Add project_sponsor column to moped_projects

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3681,173 +3681,187 @@
       - project_name
       - project_order
       - project_priority
+      - project_sponsor
       - project_uuid
       - start_date
       - status_id
       - timeline_id
+      - updated_at
       backend_only: false
   - role: moped-editor
     permission:
       check: {}
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       backend_only: false
   select_permissions:
   - role: moped-admin
     permission:
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       filter: {}
       allow_aggregations: true
   - role: moped-editor
     permission:
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       filter: {}
       allow_aggregations: true
   - role: moped-viewer
     permission:
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       filter: {}
       allow_aggregations: true
   update_permissions:
   - role: moped-admin
     permission:
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       filter: {}
       check: {}
   - role: moped-editor
     permission:
       columns:
-      - added_by
       - capitally_funded
-      - current_phase
-      - current_status
-      - date_added
-      - ecapris_subproject_id
-      - end_date
-      - fiscal_year
       - is_retired
+      - end_date
+      - start_date
+      - added_by
       - milestone_id
-      - project_description
-      - project_description_public
       - project_id
       - project_importance
       - project_length
-      - project_name
       - project_order
-      - project_priority
-      - project_uuid
-      - start_date
+      - project_sponsor
       - status_id
       - timeline_id
+      - ecapris_subproject_id
+      - current_phase
+      - current_status
+      - fiscal_year
+      - project_description
+      - project_description_public
+      - project_name
+      - project_priority
+      - date_added
+      - updated_at
+      - project_uuid
       filter: {}
       check: {}
   event_triggers:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3620,6 +3620,15 @@
 - table:
     schema: public
     name: moped_project
+  object_relationships:
+  - name: moped_proj_sponsor
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: moped_entity
+        column_mapping:
+          project_sponsor: entity_id
   array_relationships:
   - name: moped_proj_components
     using:

--- a/moped-database/migrations/1635277692820_alter_table_public_moped_project_add_column_project_sponsor/down.sql
+++ b/moped-database/migrations/1635277692820_alter_table_public_moped_project_add_column_project_sponsor/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."moped_project" DROP COLUMN "project_sponsor";

--- a/moped-database/migrations/1635277692820_alter_table_public_moped_project_add_column_project_sponsor/up.sql
+++ b/moped-database/migrations/1635277692820_alter_table_public_moped_project_add_column_project_sponsor/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "public"."moped_project" ADD COLUMN "project_sponsor" integer NULL;
+
+alter table moped_project
+	add constraint moped_project_moped_entity_entity_id_fk
+		foreign key (project_sponsor) references moped_entity
+			on update restrict on delete set null;


### PR DESCRIPTION
This PR is not directly associated to an issue at this point, but it stems from the pursuit of cityofaustin/atd-data-tech/issues/7358 after completion of cityofaustin/atd-data-tech/issues/7357. 

Quoting from slack: 

> I’m working on the UI to let users set a project’s sponsor and the project’s partners. I see the table moped_proj_partners  which maps a project to one or more partners out of the entity table, but I don’t see a place to store a project’s sponsor. Because it’s 1:1, I would expect it to be a field in the moped_project table, but none exists that is jumping out at me.

>My issue is https://github.com/cityofaustin/atd-data-tech/issues/7358 which indicates that the column I’m looking for is moped_project.project_sponsor, but it’s not currently existing.

>We do have a moped_proj_entities.project_sponsors text field, but that feels like it may be a vestigial column that is being deprecated by this issue.

>I have looked at https://github.com/cityofaustin/atd-data-tech/issues/7357 which is the issue @chiaberry was just working on and concerns data similar to this, and I don’t believe it called for the creation of moped_project.project_sponsor .
My inclination is to add this column moped_project.project_sponsor as an int to establish a relationship to moped_entities.entity_id. Is this what is desired, or is there something I’m missing?

@zappfyllc agreed and suggested that this was correct and to go ahead and add the column.

@amenity @patrickm02L - If this needs an issue created for tracking purposes, please let me know if I can help with that.