### PR TITLE
Adds new subphases for Project Delivery Division

### DIFF
--- a/moped-database/migrations/1663082078687_adds_pd_subphases_and_updates_phase_description/down.sql
+++ b/moped-database/migrations/1663082078687_adds_pd_subphases_and_updates_phase_description/down.sql
@@ -1,0 +1,11 @@
+-- reverts add subphase "Preliminary Engineering Report" to the "Preliminary Engineering" phase
+DELETE FROM moped_subphases  WHERE subphase_name ='Preliminary Engineering Report' and related_phase_id = 3;
+
+-- reverts add the subphase "Bid Preparation" to "Pre-Construction" phase
+DELETE FROM moped_subphases WHERE subphase_name ='Bid Preparation' and related_phase_id = 7;
+
+-- reverts add the subphase "Substantially Complete" to the "Post-Construction" phase
+DELETE FROM moped_subphases  WHERE subphase_name ='Substantially Complete' and related_phase_id = 10;
+
+--reverts add "bid preparation" to the description of phase "Pre-Construction"
+UPDATE moped_phases SET phase_description = 'Project is dealing with permitting, procurement, or other processes needed between design and construction' WHERE phase_id = 7;

--- a/moped-database/migrations/1663082078687_adds_pd_subphases_and_updates_phase_description/up.sql
+++ b/moped-database/migrations/1663082078687_adds_pd_subphases_and_updates_phase_description/up.sql
@@ -1,0 +1,11 @@
+-- add subphase "Preliminary Engineering Report" to the "Preliminary Engineering" phase
+INSERT INTO moped_subphases (subphase_name, subphase_order, related_phase_id) VALUES ('Preliminary Engineering Report', 22, 3);
+
+-- add the subphase "Bid Preparation" to "Pre-Construction" phase
+INSERT INTO moped_subphases (subphase_name, subphase_order, related_phase_id) VALUES ('Bid Preparation', 23, 7);
+
+-- add the subphase "Substantially Complete" to the "Post-Construction" phase
+INSERT INTO moped_subphases (subphase_name, subphase_order, related_phase_id) VALUES ('Substantially Complete', 24, 10);
+
+-- Add "bid preparation" to the description of phase "Pre-Construction"
+UPDATE moped_phases SET phase_description = 'Project is dealing with bid preparation, permitting, procurement, or other processes needed between design and construction' WHERE phase_id = 7;

--- a/moped-database/migrations/1663083290227_alter_table_public_moped_subphases_alter_column_subphase_order/down.sql
+++ b/moped-database/migrations/1663083290227_alter_table_public_moped_subphases_alter_column_subphase_order/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."moped_subphases" drop constraint "moped_subphases_subphase_order_key";
+alter table "public"."moped_subphases" alter column "subphase_order" drop not null;

--- a/moped-database/migrations/1663083290227_alter_table_public_moped_subphases_alter_column_subphase_order/up.sql
+++ b/moped-database/migrations/1663083290227_alter_table_public_moped_subphases_alter_column_subphase_order/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."moped_subphases" alter column "subphase_order" set not null;
+alter table "public"."moped_subphases" add constraint "moped_subphases_subphase_order_key" unique ("subphase_order");

--- a/moped-database/migrations/1663084376667_alter_table_public_moped_subphases_add_unique_subphase_name_related_phase_id/down.sql
+++ b/moped-database/migrations/1663084376667_alter_table_public_moped_subphases_add_unique_subphase_name_related_phase_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_subphases" drop constraint "moped_subphases_subphase_name_related_phase_id_key";

--- a/moped-database/migrations/1663084376667_alter_table_public_moped_subphases_add_unique_subphase_name_related_phase_id/up.sql
+++ b/moped-database/migrations/1663084376667_alter_table_public_moped_subphases_add_unique_subphase_name_related_phase_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_subphases" add constraint "moped_subphases_subphase_name_related_phase_id_key" unique ("subphase_name", "related_phase_id");


### PR DESCRIPTION
## Associated issues
Resolves https://github.com/cityofaustin/atd-data-tech/issues/10069

In addition to ☝️ - I went ahead and added a few constraints to the `moped_subphases` table:
- `subphase_order` cannot be null
- `subphase_order` must be unique
- The combination of `subphase_name` + `related_phase_id` must be unique: i.e., we cannot have duplicate subphase names related to the same phase.

## Testing
**URL to test:** Local or [Moped test deploy](https://10069-jc-pd-phase-updates--atd-moped-main.netlify.app/moped)


**Steps to test:**
Navigate to `moped/dev/lookups` and confirm the following changes:

- subphase "Preliminary Engineering Report" exists in the "Preliminary Engineering" phase
- subphase "Bid Preparation" exists in the "Pre-Construction" phase
- subphase "Substantially Complete" exists in the "Post-Construction" phase
- the description of the phase "Pre-Construction" is "Project is dealing with bid preparation, permitting, procurement, or other processes needed between design and construction"
- locally, login to the Hasura console and verify that:
  - the `moped_subphases` table has a `unique` constraint on the `subphase_order` column
  -  the `moped_subphases` table has a `unique` constraint on the combined (`subphase_name`, `related_phase_id`) columns
  - the `subphase_order` column cannot be `NULL`

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
