### PR TITLE
Update λ function to use `recordProjectId` when mutating `moped_project` table

### DIFF
--- a/moped-data-events/activity_log/MopedEvent.py
+++ b/moped-data-events/activity_log/MopedEvent.py
@@ -47,7 +47,7 @@ class MopedEvent:
           }) {
             affected_rows
           }
-          update_moped_project(where: {project_id: {_eq: $projectRecordId}}, _set: {updated_at: $timestamp}) {
+          update_moped_project(where: {project_id: {_eq: $recordProjectId}}, _set: {updated_at: $timestamp}) {
             affected_rows
           }
         }

--- a/moped-data-events/activity_log/MopedEvent.py
+++ b/moped-data-events/activity_log/MopedEvent.py
@@ -47,7 +47,7 @@ class MopedEvent:
           }) {
             affected_rows
           }
-          update_moped_project(where: {project_id: {_eq: $recordId}}, _set: {updated_at: $timestamp}) {
+          update_moped_project(where: {project_id: {_eq: $projectRecordId}}, _set: {updated_at: $timestamp}) {
             affected_rows
           }
         }


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/8640.

## Note

My branch name has the issue number typo'd in it. I can delete that branch and cherry pick these two commits into a new one if needed.

## Testing

https://moped-test.austinmobility.io/moped

**Steps to test:**

1) Deploy this branch to test
1) Connect to the heroku DB directly with an SQL client so you can look at exact values in `moped_project.updated_at`
1) Update a project itself (the description or name, perhaps) and see that the last updated value for that record updates to `now()`
1) Update a record that is tied to the project but not stored in the project table, such as adding a note or a phase
1) Observe that the new "child" record is created and documented in the activity log, *and* that the project's `updated_at` field is updated in the project table.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
