### PR TITLE
Adds hash links and related phase column to lookups view

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -543,6 +543,18 @@
 - table:
     schema: public
     name: moped_milestones
+  object_relationships:
+    - name: moped_phase
+      using:
+        foreign_key_constraint_on: related_phase_id
+  array_relationships:
+    - name: moped_proj_milestones
+      using:
+        foreign_key_constraint_on:
+          column: milestone_id
+          table:
+            schema: public
+            name: moped_proj_milestones
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-database/migrations/1659028303595_set_fk_public_moped_milestones_related_phase_id/down.sql
+++ b/moped-database/migrations/1659028303595_set_fk_public_moped_milestones_related_phase_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_milestones" drop constraint "moped_milestones_related_phase_id_fkey";

--- a/moped-database/migrations/1659028303595_set_fk_public_moped_milestones_related_phase_id/up.sql
+++ b/moped-database/migrations/1659028303595_set_fk_public_moped_milestones_related_phase_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_milestones"
+  add constraint "moped_milestones_related_phase_id_fkey"
+  foreign key ("related_phase_id")
+  references "public"."moped_phases"
+  ("phase_id") on update cascade on delete set null;

--- a/moped-editor/src/queries/timelineLookups.js
+++ b/moped-editor/src/queries/timelineLookups.js
@@ -9,7 +9,6 @@ export const TIMELINE_LOOKUPS_QUERY = gql`
       phase_order
       moped_subphases(order_by: { subphase_order: asc }) {
         subphase_id
-        related_phase_id
         subphase_description
         subphase_name
         subphase_order
@@ -20,7 +19,9 @@ export const TIMELINE_LOOKUPS_QUERY = gql`
       milestone_name
       milestone_description
       milestone_order
