### PR TITLE
Backfill projects with template milestones

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1512,6 +1512,9 @@
   - name: moped_milestone
     using:
       foreign_key_constraint_on: milestone_id
+  - name: moped_project
+    using:
+      foreign_key_constraint_on: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2372,6 +2375,13 @@
         table:
           schema: public
           name: moped_project_types
+  - name: moped_proj_milestones
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_milestones
+          schema: public
+        column: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2387,7 +2397,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2422,7 +2432,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2457,7 +2467,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2491,7 +2501,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2525,7 +2535,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2560,7 +2570,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2595,7 +2605,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_deleted
+      - is_retired
       - knack_project_id
       - milestone_id
       - project_description
@@ -2628,7 +2638,7 @@
       update:
         columns:
         - capitally_funded
-        - is_deleted
+        - is_retired
         - end_date
         - added_by
         - milestone_id
@@ -2682,7 +2692,7 @@
     permission:
       check: {}
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2701,7 +2711,7 @@
     permission:
       check: {}
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2730,7 +2740,7 @@
       - file_permissions
       - file_size
       - file_type
-      - is_deleted
+      - is_retired
       - is_scanned
       - project_file_id
       - project_id
@@ -2738,7 +2748,7 @@
   - role: moped-editor
     permission:
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2756,7 +2766,7 @@
   - role: moped-viewer
     permission:
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2775,7 +2785,7 @@
   - role: moped-admin
     permission:
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2794,7 +2804,7 @@
   - role: moped-editor
     permission:
       columns:
-      - is_deleted
+      - is_retired
       - is_scanned
       - created_by
       - file_size
@@ -2820,7 +2830,7 @@
         columns: '*'
       update:
         columns:
-        - is_deleted
+        - is_retired
         - is_scanned
         - created_by
         - file_size
@@ -3659,7 +3669,7 @@
       - capitally_funded
       - date_added
       - added_by
-      - is_deleted
+      - is_retired
       - milestone_id
       - status_id
       - project_team_members
@@ -3685,7 +3695,7 @@
     permission:
       columns:
       - capitally_funded
-      - is_deleted
+      - is_retired
       - end_date
       - added_by
       - milestone_id
@@ -3725,7 +3735,7 @@
     permission:
       columns:
       - capitally_funded
-      - is_deleted
+      - is_retired
       - end_date
       - added_by
       - milestone_id

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1,13 +1,13 @@
 - table:
-    schema: public
     name: moped_activity_log
+    schema: public
   object_relationships:
   - name: moped_user
     using:
       manual_configuration:
         remote_table:
-          schema: public
           name: moped_users
+          schema: public
         column_mapping:
           updated_by: cognito_user_id
   select_permissions:
@@ -54,8 +54,8 @@
       filter: {}
       allow_aggregations: true
 - table:
-    schema: public
     name: moped_city_fiscal_years
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -123,8 +123,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_components
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -196,34 +196,34 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_department
-- table:
     schema: public
+- table:
     name: moped_entity
+    schema: public
   array_relationships:
   - name: entity_department
     using:
       manual_configuration:
         remote_table:
-          schema: public
           name: moped_department
+          schema: public
         column_mapping:
           department_id: department_id
   - name: entity_organization
     using:
       manual_configuration:
         remote_table:
-          schema: public
           name: moped_organization
+          schema: public
         column_mapping:
           organization_id: organization_id
   - name: entity_workgroup
     using:
       manual_configuration:
         remote_table:
-          schema: public
           name: moped_workgroup
+          schema: public
         column_mapping:
           workgroup_id: workgroup_id
   insert_permissions:
@@ -314,8 +314,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_fund_programs
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -369,8 +369,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_fund_sources
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -431,8 +431,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_fund_status
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -490,8 +490,8 @@
     permission:
       filter: {}
 - table:
-    schema: public
     name: moped_funds
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -549,8 +549,8 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_milestones
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -636,11 +636,11 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_organization
-- table:
     schema: public
+- table:
     name: moped_phases
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -726,8 +726,8 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_proj_components
+    schema: public
   object_relationships:
   - name: moped_components
     using:
@@ -736,17 +736,17 @@
   - name: moped_proj_components_subcomponents
     using:
       foreign_key_constraint_on:
-        column: project_component_id
         table:
-          schema: public
           name: moped_proj_components_subcomponents
+          schema: public
+        column: project_component_id
   - name: moped_proj_features
     using:
       foreign_key_constraint_on:
-        column: project_component_id
         table:
-          schema: public
           name: moped_proj_features
+          schema: public
+        column: project_component_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -827,7 +827,6 @@
   event_triggers:
   - name: activity_log_moped_proj_components
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -840,6 +839,7 @@
         - status_id
         - description
         - name
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -848,11 +848,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_components_subcomponents
+    schema: public
   object_relationships:
   - name: moped_subcomponent
     using:
@@ -921,8 +921,8 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_proj_entities
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1020,7 +1020,6 @@
   event_triggers:
   - name: activity_log_moped_proj_entities
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1035,6 +1034,7 @@
         - project_personnel
         - project_sponsors
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1043,11 +1043,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_features
+    schema: public
   object_relationships:
   - name: moped_proj_component
     using:
@@ -1116,8 +1116,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_proj_financials
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1248,8 +1248,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_proj_fiscal_years
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1345,8 +1345,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_proj_funding
+    schema: public
   object_relationships:
   - name: moped_fund_source
     using:
@@ -1476,7 +1476,6 @@
   event_triggers:
   - name: activity_log_moped_proj_funding
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1495,6 +1494,7 @@
         - fund_dept_unit
         - funding_description
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1503,15 +1503,18 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_milestones
+    schema: public
   object_relationships:
   - name: moped_milestone
     using:
       foreign_key_constraint_on: milestone_id
+  - name: moped_project
+    using:
+      foreign_key_constraint_on: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1683,7 +1686,6 @@
   event_triggers:
   - name: activity_log_moped_proj_milestones
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1709,6 +1711,7 @@
         - milestone_description
         - milestone_status
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1717,11 +1720,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_notes
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1819,7 +1822,6 @@
   event_triggers:
   - name: activity_log_moped_proj_notes
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1834,6 +1836,7 @@
         - status_id
         - project_note
         - date_created
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1842,11 +1845,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_partners
+    schema: public
   object_relationships:
   - name: moped_entity
     using:
