### PR TITLE
Change from description to name for label value in Knack Sync functionality

### DIFF
--- a/moped-editor/README.md
+++ b/moped-editor/README.md
@@ -1,7 +1,6 @@
 # Moped Editor
 
-Web application for intereacting with Moped data. 
-
+Web application for interacting with Moped data.
 
 ## Quick start
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -111,12 +111,12 @@ const ProjectSummaryKnackDataTrackerSync = ({
 
     const url_payload = {
       url: url,
-      label: project.project_description,
+      label: project.project_name,
     };
 
     body[process.env.REACT_APP_KNACK_DATA_TRACKER_MOPED_URL] = url;
     body[process.env.REACT_APP_KNACK_DATA_TRACKER_MOPED_LINK_LABEL] =
-      project.project_description;
+      project.project_name;
     body[
       process.env.REACT_APP_KNACK_DATA_TRACKER_MOPED_LINK_LABEL
     ] = url_payload;


### PR DESCRIPTION
## Associated issues

This PR is associated with and a child of PR #632 and is ultimately spawned from issue https://github.com/cityofaustin/atd-data-tech/issues/8868. 

This changes the field in the moped database which is used for the label field when synchronizing to Knack. I generally work from the first project in our seed data, and it just so happens to have the same value for hte `project_name` and `project_description` which caused me to mix up the two fields. This was my error and oversight 👎 .


While we can run the script provided by https://github.com/cityofaustin/atd-moped/pull/632 prior to this getting into production, there is opportunity for the data tracker app to very slowly drift out sync. Once this PR gets into production, if we run the script from https://github.com/cityofaustin/atd-moped/pull/632 one last time, we'll be squared away.

This PR also has a tag-along change to fix a typo in the editor's `README.md`.

## Testing
**URL to test:**

https://deploy-preview-633--atd-moped-main.netlify.app/

**Steps to test:**

Synchronize a project to Data Tracker and check that the `project_name` field is used in lieu of `project_description` 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
