### PR TITLE
Add components to lookups view

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -124,6 +124,14 @@
 - table:
     schema: public
     name: moped_components
+  array_relationships:
+    - name: moped_subcomponents
+      using:
+        foreign_key_constraint_on:
+          column: component_id
+          table:
+            schema: public
+            name: moped_subcomponents
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
-export const TIMELINE_LOOKUPS_QUERY = gql`
-  query TimelineQuery {
+export const TABLE_LOOKUPS_QUERY = gql`
+  query TableLookupQuery {
     moped_phases(order_by: { phase_order: asc }) {
       phase_id
       phase_name
@@ -21,6 +21,16 @@ export const TIMELINE_LOOKUPS_QUERY = gql`
       milestone_order
       moped_phase {
         phase_name
+      }
+    }
+    moped_components {
+      component_name
+      component_subtype
+      component_id
+      line_representation
+      moped_subcomponents {
+        subcomponent_name
+        subcomponent_id
       }
     }
   }

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -12,7 +12,7 @@ import LinkIcon from "@material-ui/icons/Link";
 import { makeStyles } from "@material-ui/styles";
 import Page from "src/components/Page";
 import RecordTable from "./RecordTable";
-import { TIMELINE_LOOKUPS_QUERY } from "src/queries/timelineLookups";
+import { TABLE_LOOKUPS_QUERY } from "src/queries/tableLookups";
 import { SETTINGS } from "./settings";
 
 const useStyles = makeStyles((theme) => ({
@@ -35,11 +35,13 @@ const createRecordKeyHash = (recordKey) => `#${recordKey.replace("_", "-")}`;
  */
 const LookupsView = () => {
   const classes = useStyles();
-  const { loading, error, data } = useQuery(TIMELINE_LOOKUPS_QUERY, {
+  const { loading, error, data } = useQuery(TABLE_LOOKUPS_QUERY, {
     fetchPolicy: "no-cache",
   });
 
   const [selectedRecordKey, setSelectedRecordKey] = useState(null);
+
+  console.log(SETTINGS);
 
   /**
    * We're using history here (and elsewhere) because it's not possible to use react-router
@@ -86,6 +88,7 @@ const LookupsView = () => {
     }
   }, [selectedRecordKey, refs]);
 
+  console.log(data)
   return (
     <ApolloErrorHandler error={error}>
       <Page title="Moped lookup values">

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -41,8 +41,6 @@ const LookupsView = () => {
 
   const [selectedRecordKey, setSelectedRecordKey] = useState(null);
 
-  console.log(SETTINGS);
-
   /**
    * We're using history here (and elsewhere) because it's not possible to use react-router
    * to replace window.loctation w/o forcing a re-render.
@@ -88,7 +86,6 @@ const LookupsView = () => {
     }
   }, [selectedRecordKey, refs]);
 
-  console.log(data)
   return (
     <ApolloErrorHandler error={error}>
       <Page title="Moped lookup values">

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -17,6 +17,19 @@ const subPhaseHandler = (subphases) =>
 const relatedPhaseHandler = (phase) => phase?.phase_name;
 
 /**
+ * Parses an array of subcomponents into an array of subcomponent names
+ * @param {Object[]} subcomponents - array of moped_subcomponents objects
+ * @returns { JSX } An array of <div>s with the subcomponent name
+ */
+const subComponentHandler = (subcomponents) =>
+  subcomponents &&
+  subcomponents.map((subcomponent) => (
+    <div key={subcomponent.subcomponent_id}>
+      {subcomponent.subcomponent_name}
+    </div>
+  ));
+
+/**
  * Definitions for data tables.
  * @type { Object[]}  - An array of settings for data tables. Each object references a typename
  * returned from a Hasura query
@@ -104,7 +117,7 @@ export const SETTINGS = [
        */
       {
         key: "component_id",
-        label: "Component ID"
+        label: "Component ID",
       },
       {
         key: "component_name",
@@ -117,13 +130,14 @@ export const SETTINGS = [
       {
         key: "line_representation",
         label: "Geometry type",
-        handler: lineRepresentation => lineRepresentation ? "Line" : "Point"
-      }
-      // {
-      //   key: "moped_subphases",
-      //   label: "Subphases",
-      //   handler: subPhaseHandler,
-      // },
+        handler: (lineRepresentation) =>
+          lineRepresentation ? "Line" : "Point",
+      },
+      {
+        key: "moped_subcomponents",
+        label: "Subcomponents",
+        handler: subComponentHandler,
+      },
     ],
   },
 ];

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -10,9 +10,9 @@ const subPhaseHandler = (subphases) =>
   ));
 
 /**
- * Parses an array of phase-subphases into an array of subphase names
- * @param {Object[]} subphases - array of moped_subphases objects
- * @returns { JSX } An array of <div>s with the subphase name
+ * Retrieves phase name from phase object
+ * @param {Object} phase - phase object
+ * @returns { string } phase name
  */
 const relatedPhaseHandler = (phase) => phase?.phase_name;
 
@@ -88,6 +88,42 @@ export const SETTINGS = [
         key: "milestone_description",
         label: "Description",
       },
+    ],
+  },
+  {
+    key: "moped_components",
+    label: "Moped components",
+    columns: [
+      /**
+       * @type { Object } Column definition
+       * @property { string } key - the accessor that will be used to retrieve data from a table row
+       * object
+       * @property { string} label - a human-friendly label which will be used as a table column header
+       * @property { Function } [handler] - an optional transform function that receives any object and
+       * returns a string. You'll want to use this on complex data types.
+       */
+      {
+        key: "component_id",
+        label: "Component ID"
+      },
+      {
+        key: "component_name",
+        label: "Component name",
+      },
+      {
+        key: "component_subtype",
+        label: "Component subtype",
+      },
+      {
+        key: "line_representation",
+        label: "Geometry type",
+        handler: lineRepresentation => lineRepresentation ? "Line" : "Point"
+      }
+      // {
+      //   key: "moped_subphases",
+      //   label: "Subphases",
+      //   handler: subPhaseHandler,
+      // },
     ],
   },
 ];


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10107


## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->
had to change the metadata and add an array relationship, so unfortunately this won't work on the netlify deploy. 

**Steps to test:**

go to `/moped/dev/lookups#moped-components` and see the components with subcomponents. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