@@ -1938,7 +1941,6 @@
   event_triggers:
   - name: activity_log_moped_proj_partners
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1952,6 +1954,7 @@
         - status_id
         - partner_name
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1960,11 +1963,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_personnel
+    schema: public
   object_relationships:
   - name: moped_project_role
     using:
@@ -2069,7 +2072,6 @@
   event_triggers:
   - name: activity_log_moped_proj_personnel
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2084,6 +2086,7 @@
         - user_id
         - notes
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2092,11 +2095,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_proj_phases
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2275,7 +2278,6 @@
   event_triggers:
   - name: activity_log_moped_proj_phases
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2302,6 +2304,7 @@
         - phase_status
         - subphase_name
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2310,11 +2313,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_project
+    schema: public
   object_relationships:
   - name: moped_entity
     using:
@@ -2326,52 +2329,59 @@
   - name: moped_proj_components
     using:
       foreign_key_constraint_on:
-        column: project_id
         table:
-          schema: public
           name: moped_proj_components
-  - name: moped_proj_funding
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
           schema: public
-          name: moped_proj_funding
-  - name: moped_proj_notes
-    using:
-      foreign_key_constraint_on:
         column: project_id
-        table:
-          schema: public
-          name: moped_proj_notes
-  - name: moped_proj_partners
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          schema: public
-          name: moped_proj_partners
-  - name: moped_proj_personnel
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          schema: public
-          name: moped_proj_personnel
-  - name: moped_proj_phases
-    using:
-      foreign_key_constraint_on:
-        column: project_id
-        table:
-          schema: public
-          name: moped_proj_phases
   - name: moped_project_types
     using:
       foreign_key_constraint_on:
-        column: project_id
         table:
-          schema: public
           name: moped_project_types
+          schema: public
+        column: project_id
+  - name: moped_proj_funding
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_funding
+          schema: public
+        column: project_id
+  - name: moped_proj_milestones
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_milestones
+          schema: public
+        column: project_id
+  - name: moped_proj_notes
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_notes
+          schema: public
+        column: project_id
+  - name: moped_proj_partners
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_partners
+          schema: public
+        column: project_id
+  - name: moped_proj_personnel
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_personnel
+          schema: public
+        column: project_id
+  - name: moped_proj_phases
+    using:
+      foreign_key_constraint_on:
+        table:
+          name: moped_proj_phases
+          schema: public
+        column: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2620,7 +2630,6 @@
   event_triggers:
   - name: activity_log_moped_project
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2657,6 +2666,7 @@
         - date_added
         - updated_at
         - project_uuid
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2665,11 +2675,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_project_files
+    schema: public
   object_relationships:
   - name: moped_project
     using:
@@ -2813,7 +2823,6 @@
   event_triggers:
   - name: activity_log_moped_project_files
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2834,6 +2843,7 @@
         - file_key
         - file_name
         - create_date
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2842,11 +2852,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_project_roles
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2925,8 +2935,8 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_project_types
+    schema: public
   object_relationships:
   - name: moped_type
     using:
@@ -3010,7 +3020,6 @@
   event_triggers:
   - name: activity_log_moped_project_types
     definition:
-      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -3023,6 +3032,7 @@
         - project_type_id
         - status_id
         - date_added
+      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -3031,11 +3041,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - value: activity_log
-      name: MOPED_API_EVENT_NAME
+    - name: MOPED_API_EVENT_NAME
+      value: activity_log
 - table:
-    schema: public
     name: moped_status
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3114,8 +3124,8 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_subcomponents
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3173,8 +3183,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_subphases
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3260,8 +3270,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: moped_types
+    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3347,12 +3357,12 @@
       filter: {}
       check: {}
 - table:
-    schema: public
     name: moped_user_followed_projects
+    schema: public
   object_relationships:
-    - name: project
-      using:
-        foreign_key_constraint_on: project_id
+  - name: project
+    using:
+      foreign_key_constraint_on: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3445,8 +3455,8 @@
     permission:
       filter: {}
 - table:
-    schema: public
     name: moped_users
+    schema: public
   object_relationships:
   - name: moped_workgroup
     using:
@@ -3572,8 +3582,8 @@
           _eq: x-hasura-user-db-id
       check: null
 - table:
-    schema: public
     name: moped_workgroup
+    schema: public
   object_relationships:
   - name: moped_department
     using:
@@ -3638,8 +3648,8 @@
       filter: {}
       check: null
 - table:
-    schema: public
     name: project_list_view
+    schema: public
   select_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1,13 +1,13 @@
 - table:
-    name: moped_activity_log
     schema: public
+    name: moped_activity_log
   object_relationships:
   - name: moped_user
     using:
       manual_configuration:
         remote_table:
-          name: moped_users
           schema: public
+          name: moped_users
         column_mapping:
           updated_by: cognito_user_id
   select_permissions:
@@ -54,8 +54,8 @@
       filter: {}
       allow_aggregations: true
 - table:
+    schema: public
     name: moped_city_fiscal_years
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -123,8 +123,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_components
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -196,34 +196,34 @@
       filter: {}
       check: {}
 - table:
+    schema: public
     name: moped_department
-    schema: public
 - table:
-    name: moped_entity
     schema: public
+    name: moped_entity
   array_relationships:
   - name: entity_department
     using:
       manual_configuration:
         remote_table:
-          name: moped_department
           schema: public
+          name: moped_department
         column_mapping:
           department_id: department_id
   - name: entity_organization
     using:
       manual_configuration:
         remote_table:
-          name: moped_organization
           schema: public
+          name: moped_organization
         column_mapping:
           organization_id: organization_id
   - name: entity_workgroup
     using:
       manual_configuration:
         remote_table:
-          name: moped_workgroup
           schema: public
+          name: moped_workgroup
         column_mapping:
           workgroup_id: workgroup_id
   insert_permissions:
@@ -314,8 +314,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_fund_programs
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -369,8 +369,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_fund_sources
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -431,8 +431,8 @@
       filter: {}
       check: null
 - table:
-    name: moped_fund_status
     schema: public
+    name: moped_fund_status
   insert_permissions:
   - role: moped-admin
     permission:
@@ -490,8 +490,8 @@
     permission:
       filter: {}
 - table:
+    schema: public
     name: moped_funds
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -549,8 +549,8 @@
       filter: {}
       check: {}
 - table:
