### PR TITLE
Adds a delete confirmation modal to project tags and comments

### DIFF
--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Button,
-  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -14,19 +13,16 @@ const useStyles = makeStyles((theme) => ({
   deleteButton: {
     color: theme.palette.error.main,
   },
-  chip: {
-    margin: theme.spacing(0.5),
-  },
 }));
 
-const DeleteConfirmationModal = ({ type, item, submitDelete, children }) => {
+const DeleteConfirmationModal = ({
+  type,
+  submitDelete,
+  deleteConfirmationOpen,
+  setDeleteConfirmationOpen,
+  children
+}) => {
   const classes = useStyles();
-
-  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
-
-  const handleDeleteOpen = () => {
-    setDeleteConfirmationOpen(true);
-  };
 
   const handleDeleteClose = () => {
     setDeleteConfirmationOpen(false);
@@ -34,16 +30,7 @@ const DeleteConfirmationModal = ({ type, item, submitDelete, children }) => {
 
   return (
     <span>
-      {type === "comment" && (
-        <span onClick={() => handleDeleteOpen()}>{children}</span>
-      )}
-      {type === "tag" && (
-        <Chip
-          label={item.moped_tag.name}
-          onDelete={() => handleDeleteOpen()}
-          className={classes.chip}
-        />
-      )}
+      {children}
       <Dialog
         open={deleteConfirmationOpen}
         onClose={handleDeleteClose}
@@ -61,8 +48,7 @@ const DeleteConfirmationModal = ({ type, item, submitDelete, children }) => {
             className={classes.deleteButton}
             startIcon={<DeleteIcon />}
             onClick={() => {
-              type === "comment" && submitDelete(item.project_note_id);
-              type === "tag" && submitDelete(item);
+              submitDelete();
               handleDeleteClose();
             }}
           >

--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -1,61 +1,77 @@
 import React, { useState } from "react";
 import {
   Button,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 
 const useStyles = makeStyles((theme) => ({
-  deleteCommentButton: {
+  deleteButton: {
     color: theme.palette.error.main,
+  },
+  chip: {
+    margin: theme.spacing(0.5),
   },
 }));
 
-const DeleteConfirmationModal = ({ item, submitDeleteComment, children }) => {
+const DeleteConfirmationModal = ({ type, item, submitDelete, children }) => {
   const classes = useStyles();
 
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
-  const handleDeleteCommentOpen = () => {
+  const handleDeleteOpen = () => {
     setDeleteConfirmationOpen(true);
   };
 
-  const handleDeleteCommentClose = () => {
+  const handleDeleteClose = () => {
     setDeleteConfirmationOpen(false);
   };
 
   return (
     <span>
-      <span onClick={() => handleDeleteCommentOpen()}>{children}</span>
+      {type === "comment" && (
+        <span onClick={() => handleDeleteOpen()}>{children}</span>
+      )}
+      {type === "tag" && (
+        <Chip
+          label={item.moped_tag.name}
+          onDelete={() => handleDeleteOpen()}
+          className={classes.chip}
+        />
+      )}
       <Dialog
         open={deleteConfirmationOpen}
-        onClose={handleDeleteCommentClose}
+        onClose={handleDeleteClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            Are you sure you want to delete this comment?
+            {`Are you sure you want to delete this ${type}?`}
           </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button
             variant="outlined"
-            className={classes.deleteCommentButton}
+            className={classes.deleteButton}
+            startIcon={<DeleteIcon />}
             onClick={() => {
-              submitDeleteComment(item.project_note_id);
-              handleDeleteCommentClose();
+              type === "comment" && submitDelete(item.project_note_id);
+              type === "tag" && submitDelete(item);
+              handleDeleteClose();
             }}
           >
-            Delete
+            <span>Delete</span>
           </Button>
           <Button
             variant="outlined"
             color="primary"
-            onClick={handleDeleteCommentClose}
+            onClick={handleDeleteClose}
             autoFocus
           >
             Cancel

--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -3,13 +3,20 @@ import {
   Button,
   Dialog,
   DialogActions,
-  DialogTitle,
   DialogContent,
   DialogContentText,
 } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 
-const DeleteConfirmationModal = () => {
-    console.log("you opened a modal");
+const useStyles = makeStyles((theme) => ({
+  deleteCommentButton: {
+    color: theme.palette.error.main,
+  },
+}));
+
+const DeleteConfirmationModal = ({ item, submitDeleteComment, children }) => {
+  const classes = useStyles();
+
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   const handleDeleteCommentOpen = () => {
@@ -21,30 +28,41 @@ const DeleteConfirmationModal = () => {
   };
 
   return (
-    <div>
+    <span>
+      <span onClick={() => handleDeleteCommentOpen()}>{children}</span>
       <Dialog
         open={deleteConfirmationOpen}
         onClose={handleDeleteCommentClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
-        <DialogTitle id="alert-dialog-title">
-          {"Use Google's location service?"}
-        </DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            Let Google help apps determine location. This means sending
-            anonymous location data to Google, even when no apps are running.
+            Are you sure you want to delete this comment?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleDeleteCommentClose}>Disagree</Button>
-          <Button onClick={handleDeleteCommentClose} autoFocus>
-            Agree
+          <Button
+            variant="outlined"
+            className={classes.deleteCommentButton}
+            onClick={() => {
+              submitDeleteComment(item.project_note_id);
+              handleDeleteCommentClose();
+            }}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={handleDeleteCommentClose}
+            autoFocus
+          >
+            Cancel
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </span>
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -18,21 +18,21 @@ const useStyles = makeStyles((theme) => ({
 const DeleteConfirmationModal = ({
   type,
   submitDelete,
-  deleteConfirmationOpen,
-  setDeleteConfirmationOpen,
-  children
+  isDeleteConfirmationOpen,
+  setIsDeleteConfirmationOpen,
+  children,
 }) => {
   const classes = useStyles();
 
   const handleDeleteClose = () => {
-    setDeleteConfirmationOpen(false);
+    setIsDeleteConfirmationOpen(false);
   };
 
   return (
     <span>
       {children}
       <Dialog
-        open={deleteConfirmationOpen}
+        open={isDeleteConfirmationOpen}
         onClose={handleDeleteClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
@@ -44,7 +44,14 @@ const DeleteConfirmationModal = ({
         </DialogContent>
         <DialogActions>
           <Button
-            variant="outlined"
+            color="primary"
+            onClick={handleDeleteClose}
+            autoFocus
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
             className={classes.deleteButton}
             startIcon={<DeleteIcon />}
             onClick={() => {
@@ -53,14 +60,6 @@ const DeleteConfirmationModal = ({
             }}
           >
             <span>Delete</span>
-          </Button>
-          <Button
-            variant="outlined"
-            color="primary"
-            onClick={handleDeleteClose}
-            autoFocus
-          >
-            Cancel
           </Button>
         </DialogActions>
       </Dialog>

--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+} from "@material-ui/core";
+
+const DeleteConfirmationModal = () => {
+    console.log("you opened a modal");
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+
+  const handleDeleteCommentOpen = () => {
+    setDeleteConfirmationOpen(true);
+  };
+
+  const handleDeleteCommentClose = () => {
+    setDeleteConfirmationOpen(false);
+  };
+
+  return (
+    <div>
+      <Dialog
+        open={deleteConfirmationOpen}
+        onClose={handleDeleteCommentClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Use Google's location service?"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Let Google help apps determine location. This means sending
+            anonymous location data to Google, even when no apps are running.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDeleteCommentClose}>Disagree</Button>
+          <Button onClick={handleDeleteCommentClose} autoFocus>
+            Agree
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -6,14 +6,7 @@ import {
   DialogContent,
   DialogContentText,
 } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 import DeleteIcon from "@material-ui/icons/DeleteOutlined";
-
-const useStyles = makeStyles((theme) => ({
-  deleteButton: {
-    color: theme.palette.error.main,
-  },
-}));
 
 const DeleteConfirmationModal = ({
   type,
@@ -22,7 +15,6 @@ const DeleteConfirmationModal = ({
   setIsDeleteConfirmationOpen,
   children,
 }) => {
-  const classes = useStyles();
 
   const handleDeleteClose = () => {
     setIsDeleteConfirmationOpen(false);
@@ -51,8 +43,8 @@ const DeleteConfirmationModal = ({
             Cancel
           </Button>
           <Button
+            color="primary"
             variant="contained"
-            className={classes.deleteButton}
             startIcon={<DeleteIcon />}
             onClick={() => {
               submitDelete();

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -15,6 +15,11 @@ import {
   Typography,
   Button,
   FormControlLabel,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
 } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/EditOutlined";
@@ -26,6 +31,7 @@ import { useParams } from "react-router-dom";
 import parse from "html-react-parser";
 import DOMPurify from "dompurify";
 import CommentInputQuill from "./CommentInputQuill";
+import DeleteConfirmationModal from "./DeleteConfirmationModal";
 
 import "./ProjectComments.css";
 
@@ -79,6 +85,9 @@ const useStyles = makeStyles((theme) => ({
   editDeleteButtons: {
     color: "#000000",
   },
+  deleteCommentButton: {
+    color: theme.palette.error.main,
+  },
 }));
 
 // Lookup array to convert project note types to a human readable interpretation
@@ -97,6 +106,7 @@ const ProjectComments = (props) => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params
@@ -210,6 +220,14 @@ const ProjectComments = (props) => {
         projectNoteId: project_note_id,
       },
     });
+  };
+
+  const handleDeleteCommentOpen = () => {
+    setDeleteConfirmationOpen(true);
+  };
+
+  const handleDeleteCommentClose = () => {
+    setDeleteConfirmationOpen(false);
   };
 
   /**
@@ -387,17 +405,56 @@ const ProjectComments = (props) => {
                                 </IconButton>
                               )}
                               {!editingComment && (
-                                <IconButton
-                                  edge="end"
-                                  aria-label="delete"
-                                  onClick={() =>
-                                    submitDeleteComment(item.project_note_id)
-                                  }
-                                >
-                                  <DeleteIcon
-                                    className={classes.editDeleteButtons}
-                                  />
-                                </IconButton>
+                                <span>
+                                  <IconButton
+                                    edge="end"
+                                    aria-label="delete"
+                                    onClick={() => handleDeleteCommentOpen()}
+                                  >
+                                    <DeleteIcon
+                                      className={classes.editDeleteButtons}
+                                    />
+                                  </IconButton>
+                                  {/* <DeleteConfirmationModal
+                                    open={deleteConfirmationOpen}
+                                    onClose={handleDeleteCommentClose}
+                                  /> */}
+                                  <Dialog
+                                    open={deleteConfirmationOpen}
+                                    onClose={handleDeleteCommentClose}
+                                    aria-labelledby="alert-dialog-title"
+                                    aria-describedby="alert-dialog-description"
+                                  >
+                                    <DialogContent>
+                                      <DialogContentText id="alert-dialog-description">
+                                        Are you sure you want to delete this
+                                        comment?
+                                      </DialogContentText>
+                                    </DialogContent>
+                                    <DialogActions>
+                                      <Button
+                                        variant="outlined"
+                                        className={classes.deleteCommentButton}
+                                        onClick={() => {
+                                          submitDeleteComment(
+                                            item.project_note_id
+                                          );
+                                          handleDeleteCommentClose();
+                                        }}
+                                      >
+                                        Delete
+                                      </Button>
+                                      <Button
+                                        variant="outlined"
+                                        color="primary"
+                                        onClick={handleDeleteCommentClose}
+                                        autoFocus
+                                      >
+                                        Cancel
+                                      </Button>
+                                    </DialogActions>
+                                  </Dialog>
+                                </span>
                               )}
                             </ListItemSecondaryAction>
                           )

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -390,8 +390,9 @@ const ProjectComments = (props) => {
                               {!editingComment && (
                                 <span>
                                   <DeleteConfirmationModal
+                                    type="comment"
                                     item={item}
-                                    submitDeleteComment={submitDeleteComment}
+                                    submitDelete={submitDeleteComment}
                                   >
                                     <IconButton edge="end" aria-label="delete">
                                       <DeleteIcon

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -15,11 +15,6 @@ import {
   Typography,
   Button,
   FormControlLabel,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
 } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/EditOutlined";
@@ -85,9 +80,6 @@ const useStyles = makeStyles((theme) => ({
   editDeleteButtons: {
     color: "#000000",
   },
-  deleteCommentButton: {
-    color: theme.palette.error.main,
-  },
 }));
 
 // Lookup array to convert project note types to a human readable interpretation
@@ -106,7 +98,6 @@ const ProjectComments = (props) => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
-  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params
@@ -220,14 +211,6 @@ const ProjectComments = (props) => {
         projectNoteId: project_note_id,
       },
     });
-  };
-
-  const handleDeleteCommentOpen = () => {
-    setDeleteConfirmationOpen(true);
-  };
-
-  const handleDeleteCommentClose = () => {
-    setDeleteConfirmationOpen(false);
   };
 
   /**
@@ -406,54 +389,16 @@ const ProjectComments = (props) => {
                               )}
                               {!editingComment && (
                                 <span>
-                                  <IconButton
-                                    edge="end"
-                                    aria-label="delete"
-                                    onClick={() => handleDeleteCommentOpen()}
+                                  <DeleteConfirmationModal
+                                    item={item}
+                                    submitDeleteComment={submitDeleteComment}
                                   >
-                                    <DeleteIcon
-                                      className={classes.editDeleteButtons}
-                                    />
-                                  </IconButton>
-                                  {/* <DeleteConfirmationModal
-                                    open={deleteConfirmationOpen}
-                                    onClose={handleDeleteCommentClose}
-                                  /> */}
-                                  <Dialog
-                                    open={deleteConfirmationOpen}
-                                    onClose={handleDeleteCommentClose}
-                                    aria-labelledby="alert-dialog-title"
-                                    aria-describedby="alert-dialog-description"
-                                  >
-                                    <DialogContent>
-                                      <DialogContentText id="alert-dialog-description">
-                                        Are you sure you want to delete this
-                                        comment?
-                                      </DialogContentText>
-                                    </DialogContent>
-                                    <DialogActions>
-                                      <Button
-                                        variant="outlined"
-                                        className={classes.deleteCommentButton}
-                                        onClick={() => {
-                                          submitDeleteComment(
-                                            item.project_note_id
-                                          );
-                                          handleDeleteCommentClose();
-                                        }}
-                                      >
-                                        Delete
-                                      </Button>
-                                      <Button
-                                        variant="outlined"
-                                        color="primary"
-                                        onClick={handleDeleteCommentClose}
-                                        autoFocus
-                                      >
-                                        Cancel
-                                      </Button>
-                                    </DialogActions>
-                                  </Dialog>
+                                    <IconButton edge="end" aria-label="delete">
+                                      <DeleteIcon
+                                        className={classes.editDeleteButtons}
+                                      />
+                                    </IconButton>
+                                  </DeleteConfirmationModal>
                                 </span>
                               )}
                             </ListItemSecondaryAction>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -101,7 +101,7 @@ const ProjectComments = (props) => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
-  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   // if component is being used in edit modal from dashboard
@@ -268,7 +268,7 @@ const ProjectComments = (props) => {
   );
 
   const handleDeleteOpen = (id) => {
-    setDeleteConfirmationOpen(true);
+    setIsDeleteConfirmationOpen(true);
     setDeleteConfirmationId(id);
   };
 
@@ -403,11 +403,11 @@ const ProjectComments = (props) => {
                                   submitDelete={() =>
                                     submitDeleteComment(deleteConfirmationId)
                                   }
-                                  deleteConfirmationOpen={
-                                    deleteConfirmationOpen
+                                  isDeleteConfirmationOpen={
+                                    isDeleteConfirmationOpen
                                   }
-                                  setDeleteConfirmationOpen={
-                                    setDeleteConfirmationOpen
+                                  setIsDeleteConfirmationOpen={
+                                    setIsDeleteConfirmationOpen
                                   }
                                 >
                                   <IconButton

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -80,6 +80,9 @@ const useStyles = makeStyles((theme) => ({
   editDeleteButtons: {
     color: "#000000",
   },
+  chip: {
+    margin: theme.spacing(0.5),
+  },
 }));
 
 // Lookup array to convert project note types to a human readable interpretation
@@ -98,6 +101,8 @@ const ProjectComments = (props) => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+  const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params
@@ -262,6 +267,11 @@ const ProjectComments = (props) => {
     </Button>
   );
 
+  const handleDeleteOpen = (id) => {
+    setDeleteConfirmationOpen(true);
+    setDeleteConfirmationId(id);
+  };
+
   return (
     <CardContent>
       <Grid container spacing={2}>
@@ -388,19 +398,30 @@ const ProjectComments = (props) => {
                                 </IconButton>
                               )}
                               {!editingComment && (
-                                <span>
-                                  <DeleteConfirmationModal
-                                    type="comment"
-                                    item={item}
-                                    submitDelete={submitDeleteComment}
+                                <DeleteConfirmationModal
+                                  type="comment"
+                                  submitDelete={() =>
+                                    submitDeleteComment(deleteConfirmationId)
+                                  }
+                                  deleteConfirmationOpen={
+                                    deleteConfirmationOpen
+                                  }
+                                  setDeleteConfirmationOpen={
+                                    setDeleteConfirmationOpen
+                                  }
+                                >
+                                  <IconButton
+                                    edge="end"
+                                    aria-label="delete"
+                                    onClick={() =>
+                                      handleDeleteOpen(item.project_note_id)
+                                    }
                                   >
-                                    <IconButton edge="end" aria-label="delete">
-                                      <DeleteIcon
-                                        className={classes.editDeleteButtons}
-                                      />
-                                    </IconButton>
-                                  </DeleteConfirmationModal>
-                                </span>
+                                    <DeleteIcon
+                                      className={classes.editDeleteButtons}
+                                    />
+                                  </IconButton>
+                                </DeleteConfirmationModal>
                               )}
                             </ListItemSecondaryAction>
                           )

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -65,7 +65,7 @@ const useStyles = makeStyles((theme) => ({
 const TagsSection = ({ projectId }) => {
   const [addTagMode, setAddTagMode] = useState(false);
   const [newTagList, setNewTagList] = useState([]);
-  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   const { loading, error, data, refetch } = useQuery(TAGS_QUERY, {
@@ -134,7 +134,7 @@ const TagsSection = ({ projectId }) => {
   };
 
   const handleDeleteOpen = (id) => {
-    setDeleteConfirmationOpen(true);
+    setIsDeleteConfirmationOpen(true);
     setDeleteConfirmationId(id);
   };
 
@@ -161,8 +161,8 @@ const TagsSection = ({ projectId }) => {
               <DeleteConfirmationModal
                 type="tag"
                 submitDelete={() => handleTagDelete(deleteConfirmationId)}
-                deleteConfirmationOpen={deleteConfirmationOpen}
-                setDeleteConfirmationOpen={setDeleteConfirmationOpen}
+                isDeleteConfirmationOpen={isDeleteConfirmationOpen}
+                setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
               >
                 <Chip
                   label={tag.moped_tag.name}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -4,7 +4,6 @@ import { useQuery, useMutation } from "@apollo/client";
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   Icon,
   IconButton,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -17,6 +17,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import AddCircle from "@material-ui/icons/AddCircle";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
+import DeleteConfirmationModal from "../DeleteConfirmationModal";
 
 import {
   TAGS_QUERY,
@@ -150,11 +151,12 @@ const TagsSection = ({ projectId }) => {
         <Box component={"ul"} className={classes.chipContainer}>
           {data.moped_proj_tags.map((tag) => (
             <li key={tag.id}>
-              <Chip
-                label={tag.moped_tag.name}
-                onDelete={() => handleTagDelete(tag)}
-                className={classes.chip}
-              />
+              <DeleteConfirmationModal
+                type="tag"
+                item={tag}
+                submitDelete={handleTagDelete}
+              >
+              </DeleteConfirmationModal>
             </li>
           ))}
           {addTagMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from "@apollo/client";
 import {
   Box,
   Button,
+  Chip,
   CircularProgress,
   Icon,
   IconButton,
@@ -64,6 +65,8 @@ const useStyles = makeStyles((theme) => ({
 const TagsSection = ({ projectId }) => {
   const [addTagMode, setAddTagMode] = useState(false);
   const [newTagList, setNewTagList] = useState([]);
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+  const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   const { loading, error, data, refetch } = useQuery(TAGS_QUERY, {
     variables: { projectId: projectId },
@@ -130,6 +133,11 @@ const TagsSection = ({ projectId }) => {
       .then(() => handleNewTagCancel());
   };
 
+  const handleDeleteOpen = (id) => {
+    setDeleteConfirmationOpen(true);
+    setDeleteConfirmationId(id);
+  };
+
   return (
     <ApolloErrorHandler errors={error}>
       <Paper elevation={2} className={classes.paperTags}>
@@ -152,9 +160,15 @@ const TagsSection = ({ projectId }) => {
             <li key={tag.id}>
               <DeleteConfirmationModal
                 type="tag"
-                item={tag}
-                submitDelete={handleTagDelete}
+                submitDelete={() => handleTagDelete(deleteConfirmationId)}
+                deleteConfirmationOpen={deleteConfirmationOpen}
+                setDeleteConfirmationOpen={setDeleteConfirmationOpen}
               >
+                <Chip
+                  label={tag.moped_tag.name}
+                  onDelete={() => handleDeleteOpen(tag)}
+                  className={classes.chip}
+                />
               </DeleteConfirmationModal>
             </li>
           ))}


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10292
fixes https://github.com/cityofaustin/atd-data-tech/issues/10318

## Testing
**URL to test:** <!-- [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ -->
https://deploy-preview-815--atd-moped-main.netlify.app/

**Steps to test:**
go to a project, add a comment, and click the delete icon. click cancel. click the delete icon again and click delete.
repeat the previous step on the project summary page for a project tag.

i created a reusable modal component that we should be able to implement in other places we want a delete confirmation modal. the only issue is that the delete icon on the project comments and the delete option on the chip on project tags act very differently, so the solution is not as elegant as i was hoping it would be, with a few conditionals and implementing the tag chip inside the modal rather than just rendering it as {children} (not ideal i think). on the other hand, maybe this is okay, but if anyone has any thoughts or suggestions i welcome them!

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
