### PR TITLE
Fix moped DB documentation build step by special casing the architecture detection on GNU/Linux

### DIFF
--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -19,7 +19,7 @@ function __get_platform() {
   # overloading the detected platform to work for linux machines
   if [ $PLATFORM = "GNU/Linux" ]
     then
-    PLATFORM = "x86_64";
+    PLATFORM="x86_64";
     fi
 
   echo "Detected platform: ${PLATFORM}";

--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -15,6 +15,13 @@ set -o errexit
 #
 function __get_platform() {
   PLATFORM=$(uname -a | rev | cut -d " " -f1 | rev);
+
+  # overloading the detected platform to work for linux machines
+  if [ $PLATFORM = "GNU/Linux" ]
+    then
+    PLATFORM = "x86_64";
+    fi
+
   echo "Detected platform: ${PLATFORM}";
 }
 


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/8264. 

## Testing

This is a tricky one to test. Two routes come to mind:

- [x] Checkout moped on a linux machine running on an actual, metal x86_64 chip and spin up the database. I have done this and it worked as intended.
- [ ] Test the change by _skipping testing_ and merging the PR into main and see if the change allows to DB documentation build step to complete in our automated dev-ops. 
  - This nonsensical approach is the result of us not really having direct access to the actual linux VMs on which this build step happens, I believe. 

---
#### Ship list
- [ ] Code reviewed 
- [x] ~Product manager approved~