+    schema: public
     name: moped_milestones
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -636,11 +636,11 @@
       filter: {}
       check: {}
 - table:
+    schema: public
     name: moped_organization
-    schema: public
 - table:
-    name: moped_phases
     schema: public
+    name: moped_phases
   insert_permissions:
   - role: moped-admin
     permission:
@@ -726,8 +726,8 @@
       filter: {}
       check: {}
 - table:
-    name: moped_proj_components
     schema: public
+    name: moped_proj_components
   object_relationships:
   - name: moped_components
     using:
@@ -736,17 +736,17 @@
   - name: moped_proj_components_subcomponents
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_components_subcomponents
-          schema: public
         column: project_component_id
+        table:
+          schema: public
+          name: moped_proj_components_subcomponents
   - name: moped_proj_features
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_features
-          schema: public
         column: project_component_id
+        table:
+          schema: public
+          name: moped_proj_features
   insert_permissions:
   - role: moped-admin
     permission:
@@ -827,6 +827,7 @@
   event_triggers:
   - name: activity_log_moped_proj_components
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -839,7 +840,6 @@
         - status_id
         - description
         - name
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -848,11 +848,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_components_subcomponents
     schema: public
+    name: moped_proj_components_subcomponents
   object_relationships:
   - name: moped_subcomponent
     using:
@@ -921,8 +921,8 @@
       filter: {}
       check: {}
 - table:
-    name: moped_proj_entities
     schema: public
+    name: moped_proj_entities
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1020,6 +1020,7 @@
   event_triggers:
   - name: activity_log_moped_proj_entities
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1034,7 +1035,6 @@
         - project_personnel
         - project_sponsors
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1043,11 +1043,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_features
     schema: public
+    name: moped_proj_features
   object_relationships:
   - name: moped_proj_component
     using:
@@ -1116,8 +1116,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_proj_financials
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1248,8 +1248,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_proj_fiscal_years
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1345,8 +1345,8 @@
       filter: {}
       check: null
 - table:
-    name: moped_proj_funding
     schema: public
+    name: moped_proj_funding
   object_relationships:
   - name: moped_fund_source
     using:
@@ -1476,6 +1476,7 @@
   event_triggers:
   - name: activity_log_moped_proj_funding
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1494,7 +1495,6 @@
         - fund_dept_unit
         - funding_description
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1503,18 +1503,15 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_milestones
     schema: public
+    name: moped_proj_milestones
   object_relationships:
   - name: moped_milestone
     using:
       foreign_key_constraint_on: milestone_id
-  - name: moped_project
-    using:
-      foreign_key_constraint_on: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1686,6 +1683,7 @@
   event_triggers:
   - name: activity_log_moped_proj_milestones
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1711,7 +1709,6 @@
         - milestone_description
         - milestone_status
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1720,11 +1717,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_notes
     schema: public
+    name: moped_proj_notes
   insert_permissions:
   - role: moped-admin
     permission:
@@ -1822,6 +1819,7 @@
   event_triggers:
   - name: activity_log_moped_proj_notes
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1836,7 +1834,6 @@
         - status_id
         - project_note
         - date_created
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1845,11 +1842,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_partners
     schema: public
+    name: moped_proj_partners
   object_relationships:
   - name: moped_entity
     using:
@@ -1941,6 +1938,7 @@
   event_triggers:
   - name: activity_log_moped_proj_partners
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -1954,7 +1952,6 @@
         - status_id
         - partner_name
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -1963,11 +1960,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_personnel
     schema: public
+    name: moped_proj_personnel
   object_relationships:
   - name: moped_project_role
     using:
@@ -2072,6 +2069,7 @@
   event_triggers:
   - name: activity_log_moped_proj_personnel
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2086,7 +2084,6 @@
         - user_id
         - notes
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2095,11 +2092,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_proj_phases
     schema: public
+    name: moped_proj_phases
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2278,6 +2275,7 @@
   event_triggers:
   - name: activity_log_moped_proj_phases
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2304,7 +2302,6 @@
         - phase_status
         - subphase_name
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2313,11 +2310,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_project
     schema: public
+    name: moped_project
   object_relationships:
   - name: moped_entity
     using:
@@ -2329,59 +2326,52 @@
   - name: moped_proj_components
     using:
       foreign_key_constraint_on:
+        column: project_id
         table:
+          schema: public
           name: moped_proj_components
-          schema: public
-        column: project_id
-  - name: moped_project_types
-    using:
-      foreign_key_constraint_on:
-        table:
-          name: moped_project_types
-          schema: public
-        column: project_id
   - name: moped_proj_funding
     using:
       foreign_key_constraint_on:
+        column: project_id
         table:
+          schema: public
           name: moped_proj_funding
-          schema: public
-        column: project_id
-  - name: moped_proj_milestones
-    using:
-      foreign_key_constraint_on:
-        table:
-          name: moped_proj_milestones
-          schema: public
-        column: project_id
   - name: moped_proj_notes
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_notes
-          schema: public
         column: project_id
+        table:
+          schema: public
+          name: moped_proj_notes
   - name: moped_proj_partners
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_partners
-          schema: public
         column: project_id
+        table:
+          schema: public
+          name: moped_proj_partners
   - name: moped_proj_personnel
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_personnel
-          schema: public
         column: project_id
+        table:
+          schema: public
+          name: moped_proj_personnel
   - name: moped_proj_phases
     using:
       foreign_key_constraint_on:
-        table:
-          name: moped_proj_phases
-          schema: public
         column: project_id
+        table:
+          schema: public
+          name: moped_proj_phases
+  - name: moped_project_types
+    using:
+      foreign_key_constraint_on:
+        column: project_id
+        table:
+          schema: public
+          name: moped_project_types
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2630,6 +2620,7 @@
   event_triggers:
   - name: activity_log_moped_project
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2666,7 +2657,6 @@
         - date_added
         - updated_at
         - project_uuid
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2675,11 +2665,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_project_files
     schema: public
+    name: moped_project_files
   object_relationships:
   - name: moped_project
     using:
@@ -2823,6 +2813,7 @@
   event_triggers:
   - name: activity_log_moped_project_files
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -2843,7 +2834,6 @@
         - file_key
         - file_name
         - create_date
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -2852,11 +2842,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
-    name: moped_project_roles
     schema: public
