### PR TITLE
Work around Mapbox's clipped geojson features (#6)

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -216,11 +216,7 @@ export default function TheMap({
     projectPoints,
   };
 
-  const { interactiveLayerIds } = makeInteractiveIds({
-    isEditingComponent,
-    linkMode,
-    draftLayerId,
-  });
+  const interactiveLayerIds = makeInteractiveIds();
 
   return (
     <MapGL

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -114,6 +114,7 @@ export default function TheMap({
   };
 
   const onClick = (e) => {
+    console.log(e.features);
     if (e.features.length === 0) {
       // clear clickedComponent if map is clicked elsewhere
       if (clickedComponent) {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -70,6 +70,9 @@ export default function TheMap({
   setIsFetchingFeatures,
 }) {
   const [cursor, setCursor] = useState("grap");
+  // Move this state to the parent component?
+  // Move useAgolFeatures to the parent component and then move isFetchingFeatures to parent?
+  // Then setIsFetchingFeatures can be in the custom hook too
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
   const projectFeatures = useProjectFeatures(components);
@@ -80,16 +83,12 @@ export default function TheMap({
   const componentFeatureCollection =
     useComponentFeatureCollection(clickedComponent);
 
+  const currentZoom = mapRef?.current?.getZoom();
   const {
     ctnLinesGeojson,
     ctnPointsGeojson,
     findFeatureInAgolGeojsonFeatures,
-  } = useAgolFeatures({
-    linkMode,
-    setIsFetchingFeatures,
-    mapRef,
-    bounds,
-  });
+  } = useAgolFeatures(linkMode, setIsFetchingFeatures, currentZoom, bounds);
 
   const projectLines = useFeatureTypes(projectFeatures, "line");
   const projectPoints = useFeatureTypes(projectFeatures, "point");
@@ -161,14 +160,14 @@ export default function TheMap({
 
     // if multiple features are clicked, we ignore all but one
     const clickedFeature = e.features[0];
-    const clickedFeatureFromAgolGeoJson =
+    const clickedFeatureFromAgolGeojson =
       findFeatureInAgolGeojsonFeatures(clickedFeature);
 
     const newFeature = {
-      geometry: clickedFeatureFromAgolGeoJson.geometry,
+      geometry: clickedFeatureFromAgolGeojson.geometry,
       properties: {
-        ...clickedFeatureFromAgolGeoJson.properties,
-        id: clickedFeatureFromAgolGeoJson.id,
+        ...clickedFeatureFromAgolGeojson.properties,
+        id: clickedFeatureFromAgolGeojson.id,
         // AGOL data doesn't include layer so we grab it from the clicked Mapbox feature
         _layerId: clickedFeature.layer.id,
       },

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -70,9 +70,6 @@ export default function TheMap({
   setIsFetchingFeatures,
 }) {
   const [cursor, setCursor] = useState("grap");
-  // Move this state to the parent component?
-  // Move useAgolFeatures to the parent component and then move isFetchingFeatures to parent?
-  // Then setIsFetchingFeatures can be in the custom hook too
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
   const projectFeatures = useProjectFeatures(components);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -4,15 +4,9 @@ import { cloneDeep } from "lodash";
 import FeaturePopup from "./FeaturePopup";
 import GeocoderControl from "src/components/Maps/GeocoderControl";
 import BasemapSpeedDial from "./BasemapSpeedDial";
-import {
-  basemaps,
-  mapParameters,
-  initialViewState,
-  SOURCES,
-  MIN_SELECT_FEATURE_ZOOM,
-} from "./mapSettings";
+import { basemaps, mapParameters, initialViewState } from "./mapSettings";
 import { getIntersectionLabel, useFeatureTypes } from "./utils";
-import { useFeatureService } from "./agolUtils";
+import { useAgolFeatures } from "./agolUtils";
 import {
   BaseMapSourceAndLayers,
   interactiveLayerIds,
@@ -86,27 +80,11 @@ export default function TheMap({
   const componentFeatureCollection =
     useComponentFeatureCollection(clickedComponent);
 
-  // yeah, these props are mess :/
-  const ctnLinesGeojson = useFeatureService({
-    layerId: SOURCES["ctn-lines"].featureService.layerId,
-    name: SOURCES["ctn-lines"].featureService.name,
-    bounds,
-    isVisible:
-      linkMode === "lines" &&
-      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
-    featureIdProp: SOURCES["ctn-lines"]._featureIdProp,
+  const { ctnLinesGeojson, ctnPointsGeojson } = useAgolFeatures({
+    linkMode,
     setIsFetchingFeatures,
-  });
-
-  const ctnPointsGeojson = useFeatureService({
-    layerId: SOURCES["ctn-points"].featureService.layerId,
-    name: SOURCES["ctn-points"].featureService.name,
+    mapRef,
     bounds,
-    isVisible:
-      linkMode === "points" &&
-      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
-    featureIdProp: SOURCES["ctn-points"]._featureIdProp,
-    setIsFetchingFeatures,
   });
 
   const projectLines = useFeatureTypes(projectFeatures, "line");
@@ -192,10 +170,11 @@ export default function TheMap({
     });
 
     const newFeature = {
-      geometry: clickedFeature.geometry,
+      geometry: clickedFeatureFromGeoJson.geometry,
       properties: {
-        ...clickedFeature.properties,
-        id: clickedFeature.id,
+        ...clickedFeatureFromGeoJson.properties,
+        id: clickedFeatureFromGeoJson.id,
+        // AGOL data doesn't include layer so we grab it from the clicked feature
         _layerId: clickedFeature.layer.id,
       },
     };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -80,7 +80,11 @@ export default function TheMap({
   const componentFeatureCollection =
     useComponentFeatureCollection(clickedComponent);
 
-  const { ctnLinesGeojson, ctnPointsGeojson } = useAgolFeatures({
+  const {
+    ctnLinesGeojson,
+    ctnPointsGeojson,
+    findFeatureInAgolGeojsonFeatures,
+  } = useAgolFeatures({
     linkMode,
     setIsFetchingFeatures,
     mapRef,
@@ -157,24 +161,15 @@ export default function TheMap({
 
     // if multiple features are clicked, we ignore all but one
     const clickedFeature = e.features[0];
-
-    const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
-    const clickedFeatureFromGeoJson = ctnLinesGeojson.features.find(
-      (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
-    );
-    console.log({
-      clickedFeature,
-      clickedFeatureId,
-      ctnLinesGeojson,
-      clickedFeatureFromGeoJson,
-    });
+    const clickedFeatureFromAgolGeoJson =
+      findFeatureInAgolGeojsonFeatures(clickedFeature);
 
     const newFeature = {
-      geometry: clickedFeatureFromGeoJson.geometry,
+      geometry: clickedFeatureFromAgolGeoJson.geometry,
       properties: {
-        ...clickedFeatureFromGeoJson.properties,
-        id: clickedFeatureFromGeoJson.id,
-        // AGOL data doesn't include layer so we grab it from the clicked feature
+        ...clickedFeatureFromAgolGeoJson.properties,
+        id: clickedFeatureFromAgolGeoJson.id,
+        // AGOL data doesn't include layer so we grab it from the clicked Mapbox feature
         _layerId: clickedFeature.layer.id,
       },
     };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -114,7 +114,6 @@ export default function TheMap({
   };
 
   const onClick = (e) => {
-    console.log(e.features);
     if (e.features.length === 0) {
       // clear clickedComponent if map is clicked elsewhere
       if (clickedComponent) {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -208,6 +208,7 @@ export default function TheMap({
     setBounds(newBounds.flat());
   };
 
+  // This is a temporary to get data into the map sources
   const data = {
     draftComponentFeatures,
     ctnLinesGeojson,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -180,6 +180,17 @@ export default function TheMap({
     // if multiple features are clicked, we ignore all but one
     const clickedFeature = e.features[0];
 
+    const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
+    const clickedFeatureFromGeoJson = ctnLinesGeojson.features.find(
+      (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
+    );
+    console.log({
+      clickedFeature,
+      clickedFeatureId,
+      ctnLinesGeojson,
+      clickedFeatureFromGeoJson,
+    });
+
     const newFeature = {
       geometry: clickedFeature.geometry,
       properties: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -6,7 +6,7 @@ import GeocoderControl from "src/components/Maps/GeocoderControl";
 import BasemapSpeedDial from "./BasemapSpeedDial";
 import { basemaps, mapParameters, initialViewState } from "./mapSettings";
 import { getIntersectionLabel, useFeatureTypes } from "./utils";
-import { useAgolFeatures } from "./agolUtils";
+import { useAgolFeatures, findFeatureInAgolGeojsonFeatures } from "./agolUtils";
 import {
   BaseMapSourceAndLayers,
   interactiveLayerIds,
@@ -81,11 +81,12 @@ export default function TheMap({
     useComponentFeatureCollection(clickedComponent);
 
   const currentZoom = mapRef?.current?.getZoom();
-  const {
-    ctnLinesGeojson,
-    ctnPointsGeojson,
-    findFeatureInAgolGeojsonFeatures,
-  } = useAgolFeatures(linkMode, setIsFetchingFeatures, currentZoom, bounds);
+  const { ctnLinesGeojson, ctnPointsGeojson } = useAgolFeatures(
+    linkMode,
+    setIsFetchingFeatures,
+    currentZoom,
+    bounds
+  );
 
   const projectLines = useFeatureTypes(projectFeatures, "line");
   const projectPoints = useFeatureTypes(projectFeatures, "point");
@@ -157,8 +158,12 @@ export default function TheMap({
 
     // if multiple features are clicked, we ignore all but one
     const clickedFeature = e.features[0];
-    const clickedFeatureFromAgolGeojson =
-      findFeatureInAgolGeojsonFeatures(clickedFeature);
+    const clickedFeatureFromAgolGeojson = findFeatureInAgolGeojsonFeatures(
+      clickedFeature,
+      linkMode,
+      ctnLinesGeojson,
+      ctnPointsGeojson
+    );
 
     const newFeature = {
       geometry: clickedFeatureFromAgolGeojson.geometry,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -1,4 +1,5 @@
 import { useEffect, useReducer, useRef } from "react";
+import { SOURCES, MIN_SELECT_FEATURE_ZOOM } from "./mapSettings";
 
 /**
  * Provides a hook and supporting functions to query an AGOL feature service
@@ -49,6 +50,37 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
   const allFeatures = [...geojson.features, ...features];
   const uniqueFeatures = deDeupeFeatures(allFeatures, featureIdProp);
   return { type: "FeatureCollection", features: uniqueFeatures };
+};
+
+export const useAgolFeatures = ({
+  linkMode,
+  setIsFetchingFeatures,
+  mapRef,
+  bounds,
+}) => {
+  const ctnLinesGeojson = useFeatureService({
+    layerId: SOURCES["ctn-lines"].featureService.layerId,
+    name: SOURCES["ctn-lines"].featureService.name,
+    bounds,
+    isVisible:
+      linkMode === "lines" &&
+      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
+    featureIdProp: SOURCES["ctn-lines"]._featureIdProp,
+    setIsFetchingFeatures,
+  });
+
+  const ctnPointsGeojson = useFeatureService({
+    layerId: SOURCES["ctn-points"].featureService.layerId,
+    name: SOURCES["ctn-points"].featureService.name,
+    bounds,
+    isVisible:
+      linkMode === "points" &&
+      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
+    featureIdProp: SOURCES["ctn-points"]._featureIdProp,
+    setIsFetchingFeatures,
+  });
+
+  return { ctnLinesGeojson, ctnPointsGeojson };
 };
 
 /* Hook which AGOL rest service for features within a bbox, and continuously

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -80,7 +80,27 @@ export const useAgolFeatures = ({
     setIsFetchingFeatures,
   });
 
-  return { ctnLinesGeojson, ctnPointsGeojson };
+  const findFeatureInAgolGeojsonFeatures = (clickedFeature) => {
+    if (linkMode === "lines") {
+      const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
+
+      return ctnLinesGeojson.features.find(
+        (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
+      );
+    } else if (linkMode === "points") {
+      const clickedFeatureId = clickedFeature.properties.id;
+
+      return ctnPointsGeojson.features.find(
+        (feature) => feature.properties.id === clickedFeatureId
+      );
+    }
+  };
+
+  return {
+    ctnLinesGeojson,
+    ctnPointsGeojson,
+    findFeatureInAgolGeojsonFeatures,
+  };
 };
 
 /* Hook which AGOL rest service for features within a bbox, and continuously

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -53,6 +53,35 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
 };
 
 /**
+ * Find a fetched AGOL feature record by unique ID
+ * @param {*} clickedFeature
+ * @param {*} linkMode
+ * @param {*} ctnLinesGeojson
+ * @param {*} ctnPointsGeojson
+ * @returns
+ */
+export const findFeatureInAgolGeojsonFeatures = (
+  clickedFeature,
+  linkMode,
+  ctnLinesGeojson,
+  ctnPointsGeojson
+) => {
+  if (linkMode === "lines") {
+    const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
+
+    return ctnLinesGeojson.features.find(
+      (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
+    );
+  } else if (linkMode === "points") {
+    const clickedFeatureId = clickedFeature.properties.INTERSECTION_ID;
+
+    return ctnPointsGeojson.features.find(
+      (feature) => feature.properties.INTERSECTION_ID === clickedFeatureId
+    );
+  }
+};
+
+/**
  * Fetch CTN lines and points and a helper to find a feature record that matches a clicked layer feature by ID
  * @param {String} linkMode - the current link mode ("lines" or "points")
  * @param {Function} setIsFetchingFeatures - toggle loading state of the header spinner
@@ -64,7 +93,6 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
  * @typedef {Object} AgolFeaturesObject
  * @property {Object} ctnLinesGeojson - Feature collection containing query results for CTN lines
  * @property {Object} ctnPointsGeojson - Feature collection containing query results for CTN points
- * @property {Function} findFeatureInAgolGeojsonFeatures - find a fetched AGOL feature record by unique ID
  */
 export const useAgolFeatures = (
   linkMode,
@@ -90,26 +118,9 @@ export const useAgolFeatures = (
     setIsFetchingFeatures,
   });
 
-  const findFeatureInAgolGeojsonFeatures = (clickedFeature) => {
-    if (linkMode === "lines") {
-      const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
-
-      return ctnLinesGeojson.features.find(
-        (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
-      );
-    } else if (linkMode === "points") {
-      const clickedFeatureId = clickedFeature.properties.INTERSECTION_ID;
-
-      return ctnPointsGeojson.features.find(
-        (feature) => feature.properties.INTERSECTION_ID === clickedFeatureId
-      );
-    }
-  };
-
   return {
     ctnLinesGeojson,
     ctnPointsGeojson,
-    findFeatureInAgolGeojsonFeatures,
   };
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -88,10 +88,10 @@ export const useAgolFeatures = ({
         (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
       );
     } else if (linkMode === "points") {
-      const clickedFeatureId = clickedFeature.properties.id;
+      const clickedFeatureId = clickedFeature.properties.INTERSECTION_ID;
 
       return ctnPointsGeojson.features.find(
-        (feature) => feature.properties.id === clickedFeatureId
+        (feature) => feature.properties.INTERSECTION_ID === clickedFeatureId
       );
     }
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -58,7 +58,13 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
  * @param {Function} setIsFetchingFeatures - toggle loading state of the header spinner
  * @param {Number} currentZoom - current level of zoom in the map
  * @param {Array} bounds - the current map bounds
- * @returns
+ * @returns {AgolFeaturesObject}
+ */
+/**
+ * @typedef {Object} AgolFeaturesObject
+ * @property {Object} ctnLinesGeojson - Feature collection containing query results for CTN lines
+ * @property {Object} ctnPointsGeojson - Feature collection containing query results for CTN points
+ * @property {Function} findFeatureInAgolGeojsonFeatures - find a fetched AGOL feature record by unique ID
  */
 export const useAgolFeatures = (
   linkMode,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -54,11 +54,11 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
 
 /**
  * Find a fetched AGOL feature record by unique ID
- * @param {*} clickedFeature
- * @param {*} linkMode
- * @param {*} ctnLinesGeojson
- * @param {*} ctnPointsGeojson
- * @returns
+ * @param {Object} clickedFeature - the feature clicked on the map
+ * @param {String} linkMode - the current link mode ("lines" or "points")
+ * @param {Object} ctnLinesGeojson - Feature collection containing query results for CTN lines
+ * @param {Object} ctnPointsGeojson - Feature collection containing query results for CTN points
+ * @returns {Object} - a feature object from AGOL data
  */
 export const findFeatureInAgolGeojsonFeatures = (
   clickedFeature,
@@ -67,16 +67,18 @@ export const findFeatureInAgolGeojsonFeatures = (
   ctnPointsGeojson
 ) => {
   if (linkMode === "lines") {
-    const clickedFeatureId = clickedFeature.properties.CTN_SEGMENT_ID;
+    const linesIdProperty = SOURCES["ctn-lines"]._featureIdProp;
+    const clickedFeatureId = clickedFeature.properties[linesIdProperty];
 
     return ctnLinesGeojson.features.find(
-      (feature) => feature.properties.CTN_SEGMENT_ID === clickedFeatureId
+      (feature) => feature.properties[linesIdProperty] === clickedFeatureId
     );
   } else if (linkMode === "points") {
-    const clickedFeatureId = clickedFeature.properties.INTERSECTION_ID;
+    const pointsIdProperty = SOURCES["ctn-points"]._featureIdProp;
+    const clickedFeatureId = clickedFeature.properties[pointsIdProperty];
 
     return ctnPointsGeojson.features.find(
-      (feature) => feature.properties.INTERSECTION_ID === clickedFeatureId
+      (feature) => feature.properties[pointsIdProperty] === clickedFeatureId
     );
   }
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -52,19 +52,25 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
   return { type: "FeatureCollection", features: uniqueFeatures };
 };
 
-export const useAgolFeatures = ({
+/**
+ * Fetch CTN lines and points and a helper to find a feature record that matches a clicked layer feature by ID
+ * @param {String} linkMode - the current link mode ("lines" or "points")
+ * @param {Function} setIsFetchingFeatures - toggle loading state of the header spinner
+ * @param {Number} currentZoom - current level of zoom in the map
+ * @param {Array} bounds - the current map bounds
+ * @returns
+ */
+export const useAgolFeatures = (
   linkMode,
   setIsFetchingFeatures,
-  mapRef,
-  bounds,
-}) => {
+  currentZoom,
+  bounds
+) => {
   const ctnLinesGeojson = useFeatureService({
     layerId: SOURCES["ctn-lines"].featureService.layerId,
     name: SOURCES["ctn-lines"].featureService.name,
     bounds,
-    isVisible:
-      linkMode === "lines" &&
-      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
+    isVisible: linkMode === "lines" && currentZoom >= MIN_SELECT_FEATURE_ZOOM,
     featureIdProp: SOURCES["ctn-lines"]._featureIdProp,
     setIsFetchingFeatures,
   });
@@ -73,9 +79,7 @@ export const useAgolFeatures = ({
     layerId: SOURCES["ctn-points"].featureService.layerId,
     name: SOURCES["ctn-points"].featureService.name,
     bounds,
-    isVisible:
-      linkMode === "points" &&
-      mapRef?.current?.getZoom() >= MIN_SELECT_FEATURE_ZOOM,
+    isVisible: linkMode === "points" && currentZoom >= MIN_SELECT_FEATURE_ZOOM,
     featureIdProp: SOURCES["ctn-points"]._featureIdProp,
     setIsFetchingFeatures,
   });

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -55,7 +55,6 @@ export default function MapView({ projectName, projectStatuses }) {
 
   /* holds this project's components */
   const [components, setComponents] = useState([]);
-  console.log(components);
 
   /* tracks a component clicked from the list or the projectFeature popup */
   const [clickedComponent, setClickedComponent] = useState(null);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -76,6 +76,7 @@ export const basemaps = {
         maxzoom: 22,
       },
       streetLabels: {
+        id: "street-labels",
         // borrowed from mapbox mapbox streets v11 style
         type: "symbol",
         metadata: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -24,7 +24,7 @@ export const COLORS = {
  */
 export const MAP_STYLES = {
   "project-points": {
-    isInteractive: false,
+    isInteractive: true,
     layerProps: {
       id: "project-points",
       _featureIdProp: "INTERSECTION_ID",
@@ -45,7 +45,7 @@ export const MAP_STYLES = {
     },
   },
   "project-lines": {
-    isInteractive: false,
+    isInteractive: true,
     layerProps: {
       id: "project-lines",
       _featureIdProp: "CTN_SEGMENT_ID",

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -72,7 +72,7 @@ export const MAP_STYLES = {
   "project-points-muted": {
     isInteractive: false,
     layerProps: {
-      id: "project-points",
+      id: "project-points-muted",
       _featureIdProp: "INTERSECTION_ID",
       type: "circle",
       paint: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -93,7 +93,7 @@ export const MAP_STYLES = {
   "project-lines-muted": {
     isInteractive: false,
     layerProps: {
-      id: "project-lines",
+      id: "project-lines-muted",
       _featureIdProp: "CTN_SEGMENT_ID",
       type: "line",
       paint: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -18,6 +18,7 @@ export const COLORS = {
 
 export const MAP_STYLES = {
   "project-points": {
+    isInteractive: true,
     layerProps: {
       id: "project-points",
       _featureIdProp: "INTERSECTION_ID",
@@ -38,6 +39,7 @@ export const MAP_STYLES = {
     },
   },
   "project-lines": {
+    isInteractive: true,
     layerProps: {
       id: "project-lines",
       _featureIdProp: "CTN_SEGMENT_ID",
@@ -62,6 +64,7 @@ export const MAP_STYLES = {
     },
   },
   "project-points-muted": {
+    isInteractive: false,
     layerProps: {
       id: "project-points",
       _featureIdProp: "INTERSECTION_ID",
@@ -82,6 +85,7 @@ export const MAP_STYLES = {
     },
   },
   "project-lines-muted": {
+    isInteractive: false,
     layerProps: {
       id: "project-lines",
       _featureIdProp: "CTN_SEGMENT_ID",
@@ -101,6 +105,7 @@ export const MAP_STYLES = {
     },
   },
   "project-lines-underlay": {
+    isInteractive: false,
     layerProps: {
       id: "project-lines-underlay",
       _featureIdProp: "CTN_SEGMENT_ID",
@@ -116,6 +121,7 @@ export const MAP_STYLES = {
     },
   },
   "draft-component-lines": {
+    isInteractive: true,
     layerProps: {
       id: "draft-component-lines",
       _featureIdProp: "id",
@@ -135,6 +141,7 @@ export const MAP_STYLES = {
     },
   },
   "draft-component-points": {
+    isInteractive: true,
     layerProps: {
       id: "draft-component-points",
       _featureIdProp: "id",
@@ -155,6 +162,7 @@ export const MAP_STYLES = {
     },
   },
   "ctn-lines": {
+    isInteractive: true,
     layerProps: {
       _featureIdProp: "CTN_SEGMENT_ID",
       id: "ctn-lines",
@@ -182,6 +190,7 @@ export const MAP_STYLES = {
     },
   },
   "ctn-lines-underlay": {
+    isInteractive: false,
     layerProps: {
       _featureIdProp: "CTN_SEGMENT_ID",
       id: "ctn-lines-underlay",
@@ -198,6 +207,7 @@ export const MAP_STYLES = {
     },
   },
   "ctn-points": {
+    isInteractive: true,
     layerProps: {
       id: "ctn-points",
       type: "circle",
@@ -222,6 +232,7 @@ export const MAP_STYLES = {
     },
   },
   "ctn-points-underlay": {
+    isInteractive: false,
     layerProps: {
       id: "ctn-points-underlay",
       type: "circle",
@@ -241,6 +252,7 @@ export const MAP_STYLES = {
     },
   },
   "clicked-component-features-lines": {
+    isInteractive: false,
     layerProps: {
       id: "clicked-component-features-lines",
       featureIdProp: "id",
@@ -260,6 +272,7 @@ export const MAP_STYLES = {
     },
   },
   "clicked-component-features-points": {
+    isInteractive: false,
     layerProps: {
       id: "clicked-component-features-points",
       featureIdProp: "id",

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -38,11 +38,11 @@ export const BaseMapSourceAndLayers = ({ basemapKey }) => {
 };
 
 /**
- * Iterate through the MAP_STYLES config to create an array of interactive layers
+ * Iterate through the mapStyles config to create an array of interactive layers
  * @returns {Array} Array of interactive layers
  */
 export const makeInteractiveIds = () => {
-  const interactiveLayerIds = Object.entries(MAP_STYLES).reduce(
+  const interactiveLayerIds = Object.entries(mapStyles).reduce(
     (acc, [key, value]) => {
       if (value.isInteractive) {
         acc.push(key);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -45,11 +45,12 @@ export const BaseMapSourceAndLayers = ({ basemapKey }) => {
 // Iterate the config and return an array of interactive = true
 export const makeInteractiveIds = () => {
   const interactiveLayerIds = [
-    "ctn-lines-underlay",
-    "project-lines-underlay",
-    "ctn-points-underlay",
+    "ctn-lines",
+    "project-lines",
+    "draft-component-lines",
+    "ctn-points",
     "project-points",
-    "project-lines-underlay",
+    "draft-component-points",
   ];
 
   return {
@@ -58,7 +59,6 @@ export const makeInteractiveIds = () => {
 };
 
 // This component builds sources and layers
-// Not dynamic rendering but dynamic visibility use Mapbox style spec
 // TODOs
 // 1. sources and layers in correct order
 export const ProjectComponentsSourcesAndLayers = ({
@@ -75,7 +75,6 @@ export const ProjectComponentsSourcesAndLayers = ({
     projectPoints,
     draftComponentFeatures,
   } = data;
-  console.log(linkMode);
 
   return (
     <>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -78,13 +78,10 @@ export const ProjectComponentsSourcesAndLayers = ({
     draftComponentFeatures,
   } = data;
 
-  console.log({
-    data,
-    isEditingComponent,
-    linkMode,
-    clickedComponent,
-    componentFeatureCollection,
-  });
+  const isViewingComponents = !isEditingComponent && !clickedComponent;
+  const isEditingLines = isEditingComponent && linkMode === "lines";
+  const isEditingPoints = isEditingComponent && linkMode === "points";
+  const shouldShowMutedFeatures = clickedComponent || isEditingComponent;
 
   return (
     <>
@@ -100,8 +97,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["ctn-lines-underlay"].layerProps,
             layout: {
               ...mapStyles["ctn-lines-underlay"].layerProps.layout,
-              visibility:
-                isEditingComponent && linkMode === "lines" ? "visible" : "none",
+              visibility: isEditingLines ? "visible" : "none",
             },
           }}
         />
@@ -112,8 +108,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["ctn-lines"].layerProps,
             layout: {
               ...mapStyles["ctn-lines"].layerProps.layout,
-              visibility:
-                isEditingComponent && linkMode === "lines" ? "visible" : "none",
+              visibility: isEditingLines ? "visible" : "none",
             },
           }}
         />
@@ -131,8 +126,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["project-lines-underlay"].layerProps,
             layout: {
               ...mapStyles["project-lines-underlay"].layerProps.layout,
-              visibility:
-                isEditingComponent && linkMode === "lines" ? "visible" : "none",
+              visibility: isEditingLines ? "visible" : "none",
             },
           }}
         />
@@ -142,8 +136,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["project-lines"].layerProps,
             layout: {
               ...mapStyles["project-lines"].layerProps.layout,
-              visibility:
-                !isEditingComponent && !clickedComponent ? "visible" : "none",
+              visibility: isViewingComponents ? "visible" : "none",
             },
           }}
         />
@@ -153,8 +146,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["project-lines-muted"].layerProps,
             layout: {
               ...mapStyles["project-lines-muted"].layerProps.layout,
-              visibility:
-                clickedComponent || isEditingComponent ? "visible" : "none",
+              visibility: shouldShowMutedFeatures ? "visible" : "none",
             },
           }}
         />
@@ -171,10 +163,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           {...{
             ...mapStyles["ctn-points-underlay"].layerProps,
             layout: {
-              visibility:
-                isEditingComponent && linkMode === "points"
-                  ? "visible"
-                  : "none",
+              visibility: isEditingPoints ? "visible" : "none",
             },
           }}
         />
@@ -183,10 +172,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           {...{
             ...mapStyles["ctn-points"].layerProps,
             layout: {
-              visibility:
-                isEditingComponent && linkMode === "points"
-                  ? "visible"
-                  : "none",
+              visibility: isEditingPoints ? "visible" : "none",
             },
           }}
         />
@@ -204,8 +190,7 @@ export const ProjectComponentsSourcesAndLayers = ({
             ...mapStyles["project-points"].layerProps,
             layout: {
               ...mapStyles["project-points"].layerProps.layout,
-              visibility:
-                !isEditingComponent && !clickedComponent ? "visible" : "none",
+              visibility: isViewingComponents ? "visible" : "none",
             },
           }}
         />
@@ -214,8 +199,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           {...{
             ...mapStyles["project-points-muted"].layerProps,
             layout: {
-              visibility:
-                clickedComponent || isEditingComponent ? "visible" : "none",
+              visibility: shouldShowMutedFeatures ? "visible" : "none",
             },
           }}
         />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -29,7 +29,6 @@ export const BaseMapSourceAndLayers = ({ basemapKey }) => {
           ...basemaps.aerial.layers.streetLabels,
           layout: {
             ...basemaps.aerial.layers.streetLabels.layout,
-            visibility: basemapKey === "aerial" ? "visible" : "none",
           },
         }}
       />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -17,8 +17,6 @@ export const useComponentFeatureCollection = (component) =>
  * @returns JSX.Element
  */
 export const BaseMapSourceAndLayers = ({ basemapKey }) => {
-  // TODO: Address https://github.com/cityofaustin/atd-moped/pull/837#pullrequestreview-1146234061
-  // See https://github.com/visgl/react-map-gl/issues/939
   return (
     <>
       <Source {...basemaps.aerial.sources.aerials} />
@@ -26,8 +24,6 @@ export const BaseMapSourceAndLayers = ({ basemapKey }) => {
         {...basemaps.aerial.layers.aerials}
         layout={{ visibility: basemapKey === "aerial" ? "visible" : "none" }}
       />
-      {/* show street labels on top of other layers */}
-      {/* Use beforeId on other layers to make street labels above everything else */}
       <Layer
         {...{
           ...basemaps.aerial.layers.streetLabels,
@@ -62,6 +58,7 @@ export const makeInteractiveIds = () => {
 
 /**
  * Component that renders all sources and layers for project components
+ * All layers are set to show below basemap street labels using beforeId = "street-labels"
  * @param {Object} data - GeoJSON data for all project components
  * @param {Boolean} isEditingComponent - are we editing a component?
  * @param {String} linkMode - Tracks if we are editing "lines" or "points"
@@ -94,6 +91,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId={SOURCES["ctn-lines"]._featureIdProp}
       >
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["ctn-lines-underlay"].layerProps,
             layout: {
@@ -105,6 +103,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         />
 
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["ctn-lines"].layerProps,
             layout: {
@@ -123,6 +122,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId={SOURCES["ctn-points"]._featureIdProp}
       >
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["ctn-points-underlay"].layerProps,
             layout: {
@@ -134,6 +134,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           }}
         />
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["ctn-points"].layerProps,
             layout: {
@@ -152,8 +153,12 @@ export const ProjectComponentsSourcesAndLayers = ({
         data={projectLines}
         promoteId="id"
       >
-        <Layer {...mapStyles["project-lines-underlay"].layerProps} />
         <Layer
+          beforeId="street-labels"
+          {...mapStyles["project-lines-underlay"].layerProps}
+        />
+        <Layer
+          beforeId="street-labels"
           {...mapStyles[
             clickedComponent || isEditingComponent
               ? "project-lines-muted"
@@ -169,6 +174,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId="id"
       >
         <Layer
+          beforeId="street-labels"
           {...mapStyles[
             clickedComponent || isEditingComponent
               ? "project-points-muted"
@@ -184,6 +190,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId="id"
       >
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["draft-component-lines"].layerProps,
             layout: {
@@ -202,6 +209,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId="id"
       >
         <Layer
+          beforeId="street-labels"
           {...mapStyles["draft-component-points"].layerProps}
           layout={{ visibility: linkMode === "points" ? "visible" : "none" }}
         />
@@ -214,6 +222,7 @@ export const ProjectComponentsSourcesAndLayers = ({
         promoteId="id"
       >
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["clicked-component-features-lines"].layerProps,
             layout: {
@@ -228,6 +237,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           }}
         />
         <Layer
+          beforeId="street-labels"
           {...{
             ...mapStyles["clicked-component-features-points"].layerProps,
             layout: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -78,7 +78,13 @@ export const ProjectComponentsSourcesAndLayers = ({
     draftComponentFeatures,
   } = data;
 
-  console.log(clickedComponent);
+  console.log({
+    data,
+    isEditingComponent,
+    linkMode,
+    clickedComponent,
+    componentFeatureCollection,
+  });
 
   return (
     <>
@@ -132,7 +138,14 @@ export const ProjectComponentsSourcesAndLayers = ({
         />
         <Layer
           beforeId="street-labels"
-          {...mapStyles["project-lines"].layerProps}
+          {...{
+            ...mapStyles["project-lines"].layerProps,
+            layout: {
+              ...mapStyles["project-lines"].layerProps.layout,
+              visibility:
+                !isEditingComponent && !clickedComponent ? "visible" : "none",
+            },
+          }}
         />
         <Layer
           beforeId="street-labels"
@@ -187,11 +200,24 @@ export const ProjectComponentsSourcesAndLayers = ({
       >
         <Layer
           beforeId="street-labels"
-          {...mapStyles[
-            clickedComponent || isEditingComponent
-              ? "project-points-muted"
-              : "project-points"
-          ].layerProps}
+          {...{
+            ...mapStyles["project-points"].layerProps,
+            layout: {
+              ...mapStyles["project-points"].layerProps.layout,
+              visibility:
+                !isEditingComponent && !clickedComponent ? "visible" : "none",
+            },
+          }}
+        />
+        <Layer
+          beforeId="street-labels"
+          {...{
+            ...mapStyles["project-points-muted"].layerProps,
+            layout: {
+              visibility:
+                clickedComponent || isEditingComponent ? "visible" : "none",
+            },
+          }}
         />
       </Source>
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -12,31 +12,6 @@ export const useComponentFeatureCollection = (component) =>
   }, [component]);
 
 /**
- * Component that renders a Mapbox source and layers needed for the aerial basemap
- * @param {string} basemapKey
- * @returns JSX.Element
- */
-export const BaseMapSourceAndLayers = ({ basemapKey }) => {
-  return (
-    <>
-      <Source {...basemaps.aerial.sources.aerials} />
-      <Layer
-        {...basemaps.aerial.layers.aerials}
-        layout={{ visibility: basemapKey === "aerial" ? "visible" : "none" }}
-      />
-      <Layer
-        {...{
-          ...basemaps.aerial.layers.streetLabels,
-          layout: {
-            ...basemaps.aerial.layers.streetLabels.layout,
-          },
-        }}
-      />
-    </>
-  );
-};
-
-/**
  * Iterate through the mapStyles config to create an array of interactive layers
  * @returns {Array} Array of interactive layers
  */
@@ -53,6 +28,33 @@ export const makeInteractiveIds = () => {
   );
 
   return interactiveLayerIds;
+};
+
+/**
+ * Component that renders Mapbox source and layers needed for the aerial basemap
+ * @param {string} basemapKey
+ * @returns JSX.Element
+ */
+export const BaseMapSourceAndLayers = ({ basemapKey }) => {
+  return (
+    <>
+      <Source {...basemaps.aerial.sources.aerials} />
+      <Layer
+        {...basemaps.aerial.layers.aerials}
+        layout={{ visibility: basemapKey === "aerial" ? "visible" : "none" }}
+      />
+      {/* Always show street labels so they can be the "target" of beforeId 
+      and always appear on top of everything else */}
+      <Layer
+        {...{
+          ...basemaps.aerial.layers.streetLabels,
+          layout: {
+            ...basemaps.aerial.layers.streetLabels.layout,
+          },
+        }}
+      />
+    </>
+  );
 };
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -41,21 +41,23 @@ export const BaseMapSourceAndLayers = ({ basemapKey }) => {
   );
 };
 
-// There is a config here that sets the order of layers on the map
-// Iterate the config and return an array of interactive = true
+/**
+ * Iterate through the MAP_STYLES config to create an array of interactive layers
+ * @returns {Array} Array of interactive layers
+ */
 export const makeInteractiveIds = () => {
-  const interactiveLayerIds = [
-    "ctn-lines",
-    "project-lines",
-    "draft-component-lines",
-    "ctn-points",
-    "project-points",
-    "draft-component-points",
-  ];
+  const interactiveLayerIds = Object.entries(MAP_STYLES).reduce(
+    (acc, [key, value]) => {
+      if (value.isInteractive) {
+        acc.push(key);
+      }
+      g;
+      return acc;
+    },
+    []
+  );
 
-  return {
-    interactiveLayerIds,
-  };
+  return interactiveLayerIds;
 };
 
 // This component builds sources and layers

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -51,7 +51,7 @@ export const makeInteractiveIds = () => {
       if (value.isInteractive) {
         acc.push(key);
       }
-      g;
+
       return acc;
     },
     []
@@ -60,9 +60,15 @@ export const makeInteractiveIds = () => {
   return interactiveLayerIds;
 };
 
-// This component builds sources and layers
-// TODOs
-// 1. sources and layers in correct order
+/**
+ * Component that renders all sources and layers for project components
+ * @param {Object} data - GeoJSON data for all project components
+ * @param {Boolean} isEditingComponent - are we editing a component?
+ * @param {String} linkMode - Tracks if we are editing "lines" or "points"
+ * @param {Object} clickedComponent - Details of the component that was clicked
+ * @param {Object} componentFeatureCollection - GeoJSON data for the component clicked
+ * @returns JSX.Element
+ */
 export const ProjectComponentsSourcesAndLayers = ({
   data,
   isEditingComponent,
@@ -70,6 +76,7 @@ export const ProjectComponentsSourcesAndLayers = ({
   clickedComponent,
   componentFeatureCollection,
 }) => {
+  // This is a temporary to get data into the map sources
   const {
     ctnLinesGeojson,
     ctnPointsGeojson,
@@ -154,6 +161,7 @@ export const ProjectComponentsSourcesAndLayers = ({
           ].layerProps}
         />
       </Source>
+
       <Source
         id="project-points"
         type="geojson"
@@ -219,7 +227,6 @@ export const ProjectComponentsSourcesAndLayers = ({
             },
           }}
         />
-
         <Layer
           {...{
             ...mapStyles["clicked-component-features-points"].layerProps,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -78,6 +78,8 @@ export const ProjectComponentsSourcesAndLayers = ({
     draftComponentFeatures,
   } = data;
 
+  console.log(clickedComponent);
+
   return (
     <>
       <Source
@@ -128,14 +130,20 @@ export const ProjectComponentsSourcesAndLayers = ({
             },
           }}
         />
-        {/* TODO: Split this layer into two so that we can control when visible/interactive */}
         <Layer
           beforeId="street-labels"
-          {...mapStyles[
-            clickedComponent || isEditingComponent
-              ? "project-lines-muted"
-              : "project-lines"
-          ].layerProps}
+          {...mapStyles["project-lines"].layerProps}
+        />
+        <Layer
+          beforeId="street-labels"
+          {...{
+            ...mapStyles["project-lines-muted"].layerProps,
+            layout: {
+              ...mapStyles["project-lines-muted"].layerProps.layout,
+              visibility:
+                clickedComponent || isEditingComponent ? "visible" : "none",
+            },
+          }}
         />
       </Source>
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -112,6 +112,34 @@ export const ProjectComponentsSourcesAndLayers = ({
       </Source>
 
       <Source
+        id="project-lines"
+        type="geojson"
+        data={projectLines}
+        promoteId="id"
+      >
+        <Layer
+          beforeId="street-labels"
+          {...{
+            ...mapStyles["project-lines-underlay"].layerProps,
+            layout: {
+              ...mapStyles["project-lines-underlay"].layerProps.layout,
+              visibility:
+                isEditingComponent && linkMode === "lines" ? "visible" : "none",
+            },
+          }}
+        />
+        {/* TODO: Split this layer into two so that we can control when visible/interactive */}
+        <Layer
+          beforeId="street-labels"
+          {...mapStyles[
+            clickedComponent || isEditingComponent
+              ? "project-lines-muted"
+              : "project-lines"
+          ].layerProps}
+        />
+      </Source>
+
+      <Source
         id="ctn-points"
         type="geojson"
         data={ctnPointsGeojson}
@@ -140,26 +168,6 @@ export const ProjectComponentsSourcesAndLayers = ({
                   : "none",
             },
           }}
-        />
-      </Source>
-
-      <Source
-        id="project-lines"
-        type="geojson"
-        data={projectLines}
-        promoteId="id"
-      >
-        <Layer
-          beforeId="street-labels"
-          {...mapStyles["project-lines-underlay"].layerProps}
-        />
-        <Layer
-          beforeId="street-labels"
-          {...mapStyles[
-            clickedComponent || isEditingComponent
-              ? "project-lines-muted"
-              : "project-lines"
-          ].layerProps}
         />
       </Source>
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10402

This PR updates the component draft mode to capture geometry from the same AGOL data that is populated in the map to show what lines and points are available to add to a component. Previously, we grabbed that geometry from a click event in the map library which led to the possibility of clipping geometries. Now, we click a feature, get the feature's unique ID, and then find the record within the features returned from AGOL to use its geometry and properties to eventually persist the component.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://md-10402-clipped-geojson--atd-moped-main.netlify.app/moped/

**Steps to test:**

**This PR update doesn't change the way the UI works so this is mostly verifying that points and lines are still selectable.**

1. Go to a new or existing project's **Map** tab
2. Create a new component with the type of **Access Control - Driveway Closure** and click **Continue**
3. Select some line segments and click **Save** to add the component
4. Repeat with a second component with type of **Bike box** but select some points this time and then **Save**
5. You should be able to select the components that you created from the sidebar menu or click on them on the map and then click the button in the popup to highlight a component
6. Check to make sure that you cannot click the greyed out components when highlighting a component

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
