### PR TITLE
Update filters on signal dashboard query

### DIFF
--- a/moped-editor/src/queries/signals.js
+++ b/moped-editor/src/queries/signals.js
@@ -1,5 +1,8 @@
 import { gql } from "@apollo/client";
 
+// Status ID 6 is archived (soft deleted)
+// Status ID 3 is cancelled
+
 export const SIGNAL_PROJECTS_QUERY = gql`
   query SignalProjectsQuery {
     moped_project(
@@ -15,10 +18,15 @@ export const SIGNAL_PROJECTS_QUERY = gql`
             moped_proj_components: {
               moped_components: { component_name: { _ilike: "signal" } }
             }
-            status_id: { _neq: 4 }
+            status_id: { _neq: 6 }
           }
-        ],
-        status_id: {_neq: 6}
+          {
+            moped_proj_components: {
+              moped_components: { component_name: { _ilike: "signal" } }
+            }
+            status_id: { _neq: 3 }
+          }
+        ]
       }
       order_by: {updated_at: desc_nulls_last}
     ) {


### PR DESCRIPTION
## Associated issues

the query used to be: 

``` 
where: {
        _or: [
          {
            moped_proj_components: {
              moped_components: { component_name: { _ilike: "signal" } }
            }
            status_id: { _is_null: true }
          }
          {
            moped_proj_components: {
              moped_components: { component_name: { _ilike: "signal" } }
            }
            status_id: { _neq: 4 }
          }
        ],
        status_id: {_neq: 6}
      }
```

which was preventing projects with a null status from showing up. Which seem to be existing projects / seed projects that then get a signal added to it. (I guess you can't both be is_null is true and _neq: 6?)

now it will be signal projects with either null status, or not 3 or not 6. 


## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
