### PR TITLE
Set headers on signal dashboard as sticky

### DIFF
--- a/moped-editor/src/utils/materialTableHelpers.js
+++ b/moped-editor/src/utils/materialTableHelpers.js
@@ -27,6 +27,10 @@ export const handleKeyEvent = e => {
   }
 };
 
+/**
+ * Hook to get current window size
+ * Listens for resize and returns { width, height }
+ */
 export const useWindowResize = () => {
   const [width, setWidth] = useState(window.innerWidth);
   const [height, setHeight] = useState(window.innerHeight);

--- a/moped-editor/src/utils/materialTableHelpers.js
+++ b/moped-editor/src/utils/materialTableHelpers.js
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+
 /**
  * Filter k/v pairs from an object by the key names passed in an array
  * @param {object} obj - The object with unwanted k/v pairs
@@ -23,4 +25,26 @@ export const handleKeyEvent = e => {
   if (e.key === "Enter" || e.key === " ") {
     e.stopPropagation();
   }
+};
+
+export const useWindowResize = () => {
+  const [width, setWidth] = useState(window.innerWidth);
+  const [height, setHeight] = useState(window.innerHeight);
+
+  const listener = () => {
+    setWidth(window.innerWidth);
+    setHeight(window.innerHeight);
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", listener);
+    return () => {
+      window.removeEventListener("resize", listener);
+    };
+  }, []);
+
+  return {
+    width,
+    height,
+  };
 };

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -509,7 +509,7 @@ const SignalProjectTable = () => {
                   position: "sticky",
                   top: 0,
                 },
-                maxBodyHeight: `${height - 150}px`,
+                maxBodyHeight: `${height - 225}px`,
               }}
               localization={{
                 header: {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -509,7 +509,7 @@ const SignalProjectTable = () => {
                   position: "sticky",
                   top: 0,
                 },
-                maxBodyHeight: `${height - 225}px`,
+                maxBodyHeight: `${height - 210}px`,
               }}
               localization={{
                 header: {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -17,6 +17,7 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import MaterialTable, { MTableEditRow, MTableEditField } from "material-table";
 
 import Page from "src/components/Page";
+import { useWindowResize } from "src/utils/materialTableHelpers.js";
 import typography from "../../../theme/typography";
 import {
   SIGNAL_PROJECTS_QUERY,
@@ -44,6 +45,7 @@ const useStyles = makeStyles({
 
 const SignalProjectTable = () => {
   const classes = useStyles();
+  const { height } = useWindowResize();
   const { loading, error, data, refetch } = useQuery(SIGNAL_PROJECTS_QUERY, {
     fetchPolicy: "no-cache",
   });
@@ -504,7 +506,10 @@ const SignalProjectTable = () => {
                 pageSize: 30,
                 headerStyle: {
                   whiteSpace: "nowrap",
+                  position: "sticky",
+                  top: 0,
                 },
+                maxBodyHeight: `${height - 150}px`,
               }}
               localization={{
                 header: {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -509,6 +509,8 @@ const SignalProjectTable = () => {
                   position: "sticky",
                   top: 0,
                 },
+                // maxBodyHeight is used in conjunction with headerStyle position:"sticky"
+                // maxBodyHeight is window height minus size of navbar, footer, table title, and table padding
                 maxBodyHeight: `${height - 210}px`,
               }}
               localization={{


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/7998

Thanks to Amenity for linking to this issue: https://github.com/mbrn/material-table/issues/709#issuecomment-566097441

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://7998-sticky-header--atd-moped-main.netlify.app/moped/dashboard

**Steps to test:**

Resize window and see that signal table also resizes. Headers should stay put.

---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
