### PR TITLE
Only allow users who wrote statuses to edit them

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -64,6 +64,7 @@ export const SUMMARY_QUERY = gql`
         project_note_id
         project_note
         added_by
+        added_by_user_id
         date_created
       }
       moped_project_types(where: { is_deleted: { _eq: false } }) {

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -307,6 +307,8 @@ const ProjectComments = props => {
                    */
                   const editableComment =
                     userSessionData.user_id === item.added_by_user_id;
+                  console.log(userSessionData.user_id);
+                  console.log(item.added_by_user_id);
                   console.log(editableComment);
                   return (
                     <React.Fragment key={item.project_note_id}>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -20,7 +20,7 @@ import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/EditOutlined";
 
 import { makeStyles } from "@material-ui/core/styles";
-import { getSessionDatabaseData, getHighestRole, useUser } from "src/auth/user";
+import { getSessionDatabaseData, useUser } from "src/auth/user";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import parse from "html-react-parser";
@@ -88,7 +88,6 @@ const ProjectComments = props => {
   const isStatusEditModal = props.modal;
   let { projectId } = useParams();
   const { user } = useUser();
-  const userHighestRole = getHighestRole(user);
   const classes = useStyles();
   const userSessionData = getSessionDatabaseData();
   const [noteText, setNoteText] = useState("");
@@ -98,6 +97,8 @@ const ProjectComments = props => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
+
+  console.log(props);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params
@@ -304,9 +305,13 @@ const ProjectComments = props => {
               <List className={classes.root}>
                 {displayNotes.map((item, i) => {
                   const isNotLastItem = i < displayNotes.length - 1;
+                  {
+                    /**
+                     * Only allow the user who wrote the status to edit it
+                     */
+                  }
                   const editableComment =
-                    userSessionData.user_id === item.added_by_user_id ||
-                    userHighestRole === "moped-admin";
+                    userSessionData.user_id === item.added_by_user_id;
                   return (
                     <React.Fragment key={item.project_note_id}>
                       <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -87,7 +87,6 @@ const projectNoteTypes = ["", "Internal Note", "Status Update"];
 const ProjectComments = props => {
   const isStatusEditModal = props.modal;
   let { projectId } = useParams();
-  const { user } = useUser();
   const classes = useStyles();
   const userSessionData = getSessionDatabaseData();
   const [noteText, setNoteText] = useState("");
@@ -97,8 +96,6 @@ const ProjectComments = props => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
-
-  console.log(props);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -20,7 +20,7 @@ import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/EditOutlined";
 
 import { makeStyles } from "@material-ui/core/styles";
-import { getSessionDatabaseData, useUser } from "src/auth/user";
+import { getSessionDatabaseData } from "src/auth/user";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import parse from "html-react-parser";
@@ -302,11 +302,9 @@ const ProjectComments = props => {
               <List className={classes.root}>
                 {displayNotes.map((item, i) => {
                   const isNotLastItem = i < displayNotes.length - 1;
-                  {
-                    /**
-                     * Only allow the user who wrote the status to edit it
-                     */
-                  }
+                  /**
+                   * Only allow the user who wrote the status to edit it
+                   */
                   const editableComment =
                     userSessionData.user_id === item.added_by_user_id;
                   return (

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -307,9 +307,6 @@ const ProjectComments = props => {
                    */
                   const editableComment =
                     userSessionData.user_id === item.added_by_user_id;
-                  console.log(userSessionData.user_id);
-                  console.log(item.added_by_user_id);
-                  console.log(editableComment);
                   return (
                     <React.Fragment key={item.project_note_id}>
                       <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -307,6 +307,7 @@ const ProjectComments = props => {
                    */
                   const editableComment =
                     userSessionData.user_id === item.added_by_user_id;
+                  console.log(editableComment);
                   return (
                     <React.Fragment key={item.project_note_id}>
                       <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -96,8 +96,8 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
     // Retrieve a commentId or get a null
     const commentId = getStatusUpdate("project_note_id");
     const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
+    const userId = userSessionData.user_id
     const isStatusUpdateInsert = statusUpdateAddNew || !commentId;
-
     (isStatusUpdateInsert
       ? updateProjectStatusUpdateInsert
       : updateProjectStatusUpdateUpdate)({
@@ -107,6 +107,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
               statusUpdate: {
                 project_id: Number(projectId),
                 added_by: addedBy,
+                added_by_user_id: userId,
                 project_note: statusUpdate,
                 project_note_type: 2,
               },

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -98,6 +98,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
     const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
     const userId = userSessionData.user_id
     const isStatusUpdateInsert = statusUpdateAddNew || !commentId;
+
     (isStatusUpdateInsert
       ? updateProjectStatusUpdateInsert
       : updateProjectStatusUpdateUpdate)({

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -146,7 +146,8 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    */
   const editableComment =
     userSessionData.user_id === parseInt(getStatusUpdate("added_by_user_id"));
-
+  console.log(userSessionData.user_id);
+  console.log(parseInt(getStatusUpdate("added_by_user_id")));
   console.log(editableComment);
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -147,9 +147,6 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    */
   const editableComment =
     userSessionData.user_id === parseInt(getStatusUpdate("added_by_user_id"));
-  console.log(userSessionData.user_id);
-  console.log(parseInt(getStatusUpdate("added_by_user_id")));
-  console.log(editableComment);
 
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -141,6 +141,12 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
     setStatusUpdateAddNew(false);
   };
 
+  /**
+   * Only allow the user who wrote the status to edit it
+   */
+  const editableComment =
+    userSessionData.user_id === parseInt(getStatusUpdate("added_by_user_id"));
+
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Box display="flex" justifyContent="flex-start">
@@ -168,7 +174,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
             </Typography>
             <Typography
               className={classes.fieldBoxTypography}
-              onClick={handleStatusUpdateEdit}
+              onClick={editableComment ? handleStatusUpdateEdit : null}
             >
               <span className={classes.fieldLabelTextSpan}>
                 {statusUpdate || "None"}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -147,6 +147,8 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const editableComment =
     userSessionData.user_id === parseInt(getStatusUpdate("added_by_user_id"));
 
+  console.log(editableComment);
+
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Box display="flex" justifyContent="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -147,7 +147,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
    * Only allow the user who wrote the status to edit it
    */
   const editableComment =
-    userSessionData.user_id === parseInt(getStatusUpdate("added_by_user_id"));
+    userId === parseInt(getStatusUpdate("added_by_user_id"));
 
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -32,6 +32,8 @@ import { makeUSExpandedFormDateFromTimeStampTZ } from "../../../../utils/dateAnd
  */
 const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const userSessionData = getSessionDatabaseData();
+  const userId = userSessionData.user_id
+  const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
 
   const [updateProjectStatusUpdateInsert] = useMutation(
     PROJECT_SUMMARY_STATUS_UPDATE_INSERT
@@ -97,8 +99,6 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const handleStatusUpdateSave = () => {
     // Retrieve a commentId or get a null
     const commentId = getStatusUpdate("project_note_id");
-    const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
-    const userId = userSessionData.user_id
     const isStatusUpdateInsert = statusUpdateAddNew || !commentId;
 
     (isStatusUpdateInsert
@@ -148,7 +148,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   /**
    * Only allow the user who wrote the status to edit it
    */
-  const editableComment =
+  const isEditableComment =
     userId === parseInt(getStatusUpdate("added_by_user_id"));
 
   return (
@@ -178,7 +178,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
             </Typography>
             <Typography
               className={classes.fieldBoxTypography}
-              onClick={editableComment ? handleStatusUpdateEdit : null}
+              onClick={isEditableComment ? handleStatusUpdateEdit : null}
             >
               <span className={classes.fieldLabelTextSpan}>
                 {statusUpdate || "None"}


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/9472

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-700--atd-moped-main.netlify.app/

**Steps to test:**

go to a project with a status that was added by another user
attempt to edit the status on both the summary view and the comments page
you should not be able change the status, even if you are an admin

add a project status to an existing project
you should be able to edit the status in both the summary view and comments page

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
