### PR TITLE
Add usage instructions for the Knack backfill script to README.md

### DIFF
--- a/moped-toolbox/README.md
+++ b/moped-toolbox/README.md
@@ -5,3 +5,17 @@ This is a collection of scripts which have been written to serve a one-time or i
 ## backfill_data_tracker_url_field
 
 The Moped application supports keeping correlated records in ATD's Knack Data Tracker instance. This script can be used to populate the label field for all synchronized records.
+
+### Usage instructions
+
+The docker image does not automatically run the script when it is instantiated from the container. It will spin on a `tail -f /dev/null` `CMD` and the user is expected to attach to the running container and execute the script manually.
+
+1. Spin up your local database or prepare yourself to be able to connect to the read replica
+1. Navigate to `moped-toolbox/backfill_data_tracker_url_field`
+1. Using the `environment_file_template` template, create an environment file, `development.env` named by default...
+   - **NB:** If you put production knack configuration values in this file, you will write to production Data Tracker when you run the script. Use the development Data Tracker instance set aside for moped development for testing.
+1. .. and change the reference if needed in the `docker-compose.yml` file.
+1. Start the docker image: `docker-compose up -d`
+1. Attach to the docker image, `docker exec -it moped_backfill_url_field bash`
+1. And execute the script.
+1. `docker-compose stop` will stop the container.


### PR DESCRIPTION
## Associated issues

_None_, however this PR is intended to implement @mateoclarke's [suggestion of including usage instructions](https://github.com/cityofaustin/atd-moped/pull/632) for the backfill script in the `README.md`.

## Testing
None, however, please feel free to read and suggest any changes to the documentation that you think would be helpful.


---
#### Ship list
- [ ] ~Code reviewed~ 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
