### PR TITLE
7777: New UI element for sync to Data Tracker

### DIFF
--- a/moped-editor/src/views/projects/projectView/KnackSync.js
+++ b/moped-editor/src/views/projects/projectView/KnackSync.js
@@ -31,10 +31,6 @@ const buildUrl = (scene, view, knackProjectId) => {
  * @returns string
  */
 const getHttpMethod = knackProjectId => {
-  //return project?.knack_project_id ?? false ? "PUT" : "POST";
-  //let method = knackProjectId ?? false ? "PUT" : "POST";
-  //console.log("knackProjectId: ", knackProjectId);
-  //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";
 };
 
@@ -52,8 +48,6 @@ const KnackSync = React.forwardRef(
       process.env.REACT_APP_KNACK_DATA_TRACKER_VIEW,
       project.knack_project_id
     );
-
-    //console.log("Project: ", project);
 
     let knackHttpMethod = getHttpMethod(project?.knack_project_id);
 

--- a/moped-editor/src/views/projects/projectView/KnackSync.js
+++ b/moped-editor/src/views/projects/projectView/KnackSync.js
@@ -32,7 +32,7 @@ const buildUrl = (scene, view, knackProjectId) => {
  */
 const getHttpMethod = knackProjectId => {
   //return project?.knack_project_id ?? false ? "PUT" : "POST";
-  let method = knackProjectId ?? false ? "PUT" : "POST";
+  //let method = knackProjectId ?? false ? "PUT" : "POST";
   //console.log("knackProjectId: ", knackProjectId);
   //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";

--- a/moped-editor/src/views/projects/projectView/KnackSync.js
+++ b/moped-editor/src/views/projects/projectView/KnackSync.js
@@ -33,8 +33,8 @@ const buildUrl = (scene, view, knackProjectId) => {
 const getHttpMethod = knackProjectId => {
   //return project?.knack_project_id ?? false ? "PUT" : "POST";
   let method = knackProjectId ?? false ? "PUT" : "POST";
-  console.log("knackProjectId: ", knackProjectId);
-  console.log("HTTP Method: ", method);
+  //console.log("knackProjectId: ", knackProjectId);
+  //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";
 };
 
@@ -53,7 +53,7 @@ const KnackSync = React.forwardRef(
       project.knack_project_id
     );
 
-    console.log("Project: ", project);
+    //console.log("Project: ", project);
 
     let knackHttpMethod = getHttpMethod(project?.knack_project_id);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -25,6 +25,7 @@ import ProjectSummaryProjectTypes from "./ProjectSummaryProjectTypes";
 import ProjectSummaryKnackDataTrackerSync from "./ProjectSummaryKnackDataTrackerSync";
 
 import { countFeatures } from "../../../../utils/mapHelpers";
+import { autoShowTooltip } from "aws-amplify";
 
 const useStyles = makeStyles(theme => ({
   fieldGridItem: {
@@ -32,6 +33,10 @@ const useStyles = makeStyles(theme => ({
   },
   linkIcon: {
     fontSize: "1rem",
+  },
+  syncLinkIcon: {
+    fontSize: "1.2rem",
+
   },
   editIcon: {
     cursor: "pointer",
@@ -195,6 +200,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
               <Grid item xs={6}>
                 <ProjectSummaryKnackDataTrackerSync
                   classes={classes}
+                  knackProjectId={data?.moped_project?.[0]?.knack_project_id}
                 />
               </Grid>
               <Grid item xs={6}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -22,6 +22,7 @@ import ProjectSummaryProjectWebsite from "./ProjectSummaryProjectWebsite";
 import ProjectSummaryProjectDescription from "./ProjectSummaryProjectDescription";
 import ProjectSummaryProjectECapris from "./ProjectSummaryProjectECapris";
 import ProjectSummaryProjectTypes from "./ProjectSummaryProjectTypes";
+import ProjectSummaryKnackDataTrackerSync from "./ProjectSummaryKnackDataTrackerSync";
 
 import { countFeatures } from "../../../../utils/mapHelpers";
 
@@ -192,6 +193,11 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
             </Grid>
             <Grid container spacing={0}>
               <Grid item xs={6}>
+                <ProjectSummaryKnackDataTrackerSync
+                  classes={classes}
+                />
+              </Grid>
+              <Grid item xs={6}>
                 <ProjectSummaryProjectECapris
                   projectId={projectId}
                   data={data}
@@ -199,9 +205,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   classes={classes}
                   snackbarHandle={snackbarHandle}
                 />
-              </Grid>
-              <Grid item xs={6}>
-                {null}
               </Grid>
             </Grid>
           </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -200,6 +200,8 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                 <ProjectSummaryKnackDataTrackerSync
                   classes={classes}
                   project={data?.moped_project?.[0]}
+                  refetch={refetch}
+                  snackbarHandle={snackbarHandle}
                 />
               </Grid>
               <Grid item xs={6}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -199,7 +199,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
               <Grid item xs={6}>
                 <ProjectSummaryKnackDataTrackerSync
                   classes={classes}
-                  knackProjectId={data?.moped_project?.[0]?.knack_project_id}
+                  project={data?.moped_project?.[0]}
                 />
               </Grid>
               <Grid item xs={6}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -25,7 +25,6 @@ import ProjectSummaryProjectTypes from "./ProjectSummaryProjectTypes";
 import ProjectSummaryKnackDataTrackerSync from "./ProjectSummaryKnackDataTrackerSync";
 
 import { countFeatures } from "../../../../utils/mapHelpers";
-import { autoShowTooltip } from "aws-amplify";
 
 const useStyles = makeStyles(theme => ({
   fieldGridItem: {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -6,12 +6,13 @@ import {
   Typography,
 } from "@material-ui/core";
 
-import { OpenInNew } from "@material-ui/icons";
+import { OpenInNew, Autorenew } from "@material-ui/icons";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 const ProjectSummaryKnackDataTrackerSync = ({
-  classes
+  classes,
+  knackProjectId = undefined
 }) => {
 
   return (
@@ -26,16 +27,18 @@ const ProjectSummaryKnackDataTrackerSync = ({
         >
           <ProjectSummaryLabel
             text={
-              (true && (
-              <Link
-              href={''}
-              target={"_blank"}
-            >
-              {'View it here'} <OpenInNew className={classes.linkIcon} />
-            </Link>
+              (knackProjectId && (
+                <Link
+                  href={'https://atd.knack.com/amd#projects/project-details/' + knackProjectId}
+                  target={"_blank"}
+                >
+                  {'View in Data Tracker'} <OpenInNew className={classes.linkIcon} />
+                </Link>
               )) || (
                 <>
-                  {'Synchronize'} <Autorenew className={classes.linkIcon} />
+                  <Link className={classes.fieldLabelText}>
+                    {'Synchronize'}<Autorenew viewBox={"0 -4 22 26"} className={classes.syncLinkIcon} />
+                  </Link>
                 </>
               )}
             classes={classes}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -8,6 +8,10 @@ import {
 
 import { OpenInNew, Autorenew } from "@material-ui/icons";
 
+import { UPDATE_PROJECT_KNACK_ID } from "../../../../queries/project";
+
+import { useMutation } from "@apollo/client";
+
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 /**
@@ -82,6 +86,10 @@ const ProjectSummaryKnackDataTrackerSync = ({
 
       return JSON.stringify(body);
     };
+
+  const [mutateProjectKnackId] = useMutation(UPDATE_PROJECT_KNACK_ID);
+
+
 
   return (
     <>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -23,7 +23,6 @@ const ProjectSummaryKnackDataTrackerSync = ({
         <Box
           display="flex"
           justifyContent="flex-start"
-        c  lassName={classes.fieldBox}
         >
           <ProjectSummaryLabel
             text={
@@ -34,8 +33,11 @@ const ProjectSummaryKnackDataTrackerSync = ({
             >
               {'View it here'} <OpenInNew className={classes.linkIcon} />
             </Link>
-              )) || "Synchronize"
-            }
+              )) || (
+                <>
+                  {'Synchronize'} <Autorenew className={classes.linkIcon} />
+                </>
+              )}
             classes={classes}
             spanClassName={''}
           />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -179,8 +179,6 @@ const ProjectSummaryKnackDataTrackerSync = ({
             snackbarHandle(true, "Error: Data Tracker initial sync failed.", "warning");
           });
       } // end of the creating new knack record branch
-
-      //closeHandler(); // this is used to close the Menulist
   };
 
 return (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -31,8 +31,8 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
  const getHttpMethod = knackProjectId => {
   //return project?.knack_project_id ?? false ? "PUT" : "POST";
   let method = knackProjectId ?? false ? "PUT" : "POST";
-  console.log("knackProjectId: ", knackProjectId);
-  console.log("HTTP Method: ", method);
+  //console.log("knackProjectId: ", knackProjectId);
+  //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -49,6 +49,16 @@ const ProjectSummaryKnackDataTrackerSync = ({
 
   let knackHttpMethod = getHttpMethod(project?.knack_project_id);
 
+  /**
+   * Object to hold headers which need to be sent as part of the a Knack API call
+   */
+    const buildHeaders = {
+    "Content-Type": "application/json",
+    "X-Knack-Application-Id": process.env.REACT_APP_KNACK_DATA_TRACKER_APP_ID,
+    "X-Knack-REST-API-Key": "knack",
+  };
+
+
 
   return (
     <>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -37,6 +37,7 @@ const ProjectSummaryKnackDataTrackerSync = ({
               )) || "Synchronize"
             }
             classes={classes}
+            spanClassName={''}
           />
         </Box>
       </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -38,7 +38,7 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 const ProjectSummaryKnackDataTrackerSync = ({
   classes,
-  knackProjectId = undefined
+  project,
 }) => {
 
   return (
@@ -53,9 +53,9 @@ const ProjectSummaryKnackDataTrackerSync = ({
         >
           <ProjectSummaryLabel
             text={
-              (knackProjectId && (
+              (project.knack_project_id && (
                 <Link
-                  href={'https://atd.knack.com/amd#projects/project-details/' + knackProjectId}
+                  href={'https://atd.knack.com/amd#projects/project-details/' + project.knack_project_id}
                   target={"_blank"}
                 >
                   {'View in Data Tracker'} <OpenInNew className={classes.linkIcon} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+import {
+  Grid,
+  Typography,
+} from "@material-ui/core";
+
+import ProjectSummaryLabel from "./ProjectSummaryLabel";
+
+const ProjectSummaryKnackDataTrackerSync = ({
+  classes
+}) => {
+
+  return (
+    <>
+      <Grid item xs={12} className={classes.fieldGridItem}>
+        <Typography className={classes.fieldLabel}>
+          Data Tracker signal IDs
+        </Typography>
+      </Grid>
+    </>
+  )
+
+};
+
+export default ProjectSummaryKnackDataTrackerSync;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -1,12 +1,9 @@
 import React from "react";
 import { Box, Grid, Link, Typography } from "@material-ui/core";
-
 import { OpenInNew, Autorenew } from "@material-ui/icons";
-
-import { UPDATE_PROJECT_KNACK_ID } from "../../../../queries/project";
-
 import { useMutation } from "@apollo/client";
 
+import { UPDATE_PROJECT_KNACK_ID } from "../../../../queries/project";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 /**
@@ -28,10 +25,6 @@ const buildUrl = (scene, view, knackProjectId) => {
  * @returns string
  */
 const getHttpMethod = knackProjectId => {
-  //return project?.knack_project_id ?? false ? "PUT" : "POST";
-  //let method = knackProjectId ?? false ? "PUT" : "POST";
-  //console.log("knackProjectId: ", knackProjectId);
-  //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  Box,
-  Grid,
-  Link,
-  Typography,
-} from "@material-ui/core";
+import { Box, Grid, Link, Typography } from "@material-ui/core";
 
 import { OpenInNew, Autorenew } from "@material-ui/icons";
 
@@ -19,7 +14,7 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
  * update or an initial sync.
  * @returns string
  */
- const buildUrl = (scene, view, knackProjectId) => {
+const buildUrl = (scene, view, knackProjectId) => {
   let url = `https://api.knack.com/v1/pages/scene_${scene}/views/view_${view}/records`;
   if (knackProjectId) {
     // existing record
@@ -32,7 +27,7 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
  * Function to determine the HTTP method to use base on if there will be an update or initial post to Knack
  * @returns string
  */
- const getHttpMethod = knackProjectId => {
+const getHttpMethod = knackProjectId => {
   //return project?.knack_project_id ?? false ? "PUT" : "POST";
   //let method = knackProjectId ?? false ? "PUT" : "POST";
   //console.log("knackProjectId: ", knackProjectId);
@@ -44,13 +39,12 @@ const ProjectSummaryKnackDataTrackerSync = ({
   classes,
   project,
   refetch,
-  snackbarHandle
+  snackbarHandle,
 }) => {
-
   let knackEndpointUrl = buildUrl(
     process.env.REACT_APP_KNACK_DATA_TRACKER_SCENE,
     process.env.REACT_APP_KNACK_DATA_TRACKER_VIEW,
-    project?.knackProjectId,
+    project?.knackProjectId
   );
 
   let knackHttpMethod = getHttpMethod(project?.knack_project_id);
@@ -58,168 +52,183 @@ const ProjectSummaryKnackDataTrackerSync = ({
   /**
    * Object to hold headers which need to be sent as part of the a Knack API call
    */
-    const buildHeaders = {
+  const buildHeaders = {
     "Content-Type": "application/json",
     "X-Knack-Application-Id": process.env.REACT_APP_KNACK_DATA_TRACKER_APP_ID,
     "X-Knack-REST-API-Key": "knack",
   };
 
-   /**
-     * Function to build up a JSON object of the fields which need to be updated in a call to Knack. This is needed
-     * because if you update the project number field, even with the same, extant number, Knack returns an error.
-     * @returns string
-     */
-    const buildBody = () => {
-      let body = {};
+  /**
+   * Function to build up a JSON object of the fields which need to be updated in a call to Knack. This is needed
+   * because if you update the project number field, even with the same, extant number, Knack returns an error.
+   * @returns string
+   */
+  const buildBody = () => {
+    let body = {};
 
-      const field_map = {
-        field_3998: "project_id",
-        field_3999: "project_name",
-        field_4000: "current_status",
-      };
-
-      Object.keys(field_map).forEach(element => {
-        if (
-          project.currentKnackState[element] !== project[field_map[element]]
-        ) {
-          body[element] = project[field_map[element]];
-        }
-      });
-
-      return JSON.stringify(body);
+    const field_map = {
+      field_3998: "project_id",
+      field_3999: "project_name",
+      field_4000: "current_status",
     };
+
+    Object.keys(field_map).forEach(element => {
+      if (project.currentKnackState[element] !== project[field_map[element]]) {
+        body[element] = project[field_map[element]];
+      }
+    });
+
+    return JSON.stringify(body);
+  };
 
   const [mutateProjectKnackId] = useMutation(UPDATE_PROJECT_KNACK_ID);
 
-    /**
-     * Function to handle the actual mechanics of synchronizing the data on hand to the Knack API endpoint.
-     */
-     const handleSync = () => {
-      if (project.knack_project_id) {
-        // updating knack record
-        fetch(knackEndpointUrl, {
-          // Fetch will return a promise, allowing us to start a chain of .then() calls
-          method: "GET",
-          headers: buildHeaders,
+  /**
+   * Function to handle the actual mechanics of synchronizing the data on hand to the Knack API endpoint.
+   */
+  const handleSync = () => {
+    if (project.knack_project_id) {
+      // updating knack record
+      fetch(knackEndpointUrl, {
+        // Fetch will return a promise, allowing us to start a chain of .then() calls
+        method: "GET",
+        headers: buildHeaders,
+      })
+        .then(response => response.json()) // get the json payload, passing it the next step
+        .then(result => {
+          if (result.errors) {
+            // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID.
+            // Reject the promise to fall through to the .catch() method
+            return Promise.reject(result);
+          } else {
+            // Successful HTTP request with meaningful results from Knack
+            project.currentKnackState = result; // this assignment operates on `project` which is defined in broader scope than this function
+            return fetch(knackEndpointUrl, {
+              // fetch returns a Promise for the next step
+              method: knackHttpMethod,
+              headers: buildHeaders,
+              body: buildBody(),
+            });
+          }
         })
-          .then(response => response.json()) // get the json payload, passing it the next step
-          .then(result => {
-            if (result.errors) {
-              // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID.
-              // Reject the promise to fall through to the .catch() method
-              return Promise.reject(result);
-            } else {
-              // Successful HTTP request with meaningful results from Knack
-              project.currentKnackState = result; // this assignment operates on `project` which is defined in broader scope than this function
-              return fetch(knackEndpointUrl, {
-                // fetch returns a Promise for the next step
-                method: knackHttpMethod,
-                headers: buildHeaders,
-                body: buildBody(),
-              });
-            }
-          })
-          .then(response => response.json())
-          .then(result => {
-            if (result.errors) {
-              // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID
-              return Promise.reject(result);
-            } else {
-              // Successful HTTP Update request with meaningful results from Knack
-              return Promise.resolve();
-            }
-          })
-          .then(() => refetch()) // ask the application to update its status from our graphql endpoint
-          .then(() => {
-            // End of the chain; advise the user of success
-            snackbarHandle(true, "Success: Project updated in Data Tracker", "success")
+        .then(response => response.json())
+        .then(result => {
+          if (result.errors) {
+            // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID
+            return Promise.reject(result);
+          } else {
+            // Successful HTTP Update request with meaningful results from Knack
             return Promise.resolve();
-          })
-          .catch(error => {
-            // Failure, alert the user that we've encountered an error
-            console.error(error);
-            snackbarHandle(true, "Error: Data Tracker update failed.", "warning");
-          });
-      } else {
-        // creating new knack record execution branch
-        project.currentKnackState = {};
-        fetch(knackEndpointUrl, {
-          // Fetch will return a promise, which we'll use to start a chain of .then() steps
-          method: knackHttpMethod,
-          headers: buildHeaders,
-          body: buildBody(),
+          }
         })
-          .then(response => response.json()) // get the json payload and pass it along
-          .then(result => {
-            if (result.errors) {
-              // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID.
-              // Reject this promise so we fall through to the .catch() method
-              return Promise.reject(result);
-            }
-            return Promise.resolve(result); // pass result object onto next .then()
+        .then(() => refetch()) // ask the application to update its status from our graphql endpoint
+        .then(() => {
+          // End of the chain; advise the user of success
+          snackbarHandle(
+            true,
+            "Success: Project updated in Data Tracker",
+            "success"
+          );
+          return Promise.resolve();
+        })
+        .catch(error => {
+          // Failure, alert the user that we've encountered an error
+          console.error(error);
+          snackbarHandle(true, "Error: Data Tracker update failed.", "warning");
+        });
+    } else {
+      // creating new knack record execution branch
+      project.currentKnackState = {};
+      fetch(knackEndpointUrl, {
+        // Fetch will return a promise, which we'll use to start a chain of .then() steps
+        method: knackHttpMethod,
+        headers: buildHeaders,
+        body: buildBody(),
+      })
+        .then(response => response.json()) // get the json payload and pass it along
+        .then(result => {
+          if (result.errors) {
+            // Successful HTTP request, but knack indicates an error with the query, such as non-existent ID.
+            // Reject this promise so we fall through to the .catch() method
+            return Promise.reject(result);
+          }
+          return Promise.resolve(result); // pass result object onto next .then()
+        })
+        .then(knack_record =>
+          // We've got an ID from the Knack endpoint for this project, so record it in our database
+          mutateProjectKnackId({
+            variables: {
+              project_id: project.project_id,
+              knack_id: knack_record.record.id,
+            },
           })
-          .then(knack_record =>
-            // We've got an ID from the Knack endpoint for this project, so record it in our database
-            mutateProjectKnackId({
-              variables: {
-                project_id: project.project_id,
-                knack_id: knack_record.record.id,
-              },
-            })
-          )
-          .then(() => refetch()) // ask the application to update its status from our graphql endpoint
-          .then(() => {
-            // End of the chain; advise the user of success
-            snackbarHandle(true, "Success: Project data pushed to Data Tracker", "success")
-            return Promise.resolve();
-          })
-          .catch(error => {
-            // Failure, alert the user that we've encountered an error
-            console.error(error);
-            snackbarHandle(true, "Error: Data Tracker initial sync failed.", "warning");
-          });
-      } // end of the creating new knack record branch
+        )
+        .then(() => refetch()) // ask the application to update its status from our graphql endpoint
+        .then(() => {
+          // End of the chain; advise the user of success
+          snackbarHandle(
+            true,
+            "Success: Project data pushed to Data Tracker",
+            "success"
+          );
+          return Promise.resolve();
+        })
+        .catch(error => {
+          // Failure, alert the user that we've encountered an error
+          console.error(error);
+          snackbarHandle(
+            true,
+            "Error: Data Tracker initial sync failed.",
+            "warning"
+          );
+        });
+    } // end of the creating new knack record branch
   };
 
-return (
-  <>
-    <Grid item xs={12} className={classes.fieldGridItem}>
-      <Typography className={classes.fieldLabel}>
-        Data Tracker signal IDs
-      </Typography>
-      <Box
-        display="flex"
-        justifyContent="flex-start"
-      >
-        <ProjectSummaryLabel
-          text={
-            (project.knack_project_id && (
-              <Link
-                href={'https://atd.knack.com/amd#projects/project-details/' + project.knack_project_id}
-                target={"_blank"}
-              >
-                {'View in Data Tracker'} <OpenInNew className={classes.linkIcon} />
-              </Link>
-            )) || (
-              <>
-                <Link 
-                  className={classes.fieldLabelText}
-                  onClick={() => {
-                    handleSync();
-                  }}
+  return (
+    <>
+      <Grid item xs={12} className={classes.fieldGridItem}>
+        <Typography className={classes.fieldLabel}>
+          Data Tracker signal IDs
+        </Typography>
+        <Box display="flex" justifyContent="flex-start">
+          <ProjectSummaryLabel
+            text={
+              (project.knack_project_id && (
+                <Link
+                  href={
+                    "https://atd.knack.com/amd#projects/project-details/" +
+                    project.knack_project_id
+                  }
+                  target={"_blank"}
                 >
-                  {'Synchronize'}<Autorenew viewBox={"0 -4 22 26"} className={classes.syncLinkIcon} />
+                  {"View in Data Tracker"}{" "}
+                  <OpenInNew className={classes.linkIcon} />
                 </Link>
-              </>
-            )}
-          classes={classes}
-          spanClassName={''}
-        />
-      </Box>
-    </Grid>
-  </>
-)
-
+              )) || (
+                <>
+                  <Link
+                    className={classes.fieldLabelText}
+                    onClick={() => {
+                      handleSync();
+                    }}
+                  >
+                    {"Synchronize"}
+                    <Autorenew
+                      viewBox={"0 -4 22 26"}
+                      className={classes.syncLinkIcon}
+                    />
+                  </Link>
+                </>
+              )
+            }
+            classes={classes}
+            spanClassName={""}
+          />
+        </Box>
+      </Grid>
+    </>
+  );
 };
 
 export default ProjectSummaryKnackDataTrackerSync;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Box,
   Grid,
@@ -36,7 +36,12 @@ const ProjectSummaryKnackDataTrackerSync = ({
                 </Link>
               )) || (
                 <>
-                  <Link className={classes.fieldLabelText}>
+                  <Link 
+                    className={classes.fieldLabelText}
+                    onClick={() => {
+                      console.log('clicked')
+                    }}
+                  >
                     {'Synchronize'}<Autorenew viewBox={"0 -4 22 26"} className={classes.syncLinkIcon} />
                   </Link>
                 </>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -10,6 +10,32 @@ import { OpenInNew, Autorenew } from "@material-ui/icons";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
+/**
+ * Function to build the correct Knack URL to interact with based on properties and if there will be an
+ * update or an initial sync.
+ * @returns string
+ */
+ const buildUrl = (scene, view, knackProjectId) => {
+  let url = `https://api.knack.com/v1/pages/scene_${scene}/views/view_${view}/records`;
+  if (knackProjectId) {
+    // existing record
+    url = url + "/" + knackProjectId;
+  }
+  return url;
+};
+
+/**
+ * Function to determine the HTTP method to use base on if there will be an update or initial post to Knack
+ * @returns string
+ */
+ const getHttpMethod = knackProjectId => {
+  //return project?.knack_project_id ?? false ? "PUT" : "POST";
+  let method = knackProjectId ?? false ? "PUT" : "POST";
+  console.log("knackProjectId: ", knackProjectId);
+  console.log("HTTP Method: ", method);
+  return knackProjectId ?? false ? "PUT" : "POST";
+};
+
 const ProjectSummaryKnackDataTrackerSync = ({
   classes,
   knackProjectId = undefined

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -43,6 +43,8 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
 const ProjectSummaryKnackDataTrackerSync = ({
   classes,
   project,
+  refetch,
+  snackbarHandle
 }) => {
 
   let knackEndpointUrl = buildUrl(
@@ -127,22 +129,16 @@ const ProjectSummaryKnackDataTrackerSync = ({
               return Promise.resolve();
             }
           })
-          //.then(() => refetch()) // ask the application to update its status from our graphql endpoint
+          .then(() => refetch()) // ask the application to update its status from our graphql endpoint
           .then(() => {
             // End of the chain; advise the user of success
-            //snackbarHandler({
-              //severity: "success",
-              //message: "Success: Project data updated in Data Tracker.",
-            //});
+            snackbarHandle(true, "Success: Project updated in Data Tracker", "success")
             return Promise.resolve();
           })
           .catch(error => {
             // Failure, alert the user that we've encountered an error
             console.error(error);
-            //snackbarHandler({
-              //severity: "warning",
-              //message: "Error: Data Tracker update failed.",
-            //});
+            snackbarHandle(true, "Error: Data Tracker update failed.", "warning");
           });
       } else {
         // creating new knack record execution branch
@@ -171,22 +167,16 @@ const ProjectSummaryKnackDataTrackerSync = ({
               },
             })
           )
-          //.then(() => refetch()) // ask the application to update its status from our graphql endpoint
+          .then(() => refetch()) // ask the application to update its status from our graphql endpoint
           .then(() => {
             // End of the chain; advise the user of success
-            //snackbarHandler({
-              //severity: "success",
-              //message: "Success: Project data pushed to Data Tracker.",
-            //});
+            snackbarHandle(true, "Success: Project data pushed to Data Tracker", "success")
             return Promise.resolve();
           })
           .catch(error => {
             // Failure, alert the user that we've encountered an error
             console.error(error);
-            //snackbarHandler({
-              //severity: "warning",
-              //message: "Error: Data Tracker initial sync failed.",
-            //});
+            snackbarHandle(true, "Error: Data Tracker initial sync failed.", "warning");
           });
       } // end of the creating new knack record branch
 
@@ -217,7 +207,7 @@ return (
                 <Link 
                   className={classes.fieldLabelText}
                   onClick={() => {
-                    console.log('clicked')
+                    handleSync();
                   }}
                 >
                   {'Synchronize'}<Autorenew viewBox={"0 -4 22 26"} className={classes.syncLinkIcon} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -41,6 +41,15 @@ const ProjectSummaryKnackDataTrackerSync = ({
   project,
 }) => {
 
+  let knackEndpointUrl = buildUrl(
+    process.env.REACT_APP_KNACK_DATA_TRACKER_SCENE,
+    process.env.REACT_APP_KNACK_DATA_TRACKER_VIEW,
+    project?.knackProjectId,
+  );
+
+  let knackHttpMethod = getHttpMethod(project?.knack_project_id);
+
+
   return (
     <>
       <Grid item xs={12} className={classes.fieldGridItem}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -1,8 +1,12 @@
 import React, { useState } from "react";
 import {
+  Box,
   Grid,
+  Link,
   Typography,
 } from "@material-ui/core";
+
+import { OpenInNew } from "@material-ui/icons";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
@@ -16,6 +20,25 @@ const ProjectSummaryKnackDataTrackerSync = ({
         <Typography className={classes.fieldLabel}>
           Data Tracker signal IDs
         </Typography>
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+        c  lassName={classes.fieldBox}
+        >
+          <ProjectSummaryLabel
+            text={
+              (true && (
+              <Link
+              href={''}
+              target={"_blank"}
+            >
+              {'View it here'} <OpenInNew className={classes.linkIcon} />
+            </Link>
+              )) || "Synchronize"
+            }
+            classes={classes}
+          />
+        </Box>
       </Grid>
     </>
   )

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -58,7 +58,30 @@ const ProjectSummaryKnackDataTrackerSync = ({
     "X-Knack-REST-API-Key": "knack",
   };
 
+   /**
+     * Function to build up a JSON object of the fields which need to be updated in a call to Knack. This is needed
+     * because if you update the project number field, even with the same, extant number, Knack returns an error.
+     * @returns string
+     */
+    const buildBody = () => {
+      let body = {};
 
+      const field_map = {
+        field_3998: "project_id",
+        field_3999: "project_name",
+        field_4000: "current_status",
+      };
+
+      Object.keys(field_map).forEach(element => {
+        if (
+          project.currentKnackState[element] !== project[field_map[element]]
+        ) {
+          body[element] = project[field_map[element]];
+        }
+      });
+
+      return JSON.stringify(body);
+    };
 
   return (
     <>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -30,7 +30,7 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
  */
  const getHttpMethod = knackProjectId => {
   //return project?.knack_project_id ?? false ? "PUT" : "POST";
-  let method = knackProjectId ?? false ? "PUT" : "POST";
+  //let method = knackProjectId ?? false ? "PUT" : "POST";
   //console.log("knackProjectId: ", knackProjectId);
   //console.log("HTTP Method: ", method);
   return knackProjectId ?? false ? "PUT" : "POST";

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -15,6 +15,7 @@ const ProjectSummaryLabel = ({
   classes,
   onClickEdit,
   className = null,
+  spanClassName = null,
 }) => {
   return (
     <>
@@ -22,7 +23,7 @@ const ProjectSummaryLabel = ({
         className={className ?? classes.fieldLabelText}
         onClick={onClickEdit}
       >
-        <span className={classes.fieldLabelTextSpan}>{text}</span>
+        <span className={spanClassName ?? classes.fieldLabelTextSpan}>{text}</span>
       </Typography>
     </>
   );


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/7777. 

## Testing
https://flh-7777-sync-ui-element--atd-moped-main.netlify.app/moped/projects

NB: The staging database has a number of projects which indicate they are synchronized to knack, but the development knack database has had the corresponding records removed in the course of development. I would be happy to get connected to the staging database and remove these stale knack IDs - please let me know if this would be helpful.

NB: Also, please note that the URL that is used when sending the user to knack after they click on the "View in Data Tracker" link is based on the production Knack URL even when being used in testing. I attempted to put in some logic to direct the user to the development Data Tracker instance, but the SSO mechanism employed by Knack prevents this. 

**Steps to test:**
* Find a project which does not have a knack_id associated with it yet. You'll know you've found one when you see "Synchronize" being displayed by this component. 
* Click the link to start a sync attempt.
* Observe app behavior & observe the record having been created in the development knack data tracker app.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
