### PR TITLE
Fix font rendering issues on material table

### DIFF
--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -3,13 +3,6 @@ import shadows from "./shadows";
 import typography from "./typography";
 
 const theme = createMuiTheme({
-  components: {
-    MuiTypography: {
-      defaultProps: {
-        fontFamily: "Roboto",
-      },
-    },
-  },
   palette: {
     background: {
       default: "#edeeed",

--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -3,6 +3,13 @@ import shadows from "./shadows";
 import typography from "./typography";
 
 const theme = createMuiTheme({
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        fontFamily: "Roboto",
+      },
+    },
+  },
   palette: {
     background: {
       default: "#edeeed",

--- a/moped-editor/src/theme/typography.js
+++ b/moped-editor/src/theme/typography.js
@@ -33,5 +33,5 @@ export default {
   overline: {
     fontWeight: 500,
   },
-  fontFamily: "Roboto",
+  fontFamily: `"Roboto", san-serif`,
 };

--- a/moped-editor/src/theme/typography.js
+++ b/moped-editor/src/theme/typography.js
@@ -33,5 +33,5 @@ export default {
   overline: {
     fontWeight: 500,
   },
-  fontFamily: "Roboto",
+  fontFamily: "Roboto, sans-serif",
 };

--- a/moped-editor/src/theme/typography.js
+++ b/moped-editor/src/theme/typography.js
@@ -33,5 +33,5 @@ export default {
   overline: {
     fontWeight: 500,
   },
-  fontFamily: "Roboto, sans-serif",
+  fontFamily: "Roboto",
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -240,7 +240,7 @@ const ProjectFiles = props => {
     },
     {
       title: "File size",
-      cellStyle: { fontFamily: typography.fontFamily },
+      // cellStyle: { fontFamily: typography.fontFamily },
       customSort: (a, b) => (a?.file_size ?? 0) - (b?.file_size ?? 0),
       render: record => (
         <span>{humanReadableFileSize(record?.file_size ?? 0)}</span>

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -19,7 +19,7 @@ import typography from "../../../theme/typography";
 import MaterialTable, { MTableEditRow, MTableAction } from "material-table";
 import {
   AddCircle as AddCircleIcon,
-  DeleteOutline as DeleteOutlineIcon
+  DeleteOutline as DeleteOutlineIcon,
 } from "@material-ui/icons";
 import { useMutation, useQuery } from "@apollo/client";
 
@@ -138,7 +138,7 @@ const ProjectFiles = props => {
   // If no data or loading show progress circle
   if (loading || !data) return <CircularProgress />;
 
-  const fileTypes = ['', 'Funding', 'Plans', 'Estimates', 'Other'];
+  const fileTypes = ["", "Funding", "Plans", "Estimates", "Other"];
 
   /**
    * Column configuration for <MaterialTable>
@@ -147,9 +147,9 @@ const ProjectFiles = props => {
     {
       title: "Name",
       field: "file_name",
-      validate: (rowData) => {
+      validate: rowData => {
         return rowData.file_name.length > 0 ? true : false;
-        },
+      },
       render: record => (
         <Link
           className={classes.downloadLink}
@@ -173,17 +173,25 @@ const ProjectFiles = props => {
       field: "file_type",
       render: record => <span>{fileTypes[record?.file_type]}</span>,
       editComponent: props => (
-        <FormControl >
-          <Select  
-          id="file_description"
-          name="file_description"
-          value={props?.value}
-          onChange={e => props.onChange(e.target.value)}
+        <FormControl>
+          <Select
+            id="file_description"
+            name="file_description"
+            value={props?.value}
+            onChange={e => props.onChange(e.target.value)}
           >
-            <MenuItem value={1} className={classes.inputFieldAdornmentColor}>Funding</MenuItem>
-            <MenuItem value={2} className={classes.inputFieldAdornmentColor}>Plans</MenuItem>
-            <MenuItem value={3} className={classes.inputFieldAdornmentColor}>Estimates</MenuItem>
-            <MenuItem value={4} className={classes.inputFieldAdornmentColor}>Other</MenuItem>
+            <MenuItem value={1} className={classes.inputFieldAdornmentColor}>
+              Funding
+            </MenuItem>
+            <MenuItem value={2} className={classes.inputFieldAdornmentColor}>
+              Plans
+            </MenuItem>
+            <MenuItem value={3} className={classes.inputFieldAdornmentColor}>
+              Estimates
+            </MenuItem>
+            <MenuItem value={4} className={classes.inputFieldAdornmentColor}>
+              Other
+            </MenuItem>
           </Select>
           <FormHelperText>Required</FormHelperText>
         </FormControl>
@@ -204,6 +212,7 @@ const ProjectFiles = props => {
     },
     {
       title: "Uploaded by",
+      cellStyle: { fontFamily: typography.fontFamily },
       render: record => (
         <span>
           {record?.created_by
@@ -216,6 +225,7 @@ const ProjectFiles = props => {
     },
     {
       title: "Date uploaded",
+      cellStyle: { fontFamily: typography.fontFamily },
       customSort: (a, b) =>
         new Date(a?.create_date ?? 0) - new Date(b?.create_date ?? 0),
       render: record => (
@@ -230,6 +240,7 @@ const ProjectFiles = props => {
     },
     {
       title: "File size",
+      cellStyle: { fontFamily: typography.fontFamily },
       customSort: (a, b) => (a?.file_size ?? 0) - (b?.file_size ?? 0),
       render: record => (
         <span>{humanReadableFileSize(record?.file_size ?? 0)}</span>

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -240,7 +240,7 @@ const ProjectFiles = props => {
     },
     {
       title: "File size",
-      // cellStyle: { fontFamily: typography.fontFamily },
+      cellStyle: { fontFamily: typography.fontFamily },
       customSort: (a, b) => (a?.file_size ?? 0) - (b?.file_size ?? 0),
       render: record => (
         <span>{humanReadableFileSize(record?.file_size ?? 0)}</span>

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -189,7 +189,7 @@ const SignalProjectTable = () => {
       title: "Project name",
       field: "project_name",
       editable: "never",
-      cellStyle: { minWidth: "200px" },
+      cellStyle: { ...typographyStyle, minWidth: "200px" },
       render: entry => (
         <RenderFieldLink
           projectId={entry.project_id}


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7865

## Description
Material table has this line (https://github.com/mbrn/material-table/blob/master/src/components/m-table-cell.js#L132) where the cell style has fontFamily inherit. Why does this revert to serif, I cannot seem to figure out. One fix is to explicitly set the typography on cellStyle for cells that aren't editable. 

I also set a fallback font style on the theme. That didn't solve the issue on material table rendering, but I am leaving it there as a failsafe. 

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://7865-font-issues--atd-moped-main.netlify.app/moped/projects/182?tab=files

**Steps to test:**

On a project files view, click the pencil to edit a row. Cells that arent being edited should not revert back to a serifed font. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
