### PR TITLE
Displays an alert banner in the staging environment

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -17,7 +17,9 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     flex: "1 1 auto",
     overflow: "hidden",
-    paddingTop: 64,
+    // If in staging environment, add extra padding
+    // to make room for staging environment info alert
+    paddingTop: process.env.REACT_APP_HASURA_ENV === "staging" ? 114 : 64,
   },
   contentContainer: {
     display: "flex",
@@ -32,9 +34,6 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const DashboardLayout = () => {
-  console.log(process.env.NODE_ENV);
-  console.log(process.env.REACT_APP_HASURA_ENV);
-  console.log(process.env.APP_ENVIRONMENT);
   const classes = useStyles();
   const [isOpen, setOpen] = useState(false);
   const { user } = useUser();

--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -33,6 +33,8 @@ const useStyles = makeStyles(theme => ({
 
 const DashboardLayout = () => {
   console.log(process.env.NODE_ENV);
+  console.log(process.env.REACT_APP_HASURA_ENV);
+  console.log(process.env.APP_ENVIRONMENT);
   const classes = useStyles();
   const [isOpen, setOpen] = useState(false);
   const { user } = useUser();

--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const DashboardLayout = () => {
+  console.log(process.env.NODE_ENV);
   const classes = useStyles();
   const [isOpen, setOpen] = useState(false);
   const { user } = useUser();

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -14,6 +14,7 @@ import {
   MenuItem,
   makeStyles,
 } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
 import Logo from "src/components/Logo";
 import { CanAddProjectButton } from "../../views/projects/projectsListView/ProjectListViewCustomComponents";
 import MobileDropdownMenu from "./NavBar/MobileDropdownMenu";
@@ -100,6 +101,12 @@ const TopBar = ({ className, onOpen, ...rest }) => {
 
   return (
     <AppBar className={clsx(classes.root, className)} elevation={2} {...rest}>
+      {process.env.REACT_APP_HASURA_ENV === "staging" && (
+        // If in staging environment, display info alert
+        <Alert severity="info">
+          Welcome to Moped Staging. This environment is for testing purposes.
+        </Alert>
+      )}
       <Toolbar>
         <RouterLink to="/moped">
           <Logo />
@@ -145,7 +152,7 @@ const TopBar = ({ className, onOpen, ...rest }) => {
             open={Boolean(avatarAnchorEl)}
             onClose={handleAvatarClose}
             anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            transformOrigin={{ vertical: 'top', horizontal: 'right'}}
+            transformOrigin={{ vertical: "top", horizontal: "right" }}
             getContentAnchorEl={null}
           >
             <MenuItem


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/8234

## Testing
URL to test:
https://deploy-preview-559--atd-moped-main.netlify.app/ 


**Steps to test:**
not sure how to test this because the banner will only display in the staging environment. @mateoclarke or @chiaberry , do you have any thoughts? will add @amenity for review once we sort that out.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
