### PR TITLE
Adds a secret view of moped phases and milestones

### DIFF
--- a/moped-editor/src/queries/timelineLookups.js
+++ b/moped-editor/src/queries/timelineLookups.js
@@ -1,0 +1,26 @@
+import { gql } from "@apollo/client";
+
+export const TIMELINE_LOOKUPS_QUERY = gql`
+  query TimelineQuery {
+    moped_phases(order_by: { phase_order: asc }) {
+      phase_id
+      phase_name
+      phase_description
+      phase_order
+      moped_subphases(order_by: { subphase_order: asc }) {
+        subphase_id
+        related_phase_id
+        subphase_description
+        subphase_name
+        subphase_order
+      }
+    }
+    moped_milestones {
+      milestone_id
+      milestone_name
+      milestone_description
+      milestone_order
+      related_phase_id
+    }
+  }
+`;

--- a/moped-editor/src/routes.js
+++ b/moped-editor/src/routes.js
@@ -14,6 +14,7 @@ import NewProjectView from "src/views/projects/newProjectView/NewProjectView";
 import ProjectView from "src/views/projects/projectView/ProjectView";
 import ProjectsListView from "./views/projects/projectsListView/ProjectsListView";
 import DeviasStyleView from "./views/dev/DeviasStyleView/DeviasStyleView";
+import LookupsView from "./views/dev/LookupsView";
 import SignalProjectTable from "src/views/projects/signalProjectTable/SignalProjectTable";
 import DashboardView from "./views/dashboard/DashboardView";
 
