### PR TITLE
Add filtering capability to signal dashboard table

### DIFF
--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -310,6 +310,9 @@ const SignalProjectTable = () => {
     {
       title: "Project sponsor",
       field: "project_sponsor_object",
+      customFilterAndSearch: (term, rowData) => {
+        return rowData.project_sponsor_object.entity_name.toUpperCase().includes(term.toUpperCase());
+      },
       render: entry => (
         <Typography className={classes.tableTypography}>
           {entry?.project_sponsor_object?.entity_name === "None"

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -211,6 +211,12 @@ const SignalProjectTable = () => {
       editable: "never",
       // cell style font needs to be set if editable is never
       cellStyle: typographyStyle,
+      customFilterAndSearch: (term, rowData) => {
+        const displaySignals = rowData.signal_ids
+          .map(s => s.signal_id)
+          .join(" ");
+        return displaySignals.includes(term);
+      },
       render: entry => <RenderSignalLink signals={entry.signal_ids} />,
     },
     {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -217,6 +217,12 @@ const SignalProjectTable = () => {
       title: "Project types",
       field: "project_types",
       customEdit: "projectTypes",
+      customFilterAndSearch: (term, rowData) => {
+        const displayProjectTypes = rowData.project_types
+          .map(t => typeDict[t])
+          .join(" ");
+        return displayProjectTypes.toUpperCase().includes(term.toUpperCase());
+      },
       render: entry => {
         if (entry?.project_types?.length) {
           return (
@@ -246,6 +252,12 @@ const SignalProjectTable = () => {
       field: "task_order",
       customEdit: "taskOrders",
       emptyValue: "-",
+      customFilterAndSearch: (term, rowData) => {
+        const displayTaskOrders = rowData.task_order
+          .map(taskOrder => taskOrder.display_name)
+          .join(" ");
+        return displayTaskOrders.toUpperCase().includes(term.toUpperCase());
+      },
       render: entry => {
         // Empty value won't work in some cases where task_order is an empty array.
         if (entry.task_order.length < 1) {

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -536,7 +536,7 @@ const SignalProjectTable = () => {
                   paging: false,
                 }),
                 search: true,
-                filtering: false,
+                filtering: true,
                 rowStyle: typographyStyle,
                 actionsColumnIndex: -1,
                 pageSize: 30,

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -254,8 +254,10 @@ const SignalProjectTable = () => {
       emptyValue: "-",
       customFilterAndSearch: (term, rowData) => {
         const displayTaskOrders = rowData.task_order
-          .map(taskOrder => taskOrder.display_name)
-          .join(" ");
+          ? rowData.task_order
+              .map(taskOrder => taskOrder.display_name)
+              .join(" ")
+          : "";
         return displayTaskOrders.toUpperCase().includes(term.toUpperCase());
       },
       render: entry => {
@@ -311,7 +313,9 @@ const SignalProjectTable = () => {
       title: "Project sponsor",
       field: "project_sponsor_object",
       customFilterAndSearch: (term, rowData) => {
-        return rowData.project_sponsor_object.entity_name.toUpperCase().includes(term.toUpperCase());
+        return rowData.project_sponsor_object.entity_name
+          .toUpperCase()
+          .includes(term.toUpperCase());
       },
       render: entry => (
         <Typography className={classes.tableTypography}>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/8098

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
 https://8098-column-filter--atd-moped-main.netlify.app/moped/dashboard 

**Steps to test:**

Test the filters that appear at the top of the signals table. Specifically test that 
 - project types
 - task orders
 - project sponsors
are able to be filtered. Also we have the option to change the filter icon, if that is desired. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
