### PR TITLE
Fix map controls UI bug

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0 1.0 Universal",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "homepage": "/moped",
   "private": false,
   "scripts": {

--- a/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponentsMapView.js
@@ -57,8 +57,8 @@ const useStyles = makeStyles(theme => ({
   toolTip: mapStyles.toolTipStyles,
   navStyle: {
     position: "absolute",
-    bottom: "3rem",
-    right: "1rem",
+    bottom: "6rem",
+    right: "3rem",
   },
   mapBox: {
     padding: 25,
@@ -121,7 +121,7 @@ const useStyles = makeStyles(theme => ({
   },
   speedDial: {
     right: "3.5rem !important",
-    bottom: "4.5rem !important",
+    bottom: "1.7rem !important",
     position: "absolute",
     zIndex: 1,
     "&.MuiSpeedDial-directionUp, &.MuiSpeedDial-directionLeft": {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -22,8 +22,8 @@ const useStyles = makeStyles({
   },
   toolTip: mapStyles.toolTipStyles,
   navStyle: {
-    bottom: "1.5rem",
-    right: 0,
+    right: "2rem",
+    bottom: "5.5rem",
     padding: "10px",
     position: "absolute",
   },


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/8440

![Screen Shot 2022-02-16 at 3 32 12 PM](https://user-images.githubusercontent.com/5697474/154367653-cf47d5dd-a64f-4fec-a788-8ef11f253808.png)
![Screen Shot 2022-02-16 at 3 32 02 PM](https://user-images.githubusercontent.com/5697474/154367655-6aa6ad10-c9b8-4902-8a9f-b9bb53d32532.png)



## Testing
**URL to test:** https://deploy-preview-584--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
- check positioning of Zoom controls and Basemap switcher. They should be in the bottom right for both the Project Summary and Project Map pages.

---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)~
