### PR TITLE
Use wider team role select menu

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
@@ -8,14 +8,13 @@ import {
   ListItemText,
   MenuItem,
   Select,
+  Typography,
 } from "@material-ui/core";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
     margin: theme.spacing(1),
-    minWidth: 120,
-    maxWidth: 300,
   },
   noLabel: {
     marginTop: theme.spacing(3),
@@ -41,10 +40,9 @@ const ProjectTeamRoleMultiselect = ({ roles, value, onChange }) => {
           const selectedRoles = roles.filter((role) =>
             value.includes(role.project_role_id)
           );
-          const roleNames = selectedRoles.map(
-            ({ project_role_name }) => project_role_name
-          );
-          return roleNames.join(", ");
+          return selectedRoles.map(({ project_role_name }) => (
+            <Typography key={project_role_name}>{project_role_name}</Typography>
+          ));
         }}
         /*  
             There appears to be a problem with MenuProps in version 4.x (which is fixed in 5.0),
@@ -54,8 +52,7 @@ const ProjectTeamRoleMultiselect = ({ roles, value, onChange }) => {
         MenuProps={{
           getContentAnchorEl: () => null,
           style: {
-            maxHeight: 400,
-            width: 450,
+            maxHeight: 500,
           },
         }}
       >

--- a/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
@@ -54,6 +54,9 @@ const ProjectTeamRoleMultiselect = ({ roles, value, onChange }) => {
           style: {
             maxHeight: 500,
           },
+          PaperProps: { style: {width: "50%"}},
+          anchorOrigin: { vertical: "bottom", horizontal: "center" },
+          transformOrigin: { vertical: "top", horizontal: "center" },
         }}
       >
         {roles.map(


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/10609

## Testing
**URL to test:**  [Deploy preview](https://moped.austinmobility.io/moped/projects/1720?tab=team)


**Steps to test:**
1. Navigate to the Team tab of any project.
2. Add a team member
3. Edit the team member roles and observe:
- the drop-down menu is 50% of the screen width and is horizontally centered under the "Role" column
- when unfocused, the input menu has linebreaks between the selected role options

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
