### PR TITLE
Remove `status_id` from queries

### DIFF
--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -27,7 +27,6 @@ export const DASHBOARD_QUERY = gql`
         ) {
           added_by
           project_note_type
-          status_id
           project_note
         }
       }
@@ -54,7 +53,6 @@ export const DASHBOARD_QUERY = gql`
         ) {
           added_by
           project_note_type
-          status_id
           project_note
         }
       }


### PR DESCRIPTION
I removed the deprecated `status_id` (old soft-delete) fields from the DB recently, and there were some queries that were still requesting them. This PR removes it from those queries to get the Dashboard view working again.

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10341

## Testing
**URL to test:**
This can be tested locally

**Steps to test:**
1. Create a project.
2. From the project summary, verify you are following the project - the bookmark icon in the top right should be filled.
3. Add your self to the project personnel in the project **Team** tab
3. Navigate to the Dashboard page
4. Your project should be listed in both the **My Projects** and **Following** tabs

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
