### PR TITLE
Implement design and layout refinements to "Summary" tab #7491

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -174,7 +174,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                 />
               </Grid>
             </Grid>
-            <Grid container spacing={2} xs={12}>
+            <Grid container spacing={2} xs={6}>
               <ProjectSummaryProjectWebsite
                 projectId={projectId}
                 data={data}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => ({
   },
   fieldLabel: {
     width: "100%",
-    color: theme.palette.grey["600"],
+    color: theme.palette.text.secondary,
     fontSize: ".8rem",
   },
   fieldLabelText: {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -49,6 +49,11 @@ const useStyles = makeStyles(theme => ({
   fieldLabelText: {
     width: "calc(100% - 2rem)",
   },
+  fieldLabelLink: {
+    width: "calc(100% - 2rem)",
+    overflow: "hidden",
+    "white-space": "nowrap",
+  },
   fieldBox: {
     width: "100%",
   },

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -52,7 +52,7 @@ const useStyles = makeStyles(theme => ({
   fieldLabelLink: {
     width: "calc(100% - 2rem)",
     overflow: "hidden",
-    "white-space": "nowrap",
+    whiteSpace: "nowrap",
   },
   fieldBox: {
     width: "100%",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -14,9 +14,7 @@ const ProjectSummaryLabel = ({ text, classes, onClickEdit }) => {
   return (
     <>
       <Typography className={classes.fieldLabelText}>{text}</Typography>
-      <Icon className={classes.editIcon} onClick={onClickEdit}>
-        edit
-      </Icon>
+      <CreateOutlinedIcon className={classes.editIcon} onClick={onClickEdit} />
     </>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Icon, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
+import CreateOutlinedIcon from "@material-ui/icons/CreateOutlined";
 
 /**
  *

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -7,13 +7,21 @@ import CreateOutlinedIcon from "@material-ui/icons/CreateOutlined";
  * @param {String} text - Label text
  * @param {Object} classes - The style classes from parent
  * @param {function} onClickEdit - The function to call on edit click
+ * @param {Object} className - Class name override if present
  * @returns {JSX.Element}
  * @constructor
  */
-const ProjectSummaryLabel = ({ text, classes, onClickEdit }) => {
+const ProjectSummaryLabel = ({
+  text,
+  classes,
+  onClickEdit,
+  className = null,
+}) => {
   return (
     <>
-      <Typography className={classes.fieldLabelText}>{text}</Typography>
+      <Typography className={className ?? classes.fieldLabelText}>
+        {text}
+      </Typography>
       <CreateOutlinedIcon className={classes.editIcon} onClick={onClickEdit} />
     </>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -23,10 +23,10 @@ const useStyles = makeStyles({
   },
   toolTip: mapStyles.toolTipStyles,
   navStyle: {
-    position: "absolute",
-    top: 0,
-    left: 0,
+    bottom: "1rem",
+    right: 0,
     padding: "10px",
+    position: "absolute",
   },
 });
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
   },
   toolTip: mapStyles.toolTipStyles,
   navStyle: {
-    bottom: "1rem",
+    bottom: "1.5rem",
     right: 0,
     padding: "10px",
     position: "absolute",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -103,7 +103,6 @@ const ProjectSummaryMap = ({
         {/* Draw tooltip on feature hover */}
         {renderTooltip(featureText, hoveredCoords, classes.toolTip)}
       </ReactMapGL>
-      {renderFeatureCount(featureCount)}
     </Box>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -11,7 +11,6 @@ import {
   MAPBOX_TOKEN,
   mapStyles,
   renderTooltip,
-  renderFeatureCount,
   countFeatures,
   useHoverLayer,
   useFeatureCollectionToFitBounds,
@@ -31,9 +30,7 @@ const useStyles = makeStyles({
   },
 });
 
-const ProjectSummaryMap = ({
-  projectExtentGeoJSON,
-}) => {
+const ProjectSummaryMap = ({ projectExtentGeoJSON }) => {
   const classes = useStyles();
   const mapRef = useRef();
   const featureCount = countFeatures(projectExtentGeoJSON);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -115,10 +115,12 @@ const ProjectSummaryProjectWebsite = ({
         )}
         {!editMode && (
           <ProjectSummaryLabel
+            className={classes.fieldLabelLink} // Override
             text={
               (website && website.length > 0 && (
                 <Link href={website} target={"_blank"}>
-                  {website} <OpenInNew className={classes.linkIcon} />
+                  {website}
+                  <OpenInNew className={classes.linkIcon} />
                 </Link>
               )) ||
               "None"

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -38,6 +38,8 @@ const ProjectSummaryProjectWebsite = ({
 
   const [updateProjectWebsite] = useMutation(PROJECT_UPDATE_WEBSITE);
 
+  const maxLength = 32;
+
   /**
    * Resets the project website to original value
    */

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -38,8 +38,6 @@ const ProjectSummaryProjectWebsite = ({
 
   const [updateProjectWebsite] = useMutation(PROJECT_UPDATE_WEBSITE);
 
-  const maxLength = 32;
-
   /**
    * Resets the project website to original value
    */

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -254,9 +254,9 @@ const ProjectView = () => {
     setDialogContent(
       "Are you sure?",
       <span>
-        Deleting this project will make it inaccessible to Moped users and only
-        available to administrators. Users may request a deleted project be
-        restored by{" "}
+        Cancelling this project will make it inaccessible to Moped users and
+        only available to administrators. Users may request a cancelled project
+        be restored by{" "}
         <Link
           href={"https://atd.knack.com/dts#new-service-request/"}
           target="new"
@@ -266,8 +266,8 @@ const ProjectView = () => {
         .
       </span>,
       <>
-        <Button onClick={handleDelete}>Delete</Button>
-        <Button onClick={handleDialogClose}>Cancel</Button>
+        <Button onClick={handleDelete}>Cancel</Button>
+        <Button onClick={handleDialogClose}>Do not cancel</Button>
       </>
     );
     handleDialogOpen();
@@ -355,33 +355,34 @@ const ProjectView = () => {
                           horizontal: "center",
                         }}
                       >
-                        <MenuItem
-                          onClick={handleMenuClose}
-                          selected={false}
-                          disabled={true}
-                        >
+                        <MenuItem onClick={handleMenuClose} disabled={true}>
                           <ListItemIcon>
                             <Icon fontSize="small">share</Icon>
                           </ListItemIcon>
                           <ListItemText primary="Share" />
                         </MenuItem>
+                        <MenuItem onClick={handleMenuClose} disabled={true}>
+                          <ListItemIcon>
+                            <Icon fontSize="small">favorite</Icon>
+                          </ListItemIcon>
+                          <ListItemText primary="Add to favorites" />
+                        </MenuItem>
+                        <MenuItem onClick={handleRenameClick}>
+                          <ListItemIcon>
+                            <Icon fontSize="small">create</Icon>
+                          </ListItemIcon>
+                          <ListItemText primary="Rename" />
+                        </MenuItem>
                         <MenuItem
                           onClick={handleMenuClose}
                           selected={false}
                           disabled={true}
                         >
                           <ListItemIcon>
-                            <Icon fontSize="small">favorite</Icon>
+                            <Icon fontSize="small">block</Icon>
                           </ListItemIcon>
-                          <ListItemText primary="Add to favorites" />
+                          <ListItemText primary="Place on hold" />
                         </MenuItem>
-                        <MenuItem onClick={handleRenameClick} selected={false}>
-                          <ListItemIcon>
-                            <Icon fontSize="small">create</Icon>
-                          </ListItemIcon>
-                          <ListItemText primary="Rename" />
-                        </MenuItem>
-
                         <MenuItem
                           onClick={handleDeleteClick}
                           className={classes.menuDangerItem}
@@ -391,7 +392,7 @@ const ProjectView = () => {
                             <Icon fontSize="small">delete</Icon>
                           </ListItemIcon>
                           <ListItemText
-                            primary="Delete"
+                            primary="Cancel"
                             className={classes.menuDangerText}
                           />
                         </MenuItem>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/7491

- Removes text under map
- Moves map controls to bottom right
- Pencil icon is now outline
- Updates menu options (and dialog)
- Updates text color to #828282 (secondary text)
- website is 1/2 the width (xs=6)

#### Live Demo
https://deploy-preview-461--atd-moped-main.netlify.app/moped/session/signin

#### Screenshot
<img width="1680" alt="2021-11-08_17-05-56" src="https://user-images.githubusercontent.com/5282430/140832370-fbc60b43-4778-49fb-b886-2b15b102973d.png">


