### PR TITLE
7865: Return activity feed page header to a san-serif font

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -36,6 +36,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import { Alert } from "@material-ui/lab";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 import CDNAvatar from "../../../components/CDN/Avatar";
+import typography from "src/theme/typography";
 
 const useStyles = makeStyles(theme => ({
   table: {
@@ -53,6 +54,9 @@ const useStyles = makeStyles(theme => ({
   },
   avatarName: {
     margin: "0.3rem 0 0 .5rem",
+  },
+  projectPageHeader: {
+    fontFamily: typography.fontFamily,
   },
 }));
 
@@ -187,7 +191,7 @@ const ProjectActivityLog = () => {
   return (
     <ApolloErrorHandler error={error || lookupError}>
       <CardContent>
-        <h2 style={{ padding: "0rem 0 2rem 0" }}>Activity feed</h2>
+        <h2 className={classes.projectPageHeader} style={{ padding: "0rem 0 2rem 0" }}>Activity feed</h2>
         {getTotalItems() === 0 ? (
           <Alert severity="info">
             There aren't any items for this project.

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -57,6 +57,7 @@ const useStyles = makeStyles(theme => ({
   },
   projectPageHeader: {
     fontFamily: typography.fontFamily,
+    padding: "0rem 0 2rem 0",
   },
 }));
 
@@ -191,7 +192,7 @@ const ProjectActivityLog = () => {
   return (
     <ApolloErrorHandler error={error || lookupError}>
       <CardContent>
-        <h2 className={classes.projectPageHeader} style={{ padding: "0rem 0 2rem 0" }}>Activity feed</h2>
+        <h2 className={classes.projectPageHeader}>Activity feed</h2>
         {getTotalItems() === 0 ? (
           <Alert severity="info">
             There aren't any items for this project.


### PR DESCRIPTION
## Associated issues

This PR intends to address the paticular H2 seen in https://github.com/cityofaustin/atd-data-tech/issues/7865 but not to close the issue.

## Testing
**URL to test:** 
https://deploy-preview-488--atd-moped-main.netlify.app/moped/

**Steps to test:**

View a project's activity feed and observe the header.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
