### PR TITLE
Fix spelling & cause CI to run on merge-into-main

### DIFF
--- a/moped-toolbox/README.md
+++ b/moped-toolbox/README.md
@@ -20,20 +20,18 @@ The docker image does not automatically run the script when it is instantiated f
 1. And execute the script.
 1. `docker-compose stop` will stop the container.
 
-
 ## amd_milestones_backfill
 
 This tool inserts `moped_proj_milestones` records into signal and PHB projects. It was created
 to backfill project milestones after implementing the milestone template feature for issue [#9102](https://github.com/cityofaustin/atd-data-tech/issues/9102).
 
-*Be aware that this script depends on database schema values which are in flux at the time of writing. In particular, the use of `status_id` to identify deleted records may be changd in a future release. Make sure this script aligns with your current database schema*
-
+_Be aware that this script depends on database schema values which are in flux at the time of writing. In particular, the use of `status_id` to identify deleted records may be changed in a future release. Make sure this script aligns with your current database schema_
 
 ### Usage instructions
 
 1. Create a python 3.x environment with `requests` installed.
 2. Configure authentication details in `secrets.py`
-3. Run `create_milestones.py`, and set the `--env (-e)` arg to your desired environment and  `--max-date-added (-d)` arg date accordingly.
+3. Run `create_milestones.py`, and set the `--env (-e)` arg to your desired environment and `--max-date-added (-d)` arg date accordingly.
 
 ```shell
 $ python create_milestones.py -e local -d '2022-06-17 00:00:00'
@@ -41,7 +39,7 @@ $ python create_milestones.py -e local -d '2022-06-17 00:00:00'
 
 ## purchase_order_backfill
 
-This tool populates the `moped_purchase_order table` [see issue #8259](https://github.com/cityofaustin/atd-data-tech/issues/8259) with existing contractor and purchase order information from the `moped_projects` columns purchase_order_number and contractor. This script is intended only to be used once, to move the data from the moped_projects table before we remove the purchase_order_number and contractor columns. 
+This tool populates the `moped_purchase_order table` [see issue #8259](https://github.com/cityofaustin/atd-data-tech/issues/8259) with existing contractor and purchase order information from the `moped_projects` columns purchase_order_number and contractor. This script is intended only to be used once, to move the data from the moped_projects table before we remove the purchase_order_number and contractor columns.
 
 ### Usage instructions
 


### PR DESCRIPTION
## Associated issues

No issue is associated with this work, and it's really just a spelling correction in, and the linting of, the Toolbox's README. 

This PR is primarily crafted to cause a redeployment of the Moped API for `staging` when this is merged into `main`. 

