### PR TITLE
Add links to Knack Signal Projects

### DIFF
--- a/moped-editor/src/queries/signals.js
+++ b/moped-editor/src/queries/signals.js
@@ -21,7 +21,7 @@ export const SIGNAL_PROJECTS_QUERY = gql`
         is_current_phase
         phase_start
       }
-      moped_proj_features {
+      moped_proj_features(where: {status_id: {_eq: 1}}) {
         feature_id
         location
       }

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -2,6 +2,13 @@ import React, { useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { TextField } from "@material-ui/core";
 
+
+/*
+ * Socrata Endpoint
+ */
+export const SOCRATA_ENDPOINT =
+  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
+
 /*
 / MUI autocomplete filter function which limits number of options rendered in select menu
 */

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -8,10 +8,8 @@ import {
   getSignalOptionLabel,
   getSignalOptionSelected,
   renderSignalInput,
+  SOCRATA_ENDPOINT,
 } from "src/utils/signalComponentHelpers";
-
-const SOCRATA_ENDPOINT =
-  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a

--- a/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
+++ b/moped-editor/src/views/projects/newProjectView/SignalAutocomplete.js
@@ -11,7 +11,7 @@ import {
 } from "src/utils/signalComponentHelpers";
 
 const SOCRATA_ENDPOINT =
-  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
+  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -134,7 +134,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
               data={data}
               classes={classes}
             />
-            <Grid container spacing={0} xs={12}>
+            <Grid container spacing={0}>
               <Grid item xs={6}>
                 <ProjectSummaryCurrentStatus
                   projectId={projectId}
@@ -154,7 +154,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                 />
               </Grid>
             </Grid>
-            <Grid container spacing={0} xs={12}>
+            <Grid container spacing={0}>
               <Grid item xs={6}>
                 <ProjectSummaryProjectSponsor
                   projectId={projectId}
@@ -174,7 +174,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                 />
               </Grid>
             </Grid>
-            <Grid container spacing={0} xs={12}>
+            <Grid container spacing={0}>
               <Grid item xs={6}>
                 <ProjectSummaryProjectWebsite
                   projectId={projectId}

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -12,7 +12,7 @@ import {
   renderSignalInput,
 } from "src/utils/signalComponentHelpers";
 const SOCRATA_ENDPOINT =
-  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type&$order=signal_id asc&$limit=9999";
+  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -10,9 +10,8 @@ import {
   getSignalOptionSelected,
   useInitialSignalComponentValue,
   renderSignalInput,
+  SOCRATA_ENDPOINT,
 } from "src/utils/signalComponentHelpers";
-const SOCRATA_ENDPOINT =
-  "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
 
 /**
  * Material Autocomplete wrapper that enables selecting a traffic/phb signal record from a

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -48,8 +48,6 @@ const SignalComponentAutocomplete = ({
     );
   }
 
-  console.log(features)
-
   return (
     <Autocomplete
       className={classes}

--- a/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/SignalComponentAutocomplete.js
@@ -48,6 +48,8 @@ const SignalComponentAutocomplete = ({
     );
   }
 
+  console.log(features)
+
   return (
     <Autocomplete
       className={classes}

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,19 +1,22 @@
 import React from "react";
 import Link from "@material-ui/core/Link";
 
-const RenderSignalLink = ({ signals }) => (
-  <span>
-    {signals.map((signal, index) => (
-      <Link
-        href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {signal.signal_id}
-        {index < signals.length - 1 && ", "}
-      </Link>
-    ))}
-  </span>
-);
+const RenderSignalLink = ({ signals }) => {
+  const cleanSignals = signals.filter(s => s.knack_id);
+  return (
+    <span>
+      {cleanSignals.map((signal, index) => (
+        <Link
+          href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {signal.signal_id}
+          {index < cleanSignals.length - 1 && ", "}
+        </Link>
+      ))}
+    </span>
+  );
+};
 
 export default RenderSignalLink;

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,0 +1,21 @@
+import React from "react";
+import Link from "@material-ui/core/Link";
+
+const RenderSignalLink = ({signals}) => {
+  console.log(signals)
+  return (
+    <span>
+    {signals.map(signal => (
+      <Link
+        href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {signal.signal_id}{" "}
+      </Link>)
+      )}
+    </span>
+)}
+
+
+export default RenderSignalLink;

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,21 +1,19 @@
 import React from "react";
 import Link from "@material-ui/core/Link";
 
-const RenderSignalLink = ({signals}) => {
-  console.log(signals)
-  return (
-    <span>
-    {signals.map(signal => (
+const RenderSignalLink = ({ signals }) => (
+  <span>
+    {signals.map((signal, index) => (
       <Link
         href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
         target="_blank"
         rel="noopener noreferrer"
       >
-        {signal.signal_id}{" "}
-      </Link>)
-      )}
-    </span>
-)}
-
+        {signal.signal_id}
+        {index < signals.length - 1 && ", "}
+      </Link>
+    ))}
+  </span>
+);
 
 export default RenderSignalLink;

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -2,18 +2,23 @@ import React from "react";
 import Link from "@material-ui/core/Link";
 
 const RenderSignalLink = ({ signals }) => {
-  const cleanSignals = signals.filter(s => s.knack_id);
   return (
     <span>
-      {cleanSignals.map((signal, index) => (
-        <Link
-          href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {signal.signal_id}
-          {index < cleanSignals.length - 1 && ", "}
-        </Link>
+      {signals.map((signal, index) => (
+        <>
+          {signal.knack_id ? (
+            <Link
+              href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {signal.signal_id}
+            </Link>
+          ) : (
+            signal.signal_id
+          )}
+          {index < signals.length - 1 && ", "}
+        </>
       ))}
     </span>
   );

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -6,7 +6,7 @@ const RenderSignalLink = ({ signals }) => {
     <span>
       {signals.map((signal, index) => (
         <>
-          {signal.knack_id ? (
+          {signal?.knack_id ? (
             <Link
               href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
               target="_blank"

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -70,7 +70,11 @@ const SignalProjectTable = () => {
     const signal_ids = [];
     if (project?.moped_proj_features.length) {
       project.moped_proj_features.forEach(feature => {
-        signal_ids.push(feature?.location?.properties?.signal_id);
+        let signal = feature?.location?.properties?.signal_id;
+        console.log(feature?.location?.properties)
+        if (signal) {
+          signal_ids.push({signal_id: signal});
+        }
       });
     }
     project["signal_ids"] = signal_ids;

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -294,6 +294,8 @@ const SignalProjectTable = () => {
     ),
   };
 
+  console.log(data)
+
   return (
     <CardContent>
       <Grid container spacing={2}>

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -72,7 +72,6 @@ const SignalProjectTable = () => {
     if (project?.moped_proj_features.length) {
       project.moped_proj_features.forEach(feature => {
         let signal = feature?.location?.properties?.signal_id;
-        console.log(feature?.location?.properties)
         if (signal) {
           signal_ids.push({signal_id: signal, knack_id: feature.location.properties.id});
         }
@@ -309,8 +308,6 @@ const SignalProjectTable = () => {
       />
     ),
   };
-
-  console.log(data)
 
   return (
     <CardContent>

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -20,6 +20,7 @@ import {
 import { PROJECT_UPDATE_SPONSOR } from "../../../queries/project";
 import { PAGING_DEFAULT_COUNT } from "../../../constants/tables";
 import RenderFieldLink from "./RenderFieldLink";
+import RenderSignalLink from "./RenderSignalLink";
 
 const useStyles = makeStyles({
   signalsTable: {
@@ -73,7 +74,7 @@ const SignalProjectTable = () => {
         let signal = feature?.location?.properties?.signal_id;
         console.log(feature?.location?.properties)
         if (signal) {
-          signal_ids.push({signal_id: signal});
+          signal_ids.push({signal_id: signal, knack_id: feature.location.properties.id});
         }
       });
     }
@@ -145,7 +146,7 @@ const SignalProjectTable = () => {
       editable: "never",
       // cell style font needs to be set if editable is never
       cellStyle: typographyStyle,
-      render: entry => entry.signal_ids.join(", "),
+      render: entry => <RenderSignalLink signals={entry.signal_ids} />
     },
     {
       title: "Project types",

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -71,7 +71,7 @@ const SignalProjectTable = () => {
     const signal_ids = [];
     if (project?.moped_proj_features.length) {
       project.moped_proj_features.forEach(feature => {
-        let signal = feature?.location?.properties?.signal_id;
+        const signal = feature?.location?.properties?.signal_id;
         if (signal) {
           signal_ids.push({signal_id: signal, knack_id: feature.location.properties.id});
         }


### PR DESCRIPTION
## Associated issues

Addresses: https://github.com/cityofaustin/atd-data-tech/issues/7556

I’m getting the knack id for the signal from the socrata payload. Existing signal projects in our database don't include their knack ids, so those signal ids are not linked to their knack page.

Also when testing this PR I realized that I wasn't filtering on active features, so deleted signals were still showing up.


## Testing
**URL to test:** https://7556-signal-id-link--atd-moped-main.netlify.app/moped/dashboard

**Steps to test:**
Add one (or more) signals to a project. Check the dashboard view, signal ids column (2nd from left) should contain list of signals by their id. Clicking on one will open a new tab with that knack signal page. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
