### PR TITLE
Fix 0.13.0 Deployment

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -105,5 +105,8 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^2.5.1",
     "prettier": "^1.19.1"
+  },
+  "engines": {
+    "npm": ">=6.0.0"
   }
 }


### PR DESCRIPTION
## Associated issues

Fix deploy error for Moped v0.13.0 by pinning the version of `npm` that runs to 6+.

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
