### PR TITLE
Remove the phantom pencil when editing a project name

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -940,6 +940,17 @@ export const UPDATE_PROJECT_TASK_ORDER = gql`
   }
 `;
 
+export const UPDATE_PROJECT_NAME_QUERY = gql`
+  mutation UpdateProjectName($projectId: Int!, $projectName: String!) {
+    update_moped_project_by_pk(
+      pk_columns: { project_id: $projectId }
+      _set: { project_name: $projectName }
+    ) {
+      project_name
+    }
+  }
+`;
+
 export const LOOKUP_TABLES_QUERY = gql`
   query ProjectLookups {
     moped_fund_sources {

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -8,8 +8,9 @@ import {
   TextField,
   Typography,
 } from "@material-ui/core";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import { Alert } from "@material-ui/lab";
+import { UPDATE_PROJECT_NAME_QUERY } from "../../../queries/project"
 
 /**
  * GridTable Style
@@ -50,7 +51,6 @@ const ProjectNameEditable = props => {
   };
 
   const initialProjectName = props?.projectName;
-  const [showEditIcon, setShowEditIcon] = useState(false);
   const [projectName, setProjectName] = useState(initialProjectName);
   const [projectNameBeforeEdit, setProjectNameBeforeEdit] = useState(
     projectName
@@ -63,26 +63,7 @@ const ProjectNameEditable = props => {
     setIsEditing(true);
   }
 
-  const updateProjectNameQuery = gql`
-    mutation UpdateProjectName($projectId: Int!, $projectName: String!) {
-      update_moped_project(
-        where: { project_id: { _eq: $projectId } }
-        _set: { project_name: $projectName }
-      ) {
-        affected_rows
-      }
-    }
-  `;
-
-  const [updateProjectName] = useMutation(updateProjectNameQuery);
-
-  const handleMouseEnter = () => {
-    setShowEditIcon(true);
-  };
-
-  const handleMouseLeave = () => {
-    setShowEditIcon(false);
-  };
+  const [updateProjectName] = useMutation(UPDATE_PROJECT_NAME_QUERY);
 
   const handleProjectNameChange = e => {
     if (titleError) {
@@ -194,23 +175,14 @@ const ProjectNameEditable = props => {
           </Grid>
         </form>
       )}
-      {// if not Editing Project Name, show edit icon on mouse over of title
+      { // if not Editing Project Name, clicking on project title allows one to edit
       !isEditing && (
         <Typography
           color="textPrimary"
           variant="h1"
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onClick={() => setIsEditing(true)}
         >
           {projectName}
-          {showEditIcon && props?.editable && (
-            <Icon
-              className={classes.editIcon}
-              onClick={() => setIsEditing(true)}
-            >
-              create
-            </Icon>
-          )}
         </Typography>
       )}
       <Snackbar


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/8003


## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://8003-project-name--atd-moped-main.netlify.app/moped/projects/1773


**Steps to test:**

Hovering over a Project's title will no longer show the pencil icon. Instead, you can click the project title to begin editing the name. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
