### PR TITLE
update workflow to use graphql-engine-heroku where version is 1.3.3

### DIFF
--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -87,7 +87,6 @@ jobs:
           echo "ACTION/BRANCH_NAME: ${BRANCH_NAME}"
           echo "MOPED_PRNUM: ${MOPED_PRNUM}"
           source $(pwd)/.github/workflows/aws-heroku-helper.sh
-          clone_hasura_repo
           build_database
           run_database_migration
   build_activity_log_sqs:

--- a/.github/workflows/aws-heroku-helper.sh
+++ b/.github/workflows/aws-heroku-helper.sh
@@ -37,15 +37,6 @@ function build_editor() {
 # Database Deployment
 #
 
-function clone_hasura_repo() {
-  git clone https://github.com/hasura/graphql-engine-heroku;
-  echo "Patching graphql-engine-heroku/Dockerfile, before:";
-  head -1 graphql-engine-heroku/Dockerfile;
-  sed -ri "s/(2\...?\...?)/1.3.3/g" graphql-engine-heroku/Dockerfile;
-  echo "Patching graphql-engine-heroku/Dockerfile, after:";
-  head -1 graphql-engine-heroku/Dockerfile;
-}
-
 function heroku_commit_and_push() {
   echo "Working from dir: $(pwd)";
   echo "Removing existing .git file";
@@ -67,9 +58,11 @@ function build_database() {
   rm -rf "${HASURA_REPO_NAME}" || echo "Nothing to clean";
 
   print_header "Cloning Hasura Engine";
-  clone_hasura_repo;
+  git clone https://github.com/hasura/graphql-engine-heroku;
 
   cd "${HASURA_REPO_NAME}" || exit 1;
+  # checking out the commit where dockerfile uses graphql-engine v1.3.3
+  git checkout 87cbd11a397f58a159bd679a1280675ded5d9fe5;
 
   print_header "Destroying Current Application";
   {


### PR DESCRIPTION
## Associated issues

none

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

The way to test is to deploy this branch to the test instance and see if the db builds successfully on heroku.

Recently hasura's graphql-engine-heroku dockerfile was updated (https://github.com/hasura/graphql-engine-heroku/commit/da63f74c5494226e6342b4bc03ec236286370dc3) and the new command uses a [different flag](https://hasura.io/docs/latest/graphql/core/deployment/graphql-engine-flags/reference.html#graphql-engine-command-flags-environment-variables) that is only available on versions of hasura greater than 2.0.0.

Since we were editing the dockerfile to use 1.3.3, this was failing on Heroku. I changed the aws-heroku-helper script to check out the commit to master that uses 1.3.3. 

**Steps to test:**

https://atd-moped-editor-development.herokuapp.com/console/login

here is a successful db build: https://github.com/cityofaustin/atd-moped/runs/5099045084?check_suite_focus=true#step:5:34

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
