### PR TITLE
Fixes bug preventing on hold status on projects pg

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
+++ b/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
@@ -206,9 +206,6 @@ const ProjectStatusBadge = ({
   const chipClasses = useChipStyles(statusProperties);
   const iconClasses = useFontColorStyles(statusProperties);
 
-  // If we don't have a status, then do not render.
-  if (!!!status) return null;
-
   /**
    * Create an abstract component pointer
    */

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -297,7 +297,7 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
       field: "current_phase",
       hidden: hiddenColumns["current_phase"],
       render: entry =>
-        buildStatusBadge(entry.current_phase, entry.current_status),
+        buildStatusBadge(entry.current_phase, entry.status_id),
     },
     {
       title: "Team members",


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/9174

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-685--atd-moped-main.netlify.app/

**Steps to test:**
1. Go to any project summary page.
2. Click on the three dots in the top right, select "Place on hold"
3. See the gray status button added next to the project title on the Project Details Page
4. Go to All Project table, and see all status buttons (including on hold projects) render

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
