### PR TITLE
Increase number of default rows in dashboard 

### DIFF
--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -311,11 +311,11 @@ const DashboardView = () => {
                       search: false,
                       toolbar: false,
                       tableLayout: "fixed",
-                      ...(selectedData.length < 15 + 1 && {
+                      ...(selectedData.length < 51 && {
                         paging: false,
                       }),
-                      pageSize: 15,
-                      pageSizeOptions: [15, 30, 100],
+                      pageSize: 50,
+                      pageSizeOptions: [10, 50, 100],
                     }}
                   />
                 )}

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -311,6 +311,11 @@ const DashboardView = () => {
                       search: false,
                       toolbar: false,
                       tableLayout: "fixed",
+                      ...(selectedData.length < 15 + 1 && {
+                        paging: false,
+                      }),
+                      pageSize: 15,
+                      pageSizeOptions: [15, 30, 100],
                     }}
                   />
                 )}


### PR DESCRIPTION
I was opening an issue regarding a bug i found in the team table, and spotted this snackoo. 

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10463

## Testing
**URL to test:** 

https://deploy-preview-827--atd-moped-main.netlify.app/moped/dashboard

**Steps to test:**

Check out your dashboard. If you have fewer than 15 projects, you wont see pagination. But once it goes over 15, pagination appears with the option to increase the count to 30 or 100. 

I arbitrarily chose the number 15 as the minimum count, on the signals dashboard thing we have it as 30. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