+    name: moped_project_roles
   insert_permissions:
   - role: moped-admin
     permission:
@@ -2935,8 +2925,8 @@
       filter: {}
       check: {}
 - table:
-    name: moped_project_types
     schema: public
+    name: moped_project_types
   object_relationships:
   - name: moped_type
     using:
@@ -3020,6 +3010,7 @@
   event_triggers:
   - name: activity_log_moped_project_types
     definition:
+      enable_manual: false
       insert:
         columns: '*'
       delete:
@@ -3032,7 +3023,6 @@
         - project_type_id
         - status_id
         - date_added
-      enable_manual: false
     retry_conf:
       num_retries: 0
       interval_sec: 10
@@ -3041,11 +3031,11 @@
     headers:
     - name: MOPED_API_APIKEY
       value_from_env: MOPED_API_APIKEY
-    - name: MOPED_API_EVENT_NAME
-      value: activity_log
+    - value: activity_log
+      name: MOPED_API_EVENT_NAME
 - table:
+    schema: public
     name: moped_status
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3124,8 +3114,8 @@
       filter: {}
       check: {}
 - table:
+    schema: public
     name: moped_subcomponents
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3183,8 +3173,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_subphases
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3270,8 +3260,8 @@
       filter: {}
       check: null
 - table:
+    schema: public
     name: moped_types
-    schema: public
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3357,12 +3347,12 @@
       filter: {}
       check: {}
 - table:
-    name: moped_user_followed_projects
     schema: public
+    name: moped_user_followed_projects
   object_relationships:
-  - name: project
-    using:
-      foreign_key_constraint_on: project_id
+    - name: project
+      using:
+        foreign_key_constraint_on: project_id
   insert_permissions:
   - role: moped-admin
     permission:
@@ -3455,8 +3445,8 @@
     permission:
       filter: {}
 - table:
-    name: moped_users
     schema: public
+    name: moped_users
   object_relationships:
   - name: moped_workgroup
     using:
@@ -3582,8 +3572,8 @@
           _eq: x-hasura-user-db-id
       check: null
 - table:
-    name: moped_workgroup
     schema: public
+    name: moped_workgroup
   object_relationships:
   - name: moped_department
     using:
@@ -3648,8 +3638,8 @@
       filter: {}
       check: null
 - table:
-    name: project_list_view
     schema: public
+    name: project_list_view
   select_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2397,7 +2397,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2432,7 +2432,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2467,7 +2467,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2501,7 +2501,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2535,7 +2535,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2570,7 +2570,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2605,7 +2605,7 @@
       - ecapris_subproject_id
       - end_date
       - fiscal_year
-      - is_retired
+      - is_deleted
       - knack_project_id
       - milestone_id
       - project_description
@@ -2638,7 +2638,7 @@
       update:
         columns:
         - capitally_funded
-        - is_retired
+        - is_deleted
         - end_date
         - added_by
         - milestone_id
@@ -2692,7 +2692,7 @@
     permission:
       check: {}
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2711,7 +2711,7 @@
     permission:
       check: {}
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2740,7 +2740,7 @@
       - file_permissions
       - file_size
       - file_type
-      - is_retired
+      - is_deleted
       - is_scanned
       - project_file_id
       - project_id
@@ -2748,7 +2748,7 @@
   - role: moped-editor
     permission:
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2766,7 +2766,7 @@
   - role: moped-viewer
     permission:
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2785,7 +2785,7 @@
   - role: moped-admin
     permission:
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2804,7 +2804,7 @@
   - role: moped-editor
     permission:
       columns:
-      - is_retired
+      - is_deleted
       - is_scanned
       - created_by
       - file_size
@@ -2830,7 +2830,7 @@
         columns: '*'
       update:
         columns:
-        - is_retired
+        - is_deleted
         - is_scanned
         - created_by
         - file_size
@@ -3669,7 +3669,7 @@
       - capitally_funded
       - date_added
       - added_by
-      - is_retired
+      - is_deleted
       - milestone_id
       - status_id
       - project_team_members
@@ -3695,7 +3695,7 @@
     permission:
       columns:
       - capitally_funded
-      - is_retired
+      - is_deleted
       - end_date
       - added_by
       - milestone_id
@@ -3735,7 +3735,7 @@
     permission:
       columns:
       - capitally_funded
-      - is_retired
+      - is_deleted
       - end_date
       - added_by
       - milestone_id

--- a/moped-toolbox/README.md
+++ b/moped-toolbox/README.md
@@ -19,3 +19,19 @@ The docker image does not automatically run the script when it is instantiated f
 1. Attach to the docker image, `docker exec -it moped_backfill_url_field bash`
 1. And execute the script.
 1. `docker-compose stop` will stop the container.
