### PR TITLE
Bug Fix - Disable editing related phase on milestones table

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -435,6 +435,10 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
       title: "Related phase",
       field: "moped_milestone",
       editable: "never",
+      cellStyle: {
+        fontFamily: typography.fontFamily,
+        fontSize: "14px",
+      },
       customSort: (a, b) => {
         const aPhaseName = phaseNameLookup[a.moped_milestone.related_phase_id];
         const bPhaseName = phaseNameLookup[b.moped_milestone.related_phase_id];

--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -434,6 +434,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
     {
       title: "Related phase",
       field: "moped_milestone",
+      editable: "never",
       customSort: (a, b) => {
         const aPhaseName = phaseNameLookup[a.moped_milestone.related_phase_id];
         const bPhaseName = phaseNameLookup[b.moped_milestone.related_phase_id];


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9410

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://9410-disable-editing-phase--atd-moped-main.netlify.app/moped/session/signin

**Steps to test:**

Add a milestone to the milestone table. You should not have the option to edit the related phase. 
Editing a milestone also will not give you the option to edit the related phase. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
