### PR TITLE
Add new GitHub workflow to trigger test deployment

### DIFF
--- a/.github/workflows/initiate_test_deployment.yml
+++ b/.github/workflows/initiate_test_deployment.yml
@@ -1,0 +1,22 @@
+name: Run prefect flow
+on:
+  workflow_dispatch:
+    inputs:
+      description:
+        default: "Deploy test"
+jobs:
+  run-using-flow-path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Perform prefect login
+        uses: sp1thas/prefect-cli-action@main
+        with:
+          command: prefect auth login --key ${{ secrets.PREFECT_API_KEY }}
+      - name: Deploy Test Commission Flow 
+        uses: sp1thas/prefect-cli-action@main
+        with:
+          command: prefect run -n "Moped Test Instance Commission" --param branch=${BRANCH_NAME} --param database_seed_source=seed --param do_migrations=true

--- a/.github/workflows/initiate_test_deployment.yml
+++ b/.github/workflows/initiate_test_deployment.yml
@@ -1,4 +1,4 @@
-name: Run prefect flow
+name: "Deploy Test Instance"
 on:
   workflow_dispatch:
     inputs:
@@ -16,7 +16,7 @@ jobs:
         uses: sp1thas/prefect-cli-action@main
         with:
           command: prefect auth login --key ${{ secrets.PREFECT_API_KEY }}
-      - name: Deploy Test Commission Flow 
+      - name: Deploy Test Commission Flow
         uses: sp1thas/prefect-cli-action@main
         with:
           command: prefect run -n "Moped Test Instance Commission" --param branch=${BRANCH_NAME} --param database_seed_source=seed --param do_migrations=true


### PR DESCRIPTION
## Notes

⚠️ This is my first GitHub workflow; I'm in a bit of a learning curve while I figure out what is the best way to develop and deploy these. 

My understanding is that they must be created in `main`, but changes can be tested by invoking them and picking a feature branch that contains changes. The integrated GitHub UI on their site merges directly into main with no option for a branch target. As a result, I'd like to have this merged into main, and I will refine it as needed in a feature branch once I have a way to execute it at all. That said, I believe this should be a complete and working action definition. 

## Associated issues

This PR aims to close: https://github.com/cityofaustin/atd-data-tech/issues/10000

## Testing
I believe there is very low risk of this impacting our existing CI capabilities or the editor. This is also not testable prior to it being merged. I suggest that everyone read the workflow definition file and compare it to existing ones.


## Reviewers

I am adding our folks from Product to keep them up to date on this progress, but I'm eager to merge this to keep developing.  With developer support coupled with the very low risk profile, this should be merged sooner than later, in my opinion. I'm super happy to discuss this if this isn't the tack the group would like to take.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
