### PR TITLE
Correct DB management tool name in echoed directions for use

### DIFF
--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -335,7 +335,7 @@ function run_migration() {
   if [[ "$(__is_local)" != "TRUE" ]]; then
     echo "--------------------------------------------------------------------";
     echo " 🛑️ Non-Local environment detected. Aborting.";
-    echo " Switch back to your local environment: './hasura-console setenv local'";
+    echo " Switch back to your local environment: './hasura-cluster setenv local'";
     echo "--------------------------------------------------------------------";
     stop;
     exit 1;


### PR DESCRIPTION
## Associated issues

_none_

## Testing

Testing really is just to look at the code; this is a one-liner.

But for completeness: Testing needs to be done locally, and can be done by spinning up the database that does not have `moped-database/config/hasura.${ENVIRONMENT}.yaml` in place. One should observing that the command is correctly named in the directions that come out of the `hasura-cluster` management tool.

Previous behavior:
![image](https://user-images.githubusercontent.com/3653206/153067748-edccd5f2-f43a-49b2-bfa0-e585721f934b.png)


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
