### PR TITLE
American-style spelling of license in the editor's package.json file

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
-  "licence": "CC0 1.0 Universal",
+  "license": "CC0 1.0 Universal",
   "version": "0.12.0",
   "homepage": "/moped",
   "private": false,


### PR DESCRIPTION
## Associated issues

None. This adjusts the spelling of `license` in `moped-editor/package.json` to the common American spelling to align with the [NPM docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json). 

## Testing
**URL to test:** N/A

**Steps to test:**

* Review the code changes in this PR.
---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
