### PR TITLE
Add external link icon to signal links

### DIFF
--- a/moped-editor/src/views/projects/projectView/CommentInputQuill.js
+++ b/moped-editor/src/views/projects/projectView/CommentInputQuill.js
@@ -40,8 +40,8 @@ const CommentInputQuill = ({
 
   return (
     <Container>
-      <Grid xs={12} sm={12} container direction="column" spacing={1}>
-        <Grid item>
+      <Grid container direction="column" spacing={1}>
+        <Grid item xs={12} sm={12}>
           <Box pt={2}>
             <ReactQuill
               theme="snow"

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,8 +1,18 @@
 import React from "react";
 import Link from "@material-ui/core/Link";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+  openInNewIcon: {
+    fontSize: "16px",
+    verticalAlign: "middle",
+    paddingBottom: "1px",
+  },
+}));
 
 const RenderSignalLink = ({ signals }) => {
+  const classes = useStyles();
   return (
     <span>
       {signals.map((signal, index) => (
@@ -14,7 +24,7 @@ const RenderSignalLink = ({ signals }) => {
               rel="noopener noreferrer"
             >
               {signal.signal_id}
-              <OpenInNewIcon style={{ fontSize: 14 }} />
+              <OpenInNewIcon className={classes.openInNewIcon} />
             </Link>
           ) : (
             signal.signal_id

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "@material-ui/core/Link";
+import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 
 const RenderSignalLink = ({ signals }) => {
   return (
@@ -13,6 +14,7 @@ const RenderSignalLink = ({ signals }) => {
               rel="noopener noreferrer"
             >
               {signal.signal_id}
+              <OpenInNewIcon style={{ fontSize: 14 }} />
             </Link>
           ) : (
             signal.signal_id


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7933

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://7933-external-link-signal--atd-moped-main.netlify.app/moped/dashboard

**Steps to test:**
Check the linked signals on the signal dashboard. They links should all have icons after each link. 
![Screen Shot 2021-12-09 at 12 28 59 PM](https://user-images.githubusercontent.com/12474808/145454642-4f60a8bd-274d-4a3d-9183-0869e22b84a6.png)


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
