### PR TITLE
Refactor knack sync for new db schema and simplify chaining

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -122,8 +122,8 @@ const ProjectSummaryKnackDataTrackerSync = ({
    */
   const handleSync = () => {
     // The following code is capabale of handling a "re-sync" to knack for a given project.
-    // Currently, our /UI does not contain an element that allows a user to request a re-sync, but
-    // consensus code is ready to "re-sync" a project thanks to it's use of a dynamic knackHttpMethod
+    // Currently, our UI does not contain an element that allows a user to request a re-sync, but
+    // this code is ready to "re-sync" a project thanks to its use of a dynamic knackHttpMethod
     console.log("HTTP method: " + knackHttpMethod);
     // POST (create) or PUT (update) a project record in Knack
     const signalIds = signals.map(signal => signal.knack_id);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -141,12 +141,6 @@ const ProjectSummaryKnackDataTrackerSync = ({
         return result;
       })
       .then(knackRecord => {
-        // End of the chain; advise the user of success
-        snackbarHandle(
-          true,
-          "Success: Project updated in Data Tracker",
-          "success"
-        );
         // We've got an ID from the Knack endpoint for this project, so record it in our database
         // This ID will not have changed is we were merely updating a project
         mutateProjectKnackId({


### PR DESCRIPTION
Refactor knack sync for new db schema and simplify chaining:
- rework the method to extract + count signal features
- remove the branching on the knack PUT/POST request chain
