### PR TITLE
Minor style tweaks to signal projects dashboard

### DIFF
--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -32,9 +32,6 @@ const useStyles = makeStyles({
   tableTypography: {
     fontSize: "14px",
   },
-  projectNameStyle: {
-    minWidth: "150px",
-  },
 });
 
 const SignalProjectTable = () => {
@@ -174,7 +171,7 @@ const SignalProjectTable = () => {
       title: "Project name",
       field: "project_name",
       editable: "never",
-      cellStyle: projectNameStyle,
+      cellStyle: { minWidth: "150px" },
       render: entry => (
         <RenderFieldLink
           projectId={entry.project_id}

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -32,6 +32,9 @@ const useStyles = makeStyles({
   tableTypography: {
     fontSize: "14px",
   },
+  projectNameStyle: {
+    minWidth: "150px",
+  },
 });
 
 const SignalProjectTable = () => {
@@ -171,7 +174,7 @@ const SignalProjectTable = () => {
       title: "Project name",
       field: "project_name",
       editable: "never",
-      cellStyle: { minWidth: "150px" },
+      cellStyle: projectNameStyle,
       render: entry => (
         <RenderFieldLink
           projectId={entry.project_id}

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -171,6 +171,7 @@ const SignalProjectTable = () => {
       title: "Project name",
       field: "project_name",
       editable: "never",
+      cellStyle: { minWidth: "150px" },
       render: entry => (
         <RenderFieldLink
           projectId={entry.project_id}
@@ -217,7 +218,7 @@ const SignalProjectTable = () => {
       render: entry => (entry.contractor === "" ? "blank" : entry.contractor),
     },
     {
-      title: "Internal status note",
+      title: "Status update",
       field: "status_update", // Status update (from Project details page)
       editable: "never",
       cellStyle: { ...typographyStyle, minWidth: "300px" },

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -171,7 +171,7 @@ const SignalProjectTable = () => {
       title: "Project name",
       field: "project_name",
       editable: "never",
-      cellStyle: { minWidth: "150px" },
+      cellStyle: { minWidth: "200px" },
       render: entry => (
         <RenderFieldLink
           projectId={entry.project_id}


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7830

## Testing
**URL to test:** https://7830-signal-tweaks--atd-moped-main.netlify.app/moped/dashboard
**Steps to test:** The project name column has been widened from 60ish px wide to 150px wide. Renamed the column for status update. 

![Screen Shot 2021-11-30 at 9 49 20 AM](https://user-images.githubusercontent.com/12474808/144080442-d9799606-3a1f-4339-aa90-2ee2d0efe792.png)

---

#### Ship list
- [ ] Code reviewed 
- [x Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~ n/a
