### PR TITLE
Fixes typo in sidewalk ramps component_subtype

### DIFF
--- a/moped-database/migrations/1653656860634_sidewalk_ramps_subtype_typo/down.sql
+++ b/moped-database/migrations/1653656860634_sidewalk_ramps_subtype_typo/down.sql
@@ -1,0 +1,8 @@
+-- reinstate typo in sidewalk ramps subtype
+UPDATE
+    moped_components
+SET
+    component_subtype = 'Rams'
+WHERE
+    component_name = 'Sidewalk'
+    AND component_subtype = 'Ramps';

--- a/moped-database/migrations/1653656860634_sidewalk_ramps_subtype_typo/up.sql
+++ b/moped-database/migrations/1653656860634_sidewalk_ramps_subtype_typo/up.sql
@@ -1,0 +1,8 @@
+-- fix typo in sidewalk ramps subtype
+UPDATE
+    moped_components
+SET
+    component_subtype = 'Ramps'
+WHERE
+    component_name = 'Sidewalk'
+    AND component_subtype = 'Rams';


### PR DESCRIPTION
## Associated issues
Resolves https://github.com/cityofaustin/atd-data-tech/issues/9313 🐏 

## Testing
**URL to test:** 
- locally or Moped Test

**Steps to test:**
1. Navigate to a project's **Map** tab
2. Click the **Add new component** button
3. Select **Sidewalk** as the component **Type**
4. Select **Ramps** as the component **Subtype**
5. Select a location on the map and save the component
6. Verify that the component subtype is spelled "Ramps", not "Rams"

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable


<img width="893" alt="Screen Shot 2022-05-27 at 9 11 11 AM" src="https://user-images.githubusercontent.com/14793120/170707306-c35bc5f8-a29b-4f4c-a4c0-b1533384c8a9.png">
