### PR TITLE
displays menu option for user to follow and unfollow a project

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -52,6 +52,8 @@ import ProjectNameEditable from "./ProjectNameEditable";
 import ProjectStatusBadge from "./ProjectStatusBadge";
 
 import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
+import BookmarkBorderIcon from "@material-ui/icons/BookmarkBorder";
+import BookmarkIcon from "@material-ui/icons/Bookmark";
 import CreateOutlinedIcon from "@material-ui/icons/CreateOutlined";
 import CancelOutlinedIcon from "@material-ui/icons/CancelOutlined";
 import DeleteOutlinedIcon from "@material-ui/icons/DeleteOutlined";
@@ -172,6 +174,7 @@ const ProjectView = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogState, setDialogState] = useState(null);
+  const [isFollowing, setIsFollowing] = useState(false);
   const [anchorElement, setAnchorElement] = useState(null);
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
   const menuOpen = anchorElement ?? false;
@@ -459,6 +462,26 @@ const ProjectView = () => {
                             horizontal: "center",
                           }}
                         >
+                          <MenuItem
+                            onClick={() => setIsFollowing(!isFollowing)}
+                            className={classes.projectOptionsMenuItem}
+                            selected={false}
+                          >
+                            <ListItemIcon
+                              className={classes.projectOptionsMenuItemIcon}
+                            >
+                              {isFollowing ? (
+                                <BookmarkIcon />
+                              ) : (
+                                <BookmarkBorderIcon />
+                              )}
+                            </ListItemIcon>
+                            {isFollowing ? (
+                              <ListItemText primary="Unfollow" />
+                            ) : (
+                              <ListItemText primary="Follow" />
+                            )}
+                          </MenuItem>
                           <MenuItem
                             onClick={handleRenameClick}
                             className={classes.projectOptionsMenuItem}


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/8909

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-635--atd-moped-main.netlify.app/

**Steps to test:**
1) go to a project, select the ellipsis, toggle follow and unfollow

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable

https://user-images.githubusercontent.com/35410637/163289690-1b969c64-965b-4908-a644-5008b515ce1d.mov