### PR TITLE
Sanitize and render comments with rich text

### DIFF
--- a/moped-editor/src/views/dashboard/DashboardEditModal.js
+++ b/moped-editor/src/views/dashboard/DashboardEditModal.js
@@ -45,7 +45,7 @@ const DashboardEditModal = ({ project, displayText, queryRefetch }) => {
         onClick={() => setIsDialogOpen(true)}
       >
         {displayText.length > 0 ? (
-          parse(displayText)
+          parse(String(displayText))
         ) : (
           <Tooltip placement="bottom-start" title="Create new status update">
             <ControlPointIcon className={classes.tooltipIcon} />

--- a/moped-editor/src/views/dashboard/DashboardEditModal.js
+++ b/moped-editor/src/views/dashboard/DashboardEditModal.js
@@ -11,6 +11,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import ControlPointIcon from "@material-ui/icons/ControlPoint";
 import { makeStyles } from "@material-ui/core/styles";
 import ProjectComments from "./../projects/projectView/ProjectComments";
+import parse from "html-react-parser";
 
 const useStyles = makeStyles(theme => ({
   dialogTitle: {
@@ -44,7 +45,7 @@ const DashboardEditModal = ({ project, displayText, queryRefetch }) => {
         onClick={() => setIsDialogOpen(true)}
       >
         {displayText.length > 0 ? (
-          displayText
+          parse(displayText)
         ) : (
           <Tooltip placement="bottom-start" title="Create new status update">
             <ControlPointIcon className={classes.tooltipIcon} />

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -139,7 +139,7 @@ const DashboardView = () => {
       project["current_status"] = project.project.current_status;
 
       // project status update equivalent to most recent project note
-      // note that html is parsed before being rendered in the DashboardEditModal component
+      // html is parsed before being rendered in the DashboardEditModal component
       project["status_update"] = "";
       if (project?.project?.moped_proj_notes?.length) {
         const note = project.project.moped_proj_notes[0]["project_note"];

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -139,13 +139,11 @@ const DashboardView = () => {
       project["current_status"] = project.project.current_status;
 
       // project status update equivalent to most recent project note
+      // note that html is parsed before being rendered in the DashboardEditModal component
       project["status_update"] = "";
       if (project?.project?.moped_proj_notes?.length) {
         const note = project.project.moped_proj_notes[0]["project_note"];
-        // Remove any HTML tags
-        project["status_update"] = note
-          ? String(note).replace(/(<([^>]+)>)/gi, "")
-          : "";
+        project["status_update"] = note ? note : ""
       }
     });
   }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -73,7 +73,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Handles updating the state for "status update"
    * @param {Object} event
    */
-  const handleStatusUpdateChange = event => setStatusUpdate(DOMPurify.sanitize(noteText));
+  const handleStatusUpdateChange = event => setStatusUpdate(DOMPurify.sanitize(event.target.value));
 
   /**
    * Handles the edit click for status update

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -95,7 +95,6 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Handles saving the status update
    */
   const handleStatusUpdateSave = () => {
-    console.log("save new status")
     // Retrieve a commentId or get a null
     const commentId = getStatusUpdate("project_note_id");
     const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -73,7 +73,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Handles updating the state for "status update"
    * @param {Object} event
    */
-  const handleStatusUpdateChange = event => setStatusUpdate(DOMPurify.sanitize(event.target.value));
+  const handleStatusUpdateChange = event => setStatusUpdate(event.target.value);
 
   /**
    * Handles the edit click for status update
@@ -95,6 +95,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Handles saving the status update
    */
   const handleStatusUpdateSave = () => {
+    console.log("save new status")
     // Retrieve a commentId or get a null
     const commentId = getStatusUpdate("project_note_id");
     const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
@@ -109,14 +110,14 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
               statusUpdate: {
                 project_id: Number(projectId),
                 added_by: addedBy,
-                project_note: statusUpdate,
+                project_note: DOMPurify.sanitize(statusUpdate),
                 project_note_type: 2,
               },
             }
           : {
               project_note_id: { _eq: Number(commentId) },
               added_by: addedBy,
-              project_note: statusUpdate,
+              project_note: DOMPurify.sanitize(statusUpdate),
             }),
       },
     })

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -10,6 +10,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import parse from "html-react-parser";
+import DOMPurify from "dompurify";
 import ControlPointIcon from "@material-ui/icons/ControlPoint";
 
 import {
@@ -53,8 +54,8 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
       const note = data
         ? data?.moped_project[0].moped_proj_notes[lastItem][fieldName] ?? ""
         : null;
-      // Remove any HTML tags
-      return note ? parse(note) : null;
+      // Remove any HTML tags for status update string
+      return note && typeof(note) === "string" ? parse(note) : null;
     }
     return null;
   };
@@ -72,7 +73,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Handles updating the state for "status update"
    * @param {Object} event
    */
-  const handleStatusUpdateChange = event => setStatusUpdate(event.target.value);
+  const handleStatusUpdateChange = event => setStatusUpdate(DOMPurify.sanitize(noteText));
 
   /**
    * Handles the edit click for status update

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Typography,
 } from "@material-ui/core";
+import parse from "html-react-parser";
 import ControlPointIcon from "@material-ui/icons/ControlPoint";
 
 import {
@@ -53,7 +54,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
         ? data?.moped_project[0].moped_proj_notes[lastItem][fieldName] ?? ""
         : null;
       // Remove any HTML tags
-      return note ? String(note).replace(/(<([^>]+)>)/gi, "") : null;
+      return note ? parse(note) : null;
     }
     return null;
   };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -55,7 +55,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
         ? data?.moped_project[0].moped_proj_notes[lastItem][fieldName] ?? ""
         : null;
       // Remove any HTML tags for status update string
-      return note && typeof(note) === "string" ? parse(note) : null;
+      return note ? parse(String(note)) : null;
     }
     return null;
   };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -28,6 +28,7 @@ import MaterialTable, { MTableBody, MTableHeader } from "@material-table/core";
 import { filterProjectTeamMembers as renderProjectTeamMembers } from "./helpers.js";
 import { getSearchValue } from "../../../utils/gridTableHelpers";
 import { formatDateType, formatTimeStampTZType } from "src/utils/dateAndTime";
+import parse from "html-react-parser";
 
 /**
  * GridTable Style
@@ -415,6 +416,7 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
       field: "project_note",
       hidden: hiddenColumns["project_note"],
       emptyValue: "-",
+      render: entry => parse(entry.project_note),
     },
     {
       title: "Construction start",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -416,7 +416,7 @@ const ProjectsListViewTable = ({ title, query, searchTerm, referenceData }) => {
       field: "project_note",
       hidden: hiddenColumns["project_note"],
       emptyValue: "-",
-      render: entry => parse(entry.project_note),
+      render: entry => parse(String(entry.project_note)),
     },
     {
       title: "Construction start",

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -88,7 +88,7 @@ const SignalProjectTable = () => {
       const note = project.moped_proj_notes[0]["project_note"];
       // Remove any HTML tags
       project["status_update"] = note
-        ? parse(note)
+        ? parse(String(note))
         : "";
     }
 

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -18,6 +18,7 @@ import MaterialTable, {
   MTableEditRow,
   MTableEditField,
 } from "@material-table/core";
+import parse from "html-react-parser";
 
 import Page from "src/components/Page";
 import { useWindowResize } from "src/utils/materialTableHelpers.js";
@@ -87,7 +88,7 @@ const SignalProjectTable = () => {
       const note = project.moped_proj_notes[0]["project_note"];
       // Remove any HTML tags
       project["status_update"] = note
-        ? String(note).replace(/(<([^>]+)>)/gi, "")
+        ? parse(note)
         : "";
     }
 


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/9495

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-689--atd-moped-main.netlify.app/

**Steps to test:**
1. Add status updates to an existing project (for both a regular project and a signal project)
2. Follow the project and add yourself to the team
3. Go to comments tab and add formatting and an emoji to the comment 
4. Check the following views to ensure rich text is displayed: project summary, comments tab, all projects view, signals projects view, dashboard view (my projects and following)

Note: Rich text is already sanitized before being saved in comments view. Added sanitization when adding a new status update on summary page.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable

<img width="1433" alt="Screen Shot 2022-06-21 at 5 18 07 PM" src="https://user-images.githubusercontent.com/35410637/174906259-58f45763-fcf0-4087-ab7d-5b8494cb6f87.png">
<img width="1403" alt="Screen Shot 2022-06-21 at 5 17 58 PM" src="https://user-images.githubusercontent.com/35410637/174906279-ce5d6b54-5ba5-425f-b277-b0e61310ae41.png">
<img width="1410" alt="Screen Shot 2022-06-21 at 5 17 49 PM" src="https://user-images.githubusercontent.com/35410637/174906289-95b8059a-dc19-4ae6-812d-0be0adb1ff2a.png">
<img width="1377" alt="Screen Shot 2022-06-21 at 5 17 39 PM" src="https://user-images.githubusercontent.com/35410637/174906314-89baa020-4334-403e-9527-bd1a954b5c5c.png">
<img width="1371" alt="Screen Shot 2022-06-21 at 5 17 30 PM" src="https://user-images.githubusercontent.com/35410637/174906348-e53ff903-22bf-440d-8fb9-dba74134778d.png">
<img width="1413" alt="Screen Shot 2022-06-21 at 5 17 15 PM" src="https://user-images.githubusercontent.com/35410637/174906360-09fe4d8f-2e5f-4ea2-bd61-45c86b58d14b.png">