### PR TITLE
Make fund source field not required

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -418,7 +418,6 @@ const ProjectFundingTable = () => {
           data={data.moped_fund_sources}
         />
       ),
-      validate: rowData => (!rowData.funding_source_id ? "Required" : true),
     },
     {
       title: "Program",


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/9216

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-692--atd-moped-main.netlify.app/moped/session/signin

**Steps to test:**
1. go to project funding tab
2. select add new funding source
3. add new funding source without selecting a 'source'

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
