### PR TITLE
Automatically show blank advanced search filter

### DIFF
--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -416,6 +416,8 @@ const GridTableFilters = ({
   useEffect(() => {
     if (Object.keys(filterParameters).length === 0) {
       filterState.setFilterParameters(filterParameters);
+      // Add an empty filter so the user doesn't have to click the 'add filter' button
+      handleAddFilterButtonClick();
     }
   }, [filterParameters, filterState]);
 

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 import PropTypes from "prop-types";
@@ -152,6 +152,19 @@ const GridTableFilters = ({
     return { ...defaultNewFieldState, id: uuid };
   };
 
+  const generateEmptyFilter = useCallback(() => {
+    // Generate a random UUID string
+    const uuid = uuidv4();
+    // Clone state
+    const filtersNewState = {
+      ...filterParameters,
+    };
+    // Patch new state
+    filtersNewState[uuid] = generateEmptyField(uuid);
+    // Update new state
+    setFilterParameters(filtersNewState);
+  });
+
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive
    */
@@ -301,16 +314,7 @@ const GridTableFilters = ({
    * Adds an empty filter to the state
    */
   const handleAddFilterButtonClick = () => {
-    // Generate a random UUID string
-    const uuid = uuidv4();
-    // Clone state
-    const filtersNewState = {
-      ...filterParameters,
-    };
-    // Patch new state
-    filtersNewState[uuid] = generateEmptyField(uuid);
-    // Update new state
-    setFilterParameters(filtersNewState);
+    generateEmptyFilter();
   };
 
   /**
@@ -419,7 +423,7 @@ const GridTableFilters = ({
       // Add an empty filter so the user doesn't have to click the 'add filter' button
       handleAddFilterButtonClick();
     }
-  }, [filterParameters, filterState, handleAddFilterButtonClick]);
+  }, [filterParameters, filterState, generateEmptyFilter]);
 
   return (
     <Grid>

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -148,12 +148,9 @@ const GridTableFilters = ({
    * @param uuid
    * @return {Object}
    */
-  const generateEmptyField = useCallback(
-    (uuid) => {
-      return { ...defaultNewFieldState, id: uuid };
-    },
-    [uuid]
-  );
+  const generateEmptyField = useCallback((uuid) => {
+    return { ...defaultNewFieldState, id: uuid };
+  }, []);
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -167,7 +167,7 @@ const GridTableFilters = ({
     filtersNewState[uuid] = generateEmptyField(uuid);
     // Update new state
     setFilterParameters(filtersNewState);
-  }, [filterParameters, setFilterParameters, generateEmptyField]);
+  }, [filterParameters, setFilterParameters]);
 
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -421,7 +421,7 @@ const GridTableFilters = ({
     if (Object.keys(filterParameters).length === 0) {
       filterState.setFilterParameters(filterParameters);
       // Add an empty filter so the user doesn't have to click the 'add filter' button
-      handleAddFilterButtonClick();
+      generateEmptyFilter();
     }
   }, [filterParameters, filterState, generateEmptyFilter]);
 

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -419,7 +419,7 @@ const GridTableFilters = ({
       // Add an empty filter so the user doesn't have to click the 'add filter' button
       handleAddFilterButtonClick();
     }
-  }, [filterParameters, filterState]);
+  }, [filterParameters, filterState, handleAddFilterButtonClick]);
 
   return (
     <Grid>

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -150,7 +150,7 @@ const GridTableFilters = ({
    */
   const generateEmptyField = useCallback((uuid) => {
     return { ...defaultNewFieldState, id: uuid };
-  }, []);
+  }, [defaultNewFieldState]);
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -163,7 +163,7 @@ const GridTableFilters = ({
     filtersNewState[uuid] = generateEmptyField(uuid);
     // Update new state
     setFilterParameters(filtersNewState);
-  });
+  }, []);
 
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -163,7 +163,7 @@ const GridTableFilters = ({
     filtersNewState[uuid] = generateEmptyField(uuid);
     // Update new state
     setFilterParameters(filtersNewState);
-  }, []);
+  }, [filterParameters, setFilterParameters, generateEmptyField]);
 
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -434,11 +434,6 @@ const GridTableFilters = ({
           <Icon fontSize={"small"}>close</Icon>
         </IconButton>
       </Grid>
-      {Object.keys(filterParameters).length === 0 && (
-        <Alert className={classes.filterAlert} severity="info">
-          You don't have any search filters, add one below.
-        </Alert>
-      )}
       {Object.keys(filterParameters).map((filterId) => {
         return (
           <Grow in={true} key={`filter-grow-${filterId}`}>

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -19,7 +19,7 @@ import {
   makeStyles,
 } from "@material-ui/core";
 
-import { Alert, Autocomplete } from "@material-ui/lab";
+import { Autocomplete } from "@material-ui/lab";
 import BackspaceOutlinedIcon from "@material-ui/icons/BackspaceOutlined";
 import { LOOKUP_TABLES_QUERY } from "../../queries/project";
 

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -443,7 +443,7 @@ const GridTableFilters = ({
         setFilterComplete(true);
       }
     });
-  });
+  }, [filterParameters]);
 
   return (
     <Grid>
@@ -599,7 +599,7 @@ const GridTableFilters = ({
               <Hidden smDown>
                 <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
                   <IconButton
-                    disabled={!filterParameters[filterId].value}
+                    disabled={Object.keys(filterParameters).length === 1 && !filterComplete}
                     className={classes.deleteButton}
                     onClick={() => handleDeleteFilterButtonClick(filterId)}
                   >
@@ -610,7 +610,7 @@ const GridTableFilters = ({
               <Hidden mdUp>
                 <Grid item xs={12}>
                   <Button
-                    disabled={!filterParameters[filterId].value}
+                    disabled={Object.keys(filterParameters).length === 1 && !filterComplete}
                     fullWidth
                     className={classes.deleteButton}
                     variant="outlined"

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -116,41 +116,41 @@ const GridTableFilters = ({
   );
 
   /**
-   * The default structure of an empty field
-   * @type {Object}
-   * @property {string} id - The uuid of the field
-   * @property {string} field - The name of the column
-   * @property {operator} operator - The name of the operator
-   * @property {string[]} availableOperators - A string array containing the names of available operators
-   * @property {string} gqlOperator - A string containing the GraphQL operator
-   * @property {string} envelope - The a pattern to use as an envelope
-   * @property {string} value - The text value to be searched
-   * @property {string} type - The type of field it is (string, number, etc.)
-   * @constant
-   * @default
-   */
-  const defaultNewFieldState = {
-    id: null,
-    field: null,
-    operator: null,
-    availableOperators: [],
-    gqlOperator: null,
-    envelope: null,
-    placeholder: null,
-    value: null,
-    type: null,
-    specialNullValue: null,
-    label: null,
-  };
-
-  /**
    * Generates a copy of an empty field
    * @param uuid
    * @return {Object}
    */
   const generateEmptyField = useCallback((uuid) => {
+    /**
+     * The default structure of an empty field
+     * @type {Object}
+     * @property {string} id - The uuid of the field
+     * @property {string} field - The name of the column
+     * @property {operator} operator - The name of the operator
+     * @property {string[]} availableOperators - A string array containing the names of available operators
+     * @property {string} gqlOperator - A string containing the GraphQL operator
+     * @property {string} envelope - The a pattern to use as an envelope
+     * @property {string} value - The text value to be searched
+     * @property {string} type - The type of field it is (string, number, etc.)
+     * @constant
+     * @default
+     */
+    const defaultNewFieldState = {
+      id: null,
+      field: null,
+      operator: null,
+      availableOperators: [],
+      gqlOperator: null,
+      envelope: null,
+      placeholder: null,
+      value: null,
+      type: null,
+      specialNullValue: null,
+      label: null,
+    };
+
     return { ...defaultNewFieldState, id: uuid };
-  }, [defaultNewFieldState]);
+  }, []);
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -148,9 +148,12 @@ const GridTableFilters = ({
    * @param uuid
    * @return {Object}
    */
-  const generateEmptyField = useCallback(() => {
-    return { ...defaultNewFieldState, id: uuid };
-  }, [uuid]);
+  const generateEmptyField = useCallback(
+    (uuid) => {
+      return { ...defaultNewFieldState, id: uuid };
+    },
+    [uuid]
+  );
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -148,9 +148,9 @@ const GridTableFilters = ({
    * @param uuid
    * @return {Object}
    */
-  const generateEmptyField = (uuid) => {
+  const generateEmptyField = useCallback(() => {
     return { ...defaultNewFieldState, id: uuid };
-  };
+  }, [uuid]);
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string

--- a/moped-editor/src/components/GridTable/GridTableFilters.js
+++ b/moped-editor/src/components/GridTable/GridTableFilters.js
@@ -148,7 +148,6 @@ const GridTableFilters = ({
       specialNullValue: null,
       label: null,
     };
-
     return { ...defaultNewFieldState, id: uuid };
   }, []);
 


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10289

## Testing
**URL to test:** <!-- [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ -->
https://deploy-preview-804--atd-moped-main.netlify.app/

**Steps to test:**
go to projects list view, click filter button, you should see an empty field. add a filter, search, delete a filter.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
