### PR TITLE
Perform miscellaneous database updates

### DIFF
--- a/moped-database/migrations/1642785096000_update_moped_components_table/down.sql
+++ b/moped-database/migrations/1642785096000_update_moped_components_table/down.sql
@@ -1,0 +1,5 @@
+UPDATE public.moped_components SET component_name = 'Crossswalk' WHERE component_id = 13;
+UPDATE public.moped_components SET component_name = 'Crossswalk' WHERE component_id = 14;
+UPDATE public.moped_components SET component_name = 'Crossswalk' WHERE component_id = 15;
+
+UPDATE public.moped_entity SET entity_name = 'COA ATD Intersection Safety', workgroup_id = NULL WHERE entity_id = 11;

--- a/moped-database/migrations/1642785096000_update_moped_components_table/up.sql
+++ b/moped-database/migrations/1642785096000_update_moped_components_table/up.sql
@@ -1,0 +1,5 @@
+UPDATE public.moped_components SET component_name = 'Crosswalk' WHERE component_id = 13;
+UPDATE public.moped_components SET component_name = 'Crosswalk' WHERE component_id = 14;
+UPDATE public.moped_components SET component_name = 'Crosswalk' WHERE component_id = 15;
+
+UPDATE public.moped_entity SET entity_name = 'COA ATD Vision Zero', workgroup_id = 17 WHERE entity_id = 11;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -99,7 +99,7 @@ export const SUMMARY_QUERY = gql`
       phase_start
       phase_end
     }
-    moped_entity {
+    moped_entity(order_by: {entity_id: asc}) {
       entity_id
       entity_name
     }


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/8058

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

Database changes, so must be local or on moped test. 

**Steps to test:**

To see the changes on the moped entity table: Go to a projects summary page and select the partner dropdown. COA ATD Vision Zero is now an option. (Note, when I tested locally, that option moved to the bottom of the list. I'm not sure if the order in the dropdown matters, but if it does we could order by enitity_id)

To see the moped components change, go the map tab, add a new component and look for a Crosswalk with only 2 s. 


---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
