### PR TITLE
Add link to parent project from subproject summary page

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -52,6 +52,9 @@ export const SUMMARY_QUERY = gql`
       purchase_order_number
       work_assignment_id
       parent_project_id
+      moped_project {
+        project_name
+      }
       moped_proj_components(where: { is_deleted: { _eq: false } }) {
         moped_proj_features(where: { is_deleted: { _eq: false } }) {
           feature_id

--- a/moped-editor/src/queries/subprojects.js
+++ b/moped-editor/src/queries/subprojects.js
@@ -1,9 +1,8 @@
 import { gql } from "@apollo/client";
 
-
 export const SUBPROJECT_QUERY = gql`
   query SubprojectSummary($projectId: Int) {
-    subprojects: moped_project(where:{project_id: { _eq: $projectId } }) {
+    subprojects: moped_project(where: { project_id: { _eq: $projectId } }) {
       moped_projects {
         project_name
         project_id
@@ -11,14 +10,16 @@ export const SUBPROJECT_QUERY = gql`
         current_phase
       }
     }
-    subprojectOptions: moped_project(where: {
-      _and: [
-        {is_deleted: {_eq: false}},
-        {parent_project_id: {_is_null: true}}
-        {project_id: {_neq: $projectId}}
-      ],
-      _not: {moped_projects: {}}
-    }) {
+    subprojectOptions: moped_project(
+      where: {
+        _and: [
+          { is_deleted: { _eq: false } }
+          { parent_project_id: { _is_null: true } }
+          { project_id: { _neq: $projectId } }
+        ]
+        _not: { moped_projects: {} }
+      }
+    ) {
       project_id
       project_name
     }
@@ -33,23 +34,26 @@ export const SUBPROJECT_QUERY = gql`
 `;
 
 export const UPDATE_PROJECT_SUBPROJECT = gql`
-  mutation UpdateProjectSubproject($parentProjectId: Int!, $childProjectId: Int!) {
-    update_moped_project(
-      where: { project_id: { _eq: $childProjectId } }
+  mutation UpdateProjectSubproject(
+    $parentProjectId: Int!
+    $childProjectId: Int!
+  ) {
+    update_moped_project_by_pk(
+      pk_columns: { project_id: $childProjectId }
       _set: { parent_project_id: $parentProjectId }
     ) {
-      affected_rows
+      parent_project_id
     }
   }
 `;
 
 export const DELETE_PROJECT_SUBPROJECT = gql`
   mutation UpdateProjectSubproject($childProjectId: Int!) {
-    update_moped_project(
-      where: { project_id: { _eq: $childProjectId } }
+    update_moped_project_by_pk(
+      pk_columns: { project_id: $childProjectId }
       _set: { parent_project_id: null }
     ) {
-      affected_rows
+      parent_project_id
     }
   }
 `;

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -95,8 +95,8 @@ const TABS = [
 
 const DashboardView = () => {
   const userSessionData = getSessionDatabaseData();
-  const userId = userSessionData.user_id;
-  const userName = userSessionData.first_name;
+  const userId = userSessionData?.user_id;
+  const userName = userSessionData?.first_name;
 
   const classes = useStyles();
   const typographyStyle = {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -20,6 +20,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import ProjectSummarySnackbar from "./ProjectSummarySnackbar";
 import ProjectSummaryProjectWebsite from "./ProjectSummaryProjectWebsite";
 import ProjectSummaryProjectDescription from "./ProjectSummaryProjectDescription";
+import ProjectSummaryParentProjectLink from "./ProjectSummaryParentProjectLink";
 import ProjectSummaryProjectECapris from "./ProjectSummaryProjectECapris";
 import ProjectSummaryProjectTypes from "./ProjectSummaryProjectTypes";
 import ProjectSummaryKnackDataTrackerSync from "./ProjectSummaryKnackDataTrackerSync";
@@ -31,7 +32,7 @@ import ProjectSummaryContractor from "./ProjectSummaryContractor";
 import ProjectSummaryProjectDO from "./ProjectSummaryProjectDO";
 import SubprojectsTable from "./SubprojectsTable";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   fieldGridItem: {
     margin: theme.spacing(2),
   },
@@ -62,7 +63,7 @@ const useStyles = makeStyles(theme => ({
   fieldAuthor: {
     marginRight: ".25rem",
     fontSize: ".8rem",
-    fontWeight: "bold"
+    fontWeight: "bold",
   },
   knackFieldLabelText: {
     width: "calc(100% - 2rem)",
@@ -124,9 +125,8 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
   if (error) return `Error! ${error.message}`;
 
   const projectComponents = data?.moped_project[0]?.moped_proj_components || [];
-  const projectFeatureCollection = createProjectFeatureCollection(
-    projectComponents
-  );
+  const projectFeatureCollection =
+    createProjectFeatureCollection(projectComponents);
 
   const renderMap = () => {
     if (countFeatures(projectFeatureCollection) < 1) {
@@ -162,6 +162,15 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
               classes={classes}
               snackbarHandle={snackbarHandle}
             />
+            {data.moped_project[0]?.parent_project_id && (
+              <ProjectSummaryParentProjectLink
+                projectId={projectId}
+                data={data}
+                refetch={refetch}
+                classes={classes}
+                snackbarHandle={snackbarHandle}
+              />
+            )}
             {/*Status Update Component*/}
             <ProjectSummaryStatusUpdate
               projectId={projectId}
@@ -288,10 +297,9 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
             )}
           </Grid>
           <Grid item xs={12}>
-            {// If this project has a parent project id, dont render this table. 
-            // do we render a message?  
-            !data.moped_project[0].parent_project_id && <SubprojectsTable projectId={projectId}/>
-            }
+            {!data.moped_project[0].parent_project_id && (
+              <SubprojectsTable projectId={projectId} />
+            )}
           </Grid>
         </Grid>
       </CardContent>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -3,7 +3,7 @@ import { Box, Grid, Typography } from "@material-ui/core";
 import { NavLink as RouterLink } from "react-router-dom";
 
 /**
- * ProjectSummaryProjectDescription Component
+ * ProjectSummaryParentProjectLink Component
  * @param {Object} data - The data object from the GraphQL query
  * @param {Object} classes - The shared style settings
  * @returns {JSX.Element}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -25,7 +25,7 @@ const ProjectSummaryParentProjectLink = ({ data, classes }) => {
         <RouterLink
           id="projectKnackSyncLink"
           className={"MuiTypography-body1"}
-          to={`/projects/${parentProjectId}`}
+          to={`/moped/projects/${parentProjectId}`}
         >
           <Typography variant={"inherit"} color={"primary"}>
             {parentProjectName}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { Box, Grid, Typography } from "@material-ui/core";
+import { NavLink as RouterLink } from "react-router-dom";
+
+/**
+ * ProjectSummaryProjectDescription Component
+ * @param {Object} data - The data object from the GraphQL query
+ * @param {Object} classes - The shared style settings
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const ProjectSummaryParentProjectLink = ({ data, classes }) => {
+  const parentProjectId =
+    data?.moped_project?.[0]?.parent_project_id;
+  const parentProjectName = data?.moped_project[0].moped_project.project_name;
+
+  return (
+    <Grid item xs={12} className={classes.fieldGridItem}>
+      <Typography className={classes.fieldLabel}>Parent project</Typography>
+      <Box
+        display="flex"
+        justifyContent="flex-start"
+        className={classes.fieldBox}
+      >
+        <RouterLink
+          id="projectKnackSyncLink"
+          className={"MuiTypography-body1"}
+          to={`/projects/${parentProjectId}`}
+        >
+          <Typography variant={"inherit"} color={"primary"}>
+            {parentProjectName}
+          </Typography>
+        </RouterLink>
+      </Box>
+    </Grid>
+  );
+};
+
+export default ProjectSummaryParentProjectLink;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -38,7 +38,7 @@ const ProjectSummaryProjectDescription = ({
   const [updateProjectDescription] = useMutation(PROJECT_UPDATE_DESCRIPTION);
 
   /**
-   * Resets the project website to original value
+   * Resets the project description to original value
    */
   const handleProjectDescriptionClose = () => {
     setDescription(originalDescription);
@@ -46,7 +46,7 @@ const ProjectSummaryProjectDescription = ({
   };
 
   /**
-   * Saves the new project website...
+   * Saves the new project description...
    */
   const handleProjectDescriptionSave = () => {
     updateProjectDescription({
@@ -63,7 +63,7 @@ const ProjectSummaryProjectDescription = ({
       .catch(err => {
         snackbarHandle(
           true,
-          "Failed to update project website: " + String(err),
+          "Failed to update project description: " + String(err),
           "error"
         );
         handleProjectDescriptionClose();
@@ -72,7 +72,7 @@ const ProjectSummaryProjectDescription = ({
   };
 
   /**
-   * Updates the state of website
+   * Updates the description state
    * @param {Object} e - Event object
    */
   const handleProjectDescriptionChange = e => {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -66,8 +66,7 @@ const SubprojectsTable = ({ projectId = null }) => {
             name="project_name"
             options={data.subprojectOptions}
             getOptionLabel={(option) => option.project_name}
-            getOptionSelected={(option, value) => option === value}
-            value={props.value}
+            value={props.value || null}
             onChange={(event, value) => props.onChange(value)}
             renderInput={(params) => <TextField {...params} />}
           />

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -196,7 +196,7 @@ const ProjectView = () => {
   const menuOpen = anchorElement ?? false;
 
   const userSessionData = getSessionDatabaseData();
-  const userId = userSessionData.user_id;
+  const userId = userSessionData?.user_id;
 
   const handleSnackbarClose = () => {
     setSnackbarState(DEFAULT_SNACKBAR_STATE);

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -112,6 +112,7 @@ const useStyles = makeStyles(theme => ({
   },
   followDiv: {
     float: "right",
+    cursor: "pointer",
   },
   unfollowIcon: {
     color: theme.palette.primary.main,


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/9330

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://9330-link-to-parent--atd-moped-main.netlify.app/moped/projects/1841/

**Steps to test:**

1. Add a child project to an existing project. Use the link from the subprojects table to visit summary page of child project. 
2.  Child project should have a link to parent project
3.  if there is no parent project, i.e. the project is not a subproject, the field in the summary page should not render. (You can tell a project is not a subproject by checking to see if the subprojects table is showing)


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
