### PR TITLE
Add additional columns to signal project management table view

### DIFF
--- a/moped-editor/src/queries/signals.js
+++ b/moped-editor/src/queries/signals.js
@@ -20,6 +20,7 @@ export const SIGNAL_PROJECTS_QUERY = gql`
         phase_name
         is_current_phase
         phase_start
+        phase_end
       }
       moped_proj_features {
         feature_id
@@ -33,6 +34,13 @@ export const SIGNAL_PROJECTS_QUERY = gql`
       moped_project_types {
         moped_type {
           type_name
+        }
+      }
+      moped_proj_personnel(where: {status_id: {_eq: 1}}) {
+        role_id
+        moped_user {
+          first_name
+          last_name
         }
       }
     }

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -5,7 +5,7 @@ const RenderSignalLink = ({ signals }) => {
   return (
     <span>
       {signals.map((signal, index) => (
-        <>
+        <React.Fragment key={signal.signal_id}>
           {signal?.knack_id ? (
             <Link
               href={`https://atd.knack.com/amd#projects/signal-details/${signal.knack_id}`}
@@ -18,7 +18,7 @@ const RenderSignalLink = ({ signals }) => {
             signal.signal_id
           )}
           {index < signals.length - 1 && ", "}
-        </>
+        </React.Fragment>
       ))}
     </span>
   );

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -210,12 +210,19 @@ const SignalProjectTable = () => {
       field: "construction_start",
       editable: "never",
       cellStyle: typographyStyle,
-      render: entry =>
-        entry.construction_start
-          ? new Date(entry.construction_start).toLocaleDateString("en-US", {
-              timeZone: "UTC",
-            })
-          : "",
+      render: entry => (
+        <RenderFieldLink
+          projectId={entry.project_id}
+          value={
+            entry.construction_start
+              ? new Date(entry.construction_start).toLocaleDateString("en-US", {
+                  timeZone: "UTC",
+                })
+              : ""
+          }
+          tab="timeline"
+        />
+      ),
     },
     {
       title: "Last modified",

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -76,7 +76,10 @@ const SignalProjectTable = () => {
       project.moped_proj_features.forEach(feature => {
         const signal = feature?.location?.properties?.signal_id;
         if (signal) {
-          signal_ids.push({signal_id: signal, knack_id: feature.location.properties.id});
+          signal_ids.push({
+            signal_id: signal,
+            knack_id: feature.location.properties.id,
+          });
         }
       });
     }
@@ -139,14 +142,17 @@ const SignalProjectTable = () => {
     // project personnel
     const designers = [];
     const inspectors = [];
+    // role_ids come from moped_project_roles. 8 is Designer and 12 is Inspector
+    const isDesigner = personnel => personnel?.role_id === 8;
+    const isInspector = personnel => personnel?.role_id === 12;
     if (project?.moped_proj_personnel?.length) {
       project.moped_proj_personnel.forEach(personnel => {
-        if (personnel?.role_id === 8) {
+        if (isDesigner(personnel)) {
           designers.push(
             `${personnel?.moped_user?.first_name} ${personnel?.moped_user?.last_name}`
           );
         }
-        if (personnel?.role_id === 12) {
+        if (isInspector(personnel)) {
           inspectors.push(
             `${personnel?.moped_user?.first_name} ${personnel?.moped_user?.last_name}`
           );
@@ -178,7 +184,7 @@ const SignalProjectTable = () => {
       editable: "never",
       // cell style font needs to be set if editable is never
       cellStyle: typographyStyle,
-      render: entry => <RenderSignalLink signals={entry.signal_ids} />
+      render: entry => <RenderSignalLink signals={entry.signal_ids} />,
     },
     {
       title: "Project types",


### PR DESCRIPTION
## Associated issues
Addresses: https://github.com/cityofaustin/atd-data-tech/issues/7582

## Testing
**URL to test:** https://7582-add-columns--atd-moped-main.netlify.app/moped/dashboard

**Steps to test:**

Add Inspector(s) and Designer(s) to moped signal projects. You should see their names in the appropriate columns. Clicking on the cells will open that project's team tab. 

Add a completion date to a project by adding a Complete phase. Clicking on that cell or the projected construction start should open that project's timeline tab.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
