### PR TITLE
Rename purchase orders to contracts

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -941,6 +941,88 @@
         check: {}
 - table:
     schema: public
+    name: moped_proj_contract
+  object_relationships:
+    - name: moped_project
+      using:
+        foreign_key_constraint_on: project_id
+  insert_permissions:
+    - role: moped-admin
+      permission:
+        check: {}
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+    - role: moped-editor
+      permission:
+        check: {}
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+  select_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+        filter: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+        filter: {}
+    - role: moped-viewer
+      permission:
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+        filter: {}
+  update_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+        filter: {}
+        check: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - id
+          - contractor
+          - contract_number
+          - description
+          - project_id
+          - is_deleted
+        filter: {}
+        check: {}
+- table:
+    schema: public
     name: moped_proj_entities
   insert_permissions:
     - role: moped-admin
@@ -3119,88 +3201,6 @@
           value_from_env: MOPED_API_APIKEY
         - value: activity_log
           name: MOPED_API_EVENT_NAME
-- table:
-    schema: public
-    name: moped_purchase_order
-  object_relationships:
-    - name: moped_project
-      using:
-        foreign_key_constraint_on: project_id
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-  select_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-        filter: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-        filter: {}
-    - role: moped-viewer
-      permission:
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-        filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - id
-          - vendor
-          - purchase_order_number
-          - description
-          - project_id
-          - is_deleted
-        filter: {}
-        check: {}
 - table:
     schema: public
     name: moped_status

--- a/moped-database/migrations/1660317454947_rename_purchase_orders_to_contracts/down.sql
+++ b/moped-database/migrations/1660317454947_rename_purchase_orders_to_contracts/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE moped_proj_contract
+    RENAME TO moped_purchase_order;
+
+ALTER TABLE moped_purchase_order
+  RENAME COLUMN contractor to vendor;
+
+ALTER TABLE moped_purchase_order
+  RENAME COLUMN contract_number TO purchase_order_number;

--- a/moped-database/migrations/1660317454947_rename_purchase_orders_to_contracts/up.sql
+++ b/moped-database/migrations/1660317454947_rename_purchase_orders_to_contracts/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE moped_purchase_order
+    RENAME TO moped_proj_contract;
+
+ALTER TABLE moped_proj_contract
+  RENAME COLUMN vendor TO contractor;
+
+ALTER TABLE moped_proj_contract
+  RENAME COLUMN purchase_order_number TO contract_number;

--- a/moped-editor/src/queries/funding.js
+++ b/moped-editor/src/queries/funding.js
@@ -104,23 +104,23 @@ export const UPDATE_FUNDING_TASK_ORDERS = gql`
   }
 `;
 
