### PR TITLE
Enable scrollable tabs on Project View on smaller screens

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -276,7 +276,7 @@ const ProjectActivityLog = () => {
                             </Icon>
                           </Box>
                           <Box p={0} flexGrow={1}>
-                            <Grid continer>
+                            <Grid container>
                               {Array.isArray(change.description) &&
                                 change.description.length === 0 && (
                                   <Grid

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -484,6 +484,7 @@ const ProjectView = () => {
                     classes={{ indicator: classes.indicatorColor }}
                     value={activeTab}
                     onChange={handleChange}
+                    variant="scrollable"
                     aria-label="Project Details Tabs"
                   >
                     {TABS.map((tab, i) => {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7859

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://7859-screen-tabs--atd-moped-main.netlify.app/moped/projects/360/
**Steps to test:**
Load screen, make window smaller than width of tabs. See the appearance of scroll buttons. 

On mobile views, check that you can drag to scroll the tabs. 

![Screen Shot 2021-12-02 at 1 54 13 PM](https://user-images.githubusercontent.com/12474808/144493416-c7e85944-3f4d-48c2-99ff-95ac436c15b9.png)
---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~ n/a
