### PR TITLE
Drop project list view before creating new one

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4737,9 +4737,7 @@
       - project_length
       - project_name
       - project_order
-      - project_partner
       - project_priority
-      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4768,9 +4766,7 @@
       - project_length
       - project_name
       - project_order
-      - project_partner
       - project_priority
-      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4799,9 +4795,7 @@
       - project_length
       - project_name
       - project_order
-      - project_partner
       - project_priority
-      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4730,7 +4730,6 @@
       - fiscal_year
       - is_retired
       - milestone_id
-      - phase_name
       - project_description
       - project_description_public
       - project_id
@@ -4762,7 +4761,6 @@
       - fiscal_year
       - is_retired
       - milestone_id
-      - phase_name
       - project_description
       - project_description_public
       - project_id
@@ -4794,7 +4792,6 @@
       - fiscal_year
       - is_retired
       - milestone_id
-      - phase_name
       - project_description
       - project_description_public
       - project_id

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4737,7 +4737,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4766,7 +4768,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date
@@ -4795,7 +4799,9 @@
       - project_length
       - project_name
       - project_order
+      - project_partner
       - project_priority
+      - project_sponsor
       - project_team_members
       - project_uuid
       - start_date

--- a/moped-database/migrations/1637823185562_alter_project_list_view/up.sql
+++ b/moped-database/migrations/1637823185562_alter_project_list_view/up.sql
@@ -1,3 +1,5 @@
+DROP VIEW "public"."project_list_view";
+
 CREATE OR REPLACE VIEW "public"."project_list_view" AS 
  SELECT mp.project_uuid,
     mp.project_id,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -104,7 +104,7 @@ export const ProjectsListViewQueryConf = {
       hidden: true,
       searchable: false,
     },
-    phase_name: {
+    current_phase: {
       searchable: true,
       sortable: false,
       label: "Status",


### PR DESCRIPTION
## Associated issues

none

This fixes the release candidate not building. Recent commits to main have edited the Project List SQL View, but once it was merged with production, errors appeared. 

> (so it could be that this commit got patches into production, that never got merged into main https://github.com/cityofaustin/atd-moped/commit/a8f9f922b54c6c8d79ff33fb05670c0a80785ce9? (edited) )

Our newer Views drop a column, so I dropped the View before creating or replacing: https://dba.stackexchange.com/questions/77564/postgresql-drop-column-from-view

This PR also removes the other references to that dropped column. 

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
