### PR TITLE
Add "Project partners" and "Project sponsor" to "Projects" page

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4714,6 +4714,7 @@
       - date_added
       - ecapris_subproject_id
       - end_date
+      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id
@@ -4743,6 +4744,7 @@
       - date_added
       - ecapris_subproject_id
       - end_date
+      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id
@@ -4772,6 +4774,7 @@
       - date_added
       - ecapris_subproject_id
       - end_date
+      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4714,7 +4714,6 @@
       - date_added
       - ecapris_subproject_id
       - end_date
-      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id
@@ -4725,7 +4724,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4744,7 +4745,6 @@
       - date_added
       - ecapris_subproject_id
       - end_date
-      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id
@@ -4755,7 +4755,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4774,7 +4776,6 @@
       - date_added
       - ecapris_subproject_id
       - end_date
-      - entity_name
       - fiscal_year
       - is_retired
       - milestone_id
@@ -4785,7 +4786,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date

--- a/moped-database/migrations/1638905763818_run_sql_migration/down.sql
+++ b/moped-database/migrations/1638905763818_run_sql_migration/down.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE VIEW "public"."project_list_view" AS 
+ SELECT mp.project_uuid,
+    mp.project_id,
+    mp.project_name,
+    mp.project_description,
+    mp.project_description_public,
+    mp.ecapris_subproject_id,
+    mp.project_importance,
+    mp.project_order,
+    mp.current_status,
+    mp.timeline_id,
+    mp.current_phase,
+    mp.end_date,
+    mp.project_length,
+    mp.start_date,
+    mp.fiscal_year,
+    mp.capitally_funded,
+    mp.project_priority,
+    mp.date_added,
+    mp.added_by,
+    mp.is_retired,
+    mp.milestone_id,
+    COALESCE (mp.status_id, 0) AS status_id,
+    string_agg(concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members,
+    mp.updated_at
+   FROM (((moped_project mp
+     LEFT JOIN moped_proj_personnel mpp ON (((mp.project_id = mpp.project_id) AND (mpp.status_id = 1))))
+     LEFT JOIN moped_users mu ON ((mpp.user_id = mu.user_id)))
+     LEFT JOIN moped_project_roles mpr ON ((mpp.role_id = mpr.project_role_id)))
+  GROUP BY mp.project_uuid, mp.project_id, mp.project_name, mp.project_description, mp.project_description_public, mp.ecapris_subproject_id, mp.project_importance, mp.project_order, mp.current_status, mp.timeline_id, mp.current_phase, mp.end_date, mp.project_length, mp.start_date, mp.fiscal_year, mp.capitally_funded, mp.project_priority, mp.date_added, mp.added_by, mp.is_retired, mp.milestone_id, mp.status_id, mp.updated_at;

--- a/moped-database/migrations/1638905763818_run_sql_migration/up.sql
+++ b/moped-database/migrations/1638905763818_run_sql_migration/up.sql
@@ -23,10 +23,13 @@ CREATE OR REPLACE VIEW "public"."project_list_view" AS
     COALESCE(mp.status_id, 0) AS status_id,
     string_agg(concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members,
     mp.updated_at,
-    me.entity_name
+    me.entity_name,
+    string_agg(me2.entity_name, ', ') as project_partner
    FROM (((moped_project mp
      LEFT JOIN moped_proj_personnel mpp ON (((mp.project_id = mpp.project_id) AND (mpp.status_id = 1))))
      LEFT JOIN moped_users mu ON (mpp.user_id = mu.user_id))
      LEFT JOIN moped_project_roles mpr ON (mpp.role_id = mpr.project_role_id)
      LEFT JOIN moped_entity me ON (me.entity_id = mp.project_sponsor))
+     left join moped_proj_partners mpp2 on ((mp.project_id = mpp2.project_id) and (mpp2.status_id =1))
+     left join moped_entity me2 on (mpp2.entity_id = me2.entity_id)
   GROUP BY mp.project_uuid, mp.project_id, mp.project_name, mp.project_description, mp.project_description_public, mp.ecapris_subproject_id, mp.project_importance, mp.project_order, mp.current_status, mp.timeline_id, mp.current_phase, mp.end_date, mp.project_length, mp.start_date, mp.fiscal_year, mp.capitally_funded, mp.project_priority, mp.date_added, mp.added_by, mp.is_retired, mp.milestone_id, mp.status_id, me.entity_name, mp.updated_at;

--- a/moped-database/migrations/1638905763818_run_sql_migration/up.sql
+++ b/moped-database/migrations/1638905763818_run_sql_migration/up.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE VIEW "public"."project_list_view" AS 
+ SELECT mp.project_uuid,
+    mp.project_id,
+    mp.project_name,
+    mp.project_description,
+    mp.project_description_public,
+    mp.ecapris_subproject_id,
+    mp.project_importance,
+    mp.project_order,
+    mp.current_status,
+    mp.timeline_id,
+    mp.current_phase,
+    mp.end_date,
+    mp.project_length,
+    mp.start_date,
+    mp.fiscal_year,
+    mp.capitally_funded,
+    mp.project_priority,
+    mp.date_added,
+    mp.added_by,
+    mp.is_retired,
+    mp.milestone_id,
+    COALESCE(mp.status_id, 0) AS status_id,
+    string_agg(concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members,
+    mp.updated_at,
+    me.entity_name
+   FROM (((moped_project mp
+     LEFT JOIN moped_proj_personnel mpp ON (((mp.project_id = mpp.project_id) AND (mpp.status_id = 1))))
+     LEFT JOIN moped_users mu ON (mpp.user_id = mu.user_id))
+     LEFT JOIN moped_project_roles mpr ON (mpp.role_id = mpr.project_role_id)
+     LEFT JOIN moped_entity me ON (me.entity_id = mp.project_sponsor))
+  GROUP BY mp.project_uuid, mp.project_id, mp.project_name, mp.project_description, mp.project_description_public, mp.ecapris_subproject_id, mp.project_importance, mp.project_order, mp.current_status, mp.timeline_id, mp.current_phase, mp.end_date, mp.project_length, mp.start_date, mp.fiscal_year, mp.capitally_funded, mp.project_priority, mp.date_added, mp.added_by, mp.is_retired, mp.milestone_id, mp.status_id, me.entity_name, mp.updated_at;

--- a/moped-database/migrations/1638905763818_run_sql_migration/up.sql
+++ b/moped-database/migrations/1638905763818_run_sql_migration/up.sql
@@ -23,13 +23,13 @@ CREATE OR REPLACE VIEW "public"."project_list_view" AS
     COALESCE(mp.status_id, 0) AS status_id,
     string_agg(concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members,
     mp.updated_at,
-    me.entity_name,
+    me.entity_name as project_sponsor,
     string_agg(me2.entity_name, ', ') as project_partner
    FROM (((moped_project mp
      LEFT JOIN moped_proj_personnel mpp ON (((mp.project_id = mpp.project_id) AND (mpp.status_id = 1))))
      LEFT JOIN moped_users mu ON (mpp.user_id = mu.user_id))
      LEFT JOIN moped_project_roles mpr ON (mpp.role_id = mpr.project_role_id)
      LEFT JOIN moped_entity me ON (me.entity_id = mp.project_sponsor))
-     left join moped_proj_partners mpp2 on ((mp.project_id = mpp2.project_id) and (mpp2.status_id =1))
-     left join moped_entity me2 on (mpp2.entity_id = me2.entity_id)
+     LEFT JOIN moped_proj_partners mpp2 ON ((mp.project_id = mpp2.project_id) and (mpp2.status_id =1))
+     LEFT JOIN moped_entity me2 ON (mpp2.entity_id = me2.entity_id)
   GROUP BY mp.project_uuid, mp.project_id, mp.project_name, mp.project_description, mp.project_description_public, mp.ecapris_subproject_id, mp.project_importance, mp.project_order, mp.current_status, mp.timeline_id, mp.current_phase, mp.end_date, mp.project_length, mp.start_date, mp.fiscal_year, mp.capitally_funded, mp.project_priority, mp.date_added, mp.added_by, mp.is_retired, mp.milestone_id, mp.status_id, me.entity_name, mp.updated_at;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -44,7 +44,7 @@ const ProjectSummaryProjectPartners = ({
     {}
   );
 
-  // Estrablish original partners
+  // Establish original partners
   const originalPartners = data?.moped_proj_partners ?? [];
   // Establish original entities
   const originalEntities = originalPartners.map(e => e.entity_id);

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -29,7 +29,7 @@ export const ProjectsListViewExportConf = {
   ecapris_subproject_id: {
     label: "ecapris_id"
   },
-  entity_name: {
+  project_sponsor: {
     label: "project_sponsor",
   },
   start_date: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -29,6 +29,9 @@ export const ProjectsListViewExportConf = {
   ecapris_subproject_id: {
     label: "ecapris_id"
   },
+  entity_name: {
+    label: "project_sponsor",
+  },
   start_date: {
     label: "start_date",
     filter: value => new Date(value).toLocaleDateString('en-US', {timeZone: 'UTC'}),

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -1,4 +1,4 @@
-import { filterProjectTeamMembers } from "./helpers.js"
+import { filterProjectTeamMembers } from "./helpers.js";
 
 /**
  * The ProjectsListView export settings
@@ -27,13 +27,17 @@ export const ProjectsListViewExportConf = {
     filter: filterProjectTeamMembers,
   },
   ecapris_subproject_id: {
-    label: "ecapris_id"
+    label: "ecapris_id",
   },
   project_sponsor: {
     label: "project_sponsor",
   },
+  project_partner: {
+    label: "project_partner",
+  },
   start_date: {
     label: "start_date",
-    filter: value => new Date(value).toLocaleDateString('en-US', {timeZone: 'UTC'}),
+    filter: value =>
+      new Date(value).toLocaleDateString("en-US", { timeZone: "UTC" }),
   },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -91,7 +91,7 @@ export const ProjectsListViewFiltersConf = {
       ],
     },
     {
-      name: "entity_name",
+      name: "project_sponsor",
       label: "Project sponsor",
       placeholder: "Project sponsor",
       type: "string",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -90,6 +90,19 @@ export const ProjectsListViewFiltersConf = {
         "string_is_not_null_special_case",
       ],
     },
+    {
+      name: "entity_name",
+      label: "Project sponsor",
+      placeholder: "Project sponsor",
+      type: "string",
+      operators: [
+        "string_contains_case_insensitive",
+        "string_begins_with_case_insensitive",
+        "string_ends_with_case_insensitive",
+        "string_is_null",
+        "string_is_not_null",
+      ],
+    },
   ],
 
   operators: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -103,6 +103,19 @@ export const ProjectsListViewFiltersConf = {
         "string_is_not_null",
       ],
     },
+    {
+      name: "project_partner",
+      label: "Project partner",
+      placeholder: "Project partner",
+      type: "string",
+      operators: [
+        "string_contains_case_insensitive",
+        "string_begins_with_case_insensitive",
+        "string_ends_with_case_insensitive",
+        "string_is_null",
+        "string_is_not_null",
+      ],
+    },
   ],
 
   operators: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -105,8 +105,8 @@ export const ProjectsListViewFiltersConf = {
     },
     {
       name: "project_partner",
-      label: "Project partner",
-      placeholder: "Project partner",
+      label: "Project partners",
+      placeholder: "Project partners",
       type: "string",
       operators: [
         "string_contains_case_insensitive",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -3,7 +3,7 @@ import { ProjectsListViewFiltersConf } from "./ProjectsListViewFiltersConf";
 import { ProjectsListViewExportConf } from "./ProjectsListViewExportConf";
 import ExternalLink from "../../../components/ExternalLink";
 import { NavLink as RouterLink } from "react-router-dom";
-import { filterProjectTeamMembers } from "./helpers.js"
+import { filterProjectTeamMembers } from "./helpers.js";
 
 /**
  * The Query configuration (now also including filters)
@@ -135,12 +135,13 @@ export const ProjectsListViewQueryConf = {
         envelope: "%{VALUE}%",
       },
       type: "string",
+      filter: value => (value === "None" ? "-" : value),
     },
     project_partner: {
       label: "Project partner",
       searchable: true,
       search: {
-        label: "Search by project sponsor",
+        label: "Search by project partner",
         operator: "_ilike",
         quoted: true,
         envelope: "%{VALUE}%",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -125,6 +125,17 @@ export const ProjectsListViewQueryConf = {
       width: "20%",
       filter: filterProjectTeamMembers,
     },
+    entity_name: {
+      label: "Project sponsor",
+      searchable: true,
+      search: {
+        label: "Search by project sponsor",
+        operator: "_ilike",
+        quoted: true,
+        envelope: "%{VALUE}%",
+      },
+      type: "string",
+    },
     start_date: {
       searchable: false,
       sortable: true,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -138,10 +138,10 @@ export const ProjectsListViewQueryConf = {
       filter: value => (value === "None" ? "-" : value),
     },
     project_partner: {
-      label: "Project partner",
+      label: "Project partners",
       searchable: true,
       search: {
-        label: "Search by project partner",
+        label: "Search by project partners",
         operator: "_ilike",
         quoted: true,
         envelope: "%{VALUE}%",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -125,8 +125,19 @@ export const ProjectsListViewQueryConf = {
       width: "20%",
       filter: filterProjectTeamMembers,
     },
-    entity_name: {
+    project_sponsor: {
       label: "Project sponsor",
+      searchable: true,
+      search: {
+        label: "Search by project sponsor",
+        operator: "_ilike",
+        quoted: true,
+        envelope: "%{VALUE}%",
+      },
+      type: "string",
+    },
+    project_partner: {
+      label: "Project partner",
       searchable: true,
       search: {
         label: "Search by project sponsor",


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7360

I added project partner and project sponsor the Projects page, as well as the advanced search, the more straightforward search and the csv export configuration. 


## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
There are DB changes, so run locally or use moped-test.

**Steps to test:**

From a product summary page, add project partners and/or a project sponsor to a project. They should be visible on the projects page and come up in the search results. 
![Screen Shot 2021-12-08 at 1 19 10 PM](https://user-images.githubusercontent.com/12474808/145276511-85c29b4e-b1f0-4d71-bf53-63663b7c8f83.png)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
