### PR TITLE
Change loading icon and data refreshing on comments tab

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -92,7 +92,7 @@ const ProjectComments = props => {
   const [commentAddSuccess, setCommentAddSuccess] = useState(false);
   const [editingComment, setEditingComment] = useState(false);
   const [commentId, setCommentId] = useState(null);
-  const [displayNotes, setDisplayNotes] = useState({});
+  const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(0);
 
   const { loading, error, data, refetch } = useQuery(COMMENTS_QUERY, {

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -198,6 +198,8 @@ const ProjectComments = props => {
    */
   const filterNoteType = typeId => setNoteType(Number(typeId));
 
+  const mopedProjNotes = data?.moped_proj_notes;
+
   /**
    * Whenever noteType changes, we change the query conditions
    */
@@ -210,7 +212,7 @@ const ProjectComments = props => {
       });
     }
     refetch();
-  }, [noteType, setNoteTypeConditions, refetch, data]);
+  }, [noteType, setNoteTypeConditions, refetch, mopedProjNotes]);
 
   if (error) return console.log(error);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -99,8 +99,6 @@ const ProjectComments = props => {
   const [noteType, setNoteType] = useState(0);
   const [noteTypeConditions, setNoteTypeConditions] = useState({});
 
-  console.log(noteType, " the noteType is <------")
-
   const { loading, error, data, refetch } = useQuery(COMMENTS_QUERY, {
     variables: {
       projectNoteConditions: {
@@ -215,17 +213,15 @@ const ProjectComments = props => {
         project_note_type: { _eq: noteType },
       });
     }
-    console.log("im refetching")
     refetch();
   }, [noteType, setNoteTypeConditions, refetch]);
 
-  console.log("loading ", loading)
-  console.log("DATA ", data)
+  console.log("loading ", loading, "DATA ", data)
 
+  if (error) return console.log(error);
   // If the query is loading or data object is undefined,
   // stop here and just render the spinner.
   if (loading || !data) return <CircularProgress />;
-  if (error) return console.log(error);
 
   /**
    * Defines the CommentButton with a toggle style-change behavior.

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -210,7 +210,7 @@ const ProjectComments = props => {
       });
     }
     refetch();
-  }, [noteType, setNoteTypeConditions, refetch]);
+  }, [noteType, setNoteTypeConditions, refetch, data]);
 
   console.log("loading ", loading, "DATA ", data);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -79,11 +79,7 @@ const useStyles = makeStyles(theme => ({
 
 // Lookup array to convert project note types to a human readable interpretation
 // The zeroth item in the list is intentionally blank; the notes are 1-indexed.
-const projectNoteTypes = [
-  "",
-  "Internal Note",
-  "Status Update",
-];
+const projectNoteTypes = ["", "Internal Note", "Status Update"];
 
 const ProjectComments = props => {
   const { projectId } = useParams();
@@ -216,12 +212,9 @@ const ProjectComments = props => {
     refetch();
   }, [noteType, setNoteTypeConditions, refetch]);
 
-  console.log("loading ", loading, "DATA ", data)
+  console.log("loading ", loading, "DATA ", data);
 
   if (error) return console.log(error);
-  // If the query is loading or data object is undefined,
-  // stop here and just render the spinner.
-  if (loading || !data) return <CircularProgress />;
 
   /**
    * Defines the CommentButton with a toggle style-change behavior.
@@ -275,14 +268,15 @@ const ProjectComments = props => {
           {/*Now the notes*/}
           <Grid item xs={12}>
             <Card>
