### PR TITLE
Add street labels over nearmap aerial imagery (#4)

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/BasemapSpeedDial.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/BasemapSpeedDial.js
@@ -45,17 +45,11 @@ const useStyles = makeStyles((theme) => ({
     position: "absolute",
     height: MAPBOX_CONTROL_BUTTON_WIDTH * 2,
     right: `${MAPBOX_PADDING_PIXELS}px`,
-    // Mapbox basemap has copyright info below the speedial while NearMap tiles do not
-    bottom: ({ basemapKey }) =>
-      basemapKey === "aerial"
-        ? `${MAPBOX_PADDING_PIXELS}px`
-        : `${MAPBOX_PADDING_PIXELS * 3}px`,
+    // Make some room for the Mapbox attribution
+    bottom: `${MAPBOX_PADDING_PIXELS * 3}px`,
     // Mapbox copyright info collapses to a taller info icon at 990px and below
     [theme.breakpoints.down(991)]: {
-      bottom: ({ basemapKey }) =>
-        basemapKey === "aerial"
-          ? `${MAPBOX_PADDING_PIXELS}px`
-          : `${MAPBOX_PADDING_PIXELS * 4}px`,
+      bottom: `${MAPBOX_PADDING_PIXELS * 4}px`,
     },
   },
 }));
@@ -68,7 +62,7 @@ const useStyles = makeStyles((theme) => ({
  */
 const BasemapSpeedDial = ({ setBasemapKey, basemapKey }) => {
   const [isSpeedDialOpen, setIsSpeedDialOpen] = useState(false);
-  const classes = useStyles({ basemapKey, isSpeedDialOpen });
+  const classes = useStyles({ isSpeedDialOpen });
 
   /**
    * Changes the current basemap and closes the speed dial menu

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -228,7 +228,7 @@ export default function TheMap({
       onClick={onClick}
       boxZoom={false}
       cursor={cursor}
-      mapStyle={basemaps[basemapKey]}
+      mapStyle={basemaps[basemapKey].mapStyle}
       {...mapParameters}
     >
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
@@ -319,6 +319,14 @@ export default function TheMap({
             <Layer {...mapStyles["clicked-component-features-points"]} />
           )}
         </Source>
+      )}
+      {basemapKey === "aerial" && (
+        <>
+          <Source {...basemaps[basemapKey].sources.aerials} />
+          <Layer {...basemaps[basemapKey].layers.aerials} />
+          {/* show street labels on top of other layers */}
+          <Layer {...basemaps[basemapKey].layers.streetLabels} />
+        </>
       )}
       <FeaturePopup
         onClose={() => setClickedProjectFeature(null)}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -1,4 +1,5 @@
 const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
+// This API key is managed by CTM. Contact help desk for maintenance and troubleshooting.
 const NEARMAP_KEY = process.env.REACT_APP_NEARMAP_TOKEN;
 
 // minimum map zoom to display selectable features, and

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -71,3 +71,95 @@ export const basemaps = {
     ],
   },
 };
+
+// Use a custom hook that manages basemap and the
+
+// The config from VZE
+export const LOCATION_MAP_CONFIG = {
+  mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
+  sources: {
+    aerials: {
+      id: "raster-tiles",
+      type: "raster",
+      tiles: [
+        `https://api.nearmap.com/tiles/v3/Vert/{z}/{x}/{y}.jpg?apikey=${NEARMAP_KEY}`,
+      ],
+      tileSize: 256,
+    },
+  },
+  layers: {
+    aerials: {
+      id: "simple-tiles",
+      type: "raster",
+      source: "raster-tiles",
+      minzoom: 0,
+      maxzoom: 22,
+    },
+    streetLabels: {
+      // borrowed from mapbox mapbox streets v11 style
+      type: "symbol",
+      metadata: {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, road-labels",
+      },
+      source: "composite",
+      "source-layer": "road",
+      minzoom: 12,
+      filter: [
+        "all",
+        ["has", "name"],
+        [
+          "match",
+          ["get", "class"],
+          [
+            "motorway",
+            "trunk",
+            "primary",
+            "secondary",
+            "tertiary",
+            "street",
+            "street_limited",
+          ],
+          true,
+          false,
+        ],
+      ],
+      layout: {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            10,
+            9,
+          ],
+          18,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            16,
+            14,
+          ],
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": 0.01,
+      },
+      paint: {
+        "text-color": "#fff",
+        "text-halo-color": "#000",
+        "text-halo-width": 1,
+      },
+    },
+  },
+};

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -45,14 +45,20 @@ export const mapParameters = {
   mapboxAccessToken: MAPBOX_TOKEN,
 };
 