+
+
+## amd_milestones_backfill
+
+This tool inserts `moped_proj_milestones` records into signal and PHB projects. It was created
+to backfill project milestones after implementing the milestone template feature for issue [#9102](https://github.com/cityofaustin/atd-data-tech/issues/9102).
+
+### Usage instructions
+
+1. Create a python 3.x environment with `requests` installed.
+2. Configure authentication details in `secrets.py`
+3. Run `create_milestones.py`, and set the `--env (-e)` arg to your desired environment and  `--max-date-added (-d)` arg date accordingly.
+
+```shell
+$ python create_milestones.py -e local -d '2022-06-17 00:00:00'
+```

--- a/moped-toolbox/README.md
+++ b/moped-toolbox/README.md
@@ -26,6 +26,8 @@ The docker image does not automatically run the script when it is instantiated f
 This tool inserts `moped_proj_milestones` records into signal and PHB projects. It was created
 to backfill project milestones after implementing the milestone template feature for issue [#9102](https://github.com/cityofaustin/atd-data-tech/issues/9102).
 
+*Be aware that this script depends on database schema values which are in flux at the time of writing. In particular, the use of `status_id` to identify deleted records may be changd in a future release. Make sure this script aligns with your current database schema*
+
 ### Usage instructions
 
 1. Create a python 3.x environment with `requests` installed.

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -2,6 +2,7 @@ import argparse
 
 from utils import get_milestones, make_hasura_request
 from queries import PROJECTS_QUERY, PROJ_MILESTONES_MUTATION
+from secrets import HASURA
 
 
 def exclude_existing_milestones(proj_milestones_current, proj_milestones_new):
@@ -30,9 +31,9 @@ def main(env, max_date_added):
     projects = make_hasura_request(
         query=PROJECTS_QUERY,
         variables={"max_date_added": max_date_added},
-        key="moped_project",
-        env=env,
-    )
+        endpoint=HASURA["hasura_graphql_endpoint"][env],
+        admin_secret=HASURA["hasura_graphql_admin_secret"][env],
+    )["moped_project"]
 
     for proj in projects:
         proj_milestones_new = get_milestones(project_id=proj["project_id"])
@@ -47,11 +48,11 @@ def main(env, max_date_added):
 
         print("todo: error handling")
         results = make_hasura_request(
-            env=env,
             query=PROJ_MILESTONES_MUTATION,
             variables={"objects": proj_milestones_new},
-            key="insert_moped_proj_milestones",
-        )
+            endpoint=HASURA["hasura_graphql_endpoint"][env],
+            admin_secret=HASURA["hasura_graphql_admin_secret"][env],
+        )["insert_moped_proj_milestones"]
         print(results)
 
 

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -1,0 +1,77 @@
+import argparse
+
+from utils import get_milestones, make_hasura_request
+from queries import PROJECTS_QUERY, PROJ_MILESTONES_MUTATION
+
+
+def exclude_existing_milestones(proj_milestones_current, proj_milestones_new):
+    """Check if a project's existing milestones include any we intend to add. If so
+    remove them from the list of new milestones to be added.
+
+    Args:
+        proj_milestones_current (list): list of a project's current moped_proj_milestones
+        proj_milestones_new (list): list of moped_proj_milestones we intend to add to the
+            project
+
+    Returns:
+        list: the list of new milestones to add, with existing milestones excluded
+    """
+    existing_milestone_ids = [
+        m["moped_milestone"]["milestone_id"] for m in proj_milestones_current
+    ]
+    return [
+        m
+        for m in proj_milestones_new
+        if m["milestone_id"] not in existing_milestone_ids
+    ]
+
+
+def main(env, max_date_added):
+    projects = make_hasura_request(
+        query=PROJECTS_QUERY,
+        variables={"max_date_added": max_date_added},
+        key="moped_project",
+        env=env,
+    )
+
+    for proj in projects:
+        proj_milestones_new = get_milestones(project_id=proj["project_id"])
+        print("BEFORE MILESTONES", len(proj_milestones_new))
+
+        proj_milestones_new = exclude_existing_milestones(
+            proj["moped_proj_milestones"], proj_milestones_new
+        )
+        print("AFTER MILESTONES", len(proj_milestones_new))
+        if not proj_milestones_new:
+            continue
+
+        print("todo: error handling")
+        results = make_hasura_request(
+            env=env,
+            query=PROJ_MILESTONES_MUTATION,
+            variables={"objects": proj_milestones_new},
+            key="insert_moped_proj_milestones",
+        )
+        print(results)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-e",
+        "--env",
+        type=str,
+        required=True,
+        choices=["local", "staging", "prod"],
+        help=f"The environment",
+    )
+    parser.add_argument(
+        "-d",
+        "--max-date-added",
+        type=str,
+        required=True,
+        help=f"The maximum project date_added which will be used to filter projects to update",
+    )
+    args = parser.parse_args()
+    print("TODO: logging")
+    main(args.env, args.max_date_added)

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -1,3 +1,6 @@
+"""The script inserts moped_proj_milestones into signal and PHB projects. It was created
+to backfill project milestones after implementing the milestone template feature for
+AMD: https://github.com/cityofaustin/atd-data-tech/issues/9102."""
 import argparse
 
 from utils import get_milestones, make_hasura_request
@@ -28,6 +31,14 @@ def exclude_existing_milestones(proj_milestones_current, proj_milestones_new):
 
 
 def main(env, max_date_added):
+    if env == "prod" and max_date_added != "2022-06-10":
+        raise ValueError(
+            """
+    Max date must be 2022-06-10 in production, this ensures we capture all projects created up to 
+    Moped v1.4 release, including one project created the day of the v1.4 release which needs
+    milestones added.
+        """
+        )
     projects = make_hasura_request(
         query=PROJECTS_QUERY,
         variables={"max_date_added": max_date_added},
@@ -71,7 +82,7 @@ if __name__ == "__main__":
         "--max-date-added",
         type=str,
         required=True,
-        help=f"The maximum project date_added which will be used to filter projects to update",
+        help=f"The maximum project date_added to include in this update: YYYY-MM-DD",
     )
     args = parser.parse_args()
     print("TODO: logging")

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -88,17 +88,9 @@ if __name__ == "__main__":
         "--max-date-added",
         type=str,
         required=True,
-        help=f"The maximum project date_added to include in this update in format YYYY-MM-DD (UTC). Must be '2022-06-09' in prod",
+        help=f"The maximum project date_added to include in this update. Formatted as a postgres-compliant timestamptz string",
     )
 
     args = parser.parse_args()
