### PR TITLE
Standardize edit-in-place and hyperlink UIs

### DIFF
--- a/moped-editor/src/queries/signals.js
+++ b/moped-editor/src/queries/signals.js
@@ -81,8 +81,6 @@ export const UPDATE_SIGNAL_PROJECT = gql`
     $contractor: String
     $purchase_order_number: String
     $entity_id: Int
-    $projectTypes: [moped_project_types_insert_input!]!
-    $typesDeleteList: [Int!]
   ) {
     update_moped_project_by_pk(
       pk_columns: { project_id: $project_id }
@@ -93,15 +91,6 @@ export const UPDATE_SIGNAL_PROJECT = gql`
       }
     ) {
       project_id
-    }
-    insert_moped_project_types(objects: $projectTypes) {
-      affected_rows
-    }
-    update_moped_project_types(
-      where: { id: { _in: $typesDeleteList } }
-      _set: { status_id: 0 }
-    ) {
-      affected_rows
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -50,6 +50,10 @@ const useStyles = makeStyles(theme => ({
   fieldLabelText: {
     width: "calc(100% - 2rem)",
   },
+  fieldLabelTextSpan: {
+    borderBottom: "1px dashed",
+    borderBottomColor: theme.palette.text.secondary,
+  },
   fieldLabelLink: {
     width: "calc(100% - 2rem)",
     overflow: "hidden",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Typography } from "@material-ui/core";
-import CreateOutlinedIcon from "@material-ui/icons/CreateOutlined";
 
 /**
  *
@@ -19,10 +18,12 @@ const ProjectSummaryLabel = ({
 }) => {
   return (
     <>
-      <Typography className={className ?? classes.fieldLabelText}>
-        {text}
+      <Typography
+        className={className ?? classes.fieldLabelText}
+        onClick={onClickEdit}
+      >
+        <span className={classes.fieldLabelTextSpan}>{text}</span>
       </Typography>
-      <CreateOutlinedIcon className={classes.editIcon} onClick={onClickEdit} />
     </>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -10,7 +10,6 @@ import {
 } from "../../../../queries/project";
 
 import { getSessionDatabaseData } from "../../../../auth/user";
-import CreateOutlinedIcon from "@material-ui/icons/CreateOutlined";
 
 /**
  * ProjectSummaryStatusUpdate Component
@@ -158,17 +157,15 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
             <Typography className={classes.fieldLabel}>
               Status update
             </Typography>
-            <Typography className={classes.fieldBoxTypography}>
-              {statusUpdate || "None"}
+            <Typography
+              className={classes.fieldBoxTypography}
+              onClick={handleStatusUpdateEdit}
+            >
+              <span className={classes.fieldLabelTextSpan}>
+                {statusUpdate || "None"}
+              </span>
             </Typography>
           </Box>
-        )}
-        {/*Edit Button*/}
-        {!statusUpdateEditable && statusUpdate && (
-          <CreateOutlinedIcon
-            className={classes.editIcon}
-            onClick={handleStatusUpdateEdit}
-          />
         )}
         {/*Add New Button*/}
         {!statusUpdateEditable && (

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -217,9 +217,7 @@ const SignalProjectTable = () => {
             </Typography>
           );
         }
-        return (
-          <Typography className={classes.tableTypography}>None</Typography>
-        );
+        return <Typography className={classes.tableTypography}>-</Typography>;
       },
     },
     {
@@ -243,8 +241,8 @@ const SignalProjectTable = () => {
     {
       title: "Contractor/Contract",
       field: "contractor",
-      emptyValue: "blank",
-      render: entry => (entry.contractor === "" ? "blank" : entry.contractor),
+      emptyValue: "-",
+      render: entry => (entry.contractor === "" ? "-" : entry.contractor),
     },
     {
       title: "Status update",
@@ -268,14 +266,16 @@ const SignalProjectTable = () => {
     {
       title: "Project DO#",
       field: "purchase_order_number",
-      emptyValue: "blank",
+      emptyValue: "-",
     },
     {
       title: "Project sponsor",
       field: "project_sponsor",
       render: entry => (
         <Typography className={classes.tableTypography}>
-          {entry?.project_sponsor?.entity_name}
+          {entry?.project_sponsor?.entity_name === "None"
+            ? "-"
+            : entry?.project_sponsor?.entity_name}
         </Typography>
       ),
       customEdit: "projectSponsor",

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -40,6 +40,10 @@ const useStyles = makeStyles({
   tableTypography: {
     fontSize: "14px",
   },
+  editStyle: {
+    opacity: ".6",
+    fontSize: "14px",
+  }
 });
 
 const SignalProjectTable = () => {
@@ -217,7 +221,7 @@ const SignalProjectTable = () => {
             </Typography>
           );
         }
-        return <Typography className={classes.tableTypography}>-</Typography>;
+        return <Typography className={classes.editStyle}>edit</Typography>;
       },
     },
     {
@@ -241,8 +245,8 @@ const SignalProjectTable = () => {
     {
       title: "Contractor/Contract",
       field: "contractor",
-      emptyValue: "-",
-      render: entry => (entry.contractor === "" ? "-" : entry.contractor),
+      emptyValue: "edit",
+      render: entry => (entry.contractor === "" ? "edit" : entry.contractor),
     },
     {
       title: "Status update",
@@ -266,18 +270,20 @@ const SignalProjectTable = () => {
     {
       title: "Project DO#",
       field: "purchase_order_number",
-      emptyValue: "-",
+      emptyValue: "edit",
     },
     {
       title: "Project sponsor",
       field: "project_sponsor",
-      render: entry => (
-        <Typography className={classes.tableTypography}>
-          {entry?.project_sponsor?.entity_name === "None"
-            ? "-"
+      render: entry => {
+        const noEntity = entry?.project_sponsor?.entity_name === "None";
+        return (
+        <Typography className={noEntity ? classes.editStyle : classes.tableTypography}>
+          {noEntity
+            ? "edit"
             : entry?.project_sponsor?.entity_name}
         </Typography>
-      ),
+      )},
       customEdit: "projectSponsor",
     },
     {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -394,7 +394,7 @@ const SignalProjectTable = () => {
         updatedProjectObject[columnDef.field] = newData;
 
         updatedProjectObject["entity_id"] =
-          updatedProjectObject.project_sponsor.entity_id;
+          updatedProjectObject?.project_sponsor?.entity_id;
 
         // Remove extraneous fields given by MaterialTable that
         // Hasura doesn't need
@@ -508,7 +508,7 @@ const SignalProjectTable = () => {
                 },
               }}
               editable={{
-                isEditable: false,
+                isEditable: () => false,
               }}
               cellEditable={{
                 cellStyle: { minWidth: "300px" },

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -43,7 +43,7 @@ const useStyles = makeStyles({
   editStyle: {
     opacity: ".6",
     fontSize: "14px",
-  }
+  },
 });
 
 const SignalProjectTable = () => {
@@ -278,12 +278,13 @@ const SignalProjectTable = () => {
       render: entry => {
         const noEntity = entry?.project_sponsor?.entity_name === "None";
         return (
-        <Typography className={noEntity ? classes.editStyle : classes.tableTypography}>
-          {noEntity
-            ? "edit"
-            : entry?.project_sponsor?.entity_name}
-        </Typography>
-      )},
+          <Typography
+            className={noEntity ? classes.editStyle : classes.tableTypography}
+          >
+            {noEntity ? "edit" : entry?.project_sponsor?.entity_name}
+          </Typography>
+        );
+      },
       customEdit: "projectSponsor",
     },
     {
@@ -366,59 +367,6 @@ const SignalProjectTable = () => {
    * projectActions functions object
    */
   const projectActions = {
-    update: (newData, oldData) => {
-      // initialize update object with old data
-      const updatedProjectObject = {
-        ...oldData,
-      };
-      // Array of differences between new and old data
-      let differences = Object.keys(oldData).filter(
-        key => oldData[key] !== newData[key]
-      );
-
-      // Loop through the differences and assign newData values.
-      differences.forEach(diff => {
-        updatedProjectObject[diff] = newData[diff];
-      });
-
-      // Remove extraneous fields given by MaterialTable that
-      // Hasura doesn't need
-      delete updatedProjectObject.tableData;
-      delete updatedProjectObject.__typename;
-
-      updatedProjectObject["entity_id"] =
-        updatedProjectObject.project_sponsor.entity_id;
-
-      // compare moped project types
-      const oldTypesList = oldData.project_types;
-      const newTypesList = newData.project_types;
-      // Retrieves the ids of oldTypesList that are not present in newTypesList
-      const typeIdsToDelete = oldTypesList.filter(
-        t => !newTypesList.includes(t)
-      );
-      // Retrieves the ids of newTypesList that are not present in oldTypesList
-      const typeIdsToInsert = newTypesList.filter(
-        t => !oldTypesList.includes(t)
-      );
-      // List of objects to insert
-      const typeObjectsToInsert = typeIdsToInsert.map(type_id => ({
-        project_id: oldData.project_id,
-        project_type_id: type_id,
-        status_id: 1,
-      }));
-
-      // List of primary keys to delete
-      const typePksToDelete = oldData.moped_project_types
-        .filter(t => typeIdsToDelete.includes(t?.moped_type.type_id))
-        .map(t => t.id);
-
-      updatedProjectObject["projectTypes"] = typeObjectsToInsert;
-      updatedProjectObject["typesDeleteList"] = typePksToDelete;
-
-      return updateSignalProject({
-        variables: updatedProjectObject,
-      });
-    },
     cellUpdate: (newData, oldData, rowData, columnDef) => {
       // if column definition has a custom edit component, use that mutation to update
       if (columnDef.customEdit === "projectSponsor") {
@@ -567,11 +515,7 @@ const SignalProjectTable = () => {
                 },
               }}
               editable={{
-                onRowUpdate: (newData, oldData) => {
-                  return projectActions
-                    .update(newData, oldData)
-                    .then(() => refetch());
-                },
+                isEditable: false,
               }}
               cellEditable={{
                 cellStyle: { minWidth: "300px" },

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -40,10 +40,6 @@ const useStyles = makeStyles({
   tableTypography: {
     fontSize: "14px",
   },
-  editStyle: {
-    opacity: ".6",
-    fontSize: "14px",
-  },
 });
 
 const SignalProjectTable = () => {
@@ -221,7 +217,7 @@ const SignalProjectTable = () => {
             </Typography>
           );
         }
-        return <Typography className={classes.editStyle}>edit</Typography>;
+        return <Typography className={classes.tableTypography}>-</Typography>;
       },
     },
     {
@@ -245,8 +241,8 @@ const SignalProjectTable = () => {
     {
       title: "Contractor/Contract",
       field: "contractor",
-      emptyValue: "edit",
-      render: entry => (entry.contractor === "" ? "edit" : entry.contractor),
+      emptyValue: "-",
+      render: entry => (entry.contractor === "" ? "-" : entry.contractor),
     },
     {
       title: "Status update",
@@ -270,21 +266,18 @@ const SignalProjectTable = () => {
     {
       title: "Project DO#",
       field: "purchase_order_number",
-      emptyValue: "edit",
+      emptyValue: "-",
     },
     {
       title: "Project sponsor",
       field: "project_sponsor",
-      render: entry => {
-        const noEntity = entry?.project_sponsor?.entity_name === "None";
-        return (
-          <Typography
-            className={noEntity ? classes.editStyle : classes.tableTypography}
-          >
-            {noEntity ? "edit" : entry?.project_sponsor?.entity_name}
-          </Typography>
-        );
-      },
+      render: entry => (
+        <Typography className={classes.tableTypography}>
+          {entry?.project_sponsor?.entity_name === "None"
+            ? "-"
+            : entry?.project_sponsor?.entity_name}
+        </Typography>
+      ),
       customEdit: "projectSponsor",
     },
     {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7870

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://7870-edit-in-place--atd-moped-main.netlify.app/moped/dashboard
https://7870-edit-in-place--atd-moped-main.netlify.app/moped/projects/323/
**Steps to test:**

Check in the summary view that you don't see any pencils. That clicking a field will open the edit capability. 

On the signals dashboard you shouldn't be able to edit a row. Empty editable fields will have a hyphen as a placeholder. 
---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
