### PR TITLE
Exclude deleted moped_tags

### DIFF
--- a/moped-editor/src/queries/tags.js
+++ b/moped-editor/src/queries/tags.js
@@ -11,7 +11,7 @@ export const TAGS_QUERY = gql`
         id
       }
     }
-    moped_tags(order_by: { name: asc }) {
+    moped_tags(where: { is_deleted: { _eq: false } }, order_by: { name: asc }) {
       id
       name
     }


### PR DESCRIPTION
## Associated issues
After merging https://github.com/cityofaustin/atd-moped/pull/813#issuecomment-1268768849, I noticed that a deleted tag is still available on the autocomplete menu.

## Testing
[Netlify](https://deploy-preview-816--atd-moped-main.netlify.app/moped/projects/1878) or local

**Steps to test:**
1. Visit project summary page.
2. Verify you cannot add a tag named "MAP Vision Zero Intersections Potential 2023"

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
