### PR TITLE
Fix migration conflicts in local Hasura cluster 

### DIFF
--- a/moped-database/migrations/1665180093803_remove_deleted_contracts_again/down.sql
+++ b/moped-database/migrations/1665180093803_remove_deleted_contracts_again/down.sql
@@ -113,6 +113,14 @@ AS WITH project_person_list_lookup AS (
         AND personnel.is_deleted = false
         AND personnel.project_id = mp.project_id
       GROUP BY personnel.project_id) AS project_designer,
+    ( -- get me all of the tags added to a project
+    SELECT string_agg(tags.name, ', '::text) AS string_agg
+      FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+      WHERE 1 = 1
+        AND ptags.is_deleted = false
+        AND ptags.project_id = mp.project_id
+      GROUP BY tags.project_id) AS project_tags,
     string_agg(contracts.contractor, ', ') AS contractors,
     string_agg(contracts.contract_number, ', ') AS contract_numbers
    FROM moped_project mp
@@ -123,7 +131,7 @@ AS WITH project_person_list_lookup AS (
      LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
      LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
      LEFT JOIN LATERAL jsonb_array_elements(mp.task_order) task_order_filter(value) ON true
-     LEFT JOIN moped_proj_contract contracts ON (mp.project_id = contracts.project_id) AND contracts.is_deleted = false
+     LEFT JOIN moped_proj_contract contracts ON (mp.project_id = contracts.project_id)
   GROUP BY mp.project_uuid, 
     mp.project_id, 
     mp.project_name, 

--- a/moped-database/migrations/1665180093803_remove_deleted_contracts_again/up.sql
+++ b/moped-database/migrations/1665180093803_remove_deleted_contracts_again/up.sql
@@ -26,7 +26,7 @@ AS WITH project_person_list_lookup AS (
         LEFT JOIN moped_types mt ON mpt.project_type_id = mt.type_id AND mpt.is_deleted = false
     GROUP BY mpt.project_id
   )
- select
+ SELECT
     mp.project_uuid,
     mp.project_id,
     mp.project_name,
@@ -113,8 +113,16 @@ AS WITH project_person_list_lookup AS (
         AND personnel.is_deleted = false
         AND personnel.project_id = mp.project_id
       GROUP BY personnel.project_id) AS project_designer,
-    string_agg(contracts.contractor, ', ') as contractors,
-    string_agg(contracts.contract_number, ', ') as contract_numbers
+    ( -- get me all of the tags added to a project
+    SELECT string_agg(tags.name, ', '::text) AS string_agg
+      FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+      WHERE 1 = 1
+        AND ptags.is_deleted = false
+        AND ptags.project_id = mp.project_id
+      GROUP BY ptags.project_id) AS project_tags,
+    string_agg(contracts.contractor, ', ') AS contractors,
+    string_agg(contracts.contract_number, ', ') AS contract_numbers
    FROM moped_project mp
      LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
      LEFT JOIN funding_sources_lookup fsl ON fsl.project_id = mp.project_id
@@ -123,7 +131,7 @@ AS WITH project_person_list_lookup AS (
      LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
      LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
      LEFT JOIN LATERAL jsonb_array_elements(mp.task_order) task_order_filter(value) ON true
-     left join moped_proj_contract contracts on (mp.project_id = contracts.project_id)
+     LEFT JOIN moped_proj_contract contracts ON (mp.project_id = contracts.project_id) AND contracts.is_deleted = false
   GROUP BY mp.project_uuid, 
     mp.project_id, 
     mp.project_name, 

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -120,7 +120,7 @@ AS WITH project_person_list_lookup AS (
       WHERE 1 = 1
         AND ptags.is_deleted = false
         AND ptags.project_id = mp.project_id
-      GROUP BY tags.project_id) AS project_tags,
+      GROUP BY ptags.project_id) AS project_tags,
     string_agg(contracts.contractor, ', ') AS contractors,
     string_agg(contracts.contract_number, ', ') AS contract_numbers
    FROM moped_project mp


### PR DESCRIPTION
## Associated issues
See https://austininnovation.slack.com/archives/CNUEPKLB1/p1665179295381869

TLDR:
Two migrations conflict when applying locally but applied with a regression in staging. Using the same fix as [the last time something like this happened](https://github.com/cityofaustin/atd-moped/pull/680).

**Order applied in staging**
1. `1664467952757_remove_deleted_contracts_from_project_view` patched soft deleted contractors from returning from the view
2. `1664402014381_add_project_tags_to_view` added project tags to view but also reintroduced soft deleted contractors to the returned data

**Order applied locally**
1. `1664402014381_add_project_tags_to_view` adds project tags
2. `1664467952757_remove_deleted_contracts_from_project_view` replaces the view with a version that doesn't have project tags and creates a mismatch between the view and its metadata which causes an error

**The fix:** 
1. Remove `1664467952757_remove_deleted_contracts_from_project_view` so local migration in chronological order don't error
2. Add `1665180093803_remove_deleted_contracts_again` to replace the view with a version that has both the project tags portion and also filters out soft deleted project contractors

## Testing
**URL to test:** 
<!-- [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ -->
https://md-patch-migrations--atd-moped-main.netlify.app/moped/ (can also be tested locally)

**Steps to test:**
1. Go through the test steps in https://github.com/cityofaustin/atd-moped/pull/812
2. Add project contractors to a project, delete them, and then make sure that the deleted contractors don't show up in the Project list view

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
