### PR TITLE
Adds additional moped_funds

### DIFF
--- a/moped-database/migrations/1661803938508_add_four_more_moped_funds/down.sql
+++ b/moped-database/migrations/1661803938508_add_four_more_moped_funds/down.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+    "public"."moped_funds"
+WHERE
+    fund_id IN ('4730', 'PLAN', '4720', '8071');

--- a/moped-database/migrations/1661803938508_add_four_more_moped_funds/up.sql
+++ b/moped-database/migrations/1661803938508_add_four_more_moped_funds/up.sql
@@ -1,0 +1,7 @@
+INSERT INTO "public"."moped_funds"(
+  "fund_id", "fund_name") 
+VALUES 
+  (E'4730', E'PARKING CIP'),
+  (E'PLAN', E'PLANNING FAOS'),
+  (E'4720', E'ATD TRANSPORTATION CIP'),
+  (E'8071', E'GCP-TRANSP MOBILITY IMPV P1/00');

--- a/moped-editor/src/queries/funding.js
+++ b/moped-editor/src/queries/funding.js
@@ -35,7 +35,7 @@ export const FUNDING_QUERY = gql`
       funding_status_id
       funding_status_name
     }
-    moped_funds {
+    moped_funds(order_by: { fund_id: asc }) {
       fund_id
       fund_name
     }
@@ -108,7 +108,7 @@ export const CONTRACT_QUERY = gql`
   query ProjectPurchaseOrder($projectId: Int) {
     moped_proj_contract(
       where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
-      order_by: {id: asc}
+      order_by: { id: asc }
     ) {
       contractor
       id
@@ -149,14 +149,10 @@ export const UPDATE_CONTRACT = gql`
 `;
 
 export const DELETE_CONTRACT = gql`
-  mutation DeletePurchaseOrder(
-    $id: Int!
-  ) {
+  mutation DeletePurchaseOrder($id: Int!) {
     update_moped_proj_contract_by_pk(
       pk_columns: { id: $id }
-      _set: {
-        is_deleted: true
-      }
+      _set: { is_deleted: true }
     ) {
       id
     }


### PR DESCRIPTION
## Associated issues
Fixes https://github.com/cityofaustin/atd-data-tech/issues/10136.

When Chia did https://github.com/cityofaustin/atd-data-tech/issues/10025, we discovered that there are eCapris projects with fund codes unknown to Moped. This PR adds those missing funds.

I decided to also add sorting to our `moped_funds` query, since that list has grown organically and is now quite long.

## Testing
**URL to test:** Moped test.

https://10136-jc-more-fund-sources--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. go to **Funding** tab and add a new funding source
2. On the **Fund** dropdown, verify the fund names are sorted by fund code ascending.
3. Verify these funds are available:
```
4730 | PARKING CIP
PLAN | PLANNING FAOS
4720 | ATD TRANSPORTATION CIP
8071 | GCP-TRANSP MOBILITY IMPV P1/00
```

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
