### PR TITLE
Reorder project summary tabs

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -114,11 +114,11 @@ function useQueryParams() {
 const TABS = [
   { label: "Summary", Component: ProjectSummary, param: "summary" },
   { label: "Map", Component: ProjectComponents, param: "map" },
-  { label: "Funding", Component: ProjectFunding, param: "funding" },
-  { label: "Files", Component: ProjectFiles, param: "files" },
-  { label: "Team", Component: ProjectTeam, param: "team" },
   { label: "Timeline", Component: ProjectTimeline, param: "timeline" },
+  { label: "Team", Component: ProjectTeam, param: "team" },
+  { label: "Funding", Component: ProjectFunding, param: "funding" },
   { label: "Comments", Component: ProjectComments, param: "comments" },
+  { label: "Files", Component: ProjectFiles, param: "files" },
   {
     label: "Activity Log",
     Component: ProjectActivityLog,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/7667

## Testing
Only a frontend change so testing in preview app ok.
**URL to test:** https://deploy-preview-468--atd-moped-main.netlify.app/

**Steps to test:**
- Go to any project summary page and see the new order of the tabs

Ex:
![Screen Shot 2021-11-17 at 1 49 43 PM](https://user-images.githubusercontent.com/5697474/142272342-a5231f8c-b92c-4596-bf43-e750a943699f.png)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~ n/a
