### PR TITLE
Track who creates a moped project

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2468,6 +2468,9 @@
     - name: moped_status
       using:
         foreign_key_constraint_on: status_id
+    - name: moped_user
+      using:
+        foreign_key_constraint_on: added_by
   array_relationships:
     - name: moped_proj_components
       using:

--- a/moped-database/migrations/1662486549080_set_fk_public_moped_project_added_by/down.sql
+++ b/moped-database/migrations/1662486549080_set_fk_public_moped_project_added_by/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_project" drop constraint "moped_project_added_by_fkey";

--- a/moped-database/migrations/1662486549080_set_fk_public_moped_project_added_by/up.sql
+++ b/moped-database/migrations/1662486549080_set_fk_public_moped_project_added_by/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_project"
+  add constraint "moped_project_added_by_fkey"
+  foreign key ("added_by")
+  references "public"."moped_users"
+  ("user_id") on update cascade on delete set null;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 export const ADD_PROJECT = gql`
   mutation AddProject($object: moped_project_insert_input!) {
     insert_moped_project_one(object: $object) {
+      added_by
       project_id
       project_name
       project_description

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -156,7 +156,7 @@ const NewProjectView = () => {
         object: {
           // First we need to copy the project details
           ...projectDetails,
-
+          added_by: userId,
           // We need to add the potential phase as a default
           moped_proj_phases: {
             data: [


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/6730

- adds a foreign key relationship between the project table and the moped_users table
- adds the object relationship
- includes the userid in the project creation mutation

This PR does not backfill previous projects with who created them

## Testing
**URL to test:** <!-- https://moped-test.austinmobility.io/moped/ or Netlify -->

Testing locally, add a new project. If you query the database, you will see added_by is `1` whereas previous projects are `null`. (Locally, we are all signed in as JD. If you want to see a different user_id, change the id on line 104 of the file src/auth/user.js, sign out and sign back in. Add a project and the new user id is there.)


There is no change to the UI but this sets the groundwork for eventually being able to search by who added a project 
https://github.com/cityofaustin/atd-data-tech/issues/6697

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] ~~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~~