-
-    if args.env == "prod" and args.max_date_added != "2022-06-09":
-        raise ValueError(
-            """Max date must be 2022-06-09 in production, this ensures we capture all
-            projects created up to  Moped v1.4 release, including one project created the
-            day of the v1.4 release which needs milestones added.
-            """
-        )
 
     main(args.env, args.max_date_added)

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -1,73 +1,76 @@
 """The script inserts moped_proj_milestones into signal and PHB projects. It was created
 to backfill project milestones after implementing the milestone template feature for
-AMD: https://github.com/cityofaustin/atd-data-tech/issues/9102."""
+AMD: https://github.com/cityofaustin/atd-data-tech/issues/9102.
+
+Usage:
+    python create_milestones.py -e local -d 2023-01-01
+"""
 import argparse
 
-from utils import get_milestones, make_hasura_request
+from utils import get_logger, make_hasura_request, TEMPLATE_MILESTONES
 from queries import PROJECTS_QUERY, PROJ_MILESTONES_MUTATION
 from secrets import HASURA
 
 
-def exclude_existing_milestones(proj_milestones_current, proj_milestones_new):
-    """Check if a project's existing milestones include any we intend to add. If so
-    remove them from the list of new milestones to be added.
-
-    Args:
-        proj_milestones_current (list): list of a project's current moped_proj_milestones
-        proj_milestones_new (list): list of moped_proj_milestones we intend to add to the
-            project
-
-    Returns:
-        list: the list of new milestones to add, with existing milestones excluded
-    """
-    existing_milestone_ids = [
-        m["moped_milestone"]["milestone_id"] for m in proj_milestones_current
-    ]
-    return [
-        m
-        for m in proj_milestones_new
-        if m["milestone_id"] not in existing_milestone_ids
-    ]
-
-
 def main(env, max_date_added):
-    if env == "prod" and max_date_added != "2022-06-10":
-        raise ValueError(
-            """
-    Max date must be 2022-06-10 in production, this ensures we capture all projects created up to 
-    Moped v1.4 release, including one project created the day of the v1.4 release which needs
-    milestones added.
-        """
-        )
-    projects = make_hasura_request(
+
+    logger.info(f"Gettings projects added on or before {max_date_added} in {env} env")
+
+    data = make_hasura_request(
         query=PROJECTS_QUERY,
         variables={"max_date_added": max_date_added},
         endpoint=HASURA["hasura_graphql_endpoint"][env],
         admin_secret=HASURA["hasura_graphql_admin_secret"][env],
-    )["moped_project"]
+    )
 
-    for proj in projects:
-        proj_milestones_new = get_milestones(project_id=proj["project_id"])
-        print("BEFORE MILESTONES", len(proj_milestones_new))
+    projects = data["moped_project"]
+    all_milestones = data["moped_proj_milestones"]
 
-        proj_milestones_new = exclude_existing_milestones(
-            proj["moped_proj_milestones"], proj_milestones_new
-        )
-        print("AFTER MILESTONES", len(proj_milestones_new))
+    logger.info(f"{len(projects)} projects to process")
+
+    update_count = 0
+
+    for project in projects:
+        project_id = project["project_id"]
+
+        existing_milestone_ids = [
+            m["moped_milestone"]["milestone_id"]
+            for m in all_milestones
+            if m["project_id"] == project_id
+        ]
+
+        proj_milestones_new = []
+
+        for m in TEMPLATE_MILESTONES:
+            if m["milestone_id"] not in existing_milestone_ids:
+                new_milestone = dict(m).update(
+                    {"status_id": 1, "completed": False, "project_id": project_id}
+                )
+                proj_milestones_new.append(new_milestone)
+
         if not proj_milestones_new:
+            logger.info(f"#{project_id}: skipping because it has all milestones")
             continue
 
-        print("todo: error handling")
-        results = make_hasura_request(
+        logger.info(
+            f"Project #{project_id}: inserting {len(proj_milestones_new)} milestones"
+        )
+
+        make_hasura_request(
             query=PROJ_MILESTONES_MUTATION,
             variables={"objects": proj_milestones_new},
             endpoint=HASURA["hasura_graphql_endpoint"][env],
             admin_secret=HASURA["hasura_graphql_admin_secret"][env],
         )["insert_moped_proj_milestones"]
-        print(results)
+
+        update_count += 1
+
+    logger.info(f"Created milestones for {update_count} projects")
 
 
 if __name__ == "__main__":
+    logger = get_logger(name="create_milestones")
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-e",
@@ -82,8 +85,17 @@ if __name__ == "__main__":
         "--max-date-added",
         type=str,
         required=True,
-        help=f"The maximum project date_added to include in this update: YYYY-MM-DD",
+        help=f"The maximum project date_added to include in this update in format YYYY-MM-DD (UTC). Must be '2022-06-09' in prod",
     )
+
     args = parser.parse_args()
-    print("TODO: logging")
+
+    if args.env == "prod" and args.max_date_added != "2022-06-09":
+        raise ValueError(
+            """Max date must be 2022-06-09 in production, this ensures we capture all
+            projects created up to  Moped v1.4 release, including one project created the
+            day of the v1.4 release which needs milestones added.
+            """
+        )
+
     main(args.env, args.max_date_added)

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -52,7 +52,7 @@ def main(env, max_date_added):
                 proj_milestones_new.append(new_milestone)
 
         if not proj_milestones_new:
-            logger.info(f"#{project_id}: skipping because it has all milestones")
+            logger.info(f"Project #{project_id}: skipping because it has all milestones")
             continue
 
         logger.info(

--- a/moped-toolbox/amd_milestones_backfill/create_milestones.py
+++ b/moped-toolbox/amd_milestones_backfill/create_milestones.py
@@ -43,7 +43,10 @@ def main(env, max_date_added):
 
         for m in TEMPLATE_MILESTONES:
             if m["milestone_id"] not in existing_milestone_ids:
-                new_milestone = dict(m).update(
+                # copy template milestone
+                new_milestone = dict(m)
+                # add default vals and project ID
+                new_milestone.update(
                     {"status_id": 1, "completed": False, "project_id": project_id}
                 )
                 proj_milestones_new.append(new_milestone)

--- a/moped-toolbox/amd_milestones_backfill/queries.py
+++ b/moped-toolbox/amd_milestones_backfill/queries.py
@@ -1,0 +1,50 @@
+PROJECTS_QUERY = """query NeedsMilestonesProjects($max_date_added: timestamptz!) {
+	moped_project(
+		where: {
+			_and: [
+				# not-deleted projects only
+				{ is_deleted: { _eq: false } }
+				# exclude completed and post-construction projects
+				{
+					_and: [
+						{ current_phase: { _nilike: "complete" } }
+						{ current_phase: { _nilike: "post-construction" } }
+					]
+				}
+				# must contain at least one project type related to signals or PHBs
+				{
+					moped_project_types: {
+						moped_type: { type_name: { _similar: "%(Signal|PHB)%" } }
+					}
+				}
+				# only projects added before specified date - so as to filter on pre-v1.4 release
+				{ date_added: { _lte: $max_date_added } }
+			]
+		}
+	) {
+		project_id
+		project_name
+		date_added
+		moped_project_types {
+			moped_type {
+				type_name
+			}
+		}
+		# exclude soft-deleted milestones - todo: check if soft delete work has changed this
+		moped_proj_milestones(where: { status_id: { _eq: 1 } }) {
+			moped_milestone {
+				milestone_id
+				milestone_name
+			}
+		}
+	}
+}
+"""
+
+PROJ_MILESTONES_MUTATION = """mutation InsertMilestones($objects: [moped_proj_milestones_insert_input!]!) {
+  insert_moped_proj_milestones(objects: $objects) {
+    returning {
+      project_milestone_id
+    }
+  }
+}"""

--- a/moped-toolbox/amd_milestones_backfill/queries.py
+++ b/moped-toolbox/amd_milestones_backfill/queries.py
@@ -20,10 +20,13 @@ PROJECTS_QUERY = """query NeedsMilestonesProjects($max_date_added: timestamptz!)
 						{ current_phase: { _nilike: "post-construction" } }
 					]
 				}