-              {data.moped_proj_notes.length > 0 ? (
+              {loading ? (
+                <CircularProgress />
+              ) : data?.moped_proj_notes?.length > 0 ? (
                 <List className={classes.root}>
                   {data.moped_proj_notes.map((item, i) => {
                     const isNotLastItem = i < data.moped_proj_notes.length - 1;
                     const editableComment =
                       userSessionData.user_id === item.added_by_user_id ||
                       userHighestRole === "moped-admin";
-
                     return (
                       <React.Fragment key={item.project_note_id}>
                         <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -99,6 +99,8 @@ const ProjectComments = props => {
   const [noteType, setNoteType] = useState(0);
   const [noteTypeConditions, setNoteTypeConditions] = useState({});
 
+  console.log(noteType, " the noteType is <------")
+
   const { loading, error, data, refetch } = useQuery(COMMENTS_QUERY, {
     variables: {
       projectNoteConditions: {
@@ -213,8 +215,12 @@ const ProjectComments = props => {
         project_note_type: { _eq: noteType },
       });
     }
+    console.log("im refetching")
     refetch();
   }, [noteType, setNoteTypeConditions, refetch]);
+
+  console.log("loading ", loading)
+  console.log("DATA ", data)
 
   // If the query is loading or data object is undefined,
   // stop here and just render the spinner.
@@ -229,7 +235,6 @@ const ProjectComments = props => {
    */
   const CommentButton = props => (
     <Button
-      {...props}
       color="primary"
       className={classes.showButtonItem}
       variant={noteType === props.noteTypeId ? "contained" : "outlined"}
@@ -283,7 +288,7 @@ const ProjectComments = props => {
                       userHighestRole === "moped-admin";
 
                     return (
-                      <>
+                      <React.Fragment key={item.project_note_id}>
                         <ListItem alignItems="flex-start">
                           <ListItemAvatar>
                             <Avatar />
@@ -373,7 +378,7 @@ const ProjectComments = props => {
                           )}
                         </ListItem>
                         {isNotLastItem && <Divider component="li" />}
-                      </>
+                      </React.Fragment>
                     );
                   })}
                 </List>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -94,22 +94,16 @@ const ProjectComments = props => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState({});
   const [noteType, setNoteType] = useState(0);
-  const [noteTypeConditions, setNoteTypeConditions] = useState({});
 
   const { loading, error, data, refetch } = useQuery(COMMENTS_QUERY, {
     variables: {
       projectNoteConditions: {
         project_id: { _eq: Number(projectId) },
         status_id: { _eq: Number(1) },
-        // ...noteTypeConditions,
       },
     },
     fetchPolicy: "no-cache",
   });
-
-  // setDisplayNotes(data);
-
-  console.log(displayNotes)
 
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {
     onCompleted() {
@@ -166,7 +160,7 @@ const ProjectComments = props => {
 
   const editComment = (index, project_note_id) => {
     setEditingComment(true);
-    setNoteText(data.moped_proj_notes[index].project_note);
+    setNoteText(displayNotes[index].project_note);
     setCommentId(project_note_id);
   };
 
@@ -214,11 +208,8 @@ const ProjectComments = props => {
   /**
    * Whenever noteType changes, we change the query conditions
    */
-  console.log("noteType out of useEffect ", noteType)
   useEffect(() => {
-    console.log(noteType)
     if (noteType === 0) {
-      console.log("RESET")
       setDisplayNotes(mopedProjNotes);
     } else {
       const filteredNotes = mopedProjNotes.filter(n => n.project_note_type === noteType)

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -212,8 +212,6 @@ const ProjectComments = props => {
     refetch();
   }, [noteType, setNoteTypeConditions, refetch, data]);
 
-  console.log("loading ", loading, "DATA ", data);
-
   if (error) return console.log(error);
 
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -105,6 +105,8 @@ const ProjectComments = props => {
     fetchPolicy: "no-cache",
   });
 
+  const mopedProjNotes = data?.moped_proj_notes;
+
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {
     onCompleted() {
       setNoteText("");
@@ -197,23 +199,25 @@ const ProjectComments = props => {
    */
   const filterNoteType = typeId => setNoteType(Number(typeId));
 
+  // when the data changes, update the display notes state
   useEffect(() => {
     if (!loading && data) {
-      setDisplayNotes(data.moped_proj_notes)
+      setDisplayNotes(data.moped_proj_notes);
     }
   }, [loading, data]);
 
-  const mopedProjNotes = data?.moped_proj_notes;
-
   /**
-   * Whenever noteType changes, we change the query conditions
+   * Whenever noteType changes, filter the notes being displayed
    */
   useEffect(() => {
     if (noteType === 0) {
+      // show all the notes
       setDisplayNotes(mopedProjNotes);
     } else {
-      const filteredNotes = mopedProjNotes.filter(n => n.project_note_type === noteType)
-      setDisplayNotes(filteredNotes)
+      const filteredNotes = mopedProjNotes.filter(
+        n => n.project_note_type === noteType
+      );
+      setDisplayNotes(filteredNotes);
     }
   }, [noteType, mopedProjNotes]);
 
@@ -271,7 +275,7 @@ const ProjectComments = props => {
           {/*Now the notes*/}
           <Grid item xs={12}>
             <Card>
-              {(loading || !displayNotes) ? (
+              {loading || !displayNotes ? (
                 <CircularProgress />
               ) : displayNotes.length > 0 ? (
                 <List className={classes.root}>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -92,6 +92,7 @@ const ProjectComments = props => {
   const [commentAddSuccess, setCommentAddSuccess] = useState(false);
   const [editingComment, setEditingComment] = useState(false);
   const [commentId, setCommentId] = useState(null);
+  const [displayNotes, setDisplayNotes] = useState({});
   const [noteType, setNoteType] = useState(0);
   const [noteTypeConditions, setNoteTypeConditions] = useState({});
 
@@ -100,11 +101,15 @@ const ProjectComments = props => {
       projectNoteConditions: {
         project_id: { _eq: Number(projectId) },
         status_id: { _eq: Number(1) },
-        ...noteTypeConditions,
+        // ...noteTypeConditions,
       },
     },
     fetchPolicy: "no-cache",
   });
+
+  // setDisplayNotes(data);
+
+  console.log(displayNotes)
 
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {
     onCompleted() {
@@ -198,21 +203,28 @@ const ProjectComments = props => {
    */
   const filterNoteType = typeId => setNoteType(Number(typeId));
 
+  useEffect(() => {
+    if (!loading && data) {
+      setDisplayNotes(data.moped_proj_notes)
+    }
+  }, [loading, data]);
+
   const mopedProjNotes = data?.moped_proj_notes;
 
   /**
    * Whenever noteType changes, we change the query conditions
    */
+  console.log("noteType out of useEffect ", noteType)
   useEffect(() => {
+    console.log(noteType)
     if (noteType === 0) {
-      setNoteTypeConditions({});
+      console.log("RESET")
+      setDisplayNotes(mopedProjNotes);
     } else {
-      setNoteTypeConditions({
-        project_note_type: { _eq: noteType },
-      });
+      const filteredNotes = mopedProjNotes.filter(n => n.project_note_type === noteType)
+      setDisplayNotes(filteredNotes)
     }
-    refetch();
-  }, [noteType, setNoteTypeConditions, refetch, mopedProjNotes]);
+  }, [noteType, mopedProjNotes]);
 
   if (error) return console.log(error);
 
@@ -268,12 +280,12 @@ const ProjectComments = props => {
           {/*Now the notes*/}
           <Grid item xs={12}>
             <Card>
-              {loading ? (
+              {(loading || !displayNotes) ? (
                 <CircularProgress />
-              ) : data?.moped_proj_notes?.length > 0 ? (
+              ) : displayNotes.length > 0 ? (
                 <List className={classes.root}>
-                  {data.moped_proj_notes.map((item, i) => {
-                    const isNotLastItem = i < data.moped_proj_notes.length - 1;
+                  {displayNotes.map((item, i) => {
+                    const isNotLastItem = i < displayNotes.length - 1;
                     const editableComment =
                       userSessionData.user_id === item.added_by_user_id ||
                       userHighestRole === "moped-admin";


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/8001

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://8001-comments--atd-moped-main.netlify.app/moped/projects/1825?tab=comments


**Steps to test:**

This is a tricky one to test, because I couldn't get the bug to consistently occur before my changes. But periodically, quickly toggling between comment type buttons would result in just a loading icon that would go away once you refresh the page. 

I believe it was because of two things: The loading icon appeared if `loading` was true or `!data` was true. Not always, but sometimes we would fall into the state of loading being false yet having no data. The network request tab did have a successful request, so something was getting stuck. I moved the loading icon to appear under the input since the input doesn't need to disappear when the comments are loading. 

~~Also I changed it so that if there is no data, instead of there being a loading icon, the "no comments to display message appears". The message still appeared sporadically even when there were comments, so I moved `data` into the useEffect call so if there is a change in data the page will re-render.~~

Spurred on by John's comments pointing out we are firing off the same graphql query multiple times, I refactored the code to only query if something has been updated and instead use local state to filter the comment types when toggling between different types. 


---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
