### PR TITLE
Add tooltip to project status button

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
 
-import { Box, Grid, Icon, TextField, Typography } from "@material-ui/core";
+import {
+  Box,
+  Grid,
+  Icon,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
 import ControlPointIcon from "@material-ui/icons/ControlPoint";
 
 import {
@@ -169,10 +176,12 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
         )}
         {/*Add New Button*/}
         {!statusUpdateEditable && (
-          <ControlPointIcon
-            className={classes.editIcon}
-            onClick={handleStatusUpdateAddNew}
-          />
+          <Tooltip title="Create new status update">
+            <ControlPointIcon
+              className={classes.editIcon}
+              onClick={handleStatusUpdateAddNew}
+            />
+          </Tooltip>
         )}
         {/*Save Button*/}
         {statusUpdateEditable && (


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7320

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://7320-status-tooltip--atd-moped-main.netlify.app/moped/projects/182/

**Steps to test:**

![Screen Shot 2021-12-17 at 3 02 40 PM](https://user-images.githubusercontent.com/12474808/146608453-04c3818f-2489-4b5a-b968-b35b7900a228.png)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
