### PR TITLE
Use a different  task_order property to key on unique task orders

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0 1.0 Universal",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "/moped",
   "private": false,
   "scripts": {

--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -134,16 +134,16 @@ const useStyles = makeStyles(theme => ({
     width: "300px",
     fontSize: ".875em",
     "& .MuiAutocomplete-inputRoot": {
-      marginBottom: "16px"
+      marginBottom: "16px",
     },
     "& .MuiFormLabel-root": {
-      color: theme.palette.text.primary
-    }
+      color: theme.palette.text.primary,
+    },
   },
   fundSelectStyle: {
     width: "8em",
-    border: "1px green solid"
-  }
+    border: "1px green solid",
+  },
 }));
 
 const ProjectFundingTable = () => {
@@ -221,7 +221,7 @@ const ProjectFundingTable = () => {
     updateProjectTaskOrders({
       variables: {
         projectId: projectId,
-        taskOrders: taskOrderData.filter(t => t.id !== task.id),
+        taskOrders: taskOrderData.filter(t => t.task_order !== task.task_order),
       },
     })
       .then(() => refetch())
@@ -257,7 +257,7 @@ const ProjectFundingTable = () => {
         taskOrders: [
           ...taskOrderData,
           ...newTaskOrderList.filter(
-            n => !taskOrderData.find(t => t.id === n.id)
+            n => !taskOrderData.find(t => t.task_order === n.task_order)
           ),
         ],
       },


### PR DESCRIPTION
As we transition to using S3 as the source for task order data, we will no longer have the unique Knack `id` column in the [Socrata task orders dataset](https://data.austintexas.gov/Transportation-and-Mobility/-TEST-Mobility-Project-Task-Orders/ggav-ufvc). We use the `id` value in Moped to key on a unique task order when adding/removing task orders to a project record. 

This PR swaps out `id` for the the `task_order.task_order` property, which is an alphanum string that uniquely identifies each task order. 

Until this is merged, it’s now possible to duplicate the same task order on the funding tab.
<img width="1249" alt="Screen Shot 2022-03-24 at 3 53 20 PM" src="https://user-images.githubusercontent.com/14793120/160008807-1b57866f-cfb2-4280-aacc-d3bafbf24b57.png">


## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7931

## Testing
**URL to test:** [Netlify dep prev](https://deploy-preview-607--atd-moped-main.netlify.app/)

**Steps to test:**
Create a signal project.
Add and remove multiple task orders to the project.
Check the signals dashboard and make sure task orders are rendered correctly there.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
