### PR TITLE
Bump Version Number in Main to 0.13.0

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "licence": "CC0 1.0 Universal",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "homepage": "/moped",
   "private": false,
   "scripts": {


### PR DESCRIPTION
## Associated issues

_None_, please see [Amenity's question in slack](https://austininnovation.slack.com/archives/CNUEPKLB1/p1643683204342319).

## Considerations

* Our production release number is 0.13.2, reflecting the two PRs which were pushed to it during the deployment process. As those changes are back-ported into main, we should increment this number as appropriate. 

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

**Steps to test:**

* Check the version number reads 0.13.0.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