-				# must contain at least one project type related to signals or PHBs
+				# must contain at least one not-deleted project type related to signals or PHBs
 				{
 					moped_project_types: {
-						moped_type: { type_name: { _similar: "%(Signal|PHB)%" } }
+						_and: [
+							{ moped_type: { type_name: { _similar: "%(Signal|PHB)%" } } }
+							{ status_id: { _eq: 1 } }
+						]
 					}
 				}
 				# only projects added before specified date - so as to filter on pre-v1.4 release

--- a/moped-toolbox/amd_milestones_backfill/queries.py
+++ b/moped-toolbox/amd_milestones_backfill/queries.py
@@ -1,5 +1,14 @@
+"""
+Query projects which:
+- are not deleted
+- are not in a completed or post-construction phase
+- have a project type that matches the (currently) four project types which support
+  templates: Signal - Mod, Signal - New, PHB - Mod, PHB - New
+- were created on or prior to a user-supplied date ($max_date_added)
+"""
 PROJECTS_QUERY = """query NeedsMilestonesProjects($max_date_added: timestamptz!) {
 	moped_project(
+		order_by: { project_id: asc }
 		where: {
 			_and: [
 				# not-deleted projects only
@@ -30,12 +39,14 @@ PROJECTS_QUERY = """query NeedsMilestonesProjects($max_date_added: timestamptz!)
 				type_name
 			}
 		}
-		# exclude soft-deleted milestones - todo: check if soft delete work has changed this
-		moped_proj_milestones(where: { status_id: { _eq: 1 } }) {
-			moped_milestone {
-				milestone_id
-				milestone_name
-			}
+	}
+	# we don't currently have a hasura relationship between projects and milestones :/
+	# so download them all so we can join them manually
+	moped_proj_milestones(where: { status_id: { _eq: 1 } }) {
+		project_id
+		moped_milestone {
+			milestone_id
+			milestone_name
 		}
 	}
 }

--- a/moped-toolbox/amd_milestones_backfill/requirements.txt
+++ b/moped-toolbox/amd_milestones_backfill/requirements.txt
@@ -1,0 +1,2 @@
+requests
+black

--- a/moped-toolbox/amd_milestones_backfill/requirements.txt
+++ b/moped-toolbox/amd_milestones_backfill/requirements.txt
@@ -1,2 +1,1 @@
 requests
-black

