### PR TITLE
Updates component geojson extract to include project tags

### DIFF
--- a/moped-toolbox/component_geo_processing/create_components_geojson.py
+++ b/moped-toolbox/component_geo_processing/create_components_geojson.py
@@ -141,6 +141,14 @@ def add_project_properties(properties, project_data, project_list_keys):
         properties[key] = project_data[key]
 
 
+def add_project_tags(properties, moped_proj_tags):
+    if not moped_proj_tags:
+        return
+    tags = [proj_tag["moped_tag"]["name"] for proj_tag in moped_proj_tags]
+    properties["moped_proj_tags"] = ",".join(tags)
+    return
+
+
 def main(env):
     query = get_query(QUERY_TEMPLATE, PROJECT_LIST_KEYS)
     print("Fetching project data...")
@@ -166,6 +174,7 @@ def main(env):
             geometry = merge_geoms(features)
             properties = get_component_properties(proj_component["moped_components"])
             add_project_properties(properties, project_data, PROJECT_LIST_KEYS)
+            add_project_tags(properties, proj["moped_proj_tags"])
             component_features.append(
                 {
                     "type": "Feature",
@@ -176,7 +185,7 @@ def main(env):
 
     # filter features by geometry type and write geojson files
     print("Writing files...")
-    os.makedirs(OUTPUT_DIR, exist_ok=True) 
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
     for geom_type in [
         {"key": "MultiLineString", "name": "lines"},
         {"key": "MultiPoint", "name": "points"},

--- a/moped-toolbox/component_geo_processing/create_components_geojson.py
+++ b/moped-toolbox/component_geo_processing/create_components_geojson.py
@@ -143,7 +143,7 @@ def add_project_properties(properties, project_data, project_list_keys):
 
 def add_project_tags(properties, moped_proj_tags):
     tags = [proj_tag["moped_tag"]["name"] for proj_tag in moped_proj_tags]
-    properties["moped_proj_tags"] = ",".join(tags)
+    properties["moped_proj_tags"] = ",".join(tags) if tags else None
     return
 
 

--- a/moped-toolbox/component_geo_processing/create_components_geojson.py
+++ b/moped-toolbox/component_geo_processing/create_components_geojson.py
@@ -142,8 +142,6 @@ def add_project_properties(properties, project_data, project_list_keys):
 
 
 def add_project_tags(properties, moped_proj_tags):
-    if not moped_proj_tags:
-        return
     tags = [proj_tag["moped_tag"]["name"] for proj_tag in moped_proj_tags]
     properties["moped_proj_tags"] = ",".join(tags)
     return

--- a/moped-toolbox/component_geo_processing/settings.py
+++ b/moped-toolbox/component_geo_processing/settings.py
@@ -42,6 +42,11 @@ QUERY_TEMPLATE = """
     query ProjectComponentsQuery {
         moped_project(where: {is_deleted: {_eq: false}}) {
             project_id
+            moped_proj_tags(where: {is_deleted: {_eq: false}}) {
+                moped_tag {
+                    name
+                }
+            }
             moped_proj_components(where: {is_deleted: {_eq: false}}) {
                 moped_components {
                     component_name


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10384

Adds `moped_proj_tags` to the components geojson extracts.

Steps to test:
1. Activate a local python environment with `requests` installed
2. Start local Moped DB and editor
3. Create a project with a few different component types e.g. Buffered bike lane and signals
4. Add Tags to the project.
5. Run the script `python create_components_geojson.py -e local`
6. Locate the `points` and `lines` geojson files in the `_output/` directory.
7. Search the output geojson to verify that the projects' tags are populated in the `moped_proj_tags` property.
8. You can upload these to [geojson.io](https://geojson.io/) to inspect the results.
9. Optionally, add `staging` or `prod` entries to `secrets.py` to process data against those environments.