### PR TITLE
Use GridTable sort function in Material Table

### DIFF
--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -423,6 +423,8 @@ const GridTable = ({
               setFilterParameters: setFilter,
             }}
             filterQuery={filterQuery}
+            advancedSearchAnchor={advancedSearchAnchor}
+            setAdvancedSearchAnchor={setAdvancedSearchAnchor}
           />
           {customComponents?.toolbar?.after}
         </GridTableToolbar>

--- a/moped-editor/src/components/GridTable/GridTable.js
+++ b/moped-editor/src/components/GridTable/GridTable.js
@@ -149,6 +149,10 @@ const GridTable = ({
     column: "",
   });
 
+  // anchor element for advanced search popper in GridTableSearch to "attach" to
+  // State is handled here so we could listen for changes in a useeffect in this component
+  const [advancedSearchAnchor, setAdvancedSearchAnchor] = useState(null);
+
   // create URLSearchParams from url
   const filterQuery = new URLSearchParams(useLocation().search);
 

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -397,7 +397,7 @@ const GridTableFilters = ({
 
   return (
     <Grid>
-      <Grid container justify={"flex-end"}>
+      <Grid container justifyContent={"flex-end"}>
         <IconButton
           onClick={handleAdvancedSearchClose}
           className={classes.closeButton}

--- a/moped-editor/src/components/GridTable/GridTableSearch.js
+++ b/moped-editor/src/components/GridTable/GridTableSearch.js
@@ -88,13 +88,12 @@ const GridTableSearch = ({
   children,
   filterQuery,
   parentData = null,
+  advancedSearchAnchor,
+  setAdvancedSearchAnchor
 }) => {
   const classes = useStyles();
   const queryPath = useLocation().pathname;
   const divRef = React.useRef();
-
-  // anchor element for advanced search popper to "attach" to
-  const [advancedSearchAnchor, setAdvancedSearchAnchor] = useState(null);
 
   /**
    * When True, the download csv dialog is open.

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -137,6 +137,10 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
     column: "",
   });
 
+  // anchor element for advanced search popper in GridTableSearch to "attach" to
+  // State is handled here so we can listen for changes in a useeffect in this component
+  const [advancedSearchAnchor, setAdvancedSearchAnchor] = useState(null);
+
   // create URLSearchParams from url
   const filterQuery = new URLSearchParams(useLocation().search);
 
@@ -459,13 +463,15 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
 
   /*
    * Store column configution before data change triggers page refresh
+   * or opening advanced search dropdown triggers page refresh
    */
   useEffect(() => {
     const storedConfig = JSON.parse(localStorage.getItem("mopedColumnConfig"));
     if (storedConfig) {
       setHiddenColumns(storedConfig);
     }
-  }, [data]);
+  }, [data, advancedSearchAnchor]);
+
 
   return (
     <ApolloErrorHandler error={error}>
@@ -493,6 +499,8 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
               setFilterParameters: setFilter,
             }}
             filterQuery={filterQuery}
+            advancedSearchAnchor={advancedSearchAnchor}
+            setAdvancedSearchAnchor={setAdvancedSearchAnchor}
           />
         </GridTableToolbar>
         {/*Main Table Body*/}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -357,6 +357,7 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
       title: "Signal IDs",
       field: "project_feature",
       hidden: hiddenColumns["project_feature"],
+      sorting: false,
       render: entry => {
         // if there are no features, project_feature is [null]
         if (!entry?.project_feature[0]) {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -549,6 +549,7 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
                       <MTableHeader
                         {...props}
                         onOrderChange={handleTableHeaderClick}
+                        orderDirection={sort.order}
                       />
                     ),
                     Body: props => {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/9038

Takes the same sort functions that we were using in Grid Table and overrides the Material Table sorting function to use ours. 

While testing this PR, I noticed that if you toggle columns and then open the advanced filter dropdown, your column configuration gets reset. I lifted the advancedSearchAnchor's state up one level so we can listen for any changes to it and store the column configuration then as well. 

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://9038-custom-sorting--atd-moped-main.netlify.app/moped/projects/

**Steps to test:**

Click the arrow next the column header to sort by column. initially sorts asc, then if clicked again will sort desc. 

Signal IDs cannot be sorted as is, because of the way the data is in the material table. If you try sorting on the signal dashboard, signal ids could not be sorted there either. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
