### PR TITLE
Adjust column width for milestone table

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -426,13 +426,17 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
           <FormHelperText>Required</FormHelperText>
         </FormControl>
       ),
+      width: "25%",
     },
     {
       title: "Description",
       field: "milestone_description",
       render: milestone => (
-        <div style={{ width: "400px" }}>{milestone.milestone_description}</div>
+        <div style={{ width: "350px"}}>
+          {milestone.milestone_description}
+        </div>
       ),
+      width: "25%",
     },
     {
       title: "Related phase",
@@ -455,6 +459,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
       },
       render: milestone =>
         phaseNameLookup[milestone.moped_milestone.related_phase_id] ?? "",
+      width: "14%",
     },
     {
       title: "Completion estimate",
@@ -470,6 +475,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
           label="Completion estimate"
         />
       ),
+      width: "13%",
     },
     {
       title: "Date completed",
@@ -485,6 +491,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
           label="Date completed"
         />
       ),
+      width: "13%",
     },
     {
       title: "Complete",
@@ -493,6 +500,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
       editComponent: props => (
         <ToggleEditComponent {...props} name="completed" />
       ),
+      width: "10%",
     },
   ];
 
@@ -725,6 +733,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
                   search: false,
                   rowStyle: { fontFamily: typography.fontFamily },
                   actionsColumnIndex: -1,
+                  tableLayout: "fixed",
                 }}
                 localization={{
                   header: {

--- a/moped-editor/src/views/projects/projectView/ProjectTimeline.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTimeline.js
@@ -431,11 +431,7 @@ const ProjectTimeline = ({ refetch: refetchSummary }) => {
     {
       title: "Description",
       field: "milestone_description",
-      render: milestone => (
-        <div style={{ width: "350px"}}>
-          {milestone.milestone_description}
-        </div>
-      ),
+      render: milestone => milestone.milestone_description,
       width: "25%",
     },
     {


### PR DESCRIPTION
I am specifying a width for the columns in the table, previously they would just automatically size, giving all the columns the same size (except the description column which we already give a width to)

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9455

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://9455-column-width--atd-moped-main.netlify.app/moped/projects/1840?tab=timeline

**Steps to test:**
compare these column widths to issue image or what is currently in staging/prod

![Screen Shot 2022-06-14 at 2 42 55 PM](https://user-images.githubusercontent.com/12474808/173675045-47f228ae-7c4c-4eb9-b92a-e436cb1878b7.png)


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