--- a/moped-toolbox/amd_milestones_backfill/secrets.py
+++ b/moped-toolbox/amd_milestones_backfill/secrets.py
@@ -1,10 +1,10 @@
 HASURA = {
-    "HASURA_GRAPHQL_ENDPOINT": {
+    "hasura_graphql_endpoint": {
         "local": "http://localhost:8080/v1/graphql",
         "staging": "<redacted>",
         "prod": "<redacted>",
     },
-    "HASURA_GRAPHQL_ADMIN_SECRET": {
+    "hasura_graphql_admin_secret": {
         "local": "DuMmyApiKeyHFVOVto19otC1wX6sP2N0VSKrCD70L10B7Sm525ZR6L672i2F79M9!",
         "staging": "<redacted>",
         "prod": "<redacted>",

--- a/moped-toolbox/amd_milestones_backfill/secrets.py
+++ b/moped-toolbox/amd_milestones_backfill/secrets.py
@@ -1,0 +1,12 @@
+HASURA = {
+    "HASURA_GRAPHQL_ENDPOINT": {
+        "local": "http://localhost:8080/v1/graphql",
+        "staging": "<redacted>",
+        "prod": "<redacted>",
+    },
+    "HASURA_GRAPHQL_ADMIN_SECRET": {
+        "local": "DuMmyApiKeyHFVOVto19otC1wX6sP2N0VSKrCD70L10B7Sm525ZR6L672i2F79M9!",
+        "staging": "<redacted>",
+        "prod": "<redacted>",
+    },
+}

--- a/moped-toolbox/amd_milestones_backfill/utils.py
+++ b/moped-toolbox/amd_milestones_backfill/utils.py
@@ -1,17 +1,14 @@
 import requests
-from secrets import HASURA
 
 
-def make_hasura_request(*, query, variables, key, env):
-    endpoint = HASURA["HASURA_GRAPHQL_ENDPOINT"][env]
-    admin_secret = HASURA["HASURA_GRAPHQL_ADMIN_SECRET"][env]
+def make_hasura_request(*, query, variables, endpoint, admin_secret):
     headers = {"X-Hasura-Admin-Secret": admin_secret}
     payload = {"query": query, "variables": variables}
     res = requests.post(endpoint, json=payload, headers=headers)
     res.raise_for_status()
     data = res.json()
     try:
-        return data["data"][key] if key else data["data"]
+        return data["data"]
     except KeyError:
         raise ValueError(data)
 
@@ -114,7 +111,7 @@ def get_milestones(*, project_id, status_id=1, completed=False):
 
     Args:
         project_id (int): moped_project.project_id
-        status_id (int, optional): moped_proj_milestone.status_id. Defaults to 1 (active). 
+        status_id (int, optional): moped_proj_milestone.status_id. Defaults to 1 (active).
         completed (bool, optional): moped_proj_milestone.completed. Defaults to False.
 
     Returns:

--- a/moped-toolbox/amd_milestones_backfill/utils.py
+++ b/moped-toolbox/amd_milestones_backfill/utils.py
@@ -109,6 +109,17 @@ MILESTONES = [
 
 
 def get_milestones(*, project_id, status_id=1, completed=False):
+    """Generate new moped_proj_milestones for a project based on our predefined project
+    template.
+
+    Args:
+        project_id (int): moped_project.project_id
+        status_id (int, optional): moped_proj_milestone.status_id. Defaults to 1 (active). 
+        completed (bool, optional): moped_proj_milestone.completed. Defaults to False.
+
+    Returns:
+        list: moped_proj_milestones ready to be inserted
+    """
     proj_milestones = []
     for m in MILESTONES:
         # create copy of each milestone

--- a/moped-toolbox/amd_milestones_backfill/utils.py
+++ b/moped-toolbox/amd_milestones_backfill/utils.py
@@ -1,4 +1,18 @@
+import logging
+import sys
+
 import requests
+
+
+def get_logger(*, name, level=logging.INFO):
+    """Return a module logger that streams to stdout"""
+    logger = logging.getLogger(name)
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(fmt=" %(name)s.%(levelname)s: %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger
 
 
 def make_hasura_request(*, query, variables, endpoint, admin_secret):
@@ -14,7 +28,7 @@ def make_hasura_request(*, query, variables, endpoint, admin_secret):
 
 
 # copied from atd-moped/moped-editor/src/utils/timelineTemplates.js
-MILESTONES = [
+TEMPLATE_MILESTONES = [
     {
         "milestone_id": 34,
         "milestone_order": 1,
@@ -103,27 +117,3 @@ MILESTONES = [
         "milestone_order": 21,
     },
 ]
-
-
-def get_milestones(*, project_id, status_id=1, completed=False):
-    """Generate new moped_proj_milestones for a project based on our predefined project
-    template.
-
-    Args:
-        project_id (int): moped_project.project_id
-        status_id (int, optional): moped_proj_milestone.status_id. Defaults to 1 (active).
-        completed (bool, optional): moped_proj_milestone.completed. Defaults to False.
-
-    Returns:
-        list: moped_proj_milestones ready to be inserted
-    """
-    proj_milestones = []
-    for m in MILESTONES:
-        # create copy of each milestone
-        proj_milestone = dict(m)
-        # set these values
-        proj_milestone["project_id"] = project_id
-        proj_milestone["status_id"] = status_id
-        proj_milestone["completed"] = False
-        proj_milestones.append(proj_milestone)
-    return proj_milestones

--- a/moped-toolbox/amd_milestones_backfill/utils.py
+++ b/moped-toolbox/amd_milestones_backfill/utils.py
@@ -1,0 +1,121 @@
+import requests
+from secrets import HASURA
+
+
+def make_hasura_request(*, query, variables, key, env):
+    endpoint = HASURA["HASURA_GRAPHQL_ENDPOINT"][env]
+    admin_secret = HASURA["HASURA_GRAPHQL_ADMIN_SECRET"][env]
+    headers = {"X-Hasura-Admin-Secret": admin_secret}
+    payload = {"query": query, "variables": variables}
+    res = requests.post(endpoint, json=payload, headers=headers)
+    res.raise_for_status()
+    data = res.json()
+    try:
+        return data["data"][key] if key else data["data"]
+    except KeyError:
+        raise ValueError(data)
+
+
+# copied from atd-moped/moped-editor/src/utils/timelineTemplates.js
+MILESTONES = [
+    {
+        "milestone_id": 34,
+        "milestone_order": 1,
+    },
+    {
+        "milestone_id": 35,
+        "milestone_order": 2,
+    },
+    {
+        "milestone_id": 36,
+        "milestone_order": 3,
+    },
+    {
+        "milestone_id": 37,
+        "milestone_order": 4,
+    },
+    {
+        "milestone_id": 31,
+        "milestone_order": 5,
+    },
+    {
+        "milestone_id": 38,
+        "milestone_order": 6,
+    },
+    {
+        "milestone_id": 39,
+        "milestone_order": 7,
+    },
+    {
+        "milestone_id": 40,
+        "milestone_order": 8,
+    },
+    {
+        "milestone_id": 41,
+        "milestone_order": 9,
+    },
+    {
+        "milestone_id": 42,
+        "milestone_order": 10,
+    },
+    {
+        "milestone_id": 43,
+        "milestone_order": 11,
+    },
+    {
+        "milestone_id": 44,
+        "milestone_order": 12,
+    },
+    {
+        "milestone_id": 45,
+        "milestone_description": "traffic and pedestrian",
+        "milestone_order": 13,
+    },
+    {
+        "milestone_id": 46,
+        "milestone_order": 14,
+    },
+    {
+        "milestone_id": 47,
+        "milestone_order": 15,
+    },
+    {
+        "milestone_id": 48,
+        "milestone_order": 16,
+    },
+    {
+        "milestone_id": 49,
+        "milestone_order": 17,
+    },
+    {
+        "milestone_id": 50,
+        "milestone_order": 18,
+    },
+    {
+        "milestone_id": 51,
+        "milestone_order": 19,
+    },
+    {
+        "milestone_id": 52,
+        "milestone_description": "typically 30 days",
+        "milestone_order": 20,
+    },
+    {
+        "milestone_id": 53,
+        "milestone_description": "for signals constructed by others/documentation that burn in period is complete",
+        "milestone_order": 21,
+    },
+]
+
+
+def get_milestones(*, project_id, status_id=1, completed=False):
+    proj_milestones = []
+    for m in MILESTONES:
+        # create copy of each milestone
+        proj_milestone = dict(m)
+        # set these values
+        proj_milestone["project_id"] = project_id
+        proj_milestone["status_id"] = status_id
+        proj_milestone["completed"] = False
+        proj_milestones.append(proj_milestone)
+    return proj_milestones


### PR DESCRIPTION
## Associated issues
This will resolve https://github.com/cityofaustin/atd-data-tech/issues/9257 once it's approved and tested in staging and run against production.

## Testing
**URL to test:** Local

**Steps to test:**
1. You'll need a python 3.x environment with `requests` installed.
2. Use the Moped editor to create a new project. Do not use the milestone template when you create the project.
3. Edit the project type of your project to one of "Signal - Mod", "Signal - New", "PHB - Mod", "PHB - New"
4. Run `create_milestones.py`, and set `--env (-e)` to `local` and the `max-date-added (-d)` arg date to be in the future

```
python create_milestones.py -e local -d '2022-06-17 00:00:00'
```

5. Navigate to your project timeline can confirm the template milestones have been added.

Other things you can test:
- Repeat the above steps, but use a milestone template from the new project workflow. Run the script. No milestones should be added to the project.
- Repeat the above steps, but set the project type to "Fiber - Mod". Run the script. No milestones should be added to the project.
- Repeat the above steps, but add a "Completed" phase to your project and set it as the current phase. Run the script. Your project should **not** have milestones added. Completed and post-construction projects are excluded.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Run against staging environment
- [ ] Run against production environment

