### PR TITLE
[Bug] unneccessary scroll bars show up in map components panel on Windows/Chrome #7665

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentEdit.js
@@ -90,6 +90,12 @@ const useStyles = makeStyles(theme => ({
   layerSelectBox: {
     maxHeight: "35vh",
     overflow: "scroll",
+    // Chrome
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+    "-ms-overflow-style": "none" /* IE and Edge */,
+    "scrollbar-width": "none" /* Firefox */,
   },
 }));
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -25,10 +25,7 @@ import {
   useLayerSelect,
   getLayerNames,
 } from "../../../utils/mapHelpers";
-import {
-  KeyboardArrowDown,
-  KeyboardArrowUp,
-} from "@material-ui/icons";
+import { KeyboardArrowDown, KeyboardArrowUp } from "@material-ui/icons";
 import Geocoder from "react-map-gl-geocoder";
 import NewProjectMapBaseMap from "../newProjectView/NewProjectMapBaseMap";
 
@@ -40,6 +37,12 @@ const useStyles = makeStyles(theme => ({
   layerSelectBox: {
     maxHeight: "35vh",
     overflow: "scroll",
+    // Chrome
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+    "-ms-overflow-style": "none" /* IE and Edge */,
+    "scrollbar-width": "none" /* Firefox */,
   },
   layerSelectButton: {
     position: "absolute",
@@ -236,7 +239,12 @@ const ProjectComponentsMapView = ({
         onExited={() => setEditPanelCollapsedShow(true)}
       >
         <Grid>
-          <Grid className={classes.layerSelectBox}>{children}</Grid>
+          <Grid
+            id={"moped-component-editor-container"}
+            className={classes.layerSelectBox}
+          >
+            {children}
+          </Grid>
           <Grid item xs={12}>
             <Divider className={classes.mapToolsDivider} />
             <Button


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/7665

## Testing
**URL to test:** 
https://deploy-preview-465--atd-moped-main.netlify.app/moped/session/signin

**Steps to test:**
Be sure you are in Windows 10, Chrome 98

Go to Map, look at list of components, it should not show scrollbars:

![image](https://user-images.githubusercontent.com/5282430/141429013-c442ec37-79d0-4ba2-ae1b-c78048ab9e8a.png)


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~ n/a
