### PR TITLE
Adds project tags to lookups view

### DIFF
--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -33,5 +33,11 @@ export const TABLE_LOOKUPS_QUERY = gql`
         subcomponent_id
       }
     }
+    moped_tags {
+      id
+      name
+      slug
+      type
+    }
   }
 `;

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -33,7 +33,7 @@ export const TABLE_LOOKUPS_QUERY = gql`
         subcomponent_id
       }
     }
-    moped_tags {
+    moped_tags(where: { is_deleted: { _eq: false } }) {
       id
       name
       slug

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -140,4 +140,26 @@ export const SETTINGS = [
       },
     ],
   },
+  {
+    key: "moped_tags",
+    label: "Project Tags",
+    columns: [
+      {
+        key: "id",
+        label: "Tag ID",
+      },
+      {
+        key: "type",
+        label: "Type",
+      },
+      {
+        key: "name",
+        label: "Name",
+      },
+      {
+        key: "slug",
+        label: "Slug",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10319

## Testing
**URL to test:** [Deploy preview](https://deploy-preview-800--atd-moped-main.netlify.app/moped/projects/1824?tab=map) on Netlify.

**Steps to test:**
Navigate to `/moped/dev/lookups` and verify the "Project tags" nav link is functional as well as the "Project tags" table at the bottom of the page.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
