### PR TITLE
Enable testing of `test` with other moped feature branches

### DIFF
--- a/moped-editor/netlify.toml
+++ b/moped-editor/netlify.toml
@@ -5,7 +5,7 @@
 #   From: https://docs.netlify.com/site-deploys/overview/#deploy-contexts
 #   Also: https://docs.netlify.com/configure-builds/environment-variables/
 [context.branch-deploy]
-    command = "echo 'Build Context Mode: Branch-Deploy' && npm run build:netlifypr"
+    command = "echo 'Build Context Mode: Branch-Deploy' && npm run build:netlifybranch"
     [context.branch-deploy.environment]
       ATD_MOPED_BUILD_CONTEXT = "Netlify PR -- branch-deploy"
 

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -21,6 +21,7 @@
     "build:development": "env-cmd -e development npm run build:local",
     "build:production": "env-cmd -e production npm run build:local",
     "build:netlifypr": "env-cmd -e netlifypr npm run build:local",
+    "build:netlifybranch": "./set_env_branch_build.py",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/moped-editor/set_env_branch_build.py
+++ b/moped-editor/set_env_branch_build.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import json
+import os
+
+cmd = ""
+
+print("Using payload defined environment variables, if any, to overload 'netlifypr' from .env_cmdrc")
+payload = os.environ.get("INCOMING_HOOK_BODY", "{}")
+decoded_vars = json.loads(payload)
+environment = " ".join(
+    ["{}={}".format(key, value) for key, value in decoded_vars.items()]
+)
+cmd = environment + " env-cmd --no-override -e netlifypr npm run build:local"
+
+result = os.popen(cmd)
+
+# i'm still not convinced this is giving us a build log, or is there none in a CI environment?
+print(result.read())

--- a/moped-editor/set_env_branch_build.py
+++ b/moped-editor/set_env_branch_build.py
@@ -5,7 +5,9 @@ import os
 
 cmd = ""
 
-print("Using payload defined environment variables, if any, to overload 'netlifypr' from .env_cmdrc")
+print(
+    "Using payload defined environment variables, if any, to overload 'netlifypr' from .env_cmdrc"
+)
 payload = os.environ.get("INCOMING_HOOK_BODY", "{}")
 decoded_vars = json.loads(payload)
 environment = " ".join(
@@ -15,5 +17,4 @@ cmd = environment + " env-cmd --no-override -e netlifypr npm run build:local"
 
 result = os.popen(cmd)
 
-# i'm still not convinced this is giving us a build log, or is there none in a CI environment?
 print(result.read())


### PR DESCRIPTION
In advance of the upcoming test system, there are a set of 3 change which allow the test deployment to trigger a netlify build and to set environment variables. Of note, one is to allow the deployment to have the graphql-engine endpoint defined.

These changes are non-ops in our current environment, and they will merge in cleanly when we do get the test instance work into main. 

Being able to get these into main now, or at least in a branch i can merge into other branches that I want to use to test `test`, will be helpful.