+/*
+ * This configuration sets the mapStyle, sources, and layers associated with basemaps
+ * mapStyle becomes the value of the mapStyle prop of the react-map-gl map
+ * https://visgl.github.io/react-map-gl/docs/api-reference/map#mapstyle
+ */
 export const basemaps = {
-  streets: "mapbox://styles/mapbox/light-v10",
+  streets: { mapStyle: "mapbox://styles/mapbox/light-v10" },
   // Provide style parameters to render Nearmap tiles in react-map-gl
   // https://docs.mapbox.com/mapbox-gl-js/example/map-tiles/
   aerial: {
-    version: 8,
+    mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
     sources: {
-      "raster-tiles": {
+      aerials: {
+        id: "raster-tiles",
         type: "raster",
         tiles: [
           `https://api.nearmap.com/tiles/v3/Vert/{z}/{x}/{y}.jpg?apikey=${NEARMAP_KEY}`,
@@ -60,106 +66,89 @@ export const basemaps = {
         tileSize: 256,
       },
     },
-    layers: [
-      {
+    layers: {
+      aerials: {
         id: "simple-tiles",
         type: "raster",
         source: "raster-tiles",
         minzoom: 0,
         maxzoom: 22,
       },
-    ],
+      streetLabels: {
+        // borrowed from mapbox mapbox streets v11 style
+        type: "symbol",
+        metadata: {
+          "mapbox:featureComponent": "road-network",
+          "mapbox:group": "Road network, road-labels",
+        },
+        source: "composite",
+        "source-layer": "road",
+        minzoom: 12,
+        filter: [
+          "all",
+          ["has", "name"],
+          [
+            "match",
+            ["get", "class"],
+            [
+              "motorway",
+              "trunk",
+              "primary",
+              "secondary",
+              "tertiary",
+              "street",
+              "street_limited",
+            ],
+            true,
+            false,
+          ],
+        ],
+        layout: {
+          "text-size": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            10,
+            [
+              "match",
+              ["get", "class"],
+              ["motorway", "trunk", "primary", "secondary", "tertiary"],
+              10,
+              9,
+            ],
+            18,
+            [
+              "match",
+              ["get", "class"],
+              ["motorway", "trunk", "primary", "secondary", "tertiary"],
+              16,
+              14,
+            ],
+          ],
+          "text-max-angle": 30,
+          "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+          "symbol-placement": "line",
+          "text-padding": 1,
+          "text-rotation-alignment": "map",
+          "text-pitch-alignment": "viewport",
+          "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+          "text-letter-spacing": 0.01,
+        },
+        paint: {
+          "text-color": "#fff",
+          "text-halo-color": "#000",
+          "text-halo-width": 1,
+        },
+      },
+    },
   },
 };
 
 // Use a custom hook that manages basemap and the
-
-// The config from VZE
-export const LOCATION_MAP_CONFIG = {
-  mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
-  sources: {
-    aerials: {
-      id: "raster-tiles",
-      type: "raster",
-      tiles: [
-        `https://api.nearmap.com/tiles/v3/Vert/{z}/{x}/{y}.jpg?apikey=${NEARMAP_KEY}`,
-      ],
-      tileSize: 256,
-    },
-  },
-  layers: {
-    aerials: {
-      id: "simple-tiles",
-      type: "raster",
-      source: "raster-tiles",
-      minzoom: 0,
-      maxzoom: 22,
-    },
-    streetLabels: {
-      // borrowed from mapbox mapbox streets v11 style
-      type: "symbol",
-      metadata: {
-        "mapbox:featureComponent": "road-network",
-        "mapbox:group": "Road network, road-labels",
-      },
-      source: "composite",
-      "source-layer": "road",
-      minzoom: 12,
-      filter: [
-        "all",
-        ["has", "name"],
-        [
-          "match",
-          ["get", "class"],
-          [
-            "motorway",
-            "trunk",
-            "primary",
-            "secondary",
-            "tertiary",
-            "street",
-            "street_limited",
-          ],
-          true,
-          false,
-        ],
-      ],
-      layout: {
-        "text-size": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          10,
-          [
-            "match",
-            ["get", "class"],
-            ["motorway", "trunk", "primary", "secondary", "tertiary"],
-            10,
-            9,
-          ],
-          18,
-          [
-            "match",
-            ["get", "class"],
-            ["motorway", "trunk", "primary", "secondary", "tertiary"],
-            16,
-            14,
-          ],
-        ],
-        "text-max-angle": 30,
-        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
-        "symbol-placement": "line",
-        "text-padding": 1,
-        "text-rotation-alignment": "map",
-        "text-pitch-alignment": "viewport",
-        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-        "text-letter-spacing": 0.01,
-      },
-      paint: {
-        "text-color": "#fff",
-        "text-halo-color": "#000",
-        "text-halo-width": 1,
-      },
-    },
-  },
+const useMapLayersAndSources = () => {
+  // this should manage the sources and layers needed for:
+  // 1. The NearMap aerial tiles with labels
+  // 2. A project's components feature collection (made up from the DB data)
+  // 3. The drawing things if the library doesn't take care of it
+  // 4.
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -143,12 +143,3 @@ export const basemaps = {
     },
   },
 };
-
-// Use a custom hook that manages basemap and the
-const useMapLayersAndSources = () => {
-  // this should manage the sources and layers needed for:
-  // 1. The NearMap aerial tiles with labels
-  // 2. A project's components feature collection (made up from the DB data)
-  // 3. The drawing things if the library doesn't take care of it
-  // 4.
-};

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -34,7 +34,7 @@ export const initialViewState = {
 };
 
 /**
- * See: https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters
+ * @see https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters
  */
 export const mapParameters = {
   touchPitch: false,
@@ -46,10 +46,10 @@ export const mapParameters = {
   mapboxAccessToken: MAPBOX_TOKEN,
 };
 
-/*
- * This configuration sets the mapStyle, sources, and layers associated with basemaps
- * mapStyle becomes the value of the mapStyle prop of the react-map-gl map
- * https://visgl.github.io/react-map-gl/docs/api-reference/map#mapstyle
+/**
+ * This configuration sets the mapStyle, sources, and layers for streets and aerial basemaps.
+ * The react-map-gl map's mapStyle prop is passed the value of the mapStyle key in this config.
+ * @see https://visgl.github.io/react-map-gl/docs/api-reference/map#mapstyle
  */
 export const basemaps = {
   streets: { mapStyle: "mapbox://styles/mapbox/light-v10" },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10405

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
This is best tested locally since the Netlify preview links are not on the approved list for the Moped NearMap token

**Steps to test:**
1. Go to an existing or new project's **Map** tab
2. Using the speed dial, select the aerial basemap
3. You should see the NearMap tiles pulling in with the Mapbox street labels presented on top
4. You can also try a viewport 990px or below and see that the speed dial moves above the Mapbox info icon that now it appears on the aerial view since we are using their street labels.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