@@ -75,6 +76,11 @@ export const routes = [
         path: "dev/styles",
         action: "style:visit",
         element: <DeviasStyleView />,
+      },
+      {
+        path: "dev/lookups",
+        action: "style:visit",
+        element: <LookupsView />,
       },
       {
         path: "views/signal-projects",

--- a/moped-editor/src/views/dev/LookupsView/RecordTable.js
+++ b/moped-editor/src/views/dev/LookupsView/RecordTable.js
@@ -1,0 +1,46 @@
+import React from "react";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import { COLUMNS } from "./settings";
+
+const WrappedTableCell = ({ row, column: { key, handler } }) => {
+  return <TableCell>{handler ? handler(row[key]) : row[key]}</TableCell>;
+};
+
+export default function RecordTable({ rows, name }) {
+  const columns = COLUMNS[name];
+  return (
+    <TableContainer>
+      <Table aria-label="simple table" size="small">
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <TableCell key={column.key}>{column.label}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, i) => {
+            return (
+              <TableRow key={i}>
+                {columns.map((column) => {
+                  return (
+                    <WrappedTableCell
+                      row={row}
+                      column={column}
+                      key={column.key}
+                    />
+                  );
+                })}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/moped-editor/src/views/dev/LookupsView/RecordTable.js
+++ b/moped-editor/src/views/dev/LookupsView/RecordTable.js
@@ -5,17 +5,27 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import { COLUMNS } from "./settings";
 
+/**
+ * Custom table cell component which incoporates an optional handler to transform record values
+ * @param { Object } row - a single Moped record object as returned from Hasura
+ * @param { Object } column - a column definition object as defined in ./settings/SETTINGS
+ * @returns { JSX } an MUI TableCell component with the row/column value
+ */
 const WrappedTableCell = ({ row, column: { key, handler } }) => {
   return <TableCell>{handler ? handler(row[key]) : row[key]}</TableCell>;
 };
 
-export default function RecordTable({ rows, name }) {
-  const columns = COLUMNS[name];
+/**
+ * A generic table component that can display Moped records
+ * @param { Object[] } rows - an array of records to be rendered in the table
+ * @param { Object[] } columns - the column definitions as defined in the ./settings/SETTINGS object
+ * @returns { JSX } a table of record data
+ */
+export default function RecordTable({ rows, columns }) {
   return (
     <TableContainer>
-      <Table aria-label="simple table" size="small">
+      <Table aria-label="record table" size="small">
         <TableHead>
           <TableRow>
             {columns.map((column) => (

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -1,0 +1,61 @@
+import React from "react";
+import ApolloErrorHandler from "src/components/ApolloErrorHandler";
+import { useQuery } from "@apollo/client";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Container from "@material-ui/core/Container";
+import Grid from "@material-ui/core/Grid";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/styles";
+import Page from "src/components/Page";
+import RecordTable from "./RecordTable";
+import { TIMELINE_LOOKUPS_QUERY } from "src/queries/timelineLookups";
+import { NAMES } from "./settings";
+
+const useStyles = makeStyles((theme) => ({
+  topMargin: {
+    marginTop: theme.spacing(3),
+  },
+}));
+
+const LookupsView = () => {
+  const classes = useStyles();
+  const { loading, error, data } = useQuery(TIMELINE_LOOKUPS_QUERY, {
+    fetchPolicy: "no-cache",
+  });
+  const recordNames = data ? Object.keys(data) : null;
+  if (loading) return <CircularProgress />;
+
+  return (
+    <ApolloErrorHandler error={error}>
+      <Page title="Moped timeline entities">
+        <Container maxWidth="xl">
+          <Grid container spacing={3} className={classes.topMargin}>
+            <Grid item xs={12}>
+              <Typography variant="h1">Moped lookup values</Typography>
+            </Grid>
+          </Grid>
+          {recordNames &&
+            recordNames.map((name) => (
+              <Grid
+                container
+                spacing={3}
+                className={classes.topMargin}
+                component={Paper}
+                key={name}
+              >
+                <Grid item xs={12}>
+                  <Typography variant="h2">{NAMES[name]}</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <RecordTable rows={data[name]} name={name} />
+                </Grid>
+              </Grid>
+            ))}
+        </Container>
+      </Page>
+    </ApolloErrorHandler>
+  );
+};
+
+export default LookupsView;

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -10,7 +10,7 @@ import { makeStyles } from "@material-ui/styles";
 import Page from "src/components/Page";
 import RecordTable from "./RecordTable";
 import { TIMELINE_LOOKUPS_QUERY } from "src/queries/timelineLookups";
-import { NAMES } from "./settings";
+import { SETTINGS } from "./settings";
 
 const useStyles = makeStyles((theme) => ({
   topMargin: {
@@ -18,12 +18,19 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+/**
+ * Page component which renders various Moped record types.
+ * To add a table to this page:
+ * 1. Add an entry to the ./settings/SETTINGS array with the appropriate definitions
+ * 2. Update the query that powers this view to include your data
+ * @returns { JSX } a page component
+ */
 const LookupsView = () => {
   const classes = useStyles();
   const { loading, error, data } = useQuery(TIMELINE_LOOKUPS_QUERY, {
     fetchPolicy: "no-cache",
   });
-  const recordNames = data ? Object.keys(data) : null;
+
   if (loading) return <CircularProgress />;
 
   return (
@@ -35,23 +42,25 @@ const LookupsView = () => {
               <Typography variant="h1">Moped lookup values</Typography>
             </Grid>
           </Grid>
-          {recordNames &&
-            recordNames.map((name) => (
-              <Grid
-                container
-                spacing={3}
-                className={classes.topMargin}
-                component={Paper}
-                key={name}
-              >
-                <Grid item xs={12}>
-                  <Typography variant="h2">{NAMES[name]}</Typography>
-                </Grid>
-                <Grid item xs={12}>
-                  <RecordTable rows={data[name]} name={name} />
-                </Grid>
+          {SETTINGS.map((recordType) => (
+            <Grid
+              container
+              spacing={3}
+              className={classes.topMargin}
+              component={Paper}
+              key={recordType.key}
+            >
+              <Grid item xs={12}>
+                <Typography variant="h2">{recordType.label}</Typography>
               </Grid>
-            ))}
+              <Grid item xs={12}>
+                <RecordTable
+                  rows={data[recordType.key]}
+                  columns={recordType.columns}
+                />
+              </Grid>
+            </Grid>
+          ))}
         </Container>
       </Page>
     </ApolloErrorHandler>

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -35,7 +35,7 @@ const LookupsView = () => {
 
   return (
     <ApolloErrorHandler error={error}>
-      <Page title="Moped timeline entities">
+      <Page title="Moped lookup values">
         <Container maxWidth="xl">
           <Grid container spacing={3} className={classes.topMargin}>
             <Grid item xs={12}>

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -1,0 +1,64 @@
+const subPhaseHandler = (subphases) =>
+  subphases &&
+  subphases.map((subphase) => (
+    <div key={subphase.subphase_id}>{subphase.subphase_name}</div>
+  ));
+
+export const NAMES = {
+  moped_phases: "Moped phases",
+  moped_milestones: "Moped milestones",
+};
+
+export const COLUMNS = {
+  moped_phases: [
+    {
+      key: "phase_order",
+      label: "Phase order",
+    },
+    {
+      key: "phase_id",
+      label: "Phase ID",
+    },
+    {
+      key: "phase_name",
+      label: "Phase name",
+    },
+    {
+      key: "phase_description",
+      label: "Description",
+    },
+    {
+      key: "moped_subphases",
+      label: "Subphases",
+      handler: subPhaseHandler,
+    },
+  ],
+  moped_milestones: [
+    {
+      key: "milestone_id",
+      label: "Milestone ID",
+    },
+    {
+      key: "milestone_name",
+      label: "Milestone name",
+    },
+    {
+      key: "milestone_order",
+      label: "Milestone order",
+    },
+    {
+      key: "milestone_description",
+      label: "Description",
+    },
+  ],
+  moped_subphases: [
+    {
+      key: "subphase_name",
+      label: "Subphase name",
+    },
+    {
+      key: "subphase_description",
+      label: "Description",
+    },
+  ],
+};

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -1,64 +1,81 @@
+/**
+ * Parses an array of phase-subphases into an array of subphase names
+ * @param {Object[]} subphases - array of moped_subphases objects
+ * @returns { JSX } An array of <div>s with the subphase name
+ */
 const subPhaseHandler = (subphases) =>
   subphases &&
   subphases.map((subphase) => (
     <div key={subphase.subphase_id}>{subphase.subphase_name}</div>
   ));
 
-export const NAMES = {
-  moped_phases: "Moped phases",
-  moped_milestones: "Moped milestones",
-};
-
-export const COLUMNS = {
-  moped_phases: [
-    {
-      key: "phase_order",
-      label: "Phase order",
-    },
-    {
-      key: "phase_id",
-      label: "Phase ID",
-    },
-    {
-      key: "phase_name",
-      label: "Phase name",
-    },
-    {
-      key: "phase_description",
-      label: "Description",
-    },
-    {
-      key: "moped_subphases",
-      label: "Subphases",
-      handler: subPhaseHandler,
-    },
-  ],
-  moped_milestones: [
-    {
-      key: "milestone_id",
-      label: "Milestone ID",
-    },
-    {
-      key: "milestone_name",
-      label: "Milestone name",
-    },
-    {
-      key: "milestone_order",
-      label: "Milestone order",
-    },
-    {
-      key: "milestone_description",
-      label: "Description",
-    },
-  ],
-  moped_subphases: [
-    {
-      key: "subphase_name",
-      label: "Subphase name",
-    },
-    {
-      key: "subphase_description",
-      label: "Description",
-    },
-  ],
-};
+/**
+ * Definitions for data tables.
+ * @type { Object[]}  - An array of settings for data tables. Each object references a typename
+ * returned from a Hasura query
+ */
+export const SETTINGS = [
+  /**
+   * @type { Object } Settings for one data type
+   * @property { string } key - the Hasura object name
+   * @property { string } label - a humanized label for this object
+   * @property { Object[]} columns - an array of column definitions
+   */
+  {
+    key: "moped_phases",
+    label: "Moped phases",
+    columns: [
+      /**
+       * @type { Object } Column definition
+       * @property { string } key - the accessor that will be used to retrieve data from a table row
+       * object
+       * @property { string} label - a human-friendly label which will be used as a table column header
+       * @property { Function } [handler] - an optional transform function that receives any object and
+       * returns a string. You'll want to use this on complex data types.
+       */
+      {
+        key: "phase_order",
+        label: "Phase order",
+      },
+      {
+        key: "phase_id",
+        label: "Phase ID",
+      },
+      {
+        key: "phase_name",
+        label: "Phase name",
+      },
+      {
+        key: "phase_description",
+        label: "Description",
+      },
+      {
+        key: "moped_subphases",
+        label: "Subphases",
+        handler: subPhaseHandler,
+      },
+    ],
+  },
+  {
+    key: "moped_milestones",
+    label: "Moped milestones",
+    columns: [
+      {
+        key: "milestone_id",
+        label: "Milestone ID",
+      },
+      {
+        key: "milestone_name",
+        label: "Milestone name",
+      },
+      {
+        key: "milestone_order",
+        label: "Milestone order",
+      },
+      {
+        key: "milestone_description",
+        label: "Description",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Associated issues
Hoping to replace [this spreadsheet](https://docs.google.com/spreadsheets/d/13EbvdJNoZRCXQOJZJdrUqTUb2-o2puMXhiZN_94_go0/edit#gid=217441231) in service of https://github.com/cityofaustin/atd-data-tech/issues/9593.

 Depends on https://github.com/cityofaustin/atd-moped/pull/716.

## Testing
**URL to test:** Moped test or local.

**Steps to test:**
1. Navigate to `/moped/dev/lookups`
2. Tables with `moped_phases`and `moped_milestones` should render.

<img width="1121" alt="Screen Shot 2022-07-14 at 2 13 27 PM" src="https://user-images.githubusercontent.com/14793120/179053535-3ef33bdb-1d10-401d-8410-406f70d8d239.png">

<img width="1135" alt="Screen Shot 2022-07-14 at 2 13 35 PM" src="https://user-images.githubusercontent.com/14793120/179053497-79788bae-09af-41c1-997f-40aa5614ed1a.png">

---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
