### PR TITLE
Patch project sponsor disappearing bug

### DIFF
--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -118,7 +118,7 @@ const SignalProjectTable = () => {
     project["project_types"] = project_types;
 
     // project sponsor
-    project["project_sponsor"] = entityList.find(
+    project["project_sponsor_object"] = entityList.find(
       e => e.entity_id === project?.project_sponsor
     );
 
@@ -294,12 +294,12 @@ const SignalProjectTable = () => {
     },
     {
       title: "Project sponsor",
-      field: "project_sponsor",
+      field: "project_sponsor_object",
       render: entry => (
         <Typography className={classes.tableTypography}>
-          {entry?.project_sponsor?.entity_name === "None"
+          {entry?.project_sponsor_object?.entity_name === "None"
             ? "-"
-            : entry?.project_sponsor?.entity_name}
+            : entry?.project_sponsor_object?.entity_name}
         </Typography>
       ),
       customEdit: "projectSponsor",
@@ -425,7 +425,7 @@ const SignalProjectTable = () => {
         updatedProjectObject[columnDef.field] = newData;
 
         updatedProjectObject["entity_id"] =
-          updatedProjectObject?.project_sponsor?.entity_id;
+          updatedProjectObject?.project_sponsor;
 
         // Remove extraneous fields given by MaterialTable that
         // Hasura doesn't need

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -287,6 +287,10 @@ const SignalProjectTable = () => {
       title: "Project DO#",
       field: "purchase_order_number",
       emptyValue: "-",
+      render: entry =>
+        entry.purchase_order_number.trim().length === 0
+          ? "-"
+          : entry.purchase_order_number,
     },
     {
       title: "Project sponsor",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/8244

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
Deploy to test, to test!

**Steps to test:**

Missing edit hyphen for some projects -- save a blank project DO#, by entering only empty spaces and saving. it should still render as a - instead of the blank spaces

To test the disappearing project sponsor. First, try resizing the screen. confirm the column texts dont disappear. Try updating other fields and the project sponsor shouldn't go away. 

I think this should also fix the project DO# not wanting to save. I can't see in the video of the bug, but I suspect the project sponsor had disappeared so when the project DO was trying to save, it was sending "undefined" as the project sponsor, thus preventing the update from completing. That is my conjecture though, since I wasn't able to reproduce. 

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
