### PR TITLE
Remove metadata and drop unsued moped_proj_features_components table

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -747,13 +747,6 @@
           name: moped_proj_features
           schema: public
         column: project_component_id
-  - name: moped_proj_features_components
-    using:
-      foreign_key_constraint_on:
-        table:
-          name: moped_proj_features_components
-          schema: public
-        column: moped_proj_component_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1033,14 +1026,6 @@
   - name: moped_proj_component
     using:
       foreign_key_constraint_on: project_component_id
-  array_relationships:
-  - name: moped_proj_features_components
-    using:
-      foreign_key_constraint_on:
-        table:
-          name: moped_proj_features_components
-          schema: public
-        column: moped_proj_features_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1104,108 +1089,6 @@
       - status_id
       filter: {}
       check: null
-- table:
-    name: moped_proj_features_components
-    schema: public
-  object_relationships:
-  - name: moped_proj_component
-    using:
-      foreign_key_constraint_on: moped_proj_component_id
-  - name: moped_proj_feature
-    using:
-      manual_configuration:
-        remote_table:
-          name: moped_proj_features
-          schema: public
-        column_mapping:
-          moped_proj_features_id: feature_id
-  - name: moped_proj_feature_object
-    using:
-      foreign_key_constraint_on: moped_proj_features_id
-  insert_permissions:
-  - role: moped-admin
-    permission:
-      check: {}
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      backend_only: false
-  - role: moped-editor
-    permission:
-      check: {}
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      backend_only: false
-  select_permissions:
-  - role: moped-admin
-    permission:
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      filter: {}
-  - role: moped-editor
-    permission:
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      filter: {}
-  - role: moped-viewer
-    permission:
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      filter: {}
-  update_permissions:
-  - role: moped-admin
-    permission:
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      filter: {}
-      check: {}
-  - role: moped-editor
-    permission:
-      columns:
-      - project_features_components_id
-      - moped_proj_features_id
-      - moped_proj_component_id
-      - name
-      - description
-      - create_date
-      - status_id
-      filter: {}
-      check: {}
 - table:
     name: moped_proj_financials
     schema: public

--- a/moped-database/migrations/1644608438018_drop_moped_proj_features_components/down.sql
+++ b/moped-database/migrations/1644608438018_drop_moped_proj_features_components/down.sql
@@ -1,0 +1,21 @@
+create table moped_proj_features_components
+(
+    project_features_components_id integer   default nextval('moped_proj_features_component_project_features_components_i_seq'::regclass) not null
+        primary key,
+    moped_proj_features_id         integer                                                                                                not null
+        references moped_proj_features,
+    moped_proj_component_id        integer                                                                                                not null
+        references moped_proj_components
+            on update cascade on delete cascade,
+    name                           text,
+    description                    text,
+    create_date                    timestamp default now(),
+    status_id                      integer   default 0                                                                                    not null
+);
+
+create index moped_proj_features_components_moped_proj_component_id_index
+    on moped_proj_features_components (moped_proj_component_id);
+
+create index moped_proj_features_components_moped_proj_features_id_index
+    on moped_proj_features_components (moped_proj_features_id);
+

--- a/moped-database/migrations/1644608438018_drop_moped_proj_features_components/up.sql
+++ b/moped-database/migrations/1644608438018_drop_moped_proj_features_components/up.sql
@@ -1,0 +1,1 @@
+drop table moped_proj_features_components;


### PR DESCRIPTION
This takes care of some DB cleanup related to components. We deprecated the use of the `moped_proj_features_components` table as part of https://github.com/cityofaustin/atd-moped/pull/553, but the table and relationships still exist in the DB.

This PR completely removes moped_proj_features_components from the DB.

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/8462

## Testing
**URL to test:** https://moped-test.austinmobility.io/moped

**Steps to test:**
Create and test projects with various components. Verify data is saved and rendered as expected.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved


<img width="1331" alt="Screen Shot 2022-02-11 at 1 47 54 PM" src="https://user-images.githubusercontent.com/14793120/153659626-281b761c-13b8-4f9c-ba2c-39a858f79fe6.png">
