### PR TITLE
Add an icon to indicate if the component supports line or point geometry

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
@@ -18,7 +18,6 @@ import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import {
   ComponentOptionWithIcon,
   makeRandomComponentId,
-  renderComponentOptionWithIcon,
   useComponentOptions,
   useSubcomponentOptions,
 } from "./utils";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
@@ -17,6 +17,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import {
   makeRandomComponentId,
+  renderComponentOptionWithIcon,
   useComponentOptions,
   useSubcomponentOptions,
 } from "./utils";
@@ -41,6 +42,7 @@ const ControlledAutocomplete = ({
   id,
   disabled = false,
   options,
+  renderOption,
   name,
   control,
   label,
@@ -58,6 +60,7 @@ const ControlledAutocomplete = ({
         disabled={disabled}
         getOptionLabel={(option) => option?.label || ""}
         getOptionSelected={(option, value) => option?.value === value?.value}
+        renderOption={renderOption}
         value={value}
         renderInput={(params) => (
           <TextField
@@ -155,6 +158,7 @@ const ComponentEditModal = ({
                 id="component"
                 label="Component Type"
                 options={areOptionsLoading ? [] : componentOptions}
+                renderOption={renderComponentOptionWithIcon}
                 name="component"
                 control={control}
                 autoFocus

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentEditModal.js
@@ -16,6 +16,7 @@ import { makeStyles } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import {
+  ComponentOptionWithIcon,
   makeRandomComponentId,
   renderComponentOptionWithIcon,
   useComponentOptions,
@@ -158,7 +159,9 @@ const ComponentEditModal = ({
                 id="component"
                 label="Component Type"
                 options={areOptionsLoading ? [] : componentOptions}
-                renderOption={renderComponentOptionWithIcon}
+                renderOption={(option) => (
+                  <ComponentOptionWithIcon option={option} />
+                )}
                 name="component"
                 control={control}
                 autoFocus

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -4,7 +4,10 @@ import booleanIntersects from "@turf/boolean-intersects";
 import circle from "@turf/circle";
 import { v4 as uuidv4 } from "uuid";
 import { Icon } from "@material-ui/core";
-import { Room as RoomIcon, Timeline as TimelineIcon } from "@material-ui/icons";
+import {
+  RoomOutlined as RoomOutlinedIcon,
+  Timeline as TimelineIcon,
+} from "@material-ui/icons";
 
 /* Filters a feature collection down to one type of geometry */
 export const useFeatureTypes = (featureCollection, geomType) =>
@@ -44,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: "center",
     alignItems: "center",
     marginRight: theme.spacing(1),
+    color: theme.palette.primary.main,
   },
 }));
 
@@ -60,7 +64,7 @@ export const ComponentOptionWithIcon = ({ option }) => {
     <>
       <span className={classes.iconContainer}>
         {line_representation === true && <TimelineIcon />}
-        {line_representation === false && <RoomIcon />}
+        {line_representation === false && <RoomOutlinedIcon />}
         {/* Fall back to a blank icon to keep labels lined up */}
         {line_representation === null && <Icon />}
       </span>{" "}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
-import { useMediaQuery, useTheme } from "@material-ui/core";
+import { makeStyles, useMediaQuery, useTheme } from "@material-ui/core";
 import booleanIntersects from "@turf/boolean-intersects";
 import circle from "@turf/circle";
 import { v4 as uuidv4 } from "uuid";
+import { Icon } from "@material-ui/core";
+import { Room as RoomIcon, Timeline as TimelineIcon } from "@material-ui/icons";
 
 /* Filters a feature collection down to one type of geometry */
 export const useFeatureTypes = (featureCollection, geomType) =>
@@ -36,13 +38,27 @@ export const getIntersectionLabel = (point, lines) => {
   return uniqueStreets.join(" / ");
 };
 
-export const renderComponentOptionWithIcon = (option) => {
+const useStyles = makeStyles((theme) => ({
+  iconContainer: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: theme.spacing(1),
+  },
+}));
+
+export const ComponentOptionWithIcon = ({ option }) => {
+  const classes = useStyles();
   const { line_representation = null } = option.data;
 
   return (
     <>
+      <span className={classes.iconContainer}>
+        {line_representation === true && <TimelineIcon />}
+        {line_representation === false && <RoomIcon />}
+        {line_representation === null && <Icon />}
+      </span>{" "}
       {option.label}
-      <span>{line_representation ? "line" : "point"}</span>
     </>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -47,15 +47,21 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+/**
+ * Renders an option with icon based on the type of geometry (if it exists) and component type label
+ * @param {Object} option - Autocomplete option object with label, value, and data about component type
+ * @return {JSX.Element}
+ */
 export const ComponentOptionWithIcon = ({ option }) => {
   const classes = useStyles();
-  const { line_representation = null } = option.data;
+  const { data: { line_representation = null } = {} } = option;
 
   return (
     <>
       <span className={classes.iconContainer}>
         {line_representation === true && <TimelineIcon />}
         {line_representation === false && <RoomIcon />}
+        {/* Fall back to a blank icon to keep labels lined up */}
         {line_representation === null && <Icon />}
       </span>{" "}
       {option.label}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -37,7 +37,14 @@ export const getIntersectionLabel = (point, lines) => {
 };
 
 export const renderComponentOptionWithIcon = (option) => {
-  console.log(option);
+  const { line_representation = null } = option.data;
+
+  return (
+    <>
+      {option.label}
+      <span>{line_representation ? "line" : "point"}</span>
+    </>
+  );
 };
 
 /*

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -36,6 +36,10 @@ export const getIntersectionLabel = (point, lines) => {
   return uniqueStreets.join(" / ");
 };
 
+export const renderComponentOptionWithIcon = (option) => {
+  console.log(option);
+};
+
 /*
  * Components need a unique id generated on creation to avoid collisions
  */

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils.js
@@ -18,7 +18,7 @@ export const useFeatureTypes = (featureCollection, geomType) =>
 
 /*
 Bit of a hack to generate intersection labels from nearby streets. 
-this relies on nearby lines being avaialble in-memory, which 
+this relies on nearby lines being available in-memory, which 
 is not guaranteed. a reliable solution would be query the AGOL streets
 layer on-the-fly to grab street names - not sure if this is worth it TBH 
 */


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10541

Adds icons to the component type options to show if they represent point or line geometries

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Test locally

**Steps to test:**
1. Go to a new or existing project's **Map** tab
2. Click **New Component** and then click on the **Component Type** dropdown
3. You should see an icon before each option label

<img width="858" alt="Screenshot 2022-10-27 at 4 34 54 PM" src="https://user-images.githubusercontent.com/37249039/198402756-a0171fe8-7961-4e85-aae3-3db152318f58.png">

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