-export const PURCHASE_ORDER_QUERY = gql`
+export const CONTRACT_QUERY = gql`
   query ProjectPurchaseOrder($projectId: Int) {
-    moped_purchase_order(
+    moped_proj_contract(
       where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
       order_by: {id: asc}
     ) {
-      vendor
+      contractor
       id
-      purchase_order_number
+      contract_number
       description
     }
   }
 `;
 
-export const ADD_PURCHASE_ORDER = gql`
-  mutation AddPurchaseOrder($objects: [moped_purchase_order_insert_input!]!) {
-    insert_moped_purchase_order(objects: $objects) {
+export const ADD_CONTRACT = gql`
+  mutation AddPurchaseOrder($objects: [moped_proj_contract_insert_input!]!) {
+    insert_moped_proj_contract(objects: $objects) {
       returning {
         id
       }
@@ -128,18 +128,18 @@ export const ADD_PURCHASE_ORDER = gql`
   }
 `;
 
-export const UPDATE_PURCHASE_ORDER = gql`
+export const UPDATE_CONTRACT = gql`
   mutation UpdatePurchaseOrder(
     $id: Int!
-    $vendor: String!
-    $purchase_order_number: String!
+    $contractor: String!
+    $contract_number: String!
     $description: String!
   ) {
-    update_moped_purchase_order_by_pk(
+    update_moped_proj_contract_by_pk(
       pk_columns: { id: $id }
       _set: {
-        vendor: $vendor
-        purchase_order_number: $purchase_order_number
+        contractor: $contractor
+        contract_number: $contract_number
         description: $description
       }
     ) {
@@ -148,11 +148,11 @@ export const UPDATE_PURCHASE_ORDER = gql`
   }
 `;
 
-export const DELETE_PURCHASE_ORDER = gql`
+export const DELETE_CONTRACT = gql`
   mutation DeletePurchaseOrder(
     $id: Int!
   ) {
-    update_moped_purchase_order_by_pk(
+    update_moped_proj_contract_by_pk(
       pk_columns: { id: $id }
       _set: {
         is_deleted: true

--- a/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
@@ -28,10 +28,10 @@ import { PAGING_DEFAULT_COUNT } from "../../../constants/tables";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 
 import {
-  PURCHASE_ORDER_QUERY,
-  UPDATE_PURCHASE_ORDER,
-  ADD_PURCHASE_ORDER,
-  DELETE_PURCHASE_ORDER,
+  CONTRACT_QUERY,
+  UPDATE_CONTRACT,
+  ADD_CONTRACT,
+  DELETE_CONTRACT,
 } from "../../../queries/funding";
 
 const DEFAULT_SNACKBAR_STATE = {
@@ -48,20 +48,20 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ProjectPurchaseOrderTable = () => {
+const ProjectContractsTable = () => {
   const classes = useStyles();
   const { projectId } = useParams();
 
-  const { loading, error, data, refetch } = useQuery(PURCHASE_ORDER_QUERY, {
+  const { loading, error, data, refetch } = useQuery(CONTRACT_QUERY, {
     variables: {
       projectId: projectId,
     },
     fetchPolicy: "no-cache",
   });
 
-  const [addPurchaseOrder] = useMutation(ADD_PURCHASE_ORDER);
-  const [updatePurchaseOrder] = useMutation(UPDATE_PURCHASE_ORDER);
-  const [deletePurchaseOrder] = useMutation(DELETE_PURCHASE_ORDER);
+  const [addContract] = useMutation(ADD_CONTRACT);
+  const [updateContract] = useMutation(UPDATE_CONTRACT);
+  const [deleteContract] = useMutation(DELETE_CONTRACT);
 
   const [snackbarState, setSnackbarState] = useState(DEFAULT_SNACKBAR_STATE);
 
@@ -79,12 +79,12 @@ const ProjectPurchaseOrderTable = () => {
    */
   const columns = [
     {
-      title: "Vendor",
-      field: "vendor",
+      title: "Contractor",
+      field: "contractor",
     },
     {
-      title: "DO #",
-      field: "purchase_order_number",
+      title: "Contract #",
+      field: "contract_number",
     },
     {
       title: "Description",
@@ -126,13 +126,13 @@ const ProjectPurchaseOrderTable = () => {
                   startIcon={<AddCircleIcon />}
                   onClick={props.action.onClick}
                 >
-                  Add Purchase order
+                  Add Contract
                 </Button>
               );
             }
           },
         }}
-        data={data.moped_purchase_order}
+        data={data.moped_proj_contract}
         title={
           <div>
             <Typography
@@ -140,12 +140,12 @@ const ProjectPurchaseOrderTable = () => {
               color="primary"
               style={{ paddingTop: "1em" }}
             >
-              Purchase orders
+              Contracts
             </Typography>
           </div>
         }
         options={{
-          ...(data.moped_purchase_order.length < PAGING_DEFAULT_COUNT + 1 && {
+          ...(data.moped_proj_contract.length < PAGING_DEFAULT_COUNT + 1 && {
             paging: false,
           }),
           search: false,
@@ -161,7 +161,7 @@ const ProjectPurchaseOrderTable = () => {
           body: {
             emptyDataSourceMessage: (
               <Typography variant="body1">
-                No purchase orders to display
+                No contracts to display
               </Typography>
             ),
           },
@@ -172,7 +172,7 @@ const ProjectPurchaseOrderTable = () => {
         }}
         editable={{
           onRowAdd: (newData) =>
-            addPurchaseOrder({
+            addContract({
               variables: {
                 objects: {
                   ...newData,
@@ -194,13 +194,13 @@ const ProjectPurchaseOrderTable = () => {
                 });
               }),
           onRowUpdate: (newData, oldData) => {
-            const updatePurchaseOrderData = newData;
+            const updateContractData = newData;
 
             // Remove unneeded variable
-            delete updatePurchaseOrderData.__typename;
+            delete updateContractData.__typename;
 
-            return updatePurchaseOrder({
-              variables: updatePurchaseOrderData,
+            return updateContract({
+              variables: updateContractData,
             })
               .then(() => refetch())
               .catch((error) => {
@@ -217,7 +217,7 @@ const ProjectPurchaseOrderTable = () => {
               });
           },
           onRowDelete: (oldData) =>
-            deletePurchaseOrder({
+            deleteContract({
               variables: {
                 id: oldData.id,
               },
@@ -251,4 +251,4 @@ const ProjectPurchaseOrderTable = () => {
   );
 };
 
-export default ProjectPurchaseOrderTable;
+export default ProjectContractsTable;

--- a/moped-editor/src/views/projects/projectView/ProjectFunding.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ProjectFundingTable from "./ProjectFundingTable";
-import ProjectPurchaseOrderTable from "./ProjectPurchaseOrderTable";
+import ProjectContractsTable from "./ProjectContractsTable";
 import { useParams } from "react-router-dom";
 
 import { CardContent, Grid } from "@material-ui/core";
@@ -15,7 +15,7 @@ const ProjectFunding = () => {
           <ProjectFundingTable projectId={projectId} />
         </Grid>
         <Grid item xs={12}>
-          <ProjectPurchaseOrderTable projectId={projectId} />
+          <ProjectContractsTable projectId={projectId} />
         </Grid>
       </Grid>
     </CardContent>

--- a/moped-toolbox/purchase_order_backfill/create_crontacts.py
+++ b/moped-toolbox/purchase_order_backfill/create_crontacts.py
@@ -2,7 +2,7 @@
 This script takes contractors and DO#s from existing moped projects and moves them into
 their own table
 
-Usage: python create_purchase_orders.py -e local
+Usage: python create_contracts.py -e local
 
 """
 
@@ -10,7 +10,7 @@ import argparse
 
 
 from utils import get_logger, make_hasura_request
-from queries import PROJECTS_QUERY, ADD_PURCHASE_ORDER
+from queries import PROJECTS_QUERY, ADD_CONTRACT
 from secrets import HASURA
 
 
@@ -32,16 +32,16 @@ def main(env):
     for project in projects:
         project_id = project["project_id"]
         contractor = project["contractor"]
-        purchase_order_number = project["purchase_order_number"]
-        if contractor is None and purchase_order_number is None:
+        contract_number = project["purchase_order_number"]
+        if contractor is None and contract_number is None:
             continue
 
-        records_to_add.append({"project_id": project_id, "purchase_order_number": purchase_order_number,
-                               "vendor": contractor})
+        records_to_add.append({"project_id": project_id, "contract_number": contract_number,
+                               "contractor": contractor})
 
     for record in records_to_add:
         make_hasura_request(
-            query=ADD_PURCHASE_ORDER,
+            query=ADD_CONTRACT,
             variables={"objects": record},
             endpoint=HASURA["hasura_graphql_endpoint"][env],
             admin_secret=HASURA["hasura_graphql_admin_secret"][env]
@@ -52,7 +52,7 @@ def main(env):
 
 
 if __name__ == "__main__":
-    logger = get_logger(name="create_purchase_orders")
+    logger = get_logger(name="create_contracts")
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/moped-toolbox/purchase_order_backfill/queries.py
+++ b/moped-toolbox/purchase_order_backfill/queries.py
@@ -15,10 +15,10 @@ PROJECTS_QUERY = """query PurchaseOrders {
 }
 """
 
-ADD_PURCHASE_ORDER = """
-    mutation AddPurchaseOrder($objects: [moped_purchase_order_insert_input!]!) 
+ADD_CONTRACT = """
+    mutation AddPurchaseOrder($objects: [moped_proj_contract_insert_input!]!) 
     {
-        insert_moped_purchase_order(objects: $objects) {
+        insert_moped_proj_contract(objects: $objects) {
             returning
             {
                 id


### PR DESCRIPTION
## Associated issues
Fixes https://github.com/cityofaustin/atd-data-tech/issues/9967

This is mostly a find/replace of https://github.com/cityofaustin/atd-moped/pull/720.

I did test the migrations against scenarios where we actually have existing records in the `moped_purchase_order` table.

## Testing
**URL to test:** Moped test or local

Test deployment: https://9967-jc-rename-purchase-orders-to-contracts--atd-moped-main.netlify.app/moped

**Steps to test:**
#### to test the purchase order table:

add / edit / delete / update records to the table on the funding tab.

#### to test the script:

to test locally, I added some contractors and DOs via the summary tab to various projects.
Then I ran the script (create_contracts.py -e local)
And checked on the funding tab that the information I added in the summary tab showed up on the PO table

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
