### PR TITLE
Fixes an MUI warning about conflicting menu props

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamRoleMultiselect.js
@@ -50,11 +50,11 @@ const ProjectTeamRoleMultiselect = ({ roles, value, onChange }) => {
                 Source: https://github.com/mui-org/material-ui/issues/19245#issuecomment-620488016
         */
         MenuProps={{
-          getContentAnchorEl: () => null,
+          getContentAnchorEl: null,
           style: {
             maxHeight: 500,
           },
-          PaperProps: { style: {width: "50%"}},
+          PaperProps: { style: { width: "50%" } },
           anchorOrigin: { vertical: "bottom", horizontal: "center" },
           transformOrigin: { vertical: "top", horizontal: "center" },
         }}


### PR DESCRIPTION
The `ProjectTeamRoleMultiselect` component had conflicting props:

```
Material-UI: You can not change the default `anchorOrigin.vertical` value 
when also providing the `getContentAnchorEl` prop to the popover component.
Only use one of the two props.
Set `getContentAnchorEl` to `null | undefined` or leave `anchorOrigin.vertical` unchanged. 
```

Discussion [here](https://github.com/mui/material-ui/issues/7961#issuecomment-326215406). 