### PR TITLE
Support timeline templates for multiple workgroups

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.3.6",

--- a/moped-editor/src/components/ButtonDropdownMenu.js
+++ b/moped-editor/src/components/ButtonDropdownMenu.js
@@ -13,29 +13,42 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.background.paper,
     },
     "& .MuiList-root": {
-      padding: "0px"
+      padding: "0px",
     },
     "& .MuiListItem-root": {
       textTransform: "uppercase",
       fontSize: "14px",
       fontWeight: 500,
       paddingTop: "8px",
-      paddingBottom: "8px"
+      paddingBottom: "8px",
     },
     "& .MuiListItem-root:hover": {
-      backgroundColor: theme.palette.primary.dark
+      backgroundColor: theme.palette.primary.dark,
     },
     "& .MuiListItem-root:first-of-type": {
-      borderBottom: `1px solid ${theme.palette.primary.dark}`
+      borderBottom: `1px solid ${theme.palette.primary.dark}`,
     },
     "& .MuiListItemIcon-root": {
       color: theme.palette.background.paper,
-      minWidth: "28px"
-    }
+      minWidth: "28px",
+    },
   },
 }));
 
-const ButtonDropdownMenu = ({ buttonWrapperStyle, addAction, openFundingDialog }) => {
+/**
+ * ButtonDropdownMenu - Button that opens to show two different options
+ *
+ * @return {JSX.Element}
+ * @constructor
+ */
+const ButtonDropdownMenu = ({
+  buttonWrapperStyle,
+  addAction,
+  openActionDialog,
+  parentButtonText,
+  firstOptionText,
+  secondOptionText,
+}) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -63,7 +76,7 @@ const ButtonDropdownMenu = ({ buttonWrapperStyle, addAction, openFundingDialog }
         }
         className={buttonWrapperStyle}
       >
-        Add Funding Source
+        {parentButtonText}
       </Button>
       <Menu
         className={classes.dropDownMenu}
@@ -85,13 +98,13 @@ const ButtonDropdownMenu = ({ buttonWrapperStyle, addAction, openFundingDialog }
           <ListItemIcon>
             <AddCircle fontSize="small" />
           </ListItemIcon>
-          New funding source
+          {firstOptionText}
         </MenuItem>
-        <MenuItem onClick={() => openFundingDialog(true)}>
+        <MenuItem onClick={() => openActionDialog(true)}>
           <ListItemIcon>
             <AddCircle fontSize="small" />
           </ListItemIcon>
-          From eCapris
+          {secondOptionText}
         </MenuItem>
       </Menu>
     </div>

--- a/moped-editor/src/components/ButtonDropdownMenu.js
+++ b/moped-editor/src/components/ButtonDropdownMenu.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Button, ListItemIcon, Menu, MenuItem } from "@material-ui/core";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp";
+import PlaylistAddIcon from "@material-ui/icons/PlaylistAdd";
 import AddCircle from "@material-ui/icons/AddCircle";
 import { makeStyles } from "@material-ui/core";
 
@@ -48,6 +49,7 @@ const ButtonDropdownMenu = ({
   parentButtonText,
   firstOptionText,
   secondOptionText,
+  secondOptionIcon,
 }) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState(null);
@@ -102,7 +104,11 @@ const ButtonDropdownMenu = ({
         </MenuItem>
         <MenuItem onClick={() => openActionDialog(true)}>
           <ListItemIcon>
-            <AddCircle fontSize="small" />
+            {secondOptionIcon ? (
+              <PlaylistAddIcon fontSize="small" />
+            ) : (
+              <AddCircle fontSize="small" />
+            )}
           </ListItemIcon>
           {secondOptionText}
         </MenuItem>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { TextField, Grid, InputLabel, Switch } from "@material-ui/core";
-import { Autocomplete } from "@material-ui/lab";
 import SignalAutocomplete from "./SignalAutocomplete";
 
 const DefineProjectForm = ({
@@ -14,22 +13,12 @@ const DefineProjectForm = ({
   signal,
   setSignal,
   signalError,
-  projectTypeId,
-  setProjectTypeId,
-  typeData,
 }) => {
   const handleFieldChange = (value, name) => {
     const updatedProjectDetails = { ...projectDetails, [name]: value };
 
     setProjectDetails(updatedProjectDetails);
   };
-
-  const typesList = typeData?.moped_types ?? [];
-  // We only have templates for types: Signal - New, Signal - Mod, PHB - New, PHB - Mod
-  // Filter out other types based on type_id
-  const templateTypesList = typesList.filter(object =>
-    [1, 2, 4, 5].includes(object.type_id)
-  );
 
   return (
     <form style={{ padding: 25 }}>
@@ -89,31 +78,6 @@ const DefineProjectForm = ({
             helperText="Required"
             InputLabelProps={{ required: false }}
             onChange={e => handleFieldChange(e.target.value, e.target.name)}
-          />
-        </Grid>
-      </Grid>
-
-      <Grid container spacing={3} style={{ margin: 20 }}>
-        <Grid item xs={3}>
-          <Autocomplete
-            value={
-              templateTypesList.filter(type => type.type_id === projectTypeId)
-                .type_name
-            }
-            defaultValue={null}
-            id="specify-milestone-template-autocomplete"
-            options={templateTypesList}
-            getOptionLabel={t => t.type_name}
-            onChange={(event, newValue) => {
-              setProjectTypeId(newValue.type_id);
-            }}
-            renderInput={params => (
-              <TextField
-                {...params}
-                variant="standard"
-                label={"Timeline template"}
-              />
-            )}
           />
         </Grid>
       </Grid>

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -15,11 +15,8 @@ import { useQuery, useMutation } from "@apollo/client";
 import {
   SIGNAL_COMPONENTS_QUERY,
   ADD_PROJECT,
-  TYPES_QUERY,
-  ADD_PROJECT_MILESTONE,
   PROJECT_FOLLOW,
 } from "../../../queries/project";
-import { returnSignalPHBMilestoneTemplate } from "../../../utils/timelineTemplates";
 
 import { getSessionDatabaseData } from "../../../auth/user";
 
@@ -84,7 +81,6 @@ const NewProjectView = () => {
     type: "FeatureCollection",
     features: [],
   });
-  const [projectTypeId, setProjectTypeId] = useState(null);
 
   /**
    * Signals query
@@ -94,12 +90,6 @@ const NewProjectView = () => {
     loading: componentQueryloading,
     data: componentData,
   } = useQuery(SIGNAL_COMPONENTS_QUERY);
-
-  const {
-    error: typeQueryError,
-    loading: typeQueryLoading,
-    data: typeData,
-  } = useQuery(TYPES_QUERY);
 
   /**
    * Signal component state management
@@ -118,7 +108,6 @@ const NewProjectView = () => {
    */
   const [addProject] = useMutation(ADD_PROJECT);
 
-  const [addProjectMilestone] = useMutation(ADD_PROJECT_MILESTONE);
   const [followProject] = useMutation(PROJECT_FOLLOW);
 
   /**
@@ -183,17 +172,6 @@ const NewProjectView = () => {
                 },
               }
             : {}),
-          ...(projectTypeId
-            ? {
-                moped_project_types: {
-                  data: [
-                    {
-                      project_type_id: projectTypeId,
-                    },
-                  ],
-                },
-              }
-            : {}),
         },
       };
 
@@ -217,14 +195,6 @@ const NewProjectView = () => {
               },
             },
           });
-          // if a project type has been specified, add the milestones from template
-          if (projectTypeId) {
-            return addProjectMilestone({
-              variables: {
-                objects: returnSignalPHBMilestoneTemplate(project_id),
-              },
-            });
-          }
         })
         // If there is an error, we must show it...
         .catch((err) => {
@@ -263,11 +233,10 @@ const NewProjectView = () => {
     }
   }, [success, newProjectId, navigate]);
 
-  if (componentQueryloading || typeQueryLoading) {
+  if (componentQueryloading) {
     return <CircularProgress />;
   }
   if (componentQueryError) return `Error! ${componentQueryError.message}`;
-  if (typeQueryError) return `Error! ${typeQueryError.message}`;
 
   return (
     <Page title="New project">
@@ -286,9 +255,6 @@ const NewProjectView = () => {
                 signal={signal}
                 signalError={signalError}
                 setSignal={setSignal}
-                projectTypeId={projectTypeId}
-                setProjectTypeId={setProjectTypeId}
-                typeData={typeData}
               />
               <Box pt={2} pl={2} className={classes.buttons}>
                 <ProjectSaveButton

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -34,14 +34,16 @@ const useStyles = makeStyles((theme) => ({
 
 const templateChoices = ["AMD", "PDD"];
 
- /**
-  * useMemo hook to choose milestone options
-  * @return {Object[]}
-  */
-const useMilestoneOptions = (template, projectId) =>
+/**
+ * useMemo hook to choose milestone options with already selected milestones filtered out
+ * @return {Object[]}
+ */
+const useMilestoneOptions = (template, projectId, selectedMilestonesIds) =>
   useMemo(() => {
     if (template === "AMD") {
-      return returnSignalPHBMilestoneTemplate(projectId);
+      return returnSignalPHBMilestoneTemplate(projectId).filter(
+        (option) => !selectedMilestonesIds.includes(option.milestone_id)
+      );
       // } else if (template === "PDD") {
       //   // etc return [];
     } else {
@@ -69,9 +71,10 @@ const MilestoneTemplateModal = ({
     (milestone) => milestone.milestone_id
   );
 
-  // milestone options with existing milestones filtered out
-  const milestonesList = useMilestoneOptions(template, projectId).filter(
-    (option) => !selectedMilestonesIds.includes(option.milestone_id)
+  const milestonesList = useMilestoneOptions(
+    template,
+    projectId,
+    selectedMilestonesIds
   );
 
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -53,12 +53,15 @@ const useMilestoneOptions = (template, projectId, selectedMilestonesIds) =>
  * useMemo hook to filter out already selected milestones
  * @return {Object[]}
  */
-const useMilestoneSelections = (milestonesList, selectedMilestonesIds) =>
+const useMilestoneSelections = (milestonesList, selectedMilestones) =>
   useMemo(() => {
+    const selectedMilestonesIds = selectedMilestones.map(
+      (milestone) => milestone.milestone_id
+    );
     return milestonesList.filter(
       (option) => !selectedMilestonesIds.includes(option.milestone_id)
     );
-  }, [milestonesList, selectedMilestonesIds]);
+  }, [milestonesList, selectedMilestones]);
 
 const MilestoneTemplateModal = ({
   isDialogOpen,
@@ -75,21 +78,16 @@ const MilestoneTemplateModal = ({
 
   const [addProjectMilestone] = useMutation(ADD_PROJECT_MILESTONE);
 
-  // Array of milestone ids already in moped_proj_milestones
-  const selectedMilestonesIds = selectedMilestones.map(
-    (milestone) => milestone.milestone_id
-  );
-
   const milestonesList = useMilestoneOptions(template, projectId);
 
   const filteredMilestonesList = useMilestoneSelections(
     milestonesList,
-    selectedMilestonesIds
+    selectedMilestones
   );
 
   useEffect(() => {
-    setMilestonesToAdd([...milestonesList]);
-  }, [milestonesList]);
+    setMilestonesToAdd([...filteredMilestonesList]);
+  }, [filteredMilestonesList]);
 
   // checks if milestone is in list of milestones to add
   // if in list, remove. if not, add.

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -52,20 +52,19 @@ const MilestoneTemplateModal = ({
 
   useEffect(() => {
     let options = [];
-    let filteredOptions = [];
     const selectedMilestonesIds = selectedMilestones.map(
       (milestone) => milestone.milestone_id
     );
     setMilestonesList([]);
     if (template === "AMD") {
       options = returnSignalPHBMilestoneTemplate(projectId);
-      filteredOptions = options.filter(
-        (option) => !selectedMilestonesIds.includes(option.milestone_id)
-      );
     }
     // if (template === "PDD") {
     // options = return other template
-    //}
+    // }
+    const filteredOptions = options.filter(
+      (option) => !selectedMilestonesIds.includes(option.milestone_id)
+    );
     setMilestonesList(filteredOptions);
     setMilestonesToAdd(filteredOptions);
   }, [template, selectedMilestones, projectId]);
@@ -151,7 +150,6 @@ const MilestoneTemplateModal = ({
               <ListItem
                 button
                 key={milestone.milestone_id}
-                role={undefined}
                 dense
                 onClick={() => handleToggle(milestone)}
               >

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -35,21 +35,30 @@ const useStyles = makeStyles((theme) => ({
 const templateChoices = ["AMD", "PDD"];
 
 /**
- * useMemo hook to choose milestone options with already selected milestones filtered out
+ * useMemo hook to choose milestone options
  * @return {Object[]}
  */
 const useMilestoneOptions = (template, projectId, selectedMilestonesIds) =>
   useMemo(() => {
     if (template === "AMD") {
-      return returnSignalPHBMilestoneTemplate(projectId).filter(
-        (option) => !selectedMilestonesIds.includes(option.milestone_id)
-      );
+      return returnSignalPHBMilestoneTemplate(projectId);
       // } else if (template === "PDD") {
       //   // etc return [];
     } else {
       return [];
     }
   }, [template, projectId]);
+
+/**
+ * useMemo hook to filter out already selected milestones
+ * @return {Object[]}
+ */
+const useMilestoneSelections = (milestonesList, selectedMilestonesIds) =>
+  useMemo(() => {
+    return milestonesList.filter(
+      (option) => !selectedMilestonesIds.includes(option.milestone_id)
+    );
+  }, [milestonesList, selectedMilestonesIds]);
 
 const MilestoneTemplateModal = ({
   isDialogOpen,
@@ -71,9 +80,10 @@ const MilestoneTemplateModal = ({
     (milestone) => milestone.milestone_id
   );
 
-  const milestonesList = useMilestoneOptions(
-    template,
-    projectId,
+  const milestonesList = useMilestoneOptions(template, projectId);
+
+  const filteredMilestonesList = useMilestoneSelections(
+    milestonesList,
     selectedMilestonesIds
   );
 
@@ -156,7 +166,7 @@ const MilestoneTemplateModal = ({
           </Button>
         </Box>
         <List dense>
-          {milestonesList.map((milestone) => {
+          {filteredMilestonesList.map((milestone) => {
             return (
               <ListItem
                 button

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -1,0 +1,161 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { Autocomplete } from "@material-ui/lab";
+import { makeStyles } from "@material-ui/core";
+import CloseIcon from "@material-ui/icons/Close";
+import AddCircle from "@material-ui/icons/AddCircle";
+import MaterialTable from "@material-table/core";
+import { returnSignalPHBMilestoneTemplate } from "../../../utils/timelineTemplates";
+
+
+import typography from "../../../theme/typography";
+
+const useStyles = makeStyles((theme) => ({
+  dialogTitle: {
+    color: theme.palette.primary.main,
+    fontFamily: theme.typography.fontFamily,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+}));
+
+
+const templateChoices = ["AMD", "PDD"];
+
+const MilestoneTemplateModal = ({
+  isDialogOpen,
+  handleDialogClose,
+  projectId,
+  milestoneNameLookup,
+  selectedMilestones
+}) => {
+  const classes = useStyles();
+  const typographyStyle = {
+    fontFamily: typography.fontFamily,
+    fontSize: "14px",
+  };
+
+  const [template, setTemplate] = useState(null);
+  const [milestones, setMilestones] = useState([]);
+  const data = [];
+
+
+  // when you pick a template
+  // load the milestones and put in state
+  // show on a table. 
+  // make it so you can toggle them off
+
+
+  const handleAddMilestones = () => {
+    console.log("add the thing")
+    // run the update
+  };
+
+  const selectedMilestonesIds = selectedMilestones.map(milestone => milestone.milestone_id)
+
+  const selectMilestones = () => {
+    setMilestones([]);
+    let choices = [];
+    if (template === "AMD") {
+      choices = returnSignalPHBMilestoneTemplate(projectId)
+      choices.forEach(choice=>console.log(!selectedMilestonesIds.includes(choice.milestone_id)))
+      setMilestones(choices.filter(choice => !selectedMilestonesIds.includes(choice.milestone_id)))
+    }
+  }
+
+console.log(milestones)
+const columns = [
+  {
+    field: "milestone_id",
+    title: "Milestone name",
+    cellStyle: { padding: "12px" },
+    render: (entry) => ( milestoneNameLookup[entry.milestone_id]
+      ),
+  }
+];
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onClose={handleDialogClose}
+      fullWidth
+      maxWidth={"md"}
+    >
+      <DialogTitle disableTypography className={classes.dialogTitle}>
+        <h3>Select milestone template</h3>
+        <IconButton onClick={() => handleDialogClose()}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Box my={3} sx={{display: "flex", justifyContent: "space-between" }}>
+                  <Autocomplete
+            // value={
+            //   templateTypesList.filter(type => type.type_id === projectTypeId)
+            //     .type_name
+            // }
+            style={{width: "250px"}}
+            defaultValue={null}
+            id="specify-milestone-template-autocomplete"
+            options={templateChoices}
+            // getOptionLabel={t => t.type_name}
+            onChange={(event, newValue) => {
+              console.log(newValue)
+              setTemplate(newValue);
+              selectMilestones(newValue);
+            }}
+            renderInput={params => (
+              <TextField
+                {...params}
+                variant="standard"
+                label={"Timeline template"}
+              />
+            )}
+          />
+          <Button
+            className={classes.fundingButton}
+            variant="contained"
+            color="primary"
+            size="medium"
+            startIcon={<AddCircle />}
+            onClick={handleAddMilestones}
+            disabled={!template}
+          >
+            Add milestones
+          </Button>
+        </Box>
+        {milestones.length > 0 &&
+        <MaterialTable
+          columns={columns}
+          data={milestones}
+          options={{
+            paging: false,
+            search: false,
+            toolbar: false,
+            tableLayout: "fixed",
+            selection: true,
+            rowStyle: typographyStyle,
+            pageSize: 10,
+            showSelectAllCheckbox: false,
+            selectionProps: rowData => {
+              console.log(rowData.milestone_id)
+              return {color: "primary", checked: true}}
+          }}
+          onSelectionChange={(rows) => console.log(rows)}
+        />}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MilestoneTemplateModal;

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Button,
   Box,
@@ -34,6 +34,21 @@ const useStyles = makeStyles((theme) => ({
 
 const templateChoices = ["AMD", "PDD"];
 
+ /**
+  * useMemo hook to choose milestone options
+  * @return {Object[]}
+  */
+const useMilestoneOptions = (template, projectId) =>
+  useMemo(() => {
+    if (template === "AMD") {
+      return returnSignalPHBMilestoneTemplate(projectId);
+      // } else if (template === "PDD") {
+      //   // etc return [];
+    } else {
+      return [];
+    }
+  }, [template, projectId]);
+
 const MilestoneTemplateModal = ({
   isDialogOpen,
   handleDialogClose,
@@ -45,29 +60,23 @@ const MilestoneTemplateModal = ({
   const classes = useStyles();
 
   const [template, setTemplate] = useState(null);
-  const [milestonesList, setMilestonesList] = useState([]);
   const [milestonesToAdd, setMilestonesToAdd] = useState([]);
 
   const [addProjectMilestone] = useMutation(ADD_PROJECT_MILESTONE);
 
+  // Array of milestone ids already in moped_proj_milestones
+  const selectedMilestonesIds = selectedMilestones.map(
+    (milestone) => milestone.milestone_id
+  );
+
+  // milestone options with existing milestones filtered out
+  const milestonesList = useMilestoneOptions(template, projectId).filter(
+    (option) => !selectedMilestonesIds.includes(option.milestone_id)
+  );
+
   useEffect(() => {
-    let options = [];
-    const selectedMilestonesIds = selectedMilestones.map(
-      (milestone) => milestone.milestone_id
-    );
-    setMilestonesList([]);
-    if (template === "AMD") {
-      options = returnSignalPHBMilestoneTemplate(projectId);
-    }
-    // if (template === "PDD") {
-    // options = return other template
-    // }
-    const filteredOptions = options.filter(
-      (option) => !selectedMilestonesIds.includes(option.milestone_id)
-    );
-    setMilestonesList(filteredOptions);
-    setMilestonesToAdd(filteredOptions);
-  }, [template, selectedMilestones, projectId]);
+    setMilestonesToAdd([...milestonesList]);
+  }, [milestonesList]);
 
   // checks if milestone is in list of milestones to add
   // if in list, remove. if not, add.
@@ -88,7 +97,6 @@ const MilestoneTemplateModal = ({
   const closeDialog = () => {
     handleDialogClose();
     setMilestonesToAdd([]);
-    setMilestonesList([]);
     setTemplate(null);
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -567,7 +567,10 @@ const ProjectFundingTable = () => {
                 <ButtonDropdownMenu
                   buttonWrapperStyle={classes.fundingButton}
                   addAction={props.action.onClick}
-                  openFundingDialog={setIsDialogOpen}
+                  openActionDialog={setIsDialogOpen}
+                  parentButtonText="Add Funding Source"
+                  firstOptionText="New funding source"
+                  secondOptionText="From eCapris"
                 />
               ) : (
                 <Button

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -11,7 +11,6 @@ import {
 import {
   EditOutlined as EditOutlinedIcon
 } from "@material-ui/icons";
-import PlaylistAddIcon from '@material-ui/icons/PlaylistAdd';
 import MaterialTable, {
   MTableEditRow,
   MTableAction,
@@ -68,7 +67,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
     {}
   );
 
-  // Hide Dialog
+  // Hide Milestone template dialog
   const handleTemplateModalClose = () => {
     setIsDialogOpen(false);
   }

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -9,8 +9,9 @@ import {
   FormHelperText,
 } from "@material-ui/core";
 import {
-  EditOutlined as EditOutlinedIcon,
+  EditOutlined as EditOutlinedIcon
 } from "@material-ui/icons";
+import PlaylistAddIcon from '@material-ui/icons/PlaylistAdd';
 import MaterialTable, {
   MTableEditRow,
   MTableAction,
@@ -67,9 +68,9 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
     {}
   );
 
+  // Hide Dialog
   const handleTemplateModalClose = () => {
     setIsDialogOpen(false);
-    refetch();
   }
 
   /**
@@ -202,23 +203,13 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
           } else {
             return (
               <ButtonDropdownMenu
-                // buttonWrapperStyle={classes.fundingButton}
                 addAction={props.action.onClick}
                 openActionDialog={setIsDialogOpen}
                 parentButtonText="Add milestone"
                 firstOptionText="New milestone"
                 secondOptionText="From template"
+                secondOptionIcon
               />
-              // <Button
-              //   variant="contained"
-              //   color="primary"
-              //   size="large"
-              //   startIcon={<AddCircleIcon />}
-              //   ref={addActionRefMilestones}
-              //   onClick={props.action.onClick}
-              // >
-              //   Add milestone
-              // </Button>
             );
           }
         },
@@ -326,9 +317,8 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
         handleDialogClose={handleTemplateModalClose}
         milestoneNameLookup={milestoneNameLookup}
         selectedMilestones={data.moped_proj_milestones}
-    //     selectedMilestonesIds={data?.moped_proj_milestones.map(
-    // (milestone) => milestone.milestone_id)}
         projectId={projectId}
+        refetch={refetch}
       />
       </>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 // Material
 import {
@@ -35,19 +35,16 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import { phaseNameLookup } from "src/utils/timelineTableHelpers";
 import DateFieldEditComponent from "./DateFieldEditComponent";
 import ToggleEditComponent from "./ToggleEditComponent";
+import ButtonDropdownMenu from "../../../components/ButtonDropdownMenu";
+import MilestoneTemplateModal from "./MilestoneTemplateModal";
 
 /**
- * ProjectTimeline Component - renders the view displayed when the "Timeline"
- * tab is active
+ * ProjectMilestones Component - Renders Project Milestone table
  * @return {JSX.Element}
  * @constructor
  */
 const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
-  /** addAction Ref - mutable ref object used to access add action button
-   * imperatively.
-   * @type {object} addActionRef
-   * */
-  const addActionRefMilestones = React.useRef();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   // Mutations
   const [updateProjectMilestone] = useMutation(
@@ -71,6 +68,11 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
       }),
     {}
   );
+
+  const handleTemplateModalClose = () => {
+    setIsDialogOpen(false);
+    refetch();
+  }
 
   /**
    * Column configuration for <MaterialTable> Milestones table
@@ -113,8 +115,10 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
         fontSize: "14px",
       },
       customSort: (a, b) => {
-        const aPhaseName = phaseNameLookup(data)[a.moped_milestone.related_phase_id];
-        const bPhaseName = phaseNameLookup(data)[b.moped_milestone.related_phase_id];
+        const aPhaseName =
+          phaseNameLookup(data)[a.moped_milestone.related_phase_id];
+        const bPhaseName =
+          phaseNameLookup(data)[b.moped_milestone.related_phase_id];
         if (aPhaseName > bPhaseName) {
           return 1;
         }
@@ -171,6 +175,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
   ];
 
   return (
+    <>
     <MaterialTable
       columns={milestoneColumns}
       data={data.moped_proj_milestones}
@@ -198,16 +203,24 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
             return <MTableAction {...props} />;
           } else {
             return (
-              <Button
-                variant="contained"
-                color="primary"
-                size="large"
-                startIcon={<AddCircleIcon />}
-                ref={addActionRefMilestones}
-                onClick={props.action.onClick}
-              >
-                Add milestone
-              </Button>
+              <ButtonDropdownMenu
+                // buttonWrapperStyle={classes.fundingButton}
+                addAction={props.action.onClick}
+                openActionDialog={setIsDialogOpen}
+                parentButtonText="Add milestone"
+                firstOptionText="New milestone"
+                secondOptionText="From template"
+              />
+              // <Button
+              //   variant="contained"
+              //   color="primary"
+              //   size="large"
+              //   startIcon={<AddCircleIcon />}
+              //   ref={addActionRefMilestones}
+              //   onClick={props.action.onClick}
+              // >
+              //   Add milestone
+              // </Button>
             );
           }
         },
@@ -310,6 +323,14 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
         },
       }}
     />
+      <MilestoneTemplateModal
+        isDialogOpen={isDialogOpen}
+        handleDialogClose={handleTemplateModalClose}
+        milestoneNameLookup={milestoneNameLookup}
+        selectedMilestones={data.moped_proj_milestones}
+        projectId={projectId}
+      />
+      </>
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 
 // Material
 import {
-  Button,
   CircularProgress,
   TextField,
   Typography,
@@ -10,7 +9,6 @@ import {
   FormHelperText,
 } from "@material-ui/core";
 import {
-  AddCircle as AddCircleIcon,
   EditOutlined as EditOutlinedIcon,
 } from "@material-ui/icons";
 import MaterialTable, {
@@ -328,6 +326,8 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
         handleDialogClose={handleTemplateModalClose}
         milestoneNameLookup={milestoneNameLookup}
         selectedMilestones={data.moped_proj_milestones}
+    //     selectedMilestonesIds={data?.moped_proj_milestones.map(
+    // (milestone) => milestone.milestone_id)}
         projectId={projectId}
       />
       </>

--- a/moped-editor/src/views/projects/projectView/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/SubprojectFundingModal.js
@@ -135,7 +135,7 @@ const SubprojectFundingModal = ({
             },
           }}
           options={{
-            ...(data.length < 11 && {
+            ...(filteredData.length < 11 && {
               paging: false,
             }),
             search: false,


### PR DESCRIPTION
## Associated issues

Closes https://github.com/cityofaustin/atd-data-tech/issues/10238

## Testing
**URL to test:** 
https://deploy-preview-796--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Test project creation, I removed the option to choose a type from the project workflow. No milestones should show up after a project is created
2. Navigate to the timeline tab. Open the button dropdown, select "From Template"
3. A modal should appear, with a disabled button and an autocomplete to choose templates. 
4. after choosing the AMD choice, the list should populate with preselected milestones. (PMD is still empty because we dont have the "template" listed yet) Toggling them off will not include them in the mutation. 
5. any existing milestone on the table should not show up in the modal. You can test by adding some of the milestones and then opening the modal again and seeing the list is shorter. 

---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
