### PR TITLE
Define ALB health check location and valid responses

### DIFF
--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -79,7 +79,13 @@ def create_target_group(basename):
     elb = boto3.client("elbv2")
 
     target_group = elb.create_target_group(
-        Name=basename, Protocol="HTTP", Port=8080, VpcId=VPC_ID, TargetType="ip"
+        Name=basename,
+        Protocol="HTTP",
+        Port=8080,
+        VpcId=VPC_ID,
+        TargetType="ip",
+        HealthCheckPath="/healthz",
+        Matcher={"HttpCode": "200,302"},
     )
 
     return target_group


### PR DESCRIPTION
Sibling PR: https://github.com/cityofaustin/atd-prefect/pull/32

Small change:

* Configures the health check on the ALB's target group so it can accurately tell if a graphql-engine is up and running nominally. 

This prevents the ALB from flapping the ECS task instance.