### PR TITLE
Add current phase and current status to new project mutation#7635

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "0.8.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "dependencies": {
         "@apollo/client": "^3.3.6",
         "@hookform/devtools": "^2.2.1",
@@ -34849,6 +34849,7 @@
     },
     "atd-kickstand": {
       "version": "git+ssh://git@github.com/cityofaustin/atd-kickstand.git#f71e4d3d6ddea09263410d93432c254ef2ed1793",
+      "integrity": "sha512-V/G8P2fUWnTgacMxZCn9Q3x2FoFMHhivZk9lfMok1/IP2Rh1iyWYhmkChN4uq/T6nmUZP3VR0PuUJdyuHPbipw==",
       "from": "atd-kickstand@github:cityofaustin/atd-kickstand#f71e4d3d6ddea09263410d93432c254ef2ed1793",
       "requires": {}
     },

--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "0.10.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "0.10.0",
+      "version": "0.8.0",
       "dependencies": {
         "@apollo/client": "^3.3.6",
         "@hookform/devtools": "^2.2.1",
@@ -34849,7 +34849,6 @@
     },
     "atd-kickstand": {
       "version": "git+ssh://git@github.com/cityofaustin/atd-kickstand.git#f71e4d3d6ddea09263410d93432c254ef2ed1793",
-      "integrity": "sha512-V/G8P2fUWnTgacMxZCn9Q3x2FoFMHhivZk9lfMok1/IP2Rh1iyWYhmkChN4uq/T6nmUZP3VR0PuUJdyuHPbipw==",
       "from": "atd-kickstand@github:cityofaustin/atd-kickstand#f71e4d3d6ddea09263410d93432c254ef2ed1793",
       "requires": {}
     },

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -13,6 +13,13 @@ export const ADD_PROJECT = gql`
       fiscal_year
       capitally_funded
       start_date
+      moped_proj_phases {
+        phase_name
+        is_current_phase
+        status_id
+        completion_percentage
+        completed
+      }
       moped_proj_components {
         moped_proj_features_components {
           moped_proj_feature {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -147,6 +147,7 @@ const NewProjectView = () => {
                 status_id: 1,
                 completion_percentage: 0,
                 completed: false,
+                phase_start: format(Date.now(), "yyyy-MM-dd"),
               },
             ],
           },

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -71,7 +71,8 @@ const NewProjectView = () => {
     project_description: "",
     project_name: "",
     start_date: format(Date.now(), "yyyy-MM-dd"),
-    current_status: "",
+    current_status: "active",
+    status_id: 1,
   });
 
   const {

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -67,7 +67,7 @@ const NewProjectView = () => {
    *    the project name and featureCollection will be set from the `signal` value.
    */
   const [projectDetails, setProjectDetails] = useState({
-    current_phase: "",
+    current_phase: "potential",
     project_description: "",
     project_name: "",
     start_date: format(Date.now(), "yyyy-MM-dd"),
@@ -111,8 +111,8 @@ const NewProjectView = () => {
    * Persists a new project into the database
    */
   const handleSubmit = () => {
-    let signalError = fromSignalAsset && !Boolean(signal);
-    setSignalError(signalError);
+    const newSignalError = fromSignalAsset && !Boolean(signal);
+    setSignalError(newSignalError);
 
     if (projectDetails.project_name.trim().length === 0) {
       setNameError(true);
@@ -132,28 +132,40 @@ const NewProjectView = () => {
        * If it is a signal asset, include moped_proj_components, otherwise only the project details
        * @type {Object}
        */
-      const variablePayload = fromSignalAsset
-        ? {
-            object: {
-              // First we need to copy the project details
-              ...projectDetails,
-              // Next we generate the project extent component
-              moped_proj_components: {
-                data: [
-                  generateProjectComponent(
-                    featureCollection,
-                    fromSignalAsset,
-                    componentData["moped_components"]
-                  ),
-                ],
+      const variablePayload = {
+        object: {
+          // First we need to copy the project details
+          ...projectDetails,
+
+          // We need to add the potential phase as a default
+          moped_proj_phases: {
+            data: [
+              {
+                phase_name: "potential",
+                is_current_phase: true,
+                status_id: 1,
+                completion_percentage: 0,
+                completed: false,
               },
-            },
-          }
-        : {
-            object: {
-              ...projectDetails,
-            },
-          };
+            ],
+          },
+          // Append moped_proj_components object if fromSignalAsset is true
+          ...(fromSignalAsset
+            ? {
+                moped_proj_components: {
+                  data: [
+                    generateProjectComponent(
+                      featureCollection,
+                      fromSignalAsset,
+                      componentData["moped_components"]
+                    ),
+                  ],
+                },
+              }
+            : {}),
+        },
+      };
+
       /**
        * Persist the new project to database
        */


### PR DESCRIPTION
## Associated issues

Precludes: https://github.com/cityofaustin/atd-moped/pull/475

Closes https://github.com/cityofaustin/atd-data-tech/issues/7635

## Testing

https://deploy-preview-471--atd-moped-main.netlify.app/moped/projects/new

**Steps to test:**
Create a new project (either a signal project or otherwise), you should see the "potential" phase as the default.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
