### PR TITLE
Overrides react-map-gl-draw react dependency

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -94,5 +94,11 @@
   },
   "devDependencies": {
     "babel-plugin-import": "^1.13.5"
+  },
+  "overrides": {
+    "react-map-gl-draw": {
+      "react": "^17.0.2",
+      "react-dom": "^17.0.2"
+    }
   }
 }


### PR DESCRIPTION
As discussed [here](https://github.com/cityofaustin/atd-moped/pull/695#issue-1282937937) and [in slack](https://austininnovation.slack.com/archives/CHZE6BC6L/p1655417502246739?thread_ts=1655413287.536209&cid=CHZE6BC6L), the `react-map-gl-draw` package has an outdated react dependency (`v16`) - which requires that we force install that package.

This PR adds a dependency override ([docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides)) to allow us to run a clean, lock-free install of Moped as necessary.

We'll need to keep an eye on this override as it may become undesired/outdated in the future.

## Testing

This change has no effect on our installed packages and does not need to be UI tested. To see the effects:

1. Delete `package-lock.json` and `node_modules/`
2. `$ npm install`

Moped should install without error.



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
