### PR TITLE
Disable JIT code compilation on local postgres

### DIFF
--- a/moped-database/docker-compose.arm64.yml
+++ b/moped-database/docker-compose.arm64.yml
@@ -6,7 +6,6 @@ services:
         image: "frankinaustin/postgis:12-3.2"
         volumes:
             - moped-db-vol:/var/lib/postgresql/data
-            #- ./postgres.local.conf:/etc/postgresql/postgresql.conf
         expose:
             - 5432
         ports:

--- a/moped-database/docker-compose.arm64.yml
+++ b/moped-database/docker-compose.arm64.yml
@@ -6,6 +6,7 @@ services:
         image: "frankinaustin/postgis:12-3.2"
         volumes:
             - moped-db-vol:/var/lib/postgresql/data
+            #- ./postgres.local.conf:/etc/postgresql/postgresql.conf
         expose:
             - 5432
         ports:
@@ -14,6 +15,7 @@ services:
             - POSTGRES_USER=moped
             - POSTGRES_PASSWORD=moped
             - POSTGRES_DB=moped
+        command: ["postgres", "-c", "jit=off"]
 
     hasura:
         image: frankinaustin/graphql-engine-arm64:v1.3.3

--- a/moped-database/docker-compose.x86_64.yml
+++ b/moped-database/docker-compose.x86_64.yml
@@ -14,6 +14,7 @@ services:
             - POSTGRES_USER=moped
             - POSTGRES_PASSWORD=moped
             - POSTGRES_DB=moped
+        command: ["postgres", "-c", "jit=off"]
 
     hasura:
         image: hasura/graphql-engine:v1.3.2


### PR DESCRIPTION
## TLDR

This PR disables (on our local, development database instances) a PostgreSQL feature which is not intended for the type of queries we utilize. Turning this feature off makes our development databases match the configuration of our production databases.

## Associated issues

_none_

## Background Info
This change is the result of a discussion with @chiaberry regarding the query driving the `view` she is developing that had suddenly becoming slow when a sub-select was added to the `select` clause. 

After examining the `EXPLAIN ANALYZE` output, we observed that query compiler was using JIT optimizations for the query.  Here are some docs concerning the JIT optimizer: https://www.postgresql.org/docs/current/jit.html. From those docs:

> JIT compilation is beneficial primarily for long-running CPU-bound queries. Frequently these will be analytical queries. For short queries the added overhead of performing JIT compilation will often be higher than the time it can save.

Long-running, analytical queries; I think of these as queries that run for durations measured in minutes and are queries which are full of dynamically created content which is then operated on. I might call them one-off queries, compared to the kind we embed into an application and expect to be run very frequently (for example, this `view`'s query.) 

From that, I believe that JIT query compilation is used for the types of queries we never, ever run on the moped database, and it will slow down the preparation of a query by a few seconds if the database decides to use it because the query is hitting some threshold of complexity or dynamism.

A few seconds is nothing if a query runs for minutes or longer, but it's an eternity if it delays the rendering of UI elements like the project listing. Working on a query that is supposed to be fast and is getting put through the JIT paces every time would be maddening too.

This PR turns off JIT query compilation across the board on our local development environments. It can be re-enabled as needed by issuing the query: `set jit = on;`. This will persist until the local DB server is restarted.

### Local vs. Production
* JIT is on by default on our local development environments as a result of the default configuration of the postgres images that docker provides. This PR flips that switch to off.
* JIT is off by default (rightly so) on the RDS servers that amazon provides. 

## Testing
This patch can be tested by:

1) checking out the branch
1) spinning up the database (test 1)
1) and executing the query found [here](https://gist.githubusercontent.com/frankhereford/f33ef781c3cbce7eabf9de3993d68493/raw/5f309e2a2c06fca3145e032b81c7771be1ffb16a/define-view.sql) 
1) and observing that it runs on the order of 10s of milliseconds, not 1000s (test 2)

FWIW, This PR has been tested on a local ARM64 instance and on a local X86_64 instance prior to submission.

## Story Points

I'm giving this a 1 based on the time spent figuring out what was going on and composing the fix.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