-      related_phase_id
+      moped_phase {
+        phase_name
+      }
     }
   }
 `;

--- a/moped-editor/src/views/dev/LookupsView/RecordTable.js
+++ b/moped-editor/src/views/dev/LookupsView/RecordTable.js
@@ -5,6 +5,7 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import CircularProgress from "@material-ui/core/CircularProgress";
 
 /**
  * Custom table cell component which incoporates an optional handler to transform record values
@@ -22,7 +23,7 @@ const WrappedTableCell = ({ row, column: { key, handler } }) => {
  * @param { Object[] } columns - the column definitions as defined in the ./settings/SETTINGS object
  * @returns { JSX } a table of record data
  */
-export default function RecordTable({ rows, columns }) {
+export default function RecordTable({ rows, columns, loading }) {
   return (
     <TableContainer>
       <Table aria-label="record table" size="small">
@@ -34,7 +35,14 @@ export default function RecordTable({ rows, columns }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map((row, i) => {
+          {loading && (
+            <TableRow>
+              <TableCell colSpan={columns.length}>
+                <CircularProgress />
+              </TableCell>
+            </TableRow>
+          )}
+          {rows?.map((row, i) => {
             return (
               <TableRow key={i}>
                 {columns.map((column) => {

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -3,7 +3,6 @@ import ApolloErrorHandler from "src/components/ApolloErrorHandler";
 import { useQuery } from "@apollo/client";
 import { useLocation, Link } from "react-router-dom";
 import { createBrowserHistory } from "history";
-import CircularProgress from "@material-ui/core/CircularProgress";
 import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
@@ -62,16 +61,17 @@ const LookupsView = () => {
   );
 
   /**
-   * Use the record hash from the URL, if present. This only happens on page load.
+   * Use the record hash from the URL, if present. This only happens once after
+   * data fetch.
    * */
   const { hash: recordKeyHash } = useLocation();
   useEffect(() => {
-    if (!recordKeyHash) {
+    if (!recordKeyHash || loading) {
       return;
     }
     const recordKey = recordKeyHash.replace("#", "").replace("-", "_");
     setSelectedRecordKey(recordKey);
-  }, [recordKeyHash]);
+  }, [recordKeyHash, loading]);
 
   /**
    * Listens for changes to the selected record key and scrolls to its table
@@ -85,8 +85,6 @@ const LookupsView = () => {
       ref.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [selectedRecordKey, refs]);
-
-  if (loading) return <CircularProgress />;
 
   return (
     <ApolloErrorHandler error={error}>
@@ -126,8 +124,9 @@ const LookupsView = () => {
                   </Grid>
                   <Grid item xs={12}>
                     <RecordTable
-                      rows={data[recordType.key]}
+                      rows={data?.[recordType.key]}
                       columns={recordType.columns}
+                      loading={loading}
                     />
                   </Grid>
                 </Grid>

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -1,11 +1,15 @@
-import React from "react";
+import React, { createRef, useMemo, useEffect, useState } from "react";
 import ApolloErrorHandler from "src/components/ApolloErrorHandler";
 import { useQuery } from "@apollo/client";
+import { useLocation, Link } from "react-router-dom";
+import { createBrowserHistory } from "history";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
+import IconButton from "@material-ui/core/IconButton";
+import LinkIcon from "@material-ui/icons/Link";
 import { makeStyles } from "@material-ui/styles";
 import Page from "src/components/Page";
 import RecordTable from "./RecordTable";
@@ -17,6 +21,11 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(3),
   },
 }));
+
+/**
+ * Converts a record key (e.g. moped_phases) into a URL hash, (e.g. #moped-phases)
+ */
+const createRecordKeyHash = (recordKey) => `#${recordKey.replace("_", "-")}`;
 
 /**
  * Page component which renders various Moped record types.
@@ -31,6 +40,52 @@ const LookupsView = () => {
     fetchPolicy: "no-cache",
   });
 
+  const [selectedRecordKey, setSelectedRecordKey] = useState(null);
+
+  /**
+   * We're using history here (and elsewhere) because it's not possible to use react-router
+   * to replace window.loctation w/o forcing a re-render.
+   * See // https://github.com/remix-run/react-router/issues/8908
+   */
+  const history = createBrowserHistory();
+
+  /**
+   * Create a ref index for every table element on the page so that we can scroll to them
+   * */
+  const refs = useMemo(
+    () =>
+      SETTINGS.reduce((prev, recordType) => {
+        prev[recordType.key] = createRef();
+        return prev;
+      }, {}),
+    []
+  );
+
+  /**
+   * Use the record hash from the URL, if present. This only happens on page load.
+   * */
+  const { hash: recordKeyHash } = useLocation();
+  useEffect(() => {
+    if (!recordKeyHash) {
+      return;
+    }
+    const recordKey = recordKeyHash.replace("#", "").replace("-", "_");
+    setSelectedRecordKey(recordKey);
+  }, [recordKeyHash]);
+
+  /**
+   * Listens for changes to the selected record key and scrolls to its table
+   */
+  useEffect(() => {
+    if (!selectedRecordKey) {
+      return;
+    }
+    const ref = refs?.[selectedRecordKey];
+    if (ref?.current) {
+      ref.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [selectedRecordKey, refs]);
+
   if (loading) return <CircularProgress />;
 
   return (
@@ -42,6 +97,7 @@ const LookupsView = () => {
               <Typography variant="h1">Moped lookup values</Typography>
             </Grid>
           </Grid>
+          <Grid container spacing={3} className={classes.topMargin}></Grid>
           {SETTINGS.map((recordType) => (
             <Grid
               container
@@ -49,15 +105,33 @@ const LookupsView = () => {
               className={classes.topMargin}
               component={Paper}
               key={recordType.key}
+              ref={refs[recordType.key]}
             >
               <Grid item xs={12}>
-                <Typography variant="h2">{recordType.label}</Typography>
-              </Grid>
-              <Grid item xs={12}>
-                <RecordTable
-                  rows={data[recordType.key]}
-                  columns={recordType.columns}
-                />
+                <Grid container direction="row" alignItems="center">
+                  <Grid item>
+                    <Typography variant="h2">{recordType.label}</Typography>
+                  </Grid>
+                  <Grid item>
+                    <IconButton
+                      component={Link}
+                      to={createRecordKeyHash(recordType.key)}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setSelectedRecordKey(recordType.key);
+                        history.replace(createRecordKeyHash(recordType.key));
+                      }}
+                    >
+                      <LinkIcon fontSize="small" />
+                    </IconButton>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <RecordTable
+                      rows={data[recordType.key]}
+                      columns={recordType.columns}
+                    />
+                  </Grid>
+                </Grid>
               </Grid>
             </Grid>
           ))}

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -97,7 +97,6 @@ const LookupsView = () => {
               <Typography variant="h1">Moped lookup values</Typography>
             </Grid>
           </Grid>
-          <Grid container spacing={3} className={classes.topMargin}></Grid>
           {SETTINGS.map((recordType) => (
             <Grid
               container

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -10,6 +10,13 @@ const subPhaseHandler = (subphases) =>
   ));
 
 /**
+ * Parses an array of phase-subphases into an array of subphase names
+ * @param {Object[]} subphases - array of moped_subphases objects
+ * @returns { JSX } An array of <div>s with the subphase name
+ */
+const relatedPhaseHandler = (phase) => phase?.phase_name;
+
+/**
  * Definitions for data tables.
  * @type { Object[]}  - An array of settings for data tables. Each object references a typename
  * returned from a Hasura query
@@ -67,6 +74,11 @@ export const SETTINGS = [
       {
         key: "milestone_name",
         label: "Milestone name",
+      },
+      {
+        key: "moped_phase",
+        label: "Related phase",
+        handler: relatedPhaseHandler,
       },
       {
         key: "milestone_order",


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9871

## Testing
**URL to test:** local or moped-test

**Steps to test:**
1. Navigate to `/moped/dev/lookups/` 
2. Click on the link icon next to the **Moped phases** table
3. Observe that the table may scroll slightly into view, and the URL in your browser updates with the table's hash (`#moped-phases`)
4. Do the same thing with the **Moped milestones** table
5. Confirm that the **Related phase** column renders on the milestones table
6. Copy the full url with `#moped-milestones` into a new tab and confirm that the page scrolls to that table.


<img width="984" alt="Screen Shot 2022-07-29 at 6 13 33 PM" src="https://user-images.githubusercontent.com/14793120/181852366-766ba20b-1f88-40c7-b277-5d2a0f173d1a.png">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
