### PR TITLE
Indicate that an advanced search is active on the "Projects" page

### DIFF
--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -131,6 +131,7 @@ const GridTableFilters = ({
     value: null,
     type: null,
     specialNullValue: null,
+    label:null,
   };
 
   /**
@@ -181,6 +182,7 @@ const GridTableFilters = ({
         filtersNewState[filterId].field = fieldDetails.name;
         filtersNewState[filterId].type = fieldDetails.type;
         filtersNewState[filterId].placeholder = fieldDetails.placeholder;
+        filtersNewState[filterId].label = fieldDetails.label
 
         // Update Available Operators
         if (

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -323,6 +323,7 @@ const GridTableSearch = ({
               <GridTableSearchBar
                 query={query}
                 searchState={searchState}
+                filterState={filterState}
                 toggleAdvancedSearch={toggleAdvancedSearch}
                 advancedSearchAnchor={advancedSearchAnchor}
               />

--- a/moped-editor/src/components/GridTable/GridTableSearchBar.js
+++ b/moped-editor/src/components/GridTable/GridTableSearchBar.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import {
   Button,
+  Box,
   TextField,
   InputAdornment,
   SvgIcon,
@@ -10,6 +11,7 @@ import {
   Icon,
   IconButton,
   makeStyles,
+  Typography,
 } from "@material-ui/core";
 import { Search as SearchIcon } from "react-feather";
 import clsx from "clsx";
@@ -39,6 +41,17 @@ const useStyles = makeStyles(theme => ({
   },
   searchButton: {
     marginTop: "12px",
+  },
+  filtersList: {
+    padding: "8px",
+    marginRight: "12px",
+  },
+  filtersText: {
+    fontSize: ".9rem",
+  },
+  filtersSpan: {
+    fontWeight: 600,
+    textTransform: "uppercase",
   },
 }));
 
@@ -142,6 +155,14 @@ const GridTableSearchBar = ({
     }
   };
 
+  const filterStateActive = !!Object.keys(filterState.filterParameters).length;
+  const filtersApplied = [];
+  if (filterStateActive) {
+    Object.keys(filterState.filterParameters).map(parameter =>
+      filtersApplied.push(filterState.filterParameters[parameter]["label"])
+    );
+  }
+
   return (
     <>
       <TextField
@@ -167,12 +188,9 @@ const GridTableSearchBar = ({
               <IconButton
                 onClick={toggleAdvancedSearch}
                 className={clsx({
-                  [classes.tuneIcon]: !Object.keys(filterState.filterParameters)
-                    .length,
+                  [classes.tuneIcon]: !filterStateActive,
                   [classes.advancedSearchSelected]: advancedSearchAnchor,
-                  [classes.advancedSearchActive]: !!Object.keys(
-                    filterState.filterParameters
-                  ).length,
+                  [classes.advancedSearchActive]: filterStateActive,
                 })}
               >
                 <Icon style={{ verticalAlign: "middle" }}>tune</Icon>
@@ -184,6 +202,16 @@ const GridTableSearchBar = ({
         variant="outlined"
         value={searchFieldValue}
       />
+      {filterStateActive && (
+        <Box className={classes.filtersList}>
+          <Typography align="right" className={classes.filtersText}>
+            Filtered by{" "}
+            <span className={classes.filtersSpan}>{`${filtersApplied.join(
+              ", "
+            )}`}</span>
+          </Typography>
+        </Box>
+      )}
       <Hidden smUp>
         <Button
           className={classes.searchButton}

--- a/moped-editor/src/components/GridTable/GridTableSearchBar.js
+++ b/moped-editor/src/components/GridTable/GridTableSearchBar.js
@@ -48,6 +48,7 @@ const useStyles = makeStyles(theme => ({
   },
   filtersText: {
     fontSize: ".9rem",
+    color: theme.palette.text.secondary,
   },
   filtersSpan: {
     fontWeight: 600,

--- a/moped-editor/src/components/GridTable/GridTableSearchBar.js
+++ b/moped-editor/src/components/GridTable/GridTableSearchBar.js
@@ -22,12 +22,20 @@ import clsx from "clsx";
 const useStyles = makeStyles(theme => ({
   advancedSearchSelected: {
     backgroundColor: "rgba(0, 0, 0, 0.04)",
-    height: "44px",
-    width: "44px",
+    height: "40px",
+    width: "40px",
+    color: "rgba(0, 0, 0, 0.54)",
+  },
+  advancedSearchActive: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.background.paper,
+    height: "40px",
+    width: "40px",
   },
   tuneIcon: {
-    height: "44px",
-    width: "44px",
+    height: "40px",
+    width: "40px",
+    color: "rgba(0, 0, 0, 0.54)",
   },
   searchButton: {
     marginTop: "12px",
@@ -38,12 +46,16 @@ const useStyles = makeStyles(theme => ({
  * Renders a search bar with optional filters
  * @param {GQLAbstract} query - The GQLAbstract object as provided by the parent component
  * @param {Object} searchState - The current state/state-modifier bundle for search
+ * @param {Object} filterState - The current state/state-modifier bundle for filter
+ * @param {function} toggleAdvancedSearch - function to toggle if advanced search (filters) is open
+ * @param {Object} advancedSearchAnchor - anchor element for advanced search popper to "attach" to
  * @return {JSX.Element}
  * @constructor
  */
 const GridTableSearchBar = ({
   query,
   searchState,
+  filterState,
   toggleAdvancedSearch,
   advancedSearchAnchor,
 }) => {
@@ -154,8 +166,13 @@ const GridTableSearchBar = ({
             <InputAdornment position="end">
               <IconButton
                 onClick={toggleAdvancedSearch}
-                className={clsx(classes.tuneIcon, {
+                className={clsx({
+                  [classes.tuneIcon]: !Object.keys(filterState.filterParameters)
+                    .length,
                   [classes.advancedSearchSelected]: advancedSearchAnchor,
+                  [classes.advancedSearchActive]: !!Object.keys(
+                    filterState.filterParameters
+                  ).length,
                 })}
               >
                 <Icon style={{ verticalAlign: "middle" }}>tune</Icon>


### PR DESCRIPTION
## Associated issues

The netlify branch has the icon's background color changed if the advanced search is active. Here is the alternative:

![Screen Shot 2022-03-03 at 10 58 49 AM](https://user-images.githubusercontent.com/12474808/156614403-7ffece01-4f65-497e-a711-bf407f68bba6.png)


## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

[https://8556-active-search--atd-moped-main.netlify.app/moped/projects?](https://8556-active-search--atd-moped-main.netlify.app/moped/projects?filter=eyIzNDA3M2JiMi1mMzk0LTQ3YmUtYWRmNi0xMzZiZWE0MjkwNjkiOnsiaWQiOiIzNDA3M2JiMi1mMzk0LTQ3YmUtYWRmNi0xMzZiZWE0MjkwNjkiLCJmaWVsZCI6InByb2plY3RfdGVhbV9tZW1iZXJzIiwib3BlcmF0b3IiOiJzdHJpbmdfY29udGFpbnNfY2FzZV9pbnNlbnNpdGl2ZSIsImF2YWlsYWJsZU9wZXJhdG9ycyI6W3sib3BlcmF0b3IiOiJfaWxpa2UiLCJsYWJlbCI6ImNvbnRhaW5zIiwiZGVzY3JpcHRpb24iOiJTdHJpbmcgaXMgY29udGFpbmVkIGluIGZpZWxkIChjYXNlLWluc2Vuc2l0aXZlKSIsImVudmVsb3BlIjoiJXtWQUxVRX0lIiwidHlwZSI6InN0cmluZyIsImlkIjoic3RyaW5nX2NvbnRhaW5zX2Nhc2VfaW5zZW5zaXRpdmUifSx7Im9wZXJhdG9yIjoiX2lsaWtlIiwibGFiZWwiOiJiZWdpbnMgd2l0aCIsImRlc2NyaXB0aW9uIjoiRmllbGQgY29udGVudCBiZWdpbnMgd2l0aCBzdHJpbmcgKGNhc2UtaW5zZW5zaXRpdmUpIiwiZW52ZWxvcGUiOiJ7VkFMVUV9JSIsInR5cGUiOiJzdHJpbmciLCJpZCI6InN0cmluZ19iZWdpbnNfd2l0aF9jYXNlX2luc2Vuc2l0aXZlIn0seyJvcGVyYXRvciI6Il9pbGlrZSIsImxhYmVsIjoiZW5kcyB3aXRoIiwiZGVzY3JpcHRpb24iOiJGaWVsZCBjb250ZW50IGVuZHMgd2l0aCBzdHJpbmcgKGNhc2UtaW5zZW5zaXRpdmUpIiwiZW52ZWxvcGUiOiIle1ZBTFVFfSIsInR5cGUiOiJzdHJpbmciLCJpZCI6InN0cmluZ19lbmRzX3dpdGhfY2FzZV9pbnNlbnNpdGl2ZSJ9LHsib3BlcmF0b3IiOiJfaXNfbnVsbCIsImxhYmVsIjoiaXMgYmxhbmsiLCJkZXNjcmlwdGlvbiI6IlNlbGVjdGVkIGZpZWxkIGRvZXMgbm90IGhhdmUgbWVhbmluZ2Z1bCBjb250ZW50IiwiZW52ZWxvcGUiOiJ0cnVlIiwic3BlY2lhbE51bGxWYWx1ZSI6IlwiIDpcIiIsInR5cGUiOiJzdHJpbmciLCJpZCI6InN0cmluZ19pc19udWxsX3NwZWNpYWxfY2FzZSJ9LHsib3BlcmF0b3IiOiJfaXNfbnVsbCIsImxhYmVsIjoiaXMgbm90IGJsYW5rIiwiZGVzY3JpcHRpb24iOiJTdHJpbmcgZmllbGQgZG9lcyBub3QgbWF0Y2ggc3BlY2lhbCBudWxsIHZhbHVlIiwiZW52ZWxvcGUiOiJmYWxzZSIsInNwZWNpYWxOdWxsVmFsdWUiOiJcIiA6XCIiLCJ0eXBlIjoic3RyaW5nIiwiaWQiOiJzdHJpbmdfaXNfbm90X251bGxfc3BlY2lhbF9jYXNlIn1dLCJncWxPcGVyYXRvciI6Il9pbGlrZSIsImVudmVsb3BlIjoiJXtWQUxVRX0lIiwicGxhY2Vob2xkZXIiOiJUZWFtIG1lbWJlciIsInZhbHVlIjoicmVuZWUiLCJ0eXBlIjoic3RyaW5nIiwibGFiZWwiOiJUZWFtIG1lbWJlciJ9fQ==
)


**Steps to test:**

Add an advanced filter, hitting search should keep the icon blue. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#gid=776973707)
