### PR TITLE
Clean up unused functions in personnel table

### DIFF
--- a/moped-editor/src/theme/index.js
+++ b/moped-editor/src/theme/index.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from "@material-ui/core";
+import { createTheme } from "@material-ui/core";
 import shadows from "./shadows";
 import typography from "./typography";
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     background: {
       default: "#edeeed",

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -232,9 +232,9 @@ const ProjectTeamTable = ({ projectId }) => {
     {
       title: "Notes",
       field: "notes",
+      render: (props) => (props.notes === "null" ? "" : props.notes),
       editComponent: (props) => {
         const val = props.value ?? "";
-        console.log(val, val!=="null")
         return (
           <TextField
             id="notes"

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -234,6 +234,7 @@ const ProjectTeamTable = ({ projectId }) => {
       field: "notes",
       editComponent: (props) => {
         const val = props.value ?? "";
+        console.log(val, val!=="null")
         return (
           <TextField
             id="notes"
@@ -316,11 +317,9 @@ const ProjectTeamTable = ({ projectId }) => {
         icons={{ Delete: DeleteOutlineIcon, Edit: EditOutlinedIcon }}
         editable={{
           onRowAdd: (newData) => {
-            console.log(newData.role_id)
             // Our new data is unique, we will attempt upsert since
             // we may have existing data in our table
             const personnelData = newData.role_id.map((roleId, index) => {
-              console.log(index, newData.notes)
               return {
                 project_id: Number.parseInt(projectId),
                 user_id: newData.user_id,

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -17,7 +17,10 @@ import {
   DeleteOutline as DeleteOutlineIcon,
   EditOutlined as EditOutlinedIcon,
 } from "@material-ui/icons";
-import MaterialTable, { MTableEditRow, MTableAction } from "@material-table/core";
+import MaterialTable, {
+  MTableEditRow,
+  MTableAction,
+} from "@material-table/core";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 
 import typography from "../../../theme/typography";
@@ -31,7 +34,7 @@ import { TEAM_QUERY, UPSERT_PROJECT_PERSONNEL } from "../../../queries/project";
 import ProjectTeamRoleMultiselect from "./ProjectTeamRoleMultiselect";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   infoIcon: {
     fontSize: "1.25rem",
     verticalAlign: "sub",
@@ -42,18 +45,12 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const ProjectTeamTable = ({
-  personnelState,
-  setPersonnelState,
-  projectId = null,
-}) => {
+const ProjectTeamTable = ({ projectId = null }) => {
   const isNewProject = projectId === null;
   const classes = useStyles();
 
   const { loading, error, data, refetch } = useQuery(TEAM_QUERY, {
-    // sending a null projectId will cause a graphql error
-    // id 0 used when creating a new project, no project personnel will be returned
-    variables: { projectId: projectId ?? 0 },
+    variables: { projectId },
     fetchPolicy: "no-cache",
   });
 
@@ -71,7 +68,7 @@ const ProjectTeamTable = ({
    */
   const tuplesContain = (tupleList, tupleItem) =>
     !!tupleList.find(
-      currentTuple =>
+      (currentTuple) =>
         currentTuple[0] === tupleItem[0] && currentTuple[1] === tupleItem[1]
     );
 
@@ -81,7 +78,7 @@ const ProjectTeamTable = ({
   let personnel = {};
 
   // For each personnel entry...
-  data.moped_proj_personnel.map(item => {
+  data.moped_proj_personnel.map((item) => {
     // If the item does not exist in the aggregated object
     if (!personnel.hasOwnProperty(item.user_id)) {
       // instantiate a new object & populate
@@ -131,21 +128,22 @@ const ProjectTeamTable = ({
   );
 
   // Options for Autocomplete form elements
-  const userIds = availableUsers.map(user => user.user_id);
+  const userIds = availableUsers.map((user) => user.user_id);
 
   /**
    * Get a user object from the users array
    * @param {number} id - User id from the moped project personnel row
    * @return {object} Object containing user data
    */
-  const getUserById = id => availableUsers.find(user => user.user_id === id);
+  const getUserById = (id) =>
+    availableUsers.find((user) => user.user_id === id);
 
   /**
    * Get personnel name from their user ID
    * @param {number} id - User id from the moped project personnel row
    * @return {string} Full name of user
    */
-  const getPersonnelName = id => {
+  const getPersonnelName = (id) => {
     const user = getUserById(id);
     return `${user?.first_name ?? "Unknown"} ${user?.last_name ?? "User"}`;
   };
@@ -155,7 +153,7 @@ const ProjectTeamTable = ({
    * @param {number} id - User id from the moped project personnel row
    * @return {string} Workgroup name of the user
    */
-  const getPersonnelWorkgroup = id => {
+  const getPersonnelWorkgroup = (id) => {
     const user = getUserById(id);
     return workgroups[user?.workgroup_id ?? 0];
   };
@@ -165,8 +163,8 @@ const ProjectTeamTable = ({
    * @param {Array} rolesArray - Array of roleIDs
    * @return {string} roles separated by comma and space
    */
-  const getPersonnelRoles = rolesArray => {
-    const roleNames = rolesArray.map(roleId => roles[roleId]);
+  const getPersonnelRoles = (rolesArray) => {
+    const roleNames = rolesArray.map((roleId) => roles[roleId]);
     return roleNames.join(", ");
   };
 
@@ -177,19 +175,19 @@ const ProjectTeamTable = ({
     {
       title: "Name",
       field: "user_id",
-      render: personnel => getPersonnelName(personnel.user_id),
-      validate: rowData => !!rowData.user_id,
-      editComponent: props => (
+      render: (personnel) => getPersonnelName(personnel.user_id),
+      validate: (rowData) => !!rowData.user_id,
+      editComponent: (props) => (
         <FormControl style={{ width: "100%" }}>
           <Autocomplete
             id="user_id"
             name="user_id"
             options={userIds}
-            getOptionLabel={option => getPersonnelName(option)}
+            getOptionLabel={(option) => getPersonnelName(option)}
             getOptionSelected={(option, value) => option === value}
             value={props.value}
             onChange={(event, value) => props.onChange(value)}
-            renderInput={params => <TextField {...params} />}
+            renderInput={(params) => <TextField {...params} />}
           />
           <FormHelperText>Required</FormHelperText>
         </FormControl>
@@ -197,7 +195,7 @@ const ProjectTeamTable = ({
     },
     {
       title: "Workgroup",
-      render: personnel => (
+      render: (personnel) => (
         <Typography>{getPersonnelWorkgroup(personnel.user_id)}</Typography>
       ),
     },
@@ -215,12 +213,12 @@ const ProjectTeamTable = ({
         </span>
       ),
       field: "role_id",
-      render: personnel => (
+      render: (personnel) => (
         <Typography>{getPersonnelRoles(personnel.role_id)}</Typography>
       ),
-      validate: rowData =>
+      validate: (rowData) =>
         Array.isArray(rowData.role_id) && rowData.role_id.length > 0,
-      editComponent: props => (
+      editComponent: (props) => (
         <ProjectTeamRoleMultiselect
           id="role_id"
           name="role_id"
@@ -235,7 +233,7 @@ const ProjectTeamTable = ({
     {
       title: "Notes",
       field: "notes",
-      editComponent: props => {
+      editComponent: (props) => {
         const val = props.value ?? "";
         return (
           <TextField
@@ -244,7 +242,7 @@ const ProjectTeamTable = ({
             multiline
             inputProps={{ maxLength: 125 }}
             value={val && val !== "null" ? val : ""}
-            onChange={e => props.onChange(e.target.value)}
+            onChange={(e) => props.onChange(e.target.value)}
           />
         );
       },
@@ -255,71 +253,16 @@ const ProjectTeamTable = ({
    * Data handlers for editable actions based on isNewProject boolean <MaterialTable>
    */
   const isNewProjectActions = {
-    true: {
-      add: newData => {
-        let activePersonnel = { ...newData };
-        // Aggregate into a unique set if there is stuff already there
-        const newPersonnelState = personnelState.map(item => {
-          if (item.user_id === newData.user_id) {
-            const output = {
-              user_id: item.user_id,
-              role_id: [...new Set([...item.role_id, ...newData.role_id])],
-              notes: (item?.notes ?? "") + " " + (newData?.notes ?? ""),
-            };
-            activePersonnel = null;
-            return output;
-          } else {
-            return item;
-          }
-        });
-
-        return setPersonnelState(
-          [...newPersonnelState, activePersonnel].filter(item => item !== null)
-        );
-      },
-      update: (newData, oldData) => {
-        // Remove the existing user and overwrite
-        const newState = personnelState.filter(
-          item => item.user_id !== newData.user_id
-        );
-        return setPersonnelState([...newState, newData]);
-      },
-      delete: oldData => {
-        const newState = personnelState.filter(
-          item => item.user_id !== oldData.user_id
-        );
-        return setPersonnelState([...newState]);
-      },
-    },
     false: {
-      add: newData => {
-        // Our new data is unique, we will attempt upsert since
-        // we may have existing data in our table
-        const personnelData = newData.role_id.map((roleId, index) => {
-          return {
-            project_id: Number.parseInt(projectId),
-            user_id: newData.user_id,
-            role_id: roleId,
-            notes: index === 0 ? newData.notes : "",
-          };
-        });
-
-        // Upsert as usual
-        return upsertProjectPersonnel({
-          variables: {
-            objects: personnelData,
-          },
-        });
-      },
       update: (newData, oldData) => {
         // Creates a set of tuples that contain the user id and the role comprised by the new state
-        const newStateTuples = newData.role_id.map(role_id => [
+        const newStateTuples = newData.role_id.map((role_id) => [
           newData.user_id,
           role_id,
         ]);
 
         // Creates a set of tuples that contain the user id and role comprised by the old state
-        const oldStateTuples = oldData.role_id.map(role_id => [
+        const oldStateTuples = oldData.role_id.map((role_id) => [
           oldData.user_id,
           role_id,
         ]);
@@ -329,7 +272,7 @@ const ProjectTeamTable = ({
          * in the new state, these tuples are 'orphans' and need to be archived.
          */
         const orphanData = oldStateTuples.filter(
-          oldTuple => !tuplesContain(newStateTuples, oldTuple)
+          (oldTuple) => !tuplesContain(newStateTuples, oldTuple)
         );
 
         /**
@@ -351,7 +294,9 @@ const ProjectTeamTable = ({
               project_id: Number.parseInt(projectId),
               user_id: currentTuple[0],
               role_id: currentTuple[1],
-              is_deleted: tuplesContain(orphanData, currentTuple) ? true : false,
+              is_deleted: tuplesContain(orphanData, currentTuple)
+                ? true
+                : false,
               notes: index === 0 ? newData.notes : "",
             };
           }
@@ -363,7 +308,7 @@ const ProjectTeamTable = ({
           },
         });
       },
-      delete: oldData => {
+      delete: (oldData) => {
         // We will soft delete by marking as is_deleted = true
         const updatedPersonnelData = oldData.role_id.map((roleId, index) => {
           return {
@@ -390,10 +335,10 @@ const ProjectTeamTable = ({
       <MaterialTable
         columns={columns}
         components={{
-          EditRow: props => (
+          EditRow: (props) => (
             <MTableEditRow
               {...props}
-              onKeyDown={e => {
+              onKeyDown={(e) => {
                 if (e.keyCode === 13) {
                   // Bypass default MaterialTable behavior of submitting the entire form when a user hits enter
                   // See https://github.com/mbrn/material-table/pull/2008#issuecomment-662529834
@@ -401,7 +346,7 @@ const ProjectTeamTable = ({
               }}
             />
           ),
-          Action: props => {
+          Action: (props) => {
             // If isn't the add action
             if (
               typeof props.action === typeof Function ||
@@ -424,13 +369,7 @@ const ProjectTeamTable = ({
             }
           },
         }}
-        data={
-          isNewProject
-            ? personnelState
-            : Object.keys(personnel).map(item => {
-                return personnel[item];
-              })
-        }
+        data={Object.keys(personnel).map((item) => personnel[item])}
         title={
           <Typography variant="h2" color="primary">
             Project team
@@ -458,15 +397,30 @@ const ProjectTeamTable = ({
         }}
         icons={{ Delete: DeleteOutlineIcon, Edit: EditOutlinedIcon }}
         editable={{
-          onRowAdd: newData =>
-            isNewProjectActions[isNewProject]
-              .add(newData)
-              .then(() => refetch()),
+          onRowAdd: (newData) =>{
+            // Our new data is unique, we will attempt upsert since
+            // we may have existing data in our table
+            const personnelData = newData.role_id.map((roleId, index) => {
+              return {
+                project_id: Number.parseInt(projectId),
+                user_id: newData.user_id,
+                role_id: roleId,
+                notes: index === 0 ? newData.notes : "",
+              };
+            });
+
+            // Upsert as usual
+            return upsertProjectPersonnel({
+              variables: {
+                objects: personnelData,
+              },
+            }).then(()=>refetch());
+          },
           onRowUpdate: (newData, oldData) =>
             isNewProjectActions[isNewProject]
               .update(newData, oldData)
               .then(() => refetch()),
-          onRowDelete: oldData =>
+          onRowDelete: (oldData) =>
             isNewProjectActions[isNewProject]
               .delete(oldData)
               .then(() => refetch()),

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -184,7 +184,7 @@ const ProjectTeamTable = ({ projectId }) => {
             options={userIds}
             getOptionLabel={(option) => getPersonnelName(option)}
             getOptionSelected={(option, value) => option === value}
-            value={props.value}
+            value={props.value || null}
             onChange={(event, value) => props.onChange(value)}
             renderInput={(params) => <TextField {...params} />}
           />
@@ -316,9 +316,11 @@ const ProjectTeamTable = ({ projectId }) => {
         icons={{ Delete: DeleteOutlineIcon, Edit: EditOutlinedIcon }}
         editable={{
           onRowAdd: (newData) => {
+            console.log(newData.role_id)
             // Our new data is unique, we will attempt upsert since
             // we may have existing data in our table
             const personnelData = newData.role_id.map((roleId, index) => {
+              console.log(index, newData.notes)
               return {
                 project_id: Number.parseInt(projectId),
                 user_id: newData.user_id,


### PR DESCRIPTION
When I was working on the subprojects table issue, I looked at the Team Table as reference and noticed that it still had the functionality to handle adding a Team member when creating a new project. I cleaned up the unused functions. And then when testing these changes, I noticed that when a team member has more than one role in staging, the word null is rendered in the notes. So I also fixed that. 

in staging: 

![Screen Shot 2022-06-28 at 3 37 26 PM](https://user-images.githubusercontent.com/12474808/176283164-ae818093-5670-475c-b9ce-87528bfe0977.png)

## Associated issues

none

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

https://chia-person-table-cleanup--atd-moped-main.netlify.app/moped/projects/1815?tab=team


**Steps to test:**

Add some personnel, remove some personnel. No functionality should change (except the bug fix)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
