### PR TITLE
Remove "Archived" row in `moped_status` table

### DIFF
--- a/moped-database/migrations/1658432462800_delete_moped_status_6_archived/down.sql
+++ b/moped-database/migrations/1658432462800_delete_moped_status_6_archived/down.sql
@@ -1,0 +1,2 @@
+INSERT INTO moped_status(status_name, status_id, status_flag, status_priority, status_description, status_order) 
+VALUES ("Archived", 6, NULL, NULL, "Project is deleted", 6)

--- a/moped-database/migrations/1658432462800_delete_moped_status_6_archived/up.sql
+++ b/moped-database/migrations/1658432462800_delete_moped_status_6_archived/up.sql
@@ -1,0 +1,3 @@
+-- Deprecated row intended to show a deleted project
+-- Soft deleted projects now use is_deleted column in the moped_project table
+DELETE FROM moped_status WHERE status_id = 6;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -25,7 +25,6 @@ export const ADD_PROJECT = gql`
       }
       moped_project_types {
         project_type_id
-        status_id
       }
     }
   }


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/8238

This PR removes a `moped_status` row that was originally intended for project soft deletes. Those deletes now use `is_deleted` (see https://github.com/cityofaustin/atd-data-tech/issues/9300) so we no longer need this row.

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
https://deploy-preview-726--atd-moped-main.netlify.app/moped/projects/new

_The database migration can be tested locally_

**Steps to test:**
Devs - I checked the staging and production read replicas and seed data for any projects that have `status_id` of 6, but I'd like if someone else can back me up that this update will not break any existing records.

1. Create a new project using a Timeline template to test that the change to the `ADD_PROJECT` mutation didn't break things

---
#### Ship list
- [x] Code reviewed 
- [ ] ~Product manager approved~
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
