### PR TITLE
Show alert banner on deleted projects

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -50,6 +50,7 @@ export const SUMMARY_QUERY = gql`
       work_assignment_id
       parent_project_id
       interim_project_id
+      is_deleted
       moped_project {
         project_name
       }

--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -73,11 +73,19 @@ const useStyles = makeStyles((theme) => ({
     margin: "8px 0",
     padding: "8px",
   },
+  editIconConfirm: {
+    cursor: "pointer",
+    margin: ".25rem 0",
+    fontSize: "24px",
+  },
   fieldLabel: {
     width: "100%",
     color: theme.palette.text.secondary,
     fontSize: ".8rem",
     margin: "8px 0",
+  },
+  fieldBox: {
+    maxWidth: "10rem",
   },
   fundingButton: {
     position: "absolute",

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -119,9 +119,6 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontSize: "2rem",
   },
-  deletedMessage: {
-    border: "1px red dotted",
-  },
 }));
 
 function a11yProps(index) {

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -29,6 +29,7 @@ import {
   ListItemText,
   Snackbar,
   Tooltip,
+  Typography,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 
@@ -455,48 +456,22 @@ const ProjectView = () => {
                           </Breadcrumbs>
                         </Box>
                       </Grid>
-                      {!isProjectDeleted && (
-                        <Grid item xs={1} md={1}>
-                          <Box
-                            className={classes.followDiv}
-                            onClick={() => handleFollowProject()}
-                          >
-                            <Tooltip
-                              title={isFollowing ? "Unfollow" : "Follow"}
-                            >
-                              {isFollowing ? (
-                                <BookmarkIcon
-                                  className={classes.unfollowIcon}
-                                />
-                              ) : (
-                                <BookmarkBorderIcon
-                                  className={classes.followIcon}
-                                />
-                              )}
-                            </Tooltip>
-                          </Box>
-                        </Grid>
-                      )}
-                      {isProjectDeleted && (
-                        <Grid item xs={12}>
-                          <Box pb={2} pt={1}>
-                            <Alert severity="error">
-                              This project has been deleted and is no longer
-                              visible in Moped. If you need to restore a deleted
-                              project, please{" "}
-                              <Link
-                                href={
-                                  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D"
-                                }
-                                target="new"
-                              >
-                                submit a Data &amp; Technology Services support
-                                request
-                              </Link>
-                            </Alert>
-                          </Box>
-                        </Grid>
-                      )}
+                      <Grid item xs={1} md={1}>
+                        <Box
+                          className={classes.followDiv}
+                          onClick={() => handleFollowProject()}
+                        >
+                          <Tooltip title={isFollowing ? "Unfollow" : "Follow"}>
+                            {isFollowing ? (
+                              <BookmarkIcon className={classes.unfollowIcon} />
+                            ) : (
+                              <BookmarkBorderIcon
+                                className={classes.followIcon}
+                              />
+                            )}
+                          </Tooltip>
+                        </Box>
+                      </Grid>
                       <Grid item xs={11} md={11} className={classes.title}>
                         <Box
                           alignItems="center"
@@ -663,6 +638,31 @@ const ProjectView = () => {
                 </DialogContentText>
               </DialogContent>
               <DialogActions>{dialogState?.actions}</DialogActions>
+            </Dialog>
+          )}
+          {isProjectDeleted && (
+            <Dialog
+              open={isProjectDeleted}
+              onClose={handleDialogClose}
+              aria-labelledby="alert-dialog-title"
+              aria-describedby="alert-dialog-description"
+            >
+              <DialogContent>
+                <Typography gutterBottom>
+                  This project has been deleted.
+                </Typography>
+                <Typography gutterBottom>
+                  If you need to restore a deleted project, please{" "}
+                  <Link
+                    href={
+                      "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D"
+                    }
+                    target="new"
+                  >
+                    submit a Data &amp; Technology Services support request
+                  </Link>
+                </Typography>
+              </DialogContent>
             </Dialog>
           )}
         </Page>

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -76,10 +76,6 @@ const useStyles = makeStyles((theme) => ({
   cardWrapper: {
     marginTop: theme.spacing(3),
   },
-  cardActions: {
-    display: "flex",
-    justifyContent: "flex-end",
-  },
   button: {
     marginTop: theme.spacing(1),
     marginRight: theme.spacing(2),
@@ -429,6 +425,8 @@ const ProjectView = () => {
     current_status: data?.moped_project?.[0]?.current_status ?? null,
   };
 
+  const isProjectDeleted = data?.moped_project[0].is_deleted;
+
   return (
     <ApolloErrorHandler error={error}>
       {data && !data?.moped_project?.length && <NotFoundView />}
@@ -457,22 +455,48 @@ const ProjectView = () => {
                           </Breadcrumbs>
                         </Box>
                       </Grid>
-                      <Grid item xs={1} md={1}>
-                        <Box
-                          className={classes.followDiv}
-                          onClick={() => handleFollowProject()}
-                        >
-                          <Tooltip title={isFollowing ? "Unfollow" : "Follow"}>
-                            {isFollowing ? (
-                              <BookmarkIcon className={classes.unfollowIcon} />
-                            ) : (
-                              <BookmarkBorderIcon
-                                className={classes.followIcon}
-                              />
-                            )}
-                          </Tooltip>
-                        </Box>
-                      </Grid>
+                      {!isProjectDeleted && (
+                        <Grid item xs={1} md={1}>
+                          <Box
+                            className={classes.followDiv}
+                            onClick={() => handleFollowProject()}
+                          >
+                            <Tooltip
+                              title={isFollowing ? "Unfollow" : "Follow"}
+                            >
+                              {isFollowing ? (
+                                <BookmarkIcon
+                                  className={classes.unfollowIcon}
+                                />
+                              ) : (
+                                <BookmarkBorderIcon
+                                  className={classes.followIcon}
+                                />
+                              )}
+                            </Tooltip>
+                          </Box>
+                        </Grid>
+                      )}
+                      {isProjectDeleted && (
+                        <Grid item xs={12}>
+                          <Box pb={2} pt={1}>
+                            <Alert severity="error">
+                              This project has been deleted and is no longer
+                              visible in Moped. If you need to restore a deleted
+                              project, please{" "}
+                              <Link
+                                href={
+                                  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D"
+                                }
+                                target="new"
+                              >
+                                submit a Data &amp; Technology Services support
+                                request
+                              </Link>
+                            </Alert>
+                          </Box>
+                        </Grid>
+                      )}
                       <Grid item xs={11} md={11} className={classes.title}>
                         <Box
                           alignItems="center"

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -119,6 +119,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontSize: "2rem",
   },
+  deletedMessage: {
+    border: "1px red dotted",
+  },
 }));
 
 function a11yProps(index) {
@@ -648,10 +651,10 @@ const ProjectView = () => {
               aria-describedby="alert-dialog-description"
             >
               <DialogContent>
-                <Typography gutterBottom>
+                <Typography variant={"h3"} align={"center"} gutterBottom>
                   This project has been deleted.
                 </Typography>
-                <Typography gutterBottom>
+                <Typography align={"center"} style={{ paddingTop: "15px" }}>
                   If you need to restore a deleted project, please{" "}
                   <Link
                     href={
@@ -663,6 +666,16 @@ const ProjectView = () => {
                   </Link>
                 </Typography>
               </DialogContent>
+              <DialogActions>
+                <Button>
+                  <RouterLink
+                    to={allProjectsLink}
+                    className={"MuiTypography-colorPrimary"}
+                  >
+                    Back to all projects
+                  </RouterLink>
+                </Button>
+              </DialogActions>
             </Dialog>
           )}
         </Page>

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -425,7 +425,7 @@ const ProjectView = () => {
     current_status: data?.moped_project?.[0]?.current_status ?? null,
   };
 
-  const isProjectDeleted = data?.moped_project[0].is_deleted;
+  const isProjectDeleted = data?.moped_project[0]?.is_deleted;
 
   return (
     <ApolloErrorHandler error={error}>

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -660,7 +660,7 @@ const ProjectView = () => {
                     target="new"
                   >
                     submit a Data &amp; Technology Services support request
-                  </Link>
+                  </Link>.
                 </Typography>
               </DialogContent>
               <DialogActions>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9525

## Testing
**URL to test:** 
https://deploy-preview-838--atd-moped-main.netlify.app/moped/projects/1841


**Steps to test:**
This is a deleted project: 
https://deploy-preview-838--atd-moped-main.netlify.app/moped/projects/1841 

~~You should see a banner above projects that have been deleted, no banner or empty space seen on normal projects.~~

There is now a dialog that pops up to inform you the project has been deleted. with a link to take you back to all projects. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
