### PR TITLE
Slugging, Seed application, API rebuild, & API correct version

### DIFF
--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -50,7 +50,7 @@ def slug_branch_name(basename):
 
     elb_basename = basename[0:32].replace("_", "-")
 
-    graphql_endpoint = re.search("^[\d_]*(.*)", basename).group(1).replace("_", "-")
+    graphql_endpoint = re.search("^[\d_-]*(.*)", basename).group(1).replace("_", "-")
 
     short_tls_basename = graphql_endpoint[0:27]
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -57,7 +57,7 @@ def slug_branch_name(basename):
     activity_log_slug = basename[0:34].replace("_", "-").strip("0123456789-_")
     database = basename[0:63].replace("-", "_").strip("0123456789-_.")
     awslambda = re.sub(
-        r"[^a-zA-Z0-9]", "", basename[0:16].replace("_", "-").strip("0123456789-_")
+        r"[^a-zA-Z0-9-]", "", basename[0:16].replace("_", "-").strip("0123456789-_")
     )
     ecs_cluster_name = basename.strip("0123456789-_.")
     # zappa_stage_name = re.sub(r"[^a-zA-Z0-9]", "", basename)
@@ -184,7 +184,6 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
 
     deploy_api = api.create_api_task(command=commission_api_command)
     api_endpoint = api.get_endpoint_from_deploy_output(deploy_api)
-
 
     ## Commission the ECS cluster
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -83,7 +83,7 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
 
     slug = slug_branch_name(branch)
 
-    ## Get github checkout 
+    ## Get github checkout
 
     rm_clone = "rm -fr /tmp/atd-moped"
     cleaned = migrations.remove_moped_checkout(command=rm_clone)
@@ -94,7 +94,7 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
     checkout_branch = migrations.get_git_checkout_command(slug=slug)
     git_repo_checked_out = migrations.checkout_target_branch(
         command=checkout_branch, upstream_tasks=[cloned]
-    ) 
+    )
 
     ## Commission the database
 
@@ -243,13 +243,10 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
         command=commission_activity_log_command
     )
 
-
-
     ## Apply Migrations, metadata and optional seed data
     graphql_endpoint = "https://" + migrations.get_graphql_engine_hostname(slug=slug)
 
     access_key = migrations.get_graphql_engine_access_key(slug=slug)
-
 
     metadata = "metadata"
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -156,7 +156,9 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
     is_deployed = api.check_if_api_is_deployed(slug=slug)
     with case(is_deployed, True):
         decommission_api_command = api.create_moped_api_undeploy_command(
-            slug=slug, config_secret_arn=remove_api_config_secret_arn
+            slug=slug,
+            config_secret_arn=remove_api_config_secret_arn,
+            upstream_tasks=[git_repo_checked_out],
         )
         undeploy_api = api.remove_api_task(command=decommission_api_command)
     ready_for_api_deployment = merge(is_deployed, undeploy_api)
@@ -165,14 +167,15 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
         slug=slug,
         config_secret_arn=create_api_config_secret_arn,
         ready_for_api_deployment=ready_for_api_deployment,
+        upstream_tasks=[git_repo_checked_out],
     )
 
     deploy_api = api.create_api_task(command=commission_api_command)
     api_endpoint = api.get_endpoint_from_deploy_output(deploy_api)
     # comment out the two lines above if you put the right endpoint here
-    #api_endpoint = (
-        #"https://g00gkqigae.execute-api.us-east-1.amazonaws.com/seed_data_source"
-    #)
+    # api_endpoint = (
+    # "https://g00gkqigae.execute-api.us-east-1.amazonaws.com/seed_data_source"
+    # )
 
     ## Commission the ECS cluster
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -184,10 +184,7 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
 
     deploy_api = api.create_api_task(command=commission_api_command)
     api_endpoint = api.get_endpoint_from_deploy_output(deploy_api)
-    # comment out the two lines above if you put the right endpoint here
-    # api_endpoint = (
-    # "https://g00gkqigae.execute-api.us-east-1.amazonaws.com/seed_data_source"
-    # )
+
 
     ## Commission the ECS cluster
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -47,9 +47,12 @@ logger = prefect.context.get("logger")
 
 @task(name="Slug branch name")
 def slug_branch_name(basename):
-    short_tls_basename = basename[0:27]
 
     elb_basename = basename[0:32].replace("_", "-")
