### PR TITLE
Add ability to populate test deployment from seed data

### DIFF
--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -78,8 +78,10 @@ def drain_service(slug):
 
 # with Flow("Moped Test Instance Commission") as test_commission:
 with Flow("Moped Test Instance Commission", executor=executor) as test_commission:
-    branch = Parameter("branch")
-    database_seed_source = Parameter("database_seed_source")
+    branch = Parameter("branch", default="feature-branch-name", required=True)
+    database_seed_source = Parameter(
+        "database_seed_source", default="seed", required=True
+    )
 
     slug = slug_branch_name(branch)
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -146,12 +146,12 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
         ready_for_api_deployment=ready_for_api_deployment,
     )
 
-    # deploy_api = api.create_api_task(command=commission_api_command)
-    # api_endpoint = api.get_endpoint_from_deploy_output(deploy_api)
+    deploy_api = api.create_api_task(command=commission_api_command)
+    api_endpoint = api.get_endpoint_from_deploy_output(deploy_api)
     # comment out the two lines above if you put the right endpoint here
-    api_endpoint = (
-        "https://g00gkqigae.execute-api.us-east-1.amazonaws.com/seed_data_source"
-    )
+    #api_endpoint = (
+        #"https://g00gkqigae.execute-api.us-east-1.amazonaws.com/seed_data_source"
+    #)
 
     ## Commission the ECS cluster
 

--- a/moped-etl/prefect/tasks/migrations.py
+++ b/moped-etl/prefect/tasks/migrations.py
@@ -49,6 +49,7 @@ clone_moped_repo = ShellTask(name="Clone Moped Repo", stream_output=True)
 checkout_target_branch = ShellTask(name="Checkout target branch", stream_output=True)
 migrate_db = ShellTask(name="Migrate DB", stream_output=True)
 apply_metadata = ShellTask(name="Apply Metadata", stream_output=True)
+insert_seed_data = ShellTask(name="Insert Seed Data", stream_output=True)
 
 check_for_consistent_metadata = ShellTask(name="Check for consistent metadata", max_retries=12, retry_delay=timedelta(seconds=10))
 

--- a/moped-etl/prefect/tasks/migrations.py
+++ b/moped-etl/prefect/tasks/migrations.py
@@ -10,6 +10,16 @@ import tasks.shared as shared
 # set up the prefect logging system
 logger = prefect.context.get("logger")
 
+@task(name="Check if database is to be built from seed data")
+def use_seed_data(database_seed_source):
+    logger.info("Seed directive: " + database_seed_source)
+    if database_seed_source == 'seed':
+        logger.info("Using seed data")
+        return True
+    else:
+        logger.info("Not using seed data")
+        return False
+
 @task(name="Get graphql-engine hostname")
 def get_graphql_engine_hostname(slug):
     basename = slug["basename"]


### PR DESCRIPTION
## Associations
* This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/10026.
* This PR has no substantive changes in the prefect repo and no sibling PR.

## Feature
This configure the flow to, when presented with the value of `seed` for the parameter `database_seed_source` to build the DB from seed data and not replicate it from the read replica.