### PR TITLE
Show inactive users in activity log and team table

### DIFF
--- a/moped-editor/src/components/CDN/Avatar.js
+++ b/moped-editor/src/components/CDN/Avatar.js
@@ -60,7 +60,7 @@ const CDNAvatar = ({
       src={imageSource}
       style={imageStyleOverride}
     >
-      {!!!useGenericAvatar && initials && initials.length > 0 ? (
+      {useGenericAvatar && initials && initials.length > 0 ? (
         <Typography className={largeInitials ? classes.userInitials : null}>
           {initials}
         </Typography>

--- a/moped-editor/src/components/CDN/Avatar.js
+++ b/moped-editor/src/components/CDN/Avatar.js
@@ -60,7 +60,7 @@ const CDNAvatar = ({
       src={imageSource}
       style={imageStyleOverride}
     >
-      {useGenericAvatar && initials && initials.length > 0 ? (
+      {!!!useGenericAvatar && initials && initials.length > 0 ? (
         <Typography className={largeInitials ? classes.userInitials : null}>
           {initials}
         </Typography>

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -24,6 +24,7 @@ import { getSessionDatabaseData, useUser } from "../../auth/user";
 import emailToInitials from "../../utils/emailToInitials";
 import CDNAvatar from "../../components/CDN/Avatar";
 import NavLink from "src/components/NavLink";
+import { getInitials } from "src/utils/userNames";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -97,7 +98,7 @@ const TopBar = ({ className, ...rest }) => {
 
   const userDbData = getSessionDatabaseData();
   const userInitials = userDbData
-    ? userDbData.first_name[0] + userDbData.last_name[0]
+    ? getInitials(userDbData)
     : emailToInitials(user?.idToken?.payload?.email);
 
   return (

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -154,7 +154,7 @@ export const TYPES_QUERY = gql`
 export const TEAM_QUERY = gql`
   query TeamSummary($projectId: Int) {
     moped_proj_personnel(
-      where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
+      where: { project_id: { _eq: $projectId } }
     ) {
       user_id
       role_id
@@ -163,6 +163,7 @@ export const TEAM_QUERY = gql`
       project_personnel_id
       date_added
       added_by
+      is_deleted
       moped_user {
         first_name
         last_name
@@ -433,7 +434,7 @@ export const PROJECT_ACTIVITY_LOG = gql`
         user_id
       }
     }
-    moped_users(where: { is_deleted: { _eq: false } }) {
+    moped_users {
       first_name
       last_name
       user_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -184,7 +184,6 @@ export const TEAM_QUERY = gql`
     }
     moped_users(
       order_by: { last_name: asc }
-      where: { is_deleted: { _eq: false } }
     ) {
       first_name
       last_name
@@ -436,7 +435,7 @@ export const PROJECT_ACTIVITY_LOG = gql`
         user_id
       }
     }
-    moped_users(where: { is_deleted: { _eq: false } }) {
+    moped_users {
       first_name
       last_name
       user_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -169,6 +169,7 @@ export const TEAM_QUERY = gql`
         last_name
         workgroup_id
         user_id
+        is_deleted
       }
     }
     moped_workgroup {
@@ -183,11 +184,12 @@ export const TEAM_QUERY = gql`
       project_role_name
       project_role_description
     }
-    moped_users(order_by: { last_name: asc }) {
+    moped_users( order_by: { last_name: asc } ) {
       first_name
       last_name
       workgroup_id
       user_id
+      is_deleted
     }
   }
 `;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -182,9 +182,7 @@ export const TEAM_QUERY = gql`
       project_role_name
       project_role_description
     }
-    moped_users(
-      order_by: { last_name: asc }
-    ) {
+    moped_users(order_by: { last_name: asc }) {
       first_name
       last_name
       workgroup_id
@@ -435,7 +433,7 @@ export const PROJECT_ACTIVITY_LOG = gql`
         user_id
       }
     }
-    moped_users {
+    moped_users(where: { is_deleted: { _eq: false } }) {
       first_name
       last_name
       user_id

--- a/moped-editor/src/utils/getInitials.js
+++ b/moped-editor/src/utils/getInitials.js
@@ -1,7 +1,0 @@
-export default (name = "") =>
-  name
-    .replace(/\s+/, " ")
-    .split(" ")
-    .slice(0, 2)
-    .map(v => v && v[0].toUpperCase())
-    .join("");

--- a/moped-editor/src/utils/test/userNames.test.js
+++ b/moped-editor/src/utils/test/userNames.test.js
@@ -24,23 +24,51 @@ const invalidUserObject = {
 describe("getFullUserName()", () => {
   it("returns a full name string from a user object", () => {
     const fullNameFromHasura = getUserFullName(userObjectFromHasura);
-    const fullNameFromLocalStorage = getUserFullName(atdMopedUserDbData);
-    const fullNameFromInvalidUserObject = getUserFullName(invalidUserObject);
 
     expect(fullNameFromHasura).toBe("Fozzie Bear");
+  });
+
+  it("returns a full name string from a Local Storage object", () => {
+    const fullNameFromLocalStorage = getUserFullName(atdMopedUserDbData);
+
     expect(fullNameFromLocalStorage).toBe("Bunsen Honeydew");
+  });
+
+  it("returns a fallback string from an invalid object", () => {
+    const fullNameFromInvalidUserObject = getUserFullName(invalidUserObject);
+
     expect(fullNameFromInvalidUserObject).toBe(unknownUserNameValue);
+  });
+
+  it("returns a fallback string from null", () => {
+    const fullNameFromNull = getUserFullName(null);
+
+    expect(fullNameFromNull).toBe(unknownUserNameValue);
   });
 });
 
 describe("getInitials()", () => {
   it("returns initials from a user object", () => {
     const initialsFromHasura = getInitials(userObjectFromHasura);
-    const initialsFromLocalStorage = getInitials(atdMopedUserDbData);
-    const initialsFromInvalidUserObject = getInitials(invalidUserObject);
 
     expect(initialsFromHasura).toBe("FB");
+  });
+
+  it("returns initials from a user object", () => {
+    const initialsFromLocalStorage = getInitials(atdMopedUserDbData);
+
     expect(initialsFromLocalStorage).toBe("BH");
+  });
+
+  it("returns initials from a user object", () => {
+    const initialsFromInvalidUserObject = getInitials(invalidUserObject);
+
     expect(initialsFromInvalidUserObject).toBe(null);
+  });
+
+  it("returns initials from a user object", () => {
+    const initialsFromNull = getInitials(null);
+
+    expect(initialsFromNull).toBe(null);
   });
 });

--- a/moped-editor/src/utils/test/userNames.test.js
+++ b/moped-editor/src/utils/test/userNames.test.js
@@ -1,0 +1,46 @@
+import {
+  unknownUserNameValue,
+  getUserFullName,
+  getInitials,
+} from "../userNames";
+
+// Some places where user names are stored
+const userObjectFromHasura = {
+  first_name: "Fozzie",
+  last_name: "Bear",
+};
+
+// This comes from Local Storage
+const atdMopedUserDbData = {
+  first_name: "Bunsen",
+  last_name: "Honeydew",
+};
+
+const invalidUserObject = {
+  first_name: null,
+  last_name: null,
+};
+
+describe("getFullUserName()", () => {
+  it("returns a full name string from a user object", () => {
+    const fullNameFromHasura = getUserFullName(userObjectFromHasura);
+    const fullNameFromLocalStorage = getUserFullName(atdMopedUserDbData);
+    const fullNameFromInvalidUserObject = getUserFullName(invalidUserObject);
+
+    expect(fullNameFromHasura).toBe("Fozzie Bear");
+    expect(fullNameFromLocalStorage).toBe("Bunsen Honeydew");
+    expect(fullNameFromInvalidUserObject).toBe(unknownUserNameValue);
+  });
+});
+
+describe("getInitials()", () => {
+  it("returns initials from a user object", () => {
+    const initialsFromHasura = getInitials(userObjectFromHasura);
+    const initialsFromLocalStorage = getInitials(atdMopedUserDbData);
+    const initialsFromInvalidUserObject = getInitials(invalidUserObject);
+
+    expect(initialsFromHasura).toBe("FB");
+    expect(initialsFromLocalStorage).toBe("BH");
+    expect(initialsFromInvalidUserObject).toBe(null);
+  });
+});

--- a/moped-editor/src/utils/test/userNames.test.js
+++ b/moped-editor/src/utils/test/userNames.test.js
@@ -40,6 +40,12 @@ describe("getFullUserName()", () => {
     expect(fullNameFromInvalidUserObject).toBe(unknownUserNameValue);
   });
 
+  it("returns a fallback string from an object without name keys", () => {
+    const fullNameFromEmptyObject = getUserFullName({});
+
+    expect(fullNameFromEmptyObject).toBe(unknownUserNameValue);
+  });
+
   it("returns a fallback string from null", () => {
     const fullNameFromNull = getUserFullName(null);
 
@@ -54,19 +60,25 @@ describe("getInitials()", () => {
     expect(initialsFromHasura).toBe("FB");
   });
 
-  it("returns initials from a user object", () => {
+  it("returns initials from a Local Storage object", () => {
     const initialsFromLocalStorage = getInitials(atdMopedUserDbData);
 
     expect(initialsFromLocalStorage).toBe("BH");
   });
 
-  it("returns initials from a user object", () => {
+  it("returns null from an invalid object", () => {
     const initialsFromInvalidUserObject = getInitials(invalidUserObject);
 
     expect(initialsFromInvalidUserObject).toBe(null);
   });
 
-  it("returns initials from a user object", () => {
+  it("returns null from an object without name keys", () => {
+    const initialsFromEmptyObject = getInitials({});
+
+    expect(initialsFromEmptyObject).toBe(null);
+  });
+
+  it("returns null from null", () => {
     const initialsFromNull = getInitials(null);
 
     expect(initialsFromNull).toBe(null);

--- a/moped-editor/src/utils/userNames.js
+++ b/moped-editor/src/utils/userNames.js
@@ -1,0 +1,46 @@
+// export const getInitials = (name = "") =>
+//   name
+//     .replace(/\s+/, " ")
+//     .split(" ")
+//     .slice(0, 2)
+//     .map(v => v && v[0].toUpperCase())
+//     .join("");
+// Fallback value for user without name set
+const unknownUserNameValue = "Unknown User";
+
+/**
+ * Retrieve the user's full name or return an "N/A"
+ * @param {object} moped_user - The user object as provided by hasura
+ * @return {string}
+ */
+export const getUserFullName = moped_user => {
+  const firstName = moped_user?.first_name ?? "";
+  const lastName = moped_user?.last_name ?? "";
+  if (firstName.length === 0 && firstName.length === 0)
+    return unknownUserNameValue;
+  return `${firstName} ${lastName}`;
+};
+
+/**
+ * Safely returns the initials from a full name
+ * @param {object} moped_user - The full name of the user
+ * @return {string}
+ */
+export const getInitials = moped_user => {
+  // Get any names if available
+  const name = getUserFullName(moped_user).trim();
+
+  // If no names are available, return null to force the generic humanoid avatar
+  if (name.length === 0 || name === unknownUserNameValue) return null;
+
+  // Else, extract initials
+  return name
+    .replace(/[^A-Za-z0-9À-ÿ ]/gi, "")
+    .replace(/ +/gi, " ")
+    .split(/ /)
+    .reduce((acc, item) => acc + item[0], "")
+    .concat(name.substr(1))
+    .concat(name)
+    .substr(0, 2)
+    .toUpperCase();
+};

--- a/moped-editor/src/utils/userNames.js
+++ b/moped-editor/src/utils/userNames.js
@@ -28,19 +28,9 @@ export const getUserFullName = moped_user => {
  */
 export const getInitials = moped_user => {
   // Get any names if available
-  const name = getUserFullName(moped_user).trim();
+  const firstInitial = moped_user?.first_name[0];
+  const lastInitial = moped_user?.last_name[0];
+  const initials = `${firstInitial}${lastInitial}`;
 
-  // If no names are available, return null to force the generic humanoid avatar
-  if (name.length === 0 || name === unknownUserNameValue) return null;
-
-  // Else, extract initials
-  return name
-    .replace(/[^A-Za-z0-9À-ÿ ]/gi, "")
-    .replace(/ +/gi, " ")
-    .split(/ /)
-    .reduce((acc, item) => acc + item[0], "")
-    .concat(name.substr(1))
-    .concat(name)
-    .substr(0, 2)
-    .toUpperCase();
+  return firstInitial && lastInitial ? initials : null;
 };

--- a/moped-editor/src/utils/userNames.js
+++ b/moped-editor/src/utils/userNames.js
@@ -1,12 +1,5 @@
-// export const getInitials = (name = "") =>
-//   name
-//     .replace(/\s+/, " ")
-//     .split(" ")
-//     .slice(0, 2)
-//     .map(v => v && v[0].toUpperCase())
-//     .join("");
 // Fallback value for user without name set
-const unknownUserNameValue = "Unknown User";
+export const unknownUserNameValue = "Unknown User";
 
 /**
  * Retrieve the user's full name or return an "N/A"
@@ -28,8 +21,8 @@ export const getUserFullName = moped_user => {
  */
 export const getInitials = moped_user => {
   // Get any names if available
-  const firstInitial = moped_user?.first_name[0];
-  const lastInitial = moped_user?.last_name[0];
+  const firstInitial = moped_user?.first_name?.[0];
+  const lastInitial = moped_user?.last_name?.[0];
   const initials = `${firstInitial}${lastInitial}`;
 
   return firstInitial && lastInitial ? initials : null;

--- a/moped-editor/src/utils/userNames.js
+++ b/moped-editor/src/utils/userNames.js
@@ -2,25 +2,26 @@
 export const unknownUserNameValue = "Unknown User";
 
 /**
- * Retrieve the user's full name or return an "N/A"
- * @param {object} moped_user - The user object as provided by hasura
+ * Retrieve the user's full name or return a fallback value
+ * @param {object} moped_user - The user object from Hasura or Local Storage
  * @return {string}
  */
 export const getUserFullName = moped_user => {
   const firstName = moped_user?.first_name ?? "";
   const lastName = moped_user?.last_name ?? "";
+
   if (firstName.length === 0 && firstName.length === 0)
     return unknownUserNameValue;
+
   return `${firstName} ${lastName}`;
 };
 
 /**
- * Safely returns the initials from a full name
- * @param {object} moped_user - The full name of the user
+ * Safely returns the initials from a user object
+ * @param {object} moped_user - The user object from Hasura or Local Storage
  * @return {string}
  */
 export const getInitials = moped_user => {
-  // Get any names if available
   const firstInitial = moped_user?.first_name?.[0];
   const lastInitial = moped_user?.last_name?.[0];
   const initials = `${firstInitial}${lastInitial}`;

--- a/moped-editor/src/views/account/AccountView/Profile.js
+++ b/moped-editor/src/views/account/AccountView/Profile.js
@@ -21,6 +21,7 @@ import {
   useUser,
 } from "../../../auth/user";
 import emailToInitials from "../../../utils/emailToInitials";
+import { getInitials } from "src/utils/userNames";
 import AddAPhotoIcon from "@material-ui/icons/AddAPhoto";
 import FileUploadDialogSimple from "../../../components/FileUpload/FileUploadDialogSimple";
 
@@ -212,9 +213,7 @@ const Profile = ({ className, ...rest }) => {
               <Box>
                 <CDNAvatar
                   src={userProfile?.picture ?? null}
-                  initials={
-                    userProfile["first_name"][0] + userProfile["last_name"][0]
-                  }
+                  initials={getInitials(userProfile)}
                   largeInitials={true}
                 />
               </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -39,6 +39,7 @@ import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 import CDNAvatar from "../../../components/CDN/Avatar";
 import typography from "src/theme/typography";
 import { formatTimeStampTZType } from "src/utils/dateAndTime";
+import { getUserFullName, getInitials } from "../../../utils/userNames";
 
 const useStyles = makeStyles(theme => ({
   table: {
@@ -72,7 +73,6 @@ const ProjectActivityLog = () => {
   const classes = useStyles();
   const userList = {};
   const phaseList = {};
-  const unknownUserNameValue = "Unknown User";
 
   const {
     getLookups,
@@ -103,43 +103,6 @@ const ProjectActivityLog = () => {
   };
 
   if (loading || lookupLoading) return <CircularProgress />;
-
-  /**
-   * Retrieve the user's full name or return an "N/A"
-   * @param {object} moped_user - The user object as provided by hasura
-   * @return {string}
-   */
-  const getUserFullName = moped_user => {
-    const firstName = moped_user?.first_name ?? "";
-    const lastName = moped_user?.last_name ?? "";
-    if (firstName.length === 0 && firstName.length === 0)
-      return unknownUserNameValue;
-    return `${firstName} ${lastName}`;
-  };
-
-  /**
-   * Safely returns the initials from a full name
-   * @param {object} moped_user - The full name of the user
-   * @return {string}
-   */
-  const getInitials = moped_user => {
-    // Get any names if available
-    const name = getUserFullName(moped_user).trim();
-
-    // If no names are available, return null to force the generic humanoid avatar
-    if (name.length === 0 || name === unknownUserNameValue) return null;
-
-    // Else, extract initials
-    return name
-      .replace(/[^A-Za-z0-9À-ÿ ]/gi, "")
-      .replace(/ +/gi, " ")
-      .split(/ /)
-      .reduce((acc, item) => acc + item[0], "")
-      .concat(name.substr(1))
-      .concat(name)
-      .substr(0, 2)
-      .toUpperCase();
-  };
 
   /**
    * Attempt to get the number of items we retrieved
@@ -292,7 +255,13 @@ const ProjectActivityLog = () => {
                                     item
                                     className={classes.tableChangeItem}
                                   >
-                                    <b>{getCreationLabel(change, userList, phaseList)}</b>
+                                    <b>
+                                      {getCreationLabel(
+                                        change,
+                                        userList,
+                                        phaseList
+                                      )}
+                                    </b>
                                   </Grid>
                                 )}
                               {change.description.map(changeItem => {

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -146,7 +146,7 @@ const ProjectActivityLog = () => {
 
   if (data) {
     data["moped_users"].forEach(user => {
-      userList[`${user.user_id}`] = `${user.first_name} ${user.last_name}`;
+      userList[`${user.user_id}`] = getUserFullName(user);
     });
     data["moped_phases"].forEach(phase => {
       phaseList[`${phase.phase_id}`] = phase.phase_name;

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogDialog.js
@@ -34,6 +34,7 @@ import {
   formatTimeStampTZType,
   makeFullTimeFromTimeStampTZ,
 } from "src/utils/dateAndTime";
+import { getUserFullName } from "src/utils/userNames";
 
 const useStyles = makeStyles(theme => ({
   appBar: {
@@ -100,11 +101,8 @@ const ProjectActivityLogDialog = ({ activity_id, handleClose }) => {
 
   const getUser = data => {
     try {
-      return (
-        data.moped_activity_log[0].moped_user.first_name +
-        " " +
-        data.moped_activity_log[0].moped_user.last_name
-      );
+      const moped_user = data.moped_activity_log[0].moped_user
+      return getUserFullName(moped_user);
     } catch {
       return null;
     }

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -40,6 +40,7 @@ import {
   makeHourAndMinutesFromTimeStampTZ,
   makeUSExpandedFormDateFromTimeStampTZ,
 } from "src/utils/dateAndTime";
+import { getUserFullName } from "src/utils/userNames";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -167,7 +168,7 @@ const ProjectComments = props => {
       variables: {
         objects: [
           {
-            added_by: `${userSessionData.first_name} ${userSessionData.last_name}`,
+            added_by: getUserFullName(userSessionData),
             project_note: DOMPurify.sanitize(noteText),
             project_id: projectId,
             added_by_user_id: Number(userSessionData.user_id),

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -20,6 +20,7 @@ import {
 
 import { getSessionDatabaseData } from "../../../../auth/user";
 import { makeUSExpandedFormDateFromTimeStampTZ } from "../../../../utils/dateAndTime";
+import { getUserFullName } from "src/utils/userNames";
 
 /**
  * ProjectSummaryStatusUpdate Component
@@ -33,7 +34,7 @@ import { makeUSExpandedFormDateFromTimeStampTZ } from "../../../../utils/dateAnd
 const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const userSessionData = getSessionDatabaseData();
   const userId = userSessionData.user_id
-  const addedBy = `${userSessionData.first_name} ${userSessionData.last_name}`;
+  const addedBy = getUserFullName(userSessionData);
 
   const [updateProjectStatusUpdateInsert] = useMutation(
     PROJECT_SUMMARY_STATUS_UPDATE_INSERT

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -45,8 +45,8 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   inactiveUserText: {
-    fontStyle: "italic"
-  }
+    fontStyle: "italic",
+  },
 }));
 
 const ProjectTeamTable = ({ projectId }) => {
@@ -77,35 +77,51 @@ const ProjectTeamTable = ({ projectId }) => {
 
   const availableUsers = data.moped_users;
 
-  // Get data from the team query payload
-  let personnel = {};
+  const makeListOfActivePersonnel = (personnelArray) => {
+    // 1. Multiple roles per user comes from multiple rows in the proj_personnel table
+    // so we have to dedupe project personnel and aggregate the roles to appear
+    // as multiple roles per personnel row in the UI
+    // 2. Similarly, personnel notes are concatenated into one string to show in the UI
+    // 3. Soft deleted personnel are filtered
+    let personnel = {};
 
-  // For each personnel entry...
-  data.moped_proj_personnel.map((item) => {
-    // If the item does not exist in the aggregated object
-    if (!personnel.hasOwnProperty(item.user_id)) {
-      // instantiate a new object & populate
-      personnel[`${item.user_id}`] = {
-        user_id: item.user_id,
-        role_id: [item.role_id],
-        notes: item.notes,
-        project_personnel_id: item.project_personnel_id,
-        is_deleted: item.moped_user.is_deleted
-      };
-    } else {
-      // Aggregate role_ids, and notes.
-      personnel[`${item.user_id}`].role_id.push(item.role_id);
-      personnel[`${item.user_id}`].notes = (
-        (personnel[`${item.user_id}`].notes ?? "") +
-        " " +
-        item.notes
-      ).trim();
-      personnel[`${item.user_id}`].project_personnel_id =
-        item.project_personnel_id;
-    }
+    // For each personnel entry...
+    personnelArray.forEach((item) => {
+      // If the item does not exist in the aggregated object
+      if (!personnel.hasOwnProperty(item.user_id)) {
+        // instantiate a new object & populate
+        personnel[`${item.user_id}`] = {
+          user_id: item.user_id,
+          role_id: [item.role_id],
+          notes: item.notes,
+          project_personnel_id: item.project_personnel_id,
+          is_moped_user_deleted: item.moped_user.is_deleted,
+          is_deleted: item.is_deleted,
+        };
+      } else {
+        // Aggregate role_ids, and notes.
+        personnel[`${item.user_id}`].role_id.push(item.role_id);
+        personnel[`${item.user_id}`].notes = (
+          (personnel[`${item.user_id}`].notes ?? "") +
+          " " +
+          item.notes
+        ).trim();
+        personnel[`${item.user_id}`].project_personnel_id =
+          item.project_personnel_id;
+      }
+    });
 
-    return null; // No need to return anything...
-  });
+    const personnelTableList = Object.keys(personnel).map(
+      (item) => personnel[item]
+    );
+
+    // Filter soft deleted project personnel
+    const activePersonnelList = personnelTableList.filter(
+      (personnel) => personnel.is_deleted === false
+    );
+
+    return activePersonnelList;
+  };
 
   // Create some objects for lookups
   const workgroups = data.moped_workgroup.reduce(
@@ -133,8 +149,8 @@ const ProjectTeamTable = ({ projectId }) => {
 
   // Options for Autocomplete form elements filtered to active users
   const userIds = availableUsers
-    .filter(user => user.is_deleted === false)
-    .map(user => user.user_id);
+    .filter((user) => user.is_deleted === false)
+    .map((user) => user.user_id);
 
   /**
    * Get a user object from the users array
@@ -181,10 +197,10 @@ const ProjectTeamTable = ({ projectId }) => {
     {
       title: "Name",
       field: "user_id",
-      render: personnel => {
-        const { is_deleted } = personnel;
+      render: (personnel) => {
+        const { is_moped_user_deleted } = personnel;
 
-        return is_deleted ? (
+        return is_moped_user_deleted ? (
           <Typography className={classes.inactiveUserText}>{`${getPersonnelName(
             personnel.user_id
           )} - Inactive`}</Typography>
@@ -305,7 +321,7 @@ const ProjectTeamTable = ({ projectId }) => {
             }
           },
         }}
-        data={Object.keys(personnel).map((item) => personnel[item])}
+        data={makeListOfActivePersonnel(data.moped_proj_personnel)}
         title={
           <Typography variant="h2" color="primary">
             Project team

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -33,6 +33,7 @@ import { TEAM_QUERY, UPSERT_PROJECT_PERSONNEL } from "../../../queries/project";
 
 import ProjectTeamRoleMultiselect from "./ProjectTeamRoleMultiselect";
 import makeStyles from "@material-ui/core/styles/makeStyles";
+import { getUserFullName } from "src/utils/userNames";
 
 const useStyles = makeStyles((theme) => ({
   infoIcon: {
@@ -144,7 +145,7 @@ const ProjectTeamTable = ({ projectId }) => {
    */
   const getPersonnelName = (id) => {
     const user = getUserById(id);
-    return `${user?.first_name ?? "Unknown"} ${user?.last_name ?? "User"}`;
+    return getUserFullName(user);
   };
 
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -44,6 +44,9 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.primary.main,
     },
   },
+  inactiveUserText: {
+    fontStyle: "italic"
+  }
 }));
 
 const ProjectTeamTable = ({ projectId }) => {
@@ -72,6 +75,7 @@ const ProjectTeamTable = ({ projectId }) => {
         currentTuple[0] === tupleItem[0] && currentTuple[1] === tupleItem[1]
     );
 
+  // Contains both active and inactive users
   const availableUsers = data.moped_users;
 
   // Get data from the team query payload
@@ -87,6 +91,7 @@ const ProjectTeamTable = ({ projectId }) => {
         role_id: [item.role_id],
         notes: item.notes,
         project_personnel_id: item.project_personnel_id,
+        is_deleted: item.is_deleted
       };
     } else {
       // Aggregate role_ids, and notes.
@@ -127,8 +132,10 @@ const ProjectTeamTable = ({ projectId }) => {
     {}
   );
 
-  // Options for Autocomplete form elements
-  const userIds = availableUsers.map((user) => user.user_id);
+  // Options for Autocomplete form elements filtered to active users only
+  const userIds = availableUsers
+    .filter(user => user.is_deleted === true)
+    .map(user => user.user_id);
 
   /**
    * Get a user object from the users array
@@ -175,7 +182,17 @@ const ProjectTeamTable = ({ projectId }) => {
     {
       title: "Name",
       field: "user_id",
-      render: (personnel) => getPersonnelName(personnel.user_id),
+      render: personnel => {
+        const { is_deleted } = personnel;
+
+        return is_deleted ? (
+          <Typography className={classes.inactiveUserText}>{`${getPersonnelName(
+            personnel.user_id
+          )} - Inactive`}</Typography>
+        ) : (
+          <Typography>{getPersonnelName(personnel.user_id)}</Typography>
+        );
+      },
       validate: (rowData) => !!rowData.user_id,
       editComponent: (props) => (
         <FormControl style={{ width: "100%" }}>

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -184,7 +184,6 @@ const ProjectTeamTable = ({ projectId }) => {
       field: "user_id",
       render: personnel => {
         const { is_deleted } = personnel;
-        console.log(personnel)
 
         return is_deleted ? (
           <Typography className={classes.inactiveUserText}>{`${getPersonnelName(

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -131,10 +131,9 @@ const ProjectTeamTable = ({ projectId }) => {
     {}
   );
 
-  // Options for Autocomplete form elements
+  // Options for Autocomplete form elements filtered to active users
   const userIds = availableUsers
-    .filter(user => { 
-      return user.is_deleted === false})
+    .filter(user => user.is_deleted === false)
     .map(user => user.user_id);
 
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -75,7 +75,6 @@ const ProjectTeamTable = ({ projectId }) => {
         currentTuple[0] === tupleItem[0] && currentTuple[1] === tupleItem[1]
     );
 
-  // Contains both active and inactive users
   const availableUsers = data.moped_users;
 
   // Get data from the team query payload
@@ -91,7 +90,7 @@ const ProjectTeamTable = ({ projectId }) => {
         role_id: [item.role_id],
         notes: item.notes,
         project_personnel_id: item.project_personnel_id,
-        is_deleted: item.is_deleted
+        is_deleted: item.moped_user.is_deleted
       };
     } else {
       // Aggregate role_ids, and notes.
@@ -132,9 +131,10 @@ const ProjectTeamTable = ({ projectId }) => {
     {}
   );
 
-  // Options for Autocomplete form elements filtered to active users only
+  // Options for Autocomplete form elements
   const userIds = availableUsers
-    .filter(user => user.is_deleted === true)
+    .filter(user => { 
+      return user.is_deleted === false})
     .map(user => user.user_id);
 
   /**
@@ -184,6 +184,7 @@ const ProjectTeamTable = ({ projectId }) => {
       field: "user_id",
       render: personnel => {
         const { is_deleted } = personnel;
+        console.log(personnel)
 
         return is_deleted ? (
           <Typography className={classes.inactiveUserText}>{`${getPersonnelName(

--- a/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
+++ b/moped-editor/src/views/projects/signalProjectTable/SignalProjectTable.js
@@ -37,6 +37,7 @@ import { PAGING_DEFAULT_COUNT } from "../../../constants/tables";
 import RenderFieldLink from "./RenderFieldLink";
 import RenderSignalLink from "./RenderSignalLink";
 import TaskOrderAutocomplete from "./TaskOrderAutocomplete";
+import { getUserFullName } from "src/utils/userNames";
 
 const useStyles = makeStyles({
   tableTypography: {
@@ -174,12 +175,12 @@ const SignalProjectTable = () => {
       project.moped_proj_personnel.forEach(personnel => {
         if (isDesigner(personnel)) {
           designers.push(
-            `${personnel?.moped_user?.first_name} ${personnel?.moped_user?.last_name}`
+            getUserFullName(personnel)
           );
         }
         if (isInspector(personnel)) {
           inspectors.push(
-            `${personnel?.moped_user?.first_name} ${personnel?.moped_user?.last_name}`
+            getUserFullName(personnel)
           );
         }
       });


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9673

This PR fixes a bug where inactivated users were showing as "Unknown User" in the team table and the activity log. The "Unknown User" came from two separate components and was implemented in two different ways so I pulled out some helpers to align how we are getting user full names and initials from the Hasura response or Local Storage and added some tests.

Let me know if some of these changes are not a good path forward. I think the two helpers cover our bases but I could also be looking at it naively. 🙏 

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-721--atd-moped-main.netlify.app/moped/projects/1859?tab=summary

**Steps to test:**

_The user in these steps is actually a soft deleted user account record with first name of **Inactive** and last name **User**. I just realized this is a little confusing since we have fallback text that says **Unknown User**_

1. Go to the above link and look at the **Team** tab
2. You will see me and "Inactive User" in the table - "Inactive User" is soft deleted and should be italicized and have " - Inactive" on the end
3. Make sure that you cannot select "Inactive User" from the dropdown you use to add a new team member
4. Go to the activity log and you should see a change row where "Inactive User" was added to the team
5. Check the following locations to make sure that user initials still show as expected:
   - Avatar in top right of app (if you don't have an uploaded profile image)
   - Avatar on the account page (if you don't have an uploaded profile image)

There is still one bug where **Unknown User** shows in the **User** column of the **Activity feed** which will be fixed in https://github.com/cityofaustin/atd-data-tech/issues/9423

Screenshot of an inactive user in the Team table
<img width="976" alt="Screen Shot 2022-07-18 at 10 12 21 AM" src="https://user-images.githubusercontent.com/37249039/179543493-9d47b78e-cc65-4462-9987-3463ff9418ef.png">

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