+
+    graphql_endpoint = re.search("^[\d_]*(.*)", basename).group(1).replace("_", "-")
+
+    short_tls_basename = graphql_endpoint[0:27]
 
     underscore_basename = basename.replace("-", "_")
     database = re.search("^[\d_]*(.*)", underscore_basename).group(
@@ -63,6 +66,7 @@ def slug_branch_name(basename):
     slug = {
         "basename": basename,
         "database": database,
+        "graphql_endpoint": graphql_endpoint,
         "awslambda": awslambda,
         "short_tls_basename": short_tls_basename,
         "elb_basename": elb_basename,

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -48,25 +48,18 @@ logger = prefect.context.get("logger")
 @task(name="Slug branch name")
 def slug_branch_name(basename):
 
-    elb_basename = basename[0:32].replace("_", "-")
-
-    graphql_endpoint = re.search("^[\d_-]*(.*)", basename).group(1).replace("_", "-")
-
+    graphql_endpoint = basename.replace("_", "-").strip("0123456789-_")
     short_tls_basename = graphql_endpoint[0:27]
-
-    underscore_basename = basename.replace("-", "_")
-    database = re.search("^[\d_]*(.*)", underscore_basename).group(
-        1
-    )  # remove leading numbers
-    internal_number_free_underscore_basename = "".join(
-        [i for i in database if not i.isdigit()]
-    )
-    awslambda = internal_number_free_underscore_basename[0:16]
+    elb_basename = basename[0:32].replace("_", "-").strip("0123456789-_")
+    activity_log_slug = basename[0:34].replace("_", "-").strip("0123456789-_")
+    database = basename[0:63].replace("-", "_").strip("0123456789-_")
+    awslambda = basename[0:16].replace("_", "-").strip("0123456789-_")
 
     slug = {
         "basename": basename,
         "database": database,
         "graphql_endpoint": graphql_endpoint,
+        "activity_log_slug": activity_log_slug,
         "awslambda": awslambda,
         "short_tls_basename": short_tls_basename,
         "elb_basename": elb_basename,

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -11,6 +11,7 @@ import time
 import os
 import platform
 import re
+import pprint
 
 # import pypi packages
 import prefect
@@ -48,12 +49,18 @@ logger = prefect.context.get("logger")
 @task(name="Slug branch name")
 def slug_branch_name(basename):
 
-    graphql_endpoint = basename.replace("_", "-").strip("0123456789-_")
+    graphql_endpoint = (
+        basename.replace("_", "-").replace(".", "-").strip("0123456789-_")
+    )
     short_tls_basename = graphql_endpoint[0:27]
-    elb_basename = basename[0:32].replace("_", "-").strip("0123456789-_")
+    elb_basename = basename[0:32].replace("_", "-").strip("0123456789-_.")
     activity_log_slug = basename[0:34].replace("_", "-").strip("0123456789-_")
-    database = basename[0:63].replace("-", "_").strip("0123456789-_")
-    awslambda = basename[0:16].replace("_", "-").strip("0123456789-_")
+    database = basename[0:63].replace("-", "_").strip("0123456789-_.")
+    awslambda = re.sub(
+        r"[^a-zA-Z0-9]", "", basename[0:16].replace("_", "-").strip("0123456789-_")
+    )
+    ecs_cluster_name = basename.strip("0123456789-_.")
+    # zappa_stage_name = re.sub(r"[^a-zA-Z0-9]", "", basename)
 
     slug = {
         "basename": basename,
@@ -63,7 +70,12 @@ def slug_branch_name(basename):
         "awslambda": awslambda,
         "short_tls_basename": short_tls_basename,
         "elb_basename": elb_basename,
+        "ecs_cluster_name": ecs_cluster_name,
+        # "zappa_stage_name": zappa_stage_name,
     }
+
+    pp = pprint.PrettyPrinter(width=41, compact=True)
+    logger.info(pp.pformat(slug))
     return slug
 
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -287,36 +287,22 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
     )
 
     # what are these parentheses doing?
-    migrate_cmd = (
-        "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check migrate apply;)"
-    )
-    migrate = migrations.migrate_db(
-        command=migrate_cmd, upstream_tasks=[config, graphql_endpoint_ready]
-    )
+        migrate_cmd = "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check migrate apply; sleep 15;)"
 
-    consistency_cmd = "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check metadata inconsistency status;)"
+        consistency_cmd = "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check metadata inconsistency status;)"
     consistent_metadata = migrations.check_for_consistent_metadata(
         command=consistency_cmd, upstream_tasks=[migrate]
     )
 
+        # Should this sleep come out or should the bash sleeps be done like this?
     settled_metadata = migrations.sleep_fifteen_seconds(
         consistent_metadata=consistent_metadata
     )
 
-    metadata_cmd = (
-        "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check metadata apply;)"
-    )
-    metadata = migrations.apply_metadata(
-        command=metadata_cmd, upstream_tasks=[migrate, settled_metadata]
-    )
+        metadata_cmd = "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check metadata apply; sleep 15;)"
 
     with case(use_seed_data, True):
-        apply_seed_cmd = (
-            "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check seed apply;)"
-        )
-        seed_data = migrations.insert_seed_data(
-            command=apply_seed_cmd, upstream_tasks=[metadata]
-        )
+            apply_seed_cmd = "(cd /tmp/atd-moped/moped-database; hasura --skip-update-check seed apply; sleep 15;)"
 
     ready_database = merge(metadata, seed_data)
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -48,7 +48,9 @@ logger = prefect.context.get("logger")
 @task(name="Slug branch name")
 def slug_branch_name(basename):
     short_tls_basename = basename[0:27]
-    elb_basename = basename[0:32]
+
+    elb_basename = basename[0:32].replace("_", "-")
+
     underscore_basename = basename.replace("-", "_")
     database = re.search("^[\d_]*(.*)", underscore_basename).group(
         1

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -237,7 +237,7 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
     ## Commission the Activity Log
 
     commission_activity_log_command = activity_log.create_activity_log_command(
-        slug=slug
+        slug=slug, upstream_tasks=[git_repo_checked_out]
     )
     deploy_activity_log = activity_log.create_activity_log_task(
         command=commission_activity_log_command

--- a/moped-etl/prefect/tasks/activity_log.py
+++ b/moped-etl/prefect/tasks/activity_log.py
@@ -22,8 +22,9 @@ function_name = "activity_log"
 def create_activity_log_lambda_config(
     basename,
     graphql_engine_api_key,
+    slug,
 ):
-    graphql_endpoint = shared.form_graphql_endpoint_hostname(basename)
+    graphql_endpoint = shared.form_graphql_endpoint_hostname(slug["graphql_endpoint"])
     return {
         "Description": f"AWS Moped Data Event: atd-moped-events-activity_log_{basename}",
         "Environment": {
@@ -55,7 +56,7 @@ def create_activity_log_command(slug):
 
     graphql_engine_api_key = shared.generate_access_key(basename)
 
-    lambda_config = create_activity_log_lambda_config(basename=basename, graphql_engine_api_key=graphql_engine_api_key)
+    lambda_config = create_activity_log_lambda_config(basename=basename, graphql_engine_api_key=graphql_engine_api_key, slug=slug)
 
     # Write Lambda config to activity_log project folder
     with open(f"{deployment_path}/handler_config.json", "w") as f:

--- a/moped-etl/prefect/tasks/activity_log.py
+++ b/moped-etl/prefect/tasks/activity_log.py
@@ -16,7 +16,7 @@ MOPED_ACTIVITY_LOG_QUEUE_URL_PREFIX = os.environ["MOPED_ACTIVITY_LOG_QUEUE_URL_P
 SHA_SALT = os.environ["SHA_SALT"]
 
 # The folder name of the event function and used in naming the AWS function
-function_name = "activity_log"
+FUNCTION_NAME = "activity_log"
 
 
 def create_activity_log_lambda_config(graphql_engine_api_key, slug):
@@ -45,10 +45,10 @@ create_activity_log_task = ShellTask(
 def create_activity_log_command(slug):
     logger.info("Creating Activity Log deploy helper command")
 
-    aws_function_name = shared.create_activity_log_aws_name(slug["activity_log_slug"], function_name)
+    aws_function_name = shared.create_activity_log_aws_name(slug["activity_log_slug"], FUNCTION_NAME)
 
     helper_script_path = "/tmp/atd-moped/.github/workflows"
-    deployment_path = f"/tmp/atd-moped/moped-data-events/{function_name}"
+    deployment_path = f"/tmp/atd-moped/moped-data-events/{FUNCTION_NAME}"
 
     graphql_engine_api_key = shared.generate_access_key(slug["basename"])
 
@@ -64,7 +64,7 @@ def create_activity_log_command(slug):
     (cd {helper_script_path} &&
     pip install awscli &&
     source aws-moped-sqs-helper.sh &&
-    deploy_moped_test_event_function {function_name} {aws_function_name} {MOPED_ACTIVITY_LOG_LAMBDA_ROLE_ARN})
+    deploy_moped_test_event_function {FUNCTION_NAME} {aws_function_name} {MOPED_ACTIVITY_LOG_LAMBDA_ROLE_ARN})
     deactivate;
     """
 
@@ -91,7 +91,7 @@ def remove_activity_log_lambda(slug):
 
     lambda_client = boto3.client("lambda")
 
-    function_name = shared.create_activity_log_aws_name(basename, function_name)
-    response = lambda_client.delete_function(FunctionName=function_name)
+    activity_log_function_name = shared.create_activity_log_aws_name(basename, FUNCTION_NAME)
+    response = lambda_client.delete_function(FunctionName=activity_log_function_name)
 
     return response

--- a/moped-etl/prefect/tasks/activity_log.py
+++ b/moped-etl/prefect/tasks/activity_log.py
@@ -50,8 +50,8 @@ def create_activity_log_command(slug):
 
     aws_function_name = shared.create_activity_log_aws_name(basename, function_name)
 
-    helper_script_path = "/root/test_instance_deployment/atd-moped/.github/workflows"
-    deployment_path = f"/root/test_instance_deployment/atd-moped/moped-data-events/{function_name}"
+    helper_script_path = "/tmp/atd-moped/.github/workflows"
+    deployment_path = f"/tmp/atd-moped/moped-data-events/{function_name}"
 
     graphql_engine_api_key = shared.generate_access_key(basename)
 

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -159,6 +159,10 @@ def create_zappa_config(basename, config_secret_arn):
             ],
         }
     }
+
+    logger.info("Zappa config:")
+    logger.info({zappa_config})
+
     return zappa_config
 
 

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 import tasks.ecs as ecs
 
+import pprint
 import prefect
 from prefect import task
 from prefect.tasks.shell import ShellTask
@@ -125,7 +126,6 @@ def remove_moped_api_secrets_entry(slug):
 
 # Create Zappa deployment configuration to deploy and undeploy Lambda + API Gateway
 def create_zappa_config(basename, config_secret_arn):
-
     zappa_config = {
         f"{basename}": {
             "app_function": "app.app",
@@ -159,10 +159,6 @@ def create_zappa_config(basename, config_secret_arn):
             ],
         }
     }
-
-    logger.info("Zappa config:")
-    logger.info({zappa_config})
-
     return zappa_config
 
 
@@ -175,9 +171,13 @@ create_api_task = ShellTask(
 def create_moped_api_deploy_command(slug, config_secret_arn, ready_for_api_deployment):
     basename = slug["awslambda"]
 
-    logger.info("Creating API Zappa deploy command")
+    logger.info("Creating API Zappa deploy command..")
+
+    logger.info("Calling it up with basename: " + basename)
+    logger.info("Calling it up with basename: " + config_secret_arn)
 
     zappa_config = create_zappa_config(basename, config_secret_arn)
+
     api_project_path = "/tmp/atd-moped/moped-api"
 
     # Write Zappa config to moped-api project folder

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -171,7 +171,7 @@ create_api_task = ShellTask(
 def create_moped_api_deploy_command(slug, config_secret_arn, ready_for_api_deployment):
     basename = slug["awslambda"]
 
-    logger.info("Creating API Zappa deploy command..")
+    logger.info("Creating API Zappa deploy command")
 
     zappa_config = create_zappa_config(basename, config_secret_arn)
 

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -69,7 +69,7 @@ def create_moped_api_secrets_entry(slug, ready_for_secret):
 
     logger.info("Creating API secret config")
 
-    graphql_endpoint = shared.form_graphql_endpoint_hostname(slug["basename"])
+    graphql_endpoint = shared.form_graphql_endpoint_hostname(slug["graphql_endpoint"])
     graphql_engine_api_key = shared.generate_access_key(slug["basename"])
 
     client = boto3.client("secretsmanager", region_name=AWS_DEFAULT_REGION)

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -169,7 +169,7 @@ def create_moped_api_deploy_command(slug, config_secret_arn, ready_for_api_deplo
     logger.info("Creating API Zappa deploy command")
 
     zappa_config = create_zappa_config(basename, config_secret_arn)
-    api_project_path = "/root/test_instance_deployment/atd-moped/moped-api"
+    api_project_path = "/tmp/atd-moped/moped-api"
 
     # Write Zappa config to moped-api project folder
     with open(f"{api_project_path}/zappa_settings.json", "w") as f:
@@ -226,7 +226,7 @@ def create_moped_api_undeploy_command(slug, config_secret_arn):
 
     zappa_config = create_zappa_config(basename, config_secret_arn)
 
-    api_project_path = "/root/test_instance_deployment/atd-moped/moped-api"
+    api_project_path = "/tmp/atd-moped/moped-api"
 
     # Write Zappa config to moped-api project folder
     with open(f"{api_project_path}/zappa_settings.json", "w") as f:

--- a/moped-etl/prefect/tasks/api.py
+++ b/moped-etl/prefect/tasks/api.py
@@ -173,9 +173,6 @@ def create_moped_api_deploy_command(slug, config_secret_arn, ready_for_api_deplo
 
     logger.info("Creating API Zappa deploy command..")
 
-    logger.info("Calling it up with basename: " + basename)
-    logger.info("Calling it up with basename: " + config_secret_arn)
-
     zappa_config = create_zappa_config(basename, config_secret_arn)
 
     api_project_path = "/tmp/atd-moped/moped-api"

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -346,7 +346,7 @@ def create_task_definition(slug, api_endpoint):
         containerDefinitions=[
             {
                 "name": "graphql-engine",
-                "image": "hasura/graphql-engine:latest",
+                "image": "hasura/graphql-engine:v2.7.0",
                 # "image": "mendhak/http-https-echo:latest",
                 "cpu": 256,
                 "memory": 512,

--- a/moped-etl/prefect/tasks/migrations.py
+++ b/moped-etl/prefect/tasks/migrations.py
@@ -22,8 +22,7 @@ def use_seed_data(database_seed_source):
 
 @task(name="Get graphql-engine hostname")
 def get_graphql_engine_hostname(slug):
-    basename = slug["basename"]
-    return shared.form_graphql_endpoint_hostname(basename)
+    return shared.form_graphql_endpoint_hostname(slug["graphql_endpoint"])
 
 @task(name="Get graphql-engine access key")
 def get_graphql_engine_access_key(slug):

--- a/moped-etl/prefect/tasks/netlify.py
+++ b/moped-etl/prefect/tasks/netlify.py
@@ -70,7 +70,9 @@ def trigger_netlify_build(slug, api_endpoint_url):
     }
 
     graphql_endpoint = (
-        "https://" + shared.form_graphql_endpoint_hostname(branch) + "/v1/graphql"
+        "https://"
+        + shared.form_graphql_endpoint_hostname(slug["graphql_endpoint"])
+        + "/v1/graphql"
     )
 
     # See https://github.com/cityofaustin/atd-moped/blob/main/moped-editor/.env-cmdrc#L52-L76


### PR DESCRIPTION
Sibling PR: https://github.com/cityofaustin/atd-prefect/pull/36

## Features
### ✨ Major Items
- [x] Rework slugging function into a more readable, maintainable pattern
- [x] Fix failing seed application by adding sleeping intervals between invocations of hasura CLI client
  - This was failing silently and was maddening 
- [x] Cause the API to be built and deployed out of a moped repo checkout of the branch being deployed, not the codebase which has the ETL script in it
- [x] Improve detection of an already deployed state and enable steps to be taken for redeployment


### Minor items
- [x] Add 3 new versions of the slug (`graphql_endpoint`, `activity_log_slug`, `ecs_cluster_name`
- [x] Lots of new `logger.info()` calls, can't have enough when viewing the schematic → task view in the web UI
- [x] Make the executions of migrations controllable via the flow parameters at invocation
- [x] Uppercase the `FUNCTION_NAME` variable defined in the global scope of `api.py`.
  - Considering if this should go into the environment?
- [x] Minor refactor of using the `slug` object directly instead of pulling a single key out and defining it in the functions scope. Readability thing; I want to remind us where to look for the upstream definition of the slugged values. 
- [x] Pin `graphql-engine` to align with production

## General comment
This is a messy PR, and in hindsight would have been better to break up. The practicality of doing that would have been questionable given how the tools have been used over the last few days -- but it does make it a bit more of a mess to review. Sorry about that! I am going to be much better about breaking them out into PRs as much as possible!