### PR TITLE
Re-implement map draw tools

### DIFF
--- a/moped-editor/src/components/Maps/ComponentsDrawControl.js
+++ b/moped-editor/src/components/Maps/ComponentsDrawControl.js
@@ -85,7 +85,7 @@ const DrawLinesControl = React.forwardRef((props, ref) => {
  * @param {function} onCreate - fires after drawing is complete and a feature is created
  * @param {function} onUpdate - fires after a feature is updated (used to update on feature drag)
  * @param {function} onDelete - fires after a feature is selected and deleted with the trash icon
- * @param {boolean} drawLines - tells us if we are drawing lines or not
+ * @param {string} linkMode - tracks if we are editing "lines" or "points"
  * @param {function} onModeChange - fires when a draw mode button is clicked and mode changes
  * @param {function} onSelectionChange - fires when a feature is selected
  * @param {function} initializeExistingDrawFeatures - passed to load existing drawn features into the draw interface on map load

--- a/moped-editor/src/components/Maps/ComponentsDrawControl.js
+++ b/moped-editor/src/components/Maps/ComponentsDrawControl.js
@@ -94,14 +94,14 @@ const ComponentsDrawControl = React.forwardRef(
       onCreate,
       onUpdate,
       onDelete,
-      drawLines,
+      linkMode,
       onModeChange,
       initializeExistingDrawFeatures,
     },
     ref
   ) => {
-    const shouldDrawLines = drawLines === true;
-    const shouldDrawPoints = drawLines === false;
+    const shouldDrawLines = linkMode === "lines";
+    const shouldDrawPoints = linkMode === "points";
 
     /**
      * direct_select allows more complex interactions like breaking line strings into midpoints

--- a/moped-editor/src/components/Maps/ComponentsDrawControl.js
+++ b/moped-editor/src/components/Maps/ComponentsDrawControl.js
@@ -1,7 +1,9 @@
 import React from "react";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import { useControl } from "react-map-gl";
-import mapboxDrawStylesOverrides from "src/styles/mapboxDrawStylesOverrides";
+import mapboxDrawStylesOverrides, {
+  activeLineWidth,
+} from "src/styles/mapboxDrawStylesOverrides";
 
 // See https://github.com/visgl/react-map-gl/blob/7.0-release/examples/draw-polygon/src/draw-control.ts
 // Ref that is forwarded is defined in useMapDrawTools and we need to drill it down here
@@ -18,6 +20,7 @@ export const DrawControl = React.forwardRef((props, ref) => {
         // This override prevents the introduction of line midpoints and vertices into line string geometries
         props.overrideDirectSelect();
       });
+      map.on("draw.selectionchange", props.onSelectionChange);
       map.on("load", props.initializeExistingDrawFeatures);
 
       return new MapboxDraw(props);
@@ -80,9 +83,11 @@ const DrawLinesControl = React.forwardRef((props, ref) => {
  * DrawPointsControl and DrawLinesControl so it can make its way to DrawControl and
  * have its current value assigned
  * @param {function} onCreate - fires after drawing is complete and a feature is created
+ * @param {function} onUpdate - fires after a feature is updated (used to update on feature drag)
  * @param {function} onDelete - fires after a feature is selected and deleted with the trash icon
  * @param {boolean} drawLines - tells us if we are drawing lines or not
  * @param {function} onModeChange - fires when a draw mode button is clicked and mode changes
+ * @param {function} onSelectionChange - fires when a feature is selected
  * @param {function} initializeExistingDrawFeatures - passed to load existing drawn features into the draw interface on map load
  * @param {function} overrideDirectSelect - overrides direct_select draw mode when map loads
  * @return {JSX.Element} The whole map draw UI
@@ -96,6 +101,7 @@ const ComponentsDrawControl = React.forwardRef(
       onDelete,
       linkMode,
       onModeChange,
+      onSelectionChange,
       initializeExistingDrawFeatures,
     },
     ref
@@ -117,11 +123,12 @@ const ComponentsDrawControl = React.forwardRef(
       position: "top-right",
       displayControlsDefault: false, // Disable to allow us to set which controls to show
       default_mode: "simple_select",
-      clickBuffer: 12,
+      clickBuffer: activeLineWidth,
       onCreate,
       onUpdate,
       onDelete,
       onModeChange,
+      onSelectionChange,
       initializeExistingDrawFeatures,
       overrideDirectSelect,
       styles: mapboxDrawStylesOverrides,

--- a/moped-editor/src/components/Maps/ComponentsDrawControl.js
+++ b/moped-editor/src/components/Maps/ComponentsDrawControl.js
@@ -97,12 +97,21 @@ const ComponentsDrawControl = React.forwardRef(
       drawLines,
       onModeChange,
       initializeExistingDrawFeatures,
-      overrideDirectSelect,
     },
     ref
   ) => {
     const shouldDrawLines = drawLines === true;
     const shouldDrawPoints = drawLines === false;
+
+    /**
+     * direct_select allows more complex interactions like breaking line strings into midpoints
+     * but we only want users to select and deselect with simple_select mode so we override on load
+     * @see https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#simple_select
+     *  @see https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#direct_select
+     */
+    const overrideDirectSelect = () => {
+      ref.current.modes.DIRECT_SELECT = "simple_select";
+    };
 
     const sharedProps = {
       position: "top-right",

--- a/moped-editor/src/styles/mapboxDrawStylesOverrides.js
+++ b/moped-editor/src/styles/mapboxDrawStylesOverrides.js
@@ -1,6 +1,8 @@
 import theme from "src/theme/index";
 import { pointsCircleRadiusStops } from "src/views/projects/projectView/ProjectComponents/mapStyleSettings";
 
+export const activeLineWidth = 8;
+
 // Default Mapbox GL Draw styles with overrides from MUI theme
 // See https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/theme.js
 // See https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/
@@ -97,7 +99,7 @@ const mapboxDrawStylesOverrides = [
     },
     paint: {
       "line-color": theme.palette.primary.main,
-      "line-width": 8,
+      "line-width": activeLineWidth,
     },
   },
   {

--- a/moped-editor/src/styles/mapboxDrawStylesOverrides.js
+++ b/moped-editor/src/styles/mapboxDrawStylesOverrides.js
@@ -1,5 +1,5 @@
 import theme from "src/theme/index";
-import { mapStyles } from "src/utils/mapHelpers";
+import { pointsCircleRadiusStops } from "src/views/projects/projectView/ProjectComponents/mapStyleSettings";
 
 // Default Mapbox GL Draw styles with overrides from MUI theme
 // See https://github.com/mapbox/mapbox-gl-draw/blob/main/src/lib/theme.js
@@ -156,7 +156,7 @@ const mapboxDrawStylesOverrides = [
       ["!=", "mode", "static"],
     ],
     paint: {
-      "circle-radius": mapStyles.circleRadiusStops,
+      "circle-radius": pointsCircleRadiusStops,
       "circle-stroke-width": 4,
       "circle-stroke-color": theme.palette.primary.main,
       "circle-color": theme.palette.secondary.main,
@@ -187,7 +187,7 @@ const mapboxDrawStylesOverrides = [
       ["!=", "meta", "vertex"],
     ],
     paint: {
-      "circle-radius": mapStyles.circleRadiusStops,
+      "circle-radius": pointsCircleRadiusStops,
       "circle-stroke-width": 8,
       "circle-stroke-color": theme.palette.primary.main,
       "circle-color": theme.palette.secondary.main,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
+import { makeDrawnFeature } from "./featureUtils";
 import { cloneDeep } from "lodash";
-import { v4 as uuidv4 } from "uuid";
 
 const ComponentDrawTools = ({
   draftComponent,
@@ -22,13 +22,13 @@ const ComponentDrawTools = ({
         prevDraftComponent.features
       ).filter((feature) => !!feature.properties?.["DRAW_ID"]);
 
-      // Add a unique id to each drawn feature's properties
-      drawnFeatures.forEach(
-        (feature) => (feature.properties["DRAW_ID"] = uuidv4())
-      );
+      // Add properties needed to distinguish drawn features from other features
+      drawnFeatures.forEach((feature) => {
+        makeDrawnFeature(feature, linkMode);
+      });
 
       // We must override the features in the draw control's internal state with ones
-      // that have "DRAW_ID" properties so that we can find them later in onDelete
+      // that have our added properties so that we can find them later in onDelete
       drawControlsRef.current.set({
         type: "FeatureCollection",
         features: [...previouslyDrawnFeatures, ...drawnFeatures],
@@ -84,7 +84,6 @@ const ComponentDrawTools = ({
       setCursor("crosshair");
       setIsDrawing(true);
     } else {
-      setCursor("grab");
       setIsDrawing(false);
     }
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -4,7 +4,6 @@ import { makeDrawnFeature } from "./featureUtils";
 import { cloneDeep } from "lodash";
 
 const ComponentDrawTools = ({
-  draftComponent,
   setDraftComponent,
   linkMode,
   setCursor,
@@ -92,11 +91,19 @@ const ComponentDrawTools = ({
     });
   };
 
-  const onModeChange = (e) => {
-    const { mode } = e;
-
+  const onModeChange = ({ mode }) => {
     if (mode === "draw_point" || mode === "draw_line_string") {
       setCursor("crosshair");
+      setIsDrawing(true);
+    } else {
+      setIsDrawing(false);
+    }
+  };
+
+  const onSelectionChange = ({ features: selectedFeaturesArray }) => {
+    const areFeaturesSelected = selectedFeaturesArray.length > 0;
+
+    if (areFeaturesSelected) {
       setIsDrawing(true);
     } else {
       setIsDrawing(false);
@@ -117,6 +124,7 @@ const ComponentDrawTools = ({
         onUpdate={onUpdate}
         linkMode={linkMode}
         onModeChange={onModeChange}
+        onSelectionChange={onSelectionChange}
         initializeExistingDrawFeatures={initializeExistingDrawFeatures}
       />
     )

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,14 +1,17 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
 
 const ComponentDrawTools = ({
   draftComponent,
   setDraftComponent,
   linkMode,
+  setCursor,
 }) => {
   const drawControlsRef = useRef();
-  const [isDrawing, setIsDrawing] = useState(false);
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
+
+  console.log({ draftComponent });
+  // TODO: Add/update/remove draftComponent.features
 
   const onCreate = () => {
     console.log("onCreate");
@@ -27,9 +30,9 @@ const ComponentDrawTools = ({
     const { mode } = e;
 
     if (mode === "draw_point" || mode === "draw_line_string") {
-      setIsDrawing(true);
+      setCursor("crosshair");
     } else {
-      setIsDrawing(false);
+      setCursor("grab");
     }
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -13,16 +13,14 @@ const ComponentDrawTools = ({
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
 
   //   console.log({ draftComponent });
-  // TODO: Add/update/remove draftComponent.features
-
   const onCreate = ({ features: createdFeaturesArray }) => {
+    // TODO: Refactor this to not pass a function
     setDraftComponent((prevDraftComponent) => {
       const drawnFeatures = cloneDeep(createdFeaturesArray);
 
       const previouslyDrawnFeatures = cloneDeep(
         prevDraftComponent.features
       ).filter((feature) => !!feature.properties?.["DRAW_ID"]);
-      console.log({ previouslyDrawnFeatures });
 
       // Add a unique id to each drawn feature's properties
       drawnFeatures.forEach(
@@ -35,8 +33,6 @@ const ComponentDrawTools = ({
         type: "FeatureCollection",
         features: [...previouslyDrawnFeatures, ...drawnFeatures],
       });
-
-      console.log(prevDraftComponent.features, drawnFeatures);
 
       return {
         ...prevDraftComponent,
@@ -53,9 +49,27 @@ const ComponentDrawTools = ({
   };
 
   const onDelete = ({ features: deletedFeaturesArray }) => {
-    console.log(deletedFeaturesArray);
+    setDraftComponent((prevDraftComponent) => {
+      const featureIdsToDelete = deletedFeaturesArray.map(
+        (feature) => feature.properties["DRAW_ID"]
+      );
 
-    // const draftFeaturesToKeep = draftComponent.features.filter(feature => {})
+      const draftFeaturesToKeep = prevDraftComponent.features.filter(
+        (feature) => {
+          if (feature.properties["DRAW_ID"]) {
+            return !featureIdsToDelete.includes(feature.properties["DRAW_ID"]);
+          } else {
+            return true;
+          }
+        }
+      );
+
+      console.log(draftFeaturesToKeep);
+      return {
+        ...prevDraftComponent,
+        features: [...draftFeaturesToKeep],
+      };
+    });
 
     // TODO: iterate deletedFeaturesArray and remove those from the draft feature
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -28,7 +28,7 @@ const ComponentDrawTools = ({
       });
 
       // We must override the features in the draw control's internal state with ones
-      // that have our added properties so that we can find them later in onDelete
+      // that have our properties so that we can find them later in onDelete
       drawControlsRef.current.set({
         type: "FeatureCollection",
         features: [...previouslyDrawnFeatures, ...drawnFeatures],
@@ -70,16 +70,11 @@ const ComponentDrawTools = ({
         features: [...draftFeaturesToKeep],
       };
     });
-
-    // TODO: iterate deletedFeaturesArray and remove those from the draft feature
   };
 
   const onModeChange = (e) => {
-    // If we are not drawing, set isDrawing to false so we can select layer features as components
     const { mode } = e;
 
-    // TODO: Move this back to isDrawing state toggle and control cursor in the map component
-    // Handle isHovering the same way so that one isn't overriding the other
     if (mode === "draw_point" || mode === "draw_line_string") {
       setCursor("crosshair");
       setIsDrawing(true);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,5 +1,7 @@
 import React, { useRef } from "react";
 import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
+import { cloneDeep } from "lodash";
+import { v4 as uuidv4 } from "uuid";
 
 const ComponentDrawTools = ({
   draftComponent,
@@ -14,10 +16,17 @@ const ComponentDrawTools = ({
   // TODO: Add/update/remove draftComponent.features
 
   const onCreate = ({ features: createdFeaturesArray }) => {
-    console.log({ createdFeaturesArray });
+    const drawnFeatures = cloneDeep(createdFeaturesArray);
 
-    // TODO: iterate createdFeaturesArray, update IDs with uuids and add to draftComponent.features
-    // probably need to update the ids of the features in the draw tools tracking too
+    // Add a unique id to each drawn feature's properties
+    drawnFeatures.forEach(
+      (feature) => (feature.properties["DRAW_ID"] = uuidv4())
+    );
+
+    setDraftComponent((prevDraftComponent) => ({
+      ...prevDraftComponent,
+      features: [...draftComponent.features, ...drawnFeatures],
+    }));
   };
 
   const onUpdate = ({ features: updatedFeaturesArray, action }) => {
@@ -37,6 +46,8 @@ const ComponentDrawTools = ({
     // If we are not drawing, set isDrawing to false so we can select layer features as components
     const { mode } = e;
 
+    // TODO: Move this back to isDrawing state toggle and control cursor in the map component
+    // Handle isHovering the same way so that one isn't overriding the other
     if (mode === "draw_point" || mode === "draw_line_string") {
       setCursor("crosshair");
     } else {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -12,7 +12,6 @@ const ComponentDrawTools = ({
   const drawControlsRef = useRef();
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
 
-  //   console.log({ draftComponent });
   const onCreate = ({ features: createdFeaturesArray }) => {
     // TODO: Refactor this to not pass a function
     setDraftComponent((prevDraftComponent) => {
@@ -27,8 +26,8 @@ const ComponentDrawTools = ({
         (feature) => (feature.properties["DRAW_ID"] = uuidv4())
       );
 
-      // We must override the draw control's features with ones that have "DRAW_ID" properties
-      // so that we can access them when we want to delete them by UUID before saving
+      // We must override the features in the draw control's internal state with ones
+      // that have "DRAW_ID" properties so that we can find them later in onDelete
       drawControlsRef.current.set({
         type: "FeatureCollection",
         features: [...previouslyDrawnFeatures, ...drawnFeatures],

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,7 +1,11 @@
 import React from "react";
 import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
 
-const ComponentDrawTools = () => {
+const ComponentDrawTools = ({
+  draftComponent,
+  setDraftComponent,
+  drawLines,
+}) => {
   const drawControlsRef = useRef();
   const [isDrawing, setIsDrawing] = useState(false);
 
@@ -16,8 +20,6 @@ const ComponentDrawTools = () => {
   const onDelete = () => {
     console.log("onDelete");
   };
-
-  const drawLines = true;
 
   const onModeChange = (e) => {
     // If we are not drawing, set isDrawing to false so we can select layer features as components

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -14,7 +14,6 @@ const ComponentDrawTools = ({
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
 
   const onCreate = ({ features: createdFeaturesArray }) => {
-    // TODO: Refactor this to not pass a function
     setDraftComponent((prevDraftComponent) => {
       const drawnFeatures = cloneDeep(createdFeaturesArray);
 
@@ -42,10 +41,15 @@ const ComponentDrawTools = ({
   };
 
   const onUpdate = ({ features: updatedFeaturesArray, action }) => {
-    console.log({ updatedFeaturesArray, action, draftComponent });
+    const wasComponentDragged = action === "move";
 
-    // TODO: look at action type, iterate updatedFeaturesArray, update IDs with uuids and add to draftComponent.features
-    // probably most concerned with drag updates (action === "move")
+    if (wasComponentDragged) {
+      const featureIdsToUpdate = updatedFeaturesArray.map(
+        (feature) => feature.properties["DRAW_ID"]
+      );
+
+      console.log({ featureIdsToUpdate, draftComponent });
+    }
   };
 
   const onDelete = ({ features: deletedFeaturesArray }) => {
@@ -64,7 +68,6 @@ const ComponentDrawTools = ({
         }
       );
 
-      console.log(draftFeaturesToKeep);
       return {
         ...prevDraftComponent,
         features: [...draftFeaturesToKeep],
@@ -85,6 +88,7 @@ const ComponentDrawTools = ({
 
   const initializeExistingDrawFeatures = () => {
     console.log("initializeExistingDrawFeatures");
+    // TODO: This may be needed when we implement editing existing components
   };
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
 
 const ComponentDrawTools = ({
   draftComponent,
   setDraftComponent,
-  drawLines,
+  linkMode,
 }) => {
   const drawControlsRef = useRef();
   const [isDrawing, setIsDrawing] = useState(false);
+  const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
 
   const onCreate = () => {
     console.log("onCreate");
@@ -37,15 +38,17 @@ const ComponentDrawTools = ({
   };
 
   return (
-    <ComponentsDrawControl
-      ref={drawControlsRef}
-      onCreate={onCreate}
-      onDelete={onDelete}
-      onUpdate={onUpdate}
-      drawLines={drawLines}
-      onModeChange={onModeChange}
-      initializeExistingDrawFeatures={initializeExistingDrawFeatures}
-    />
+    shouldShowDrawControls && (
+      <ComponentsDrawControl
+        ref={drawControlsRef}
+        onCreate={onCreate}
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+        linkMode={linkMode}
+        onModeChange={onModeChange}
+        initializeExistingDrawFeatures={initializeExistingDrawFeatures}
+      />
+    )
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -1,0 +1,50 @@
+import React from "react";
+import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
+
+const ComponentDrawTools = () => {
+  const drawControlsRef = useRef();
+  const [isDrawing, setIsDrawing] = useState(false);
+
+  const onCreate = () => {
+    console.log("onCreate");
+  };
+
+  const onUpdate = () => {
+    console.log("onUpdate");
+  };
+
+  const onDelete = () => {
+    console.log("onDelete");
+  };
+
+  const drawLines = true;
+
+  const onModeChange = (e) => {
+    // If we are not drawing, set isDrawing to false so we can select layer features as components
+    const { mode } = e;
+
+    if (mode === "draw_point" || mode === "draw_line_string") {
+      setIsDrawing(true);
+    } else {
+      setIsDrawing(false);
+    }
+  };
+
+  const initializeExistingDrawFeatures = () => {
+    console.log("initializeExistingDrawFeatures");
+  };
+
+  return (
+    <ComponentsDrawControl
+      ref={drawControlsRef}
+      onCreate={onCreate}
+      onDelete={onDelete}
+      onUpdate={onUpdate}
+      drawLines={drawLines}
+      onModeChange={onModeChange}
+      initializeExistingDrawFeatures={initializeExistingDrawFeatures}
+    />
+  );
+};
+
+export default ComponentDrawTools;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -8,6 +8,7 @@ const ComponentDrawTools = ({
   setDraftComponent,
   linkMode,
   setCursor,
+  setIsDrawing,
 }) => {
   const drawControlsRef = useRef();
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
@@ -81,8 +82,10 @@ const ComponentDrawTools = ({
     // Handle isHovering the same way so that one isn't overriding the other
     if (mode === "draw_point" || mode === "draw_line_string") {
       setCursor("crosshair");
+      setIsDrawing(true);
     } else {
       setCursor("grab");
+      setIsDrawing(false);
     }
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -3,6 +3,14 @@ import ComponentsDrawControl from "src/components/Maps/ComponentsDrawControl";
 import { makeDrawnFeature } from "./featureUtils";
 import { cloneDeep } from "lodash";
 
+/**
+ * Renders project component draw tools
+ * @param {Function} setDraftComponent - function to update the draft component
+ * @param {String} linkMode - tracks if we are editing "lines" or "points"
+ * @param {Function} setCursor - function to update the cursor type
+ * @param {Function} setIsDrawing - function to update if we are drawing or not
+ * @returns
+ */
 const ComponentDrawTools = ({
   setDraftComponent,
   linkMode,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -44,11 +44,28 @@ const ComponentDrawTools = ({
     const wasComponentDragged = action === "move";
 
     if (wasComponentDragged) {
-      const featureIdsToUpdate = updatedFeaturesArray.map(
-        (feature) => feature.properties["DRAW_ID"]
-      );
+      setDraftComponent((prevDraftComponent) => {
+        const featureIdsToUpdate = updatedFeaturesArray.map(
+          (feature) => feature.properties["DRAW_ID"]
+        );
 
-      console.log({ featureIdsToUpdate, draftComponent });
+        const draftFeaturesToKeep = prevDraftComponent.features.filter(
+          (feature) => {
+            if (feature.properties["DRAW_ID"]) {
+              return !featureIdsToUpdate.includes(
+                feature.properties["DRAW_ID"]
+              );
+            } else {
+              return true;
+            }
+          }
+        );
+
+        return {
+          ...prevDraftComponent,
+          features: [...draftFeaturesToKeep, ...updatedFeaturesArray],
+        };
+      });
     }
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -13,16 +13,24 @@ const ComponentDrawTools = ({
   console.log({ draftComponent });
   // TODO: Add/update/remove draftComponent.features
 
-  const onCreate = () => {
-    console.log("onCreate");
+  const onCreate = ({ features: createdFeaturesArray }) => {
+    console.log({ createdFeaturesArray });
+
+    // TODO: iterate createdFeaturesArray, update IDs with uuids and add to draftComponent.features
+    // probably need to update the ids of the features in the draw tools tracking too
   };
 
-  const onUpdate = () => {
-    console.log("onUpdate");
+  const onUpdate = ({ features: updatedFeaturesArray, action }) => {
+    console.log({ updatedFeaturesArray, action });
+
+    // TODO: look at action type, iterate updatedFeaturesArray, update IDs with uuids and add to draftComponent.features
+    // probably most concerned with drag updates (action === "move")
   };
 
-  const onDelete = () => {
-    console.log("onDelete");
+  const onDelete = ({ features: deletedFeaturesArray }) => {
+    console.log(deletedFeaturesArray);
+
+    // TODO: iterate deletedFeaturesArray and remove those from the draft feature
   };
 
   const onModeChange = (e) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -12,28 +12,37 @@ const ComponentDrawTools = ({
   const drawControlsRef = useRef();
   const shouldShowDrawControls = linkMode === "points" || linkMode === "lines";
 
-  console.log({ draftComponent });
+  //   console.log({ draftComponent });
   // TODO: Add/update/remove draftComponent.features
 
   const onCreate = ({ features: createdFeaturesArray }) => {
-    const drawnFeatures = cloneDeep(createdFeaturesArray);
+    setDraftComponent((prevDraftComponent) => {
+      const drawnFeatures = cloneDeep(createdFeaturesArray);
 
-    // Add a unique id to each drawn feature's properties
-    drawnFeatures.forEach(
-      (feature) => (feature.properties["DRAW_ID"] = uuidv4())
-    );
+      const previouslyDrawnFeatures = cloneDeep(
+        prevDraftComponent.features
+      ).filter((feature) => !!feature.properties?.["DRAW_ID"]);
+      console.log({ previouslyDrawnFeatures });
 
-    // We must override the draw control's features with ones that have "DRAW_ID" properties
-    // so that we can access them when we want to delete them by UUID before saving
-    drawControlsRef.current.set({
-      type: "FeatureCollection",
-      features: drawnFeatures,
+      // Add a unique id to each drawn feature's properties
+      drawnFeatures.forEach(
+        (feature) => (feature.properties["DRAW_ID"] = uuidv4())
+      );
+
+      // We must override the draw control's features with ones that have "DRAW_ID" properties
+      // so that we can access them when we want to delete them by UUID before saving
+      drawControlsRef.current.set({
+        type: "FeatureCollection",
+        features: [...previouslyDrawnFeatures, ...drawnFeatures],
+      });
+
+      console.log(prevDraftComponent.features, drawnFeatures);
+
+      return {
+        ...prevDraftComponent,
+        features: [...prevDraftComponent.features, ...drawnFeatures],
+      };
     });
-
-    setDraftComponent((prevDraftComponent) => ({
-      ...prevDraftComponent,
-      features: [...draftComponent.features, ...drawnFeatures],
-    }));
   };
 
   const onUpdate = ({ features: updatedFeaturesArray, action }) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -23,6 +23,13 @@ const ComponentDrawTools = ({
       (feature) => (feature.properties["DRAW_ID"] = uuidv4())
     );
 
+    // We must override the draw control's features with ones that have "DRAW_ID" properties
+    // so that we can access them when we want to delete them by UUID before saving
+    drawControlsRef.current.set({
+      type: "FeatureCollection",
+      features: drawnFeatures,
+    });
+
     setDraftComponent((prevDraftComponent) => ({
       ...prevDraftComponent,
       features: [...draftComponent.features, ...drawnFeatures],
@@ -30,7 +37,7 @@ const ComponentDrawTools = ({
   };
 
   const onUpdate = ({ features: updatedFeaturesArray, action }) => {
-    console.log({ updatedFeaturesArray, action });
+    console.log({ updatedFeaturesArray, action, draftComponent });
 
     // TODO: look at action type, iterate updatedFeaturesArray, update IDs with uuids and add to draftComponent.features
     // probably most concerned with drag updates (action === "move")
@@ -38,6 +45,8 @@ const ComponentDrawTools = ({
 
   const onDelete = ({ features: deletedFeaturesArray }) => {
     console.log(deletedFeaturesArray);
+
+    // const draftFeaturesToKeep = draftComponent.features.filter(feature => {})
 
     // TODO: iterate deletedFeaturesArray and remove those from the draft feature
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentDrawTools.js
@@ -9,7 +9,7 @@ import { cloneDeep } from "lodash";
  * @param {String} linkMode - tracks if we are editing "lines" or "points"
  * @param {Function} setCursor - function to update the cursor type
  * @param {Function} setIsDrawing - function to update if we are drawing or not
- * @returns
+ * @returns {JSX.Element}
  */
 const ComponentDrawTools = ({
   setDraftComponent,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -62,6 +62,7 @@ export default function TheMap({
   const [cursor, setCursor] = useState("grap");
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
+  const [isDrawing, setIsDrawing] = useState(false);
   const projectFeatures = useProjectFeatures(components);
 
   const draftComponentFeatures = useDraftComponentFeatures(draftComponent);
@@ -209,11 +210,13 @@ export default function TheMap({
         setDraftComponent={setDraftComponent}
         linkMode={linkMode}
         setCursor={setCursor}
+        setIsDrawing={setIsDrawing}
       />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
       <ProjectComponentsSourcesAndLayers
         data={data}
         isEditingComponent={isEditingComponent}
+        isDrawing={isDrawing}
         linkMode={linkMode}
         draftLayerId={draftLayerId}
         clickedComponent={clickedComponent}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -6,7 +6,7 @@ import GeocoderControl from "src/components/Maps/GeocoderControl";
 import BasemapSpeedDial from "./BasemapSpeedDial";
 import ComponentDrawTools from "./ComponentDrawTools";
 import { basemaps, mapParameters, initialViewState } from "./mapSettings";
-import { getIntersectionLabel, useFeatureTypes } from "./utils";
+import { useFeatureTypes } from "./utils";
 import { useAgolFeatures, findFeatureInAgolGeojsonFeatures } from "./agolUtils";
 import {
   BaseMapSourceAndLayers,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -15,6 +15,7 @@ import {
   ProjectComponentsSourcesAndLayers,
 } from "./mapUtils";
 import "mapbox-gl/dist/mapbox-gl.css";
+import { isDrawnFeature } from "./featureUtils";
 
 // See https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
 import mapboxgl from "mapbox-gl";
@@ -60,6 +61,7 @@ export default function TheMap({
   setIsFetchingFeatures,
 }) {
   const [cursor, setCursor] = useState("grab");
+
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
   const [isDrawing, setIsDrawing] = useState(false);
@@ -131,7 +133,10 @@ export default function TheMap({
       (feature) => feature.layer.id === draftLayerId
     );
 
-    if (clickedDraftComponentFeature) {
+    if (
+      clickedDraftComponentFeature &&
+      !isDrawnFeature(clickedDraftComponentFeature)
+    ) {
       // remove project feature, ignore underlying CTN features
       const filteredFeatures = draftComponent.features.filter((compFeature) => {
         return !(

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -59,7 +59,7 @@ export default function TheMap({
   linkMode,
   setIsFetchingFeatures,
 }) {
-  const [cursor, setCursor] = useState("grap");
+  const [cursor, setCursor] = useState("grab");
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
   const [isDrawing, setIsDrawing] = useState(false);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -22,28 +22,17 @@ mapboxgl.workerClass =
   // eslint-disable-next-line import/no-webpack-loader-syntax
   require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
 
-const deDeupeProjectFeatures = (features) => {
-  return features.filter(
-    (value, index, self) =>
-      index ===
-      self.findIndex(
-        (f) =>
-          f.properties.id === value.properties.id &&
-          f.properties._layerId === value.properties._layerId
-      )
-  );
-};
-
-// returns geojson of **unique** features across all components
+// returns geojson of features across all components
 const useProjectFeatures = (components) =>
   useMemo(() => {
     const allComponentfeatures = [];
     components.forEach((component) =>
       allComponentfeatures.push(component.features)
     );
+
     return {
       type: "FeatureCollection",
-      features: deDeupeProjectFeatures(allComponentfeatures.flat()),
+      features: allComponentfeatures.flat(),
     };
   }, [components]);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -218,7 +218,7 @@ export default function TheMap({
       <ComponentDrawTools
         draftComponent={draftComponent}
         setDraftComponent={setDraftComponent}
-        drawLines={true}
+        linkMode={linkMode}
       />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
       <ProjectComponentsSourcesAndLayers

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -133,10 +133,10 @@ export default function TheMap({
       (feature) => feature.layer.id === draftLayerId
     );
 
-    if (
-      clickedDraftComponentFeature &&
-      !isDrawnFeature(clickedDraftComponentFeature)
-    ) {
+    // If we clicked a drawn feature, we don't need to capture from the CTN layers
+    if (isDrawnFeature(clickedDraftComponentFeature)) return;
+
+    if (clickedDraftComponentFeature) {
       // remove project feature, ignore underlying CTN features
       const filteredFeatures = draftComponent.features.filter((compFeature) => {
         return !(
@@ -211,7 +211,6 @@ export default function TheMap({
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
       <GeocoderControl position="top-left" marker={false} />
       <ComponentDrawTools
-        draftComponent={draftComponent}
         setDraftComponent={setDraftComponent}
         linkMode={linkMode}
         setCursor={setCursor}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -6,7 +6,7 @@ import GeocoderControl from "src/components/Maps/GeocoderControl";
 import BasemapSpeedDial from "./BasemapSpeedDial";
 import ComponentDrawTools from "./ComponentDrawTools";
 import { basemaps, mapParameters, initialViewState } from "./mapSettings";
-import { getIntersectionLabel, useFeatureTypes } from "./utils";
+import { useFeatureTypes } from "./utils";
 import { useAgolFeatures } from "./agolUtils";
 import {
   BaseMapSourceAndLayers,
@@ -15,7 +15,7 @@ import {
   ProjectComponentsSourcesAndLayers,
 } from "./mapUtils";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { isDrawnFeature } from "./featureUtils";
+import { isDrawnFeature, makeCapturedFromLayerFeature } from "./featureUtils";
 
 // See https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
 import mapboxgl from "mapbox-gl";
@@ -153,27 +153,14 @@ export default function TheMap({
 
     // if multiple features are clicked, we ignore all but one
     const clickedFeature = e.features[0];
-    const clickedFeatureFromAgolGeojson =
+    const featureFromAgolGeojson =
       findFeatureInAgolGeojsonFeatures(clickedFeature);
 
-    const newFeature = {
-      geometry: clickedFeatureFromAgolGeojson.geometry,
-      properties: {
-        ...clickedFeatureFromAgolGeojson.properties,
-        id: clickedFeatureFromAgolGeojson.id,
-        // AGOL data doesn't include layer so we grab it from the clicked Mapbox feature
-        _layerId: clickedFeature.layer.id,
-      },
-    };
-
-    if (newFeature.properties._layerId.includes("point")) {
-      newFeature.properties._label = getIntersectionLabel(
-        newFeature,
-        ctnLinesGeojson
-      );
-    } else {
-      newFeature.properties._label = `${newFeature.properties.FROM_ADDRESS_MIN} BLK ${newFeature.properties.FULL_STREET_NAME}`;
-    }
+    const newFeature = makeCapturedFromLayerFeature(
+      featureFromAgolGeojson,
+      clickedFeature,
+      ctnLinesGeojson
+    );
 
     newDraftComponent.features.push(newFeature);
     setDraftComponent(newDraftComponent);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -4,6 +4,7 @@ import { cloneDeep } from "lodash";
 import FeaturePopup from "./FeaturePopup";
 import GeocoderControl from "src/components/Maps/GeocoderControl";
 import BasemapSpeedDial from "./BasemapSpeedDial";
+import ComponentDrawTools from "./ComponentDrawTools";
 import { basemaps, mapParameters, initialViewState } from "./mapSettings";
 import { getIntersectionLabel, useFeatureTypes } from "./utils";
 import { useAgolFeatures } from "./agolUtils";
@@ -214,6 +215,11 @@ export default function TheMap({
     >
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
       <GeocoderControl position="top-left" marker={false} />
+      <ComponentDrawTools
+        draftComponent={draftComponent}
+        setDraftComponent={setDraftComponent}
+        drawLines={true}
+      />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
       <ProjectComponentsSourcesAndLayers
         data={data}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -219,6 +219,7 @@ export default function TheMap({
         draftComponent={draftComponent}
         setDraftComponent={setDraftComponent}
         linkMode={linkMode}
+        setCursor={setCursor}
       />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
       <ProjectComponentsSourcesAndLayers

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -32,7 +32,7 @@ const getQuerySring = (bounds) => {
     .join("&");
 };
 
-const deDeupeFeatures = (features, featureIdProp) => {
+const deDedupeFeatures = (features, featureIdProp) => {
   // courtesy of: https://stackoverflow.com/questions/2218999/how-to-remove-all-duplicates-from-an-array-of-objects
   return features.filter(
     (value, index, self) =>
@@ -48,7 +48,7 @@ on a previous state is a great use case for useReducer, because
 it allows us to work around an infinite recursion scenario in useEffect  */
 const featureReducer = (geojson, { features, featureIdProp }) => {
   const allFeatures = [...geojson.features, ...features];
-  const uniqueFeatures = deDeupeFeatures(allFeatures, featureIdProp);
+  const uniqueFeatures = deDedupeFeatures(allFeatures, featureIdProp);
   return { type: "FeatureCollection", features: uniqueFeatures };
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/agolUtils.js
@@ -54,7 +54,7 @@ const featureReducer = (geojson, { features, featureIdProp }) => {
 
 /**
  * Fetch CTN lines and points and a helper to find a feature record that matches a clicked layer feature by ID
- * @param {String} linkMode - the current link mode ("lines" or "points")
+ * @param {String} linkMode - tracks if we are editing "lines" or "points"
  * @param {Function} setIsFetchingFeatures - toggle loading state of the header spinner
  * @param {Number} currentZoom - current level of zoom in the map
  * @param {Array} bounds - the current map bounds

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -24,6 +24,13 @@ import { getIntersectionLabel } from "./utils";
  * }
  */
 
+/**
+ * Make a feature object from a clicked CTN feature and AGOL returned data about it
+ * @param {Object} featureFromAgolGeojson - a feature object from AGOL
+ * @param {Object} clickedFeature - a feature object from a Mapbox click event
+ * @param {Object} ctnLinesGeojson - a feature collection of CTN lines currently in map view
+ * @returns {Object} - a feature object
+ */
 export const makeCapturedFromLayerFeature = (
   featureFromAgolGeojson,
   clickedFeature,
@@ -67,6 +74,7 @@ export const makeCapturedFromLayerFeature = (
  * Make a drawn feature object from GeoJSON output of Mapbox GL Draw
  * @param {Object} feature - GeoJSON feature object from Mapbox GL Draw onCreate
  * @param {String} linkMode - tracks if we are editing "lines" or "points"
+ * @returns {Object} - a feature object
  */
 export const makeDrawnFeature = (feature, linkMode) => {
   feature.properties["DRAW_ID"] = uuidv4();

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
 /**
- * Drawn feature properties
+ * Drawn feature object example
  * {
  *   id: "9e0c688733283be4991cb9df39ae284d",
  *   type: "Feature",
@@ -10,6 +10,12 @@ import { v4 as uuidv4 } from "uuid";
  *     _layerId: "drawnByUserLine",
  *     geometry: { coordinates: [], type: "LineString" },
  * }
+ */
+
+/**
+ * Make a drawn feature object from GeoJSON output of Mapbox GL Draw
+ * @param {Object} feature - GeoJSON feature object from Mapbox GL Draw onCreate
+ * @param {String} linkMode - tracks if we are editing "lines" or "points"
  */
 export const makeDrawnFeature = (feature, linkMode) => {
   feature.properties["DRAW_ID"] = uuidv4();
@@ -24,5 +30,10 @@ export const makeDrawnFeature = (feature, linkMode) => {
   }
 };
 
+/**
+ * Determine if a feature is drawn by the user
+ * @param {Object} feature
+ * @returns {Boolean} - true if feature is drawn by user
+ */
 export const isDrawnFeature = (feature) =>
   feature?.properties?.DRAW_ID ? true : false;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -1,4 +1,55 @@
 import { v4 as uuidv4 } from "uuid";
+import { getIntersectionLabel } from "./utils";
+
+/**
+ * Captured from feature object example
+ * {
+ *    "geometry": {
+ *        "type": "LineString",
+ *        "coordinates": [],
+ *    },
+ *    "properties": {
+ *        "OBJECTID": 20041,
+ *        "CTN_SEGMENT_ID": 153083,
+ *        "FULL_STREET_NAME": "W MARTIN LUTHER KING JR BLVD",
+ *        "FROM_ADDRESS_MIN": 300,
+ *        "TO_ADDRESS_MAX": 303,
+ *        "LINE_TYPE": "On-Street",
+ *        "GLOBALID": "cb89d800-d6a3-491f-91e6-61cab17ac738",
+ *        "Shape__Length": 60.3716805891339,
+ *        "id": 20041,
+ *        "_layerId": "ctn-lines-underlay",
+ *        "_label": "300 BLK W MARTIN LUTHER KING JR BLVD"
+ *    }
+ * }
+ */
+
+export const makeCapturedFromLayerFeature = (
+  featureFromAgolGeojson,
+  clickedFeature,
+  ctnLinesGeojson
+) => {
+  const newFeature = {
+    geometry: featureFromAgolGeojson.geometry,
+    properties: {
+      ...featureFromAgolGeojson.properties,
+      id: featureFromAgolGeojson.id,
+      // AGOL data doesn't include layer so we grab it from the clicked Mapbox feature
+      _layerId: clickedFeature.layer.id,
+    },
+  };
+
+  if (newFeature.properties._layerId.includes("point")) {
+    newFeature.properties._label = getIntersectionLabel(
+      newFeature,
+      ctnLinesGeojson
+    );
+  } else {
+    newFeature.properties._label = `${newFeature.properties.FROM_ADDRESS_MIN} BLK ${newFeature.properties.FULL_STREET_NAME}`;
+  }
+
+  return newFeature;
+};
 
 /**
  * Drawn feature object example

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -1,0 +1,25 @@
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Drawn feature properties
+ * {
+ *   id: "9e0c688733283be4991cb9df39ae284d",
+ *   type: "Feature",
+ *   properties: {
+ *     DRAW_ID: "88230580-099f-4c93-b8e5-ad3086caf0e6",
+ *     _layerId: "drawnByUserLine",
+ *     geometry: { coordinates: [], type: "LineString" },
+ * }
+ */
+export const makeDrawnFeature = (feature, linkMode) => {
+  feature.properties["DRAW_ID"] = uuidv4();
+
+  // TODO: Current schema uses "drawnByUser" for lines but we need _layerId to contain
+  // "line" or "point" to the popup to work as expected (otherwise mutliple components
+  // show up in the popup when clicking a feature)
+  if (linkMode === "lines") {
+    feature.properties["_layerId"] = "drawnByUserLine";
+  } else if (linkMode === "points") {
+    feature.properties["_layerId"] = "drawnByUserPoint";
+  }
+};

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -61,12 +61,12 @@ export const makeCapturedFromLayerFeature = (
 /**
  * Drawn feature object example
  * {
- *   id: "9e0c688733283be4991cb9df39ae284d",
- *   type: "Feature",
- *   properties: {
- *     DRAW_ID: "88230580-099f-4c93-b8e5-ad3086caf0e6",
- *     _layerId: "drawnByUserLine",
- *     geometry: { coordinates: [], type: "LineString" },
+ *   "id": "9e0c688733283be4991cb9df39ae284d",
+ *   "geometry": { coordinates: [], type: "LineString" },
+ *   "type": "Feature",
+ *   "properties": {
+ *     "DRAW_ID": "88230580-099f-4c93-b8e5-ad3086caf0e6",
+ *     "_layerId": "drawnByUserLine",
  * }
  */
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -25,4 +25,4 @@ export const makeDrawnFeature = (feature, linkMode) => {
 };
 
 export const isDrawnFeature = (feature) =>
-  feature.properties?.DRAW_ID ? true : false;
+  feature?.properties?.DRAW_ID ? true : false;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/featureUtils.js
@@ -23,3 +23,6 @@ export const makeDrawnFeature = (feature, linkMode) => {
     feature.properties["_layerId"] = "drawnByUserPoint";
   }
 };
+
+export const isDrawnFeature = (feature) =>
+  feature.properties?.DRAW_ID ? true : false;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -16,6 +16,13 @@ export const COLORS = {
   white: "#fff",
 };
 
+export const pointsCircleRadiusStops = {
+  stops: [
+    [10, 1],
+    [20, 12],
+  ],
+};
+
 /**
  * Sets the interactivity and styles of the map layers
  * isInteractive - whether the layer is included in the map's interactiveLayerIds array
@@ -30,12 +37,7 @@ export const MAP_STYLES = {
       _featureIdProp: "INTERSECTION_ID",
       type: "circle",
       paint: {
-        "circle-radius": {
-          stops: [
-            [10, 1],
-            [20, 12],
-          ],
-        },
+        "circle-radius": pointsCircleRadiusStops,
         "circle-stroke-color": COLORS.pinkBright,
         "circle-stroke-width": 2,
         "circle-stroke-opacity": 0.9,
@@ -76,12 +78,7 @@ export const MAP_STYLES = {
       _featureIdProp: "INTERSECTION_ID",
       type: "circle",
       paint: {
-        "circle-radius": {
-          stops: [
-            [10, 1],
-            [20, 12],
-          ],
-        },
+        "circle-radius": pointsCircleRadiusStops,
         "circle-stroke-color": COLORS.mutedGray,
         "circle-stroke-width": 2,
         "circle-stroke-opacity": 0.9,
@@ -153,12 +150,7 @@ export const MAP_STYLES = {
       _featureIdProp: "id",
       type: "circle",
       paint: {
-        "circle-radius": {
-          stops: [
-            [10, 1],
-            [20, 12],
-          ],
-        },
+        "circle-radius": pointsCircleRadiusStops,
         "circle-stroke-color": COLORS.blueDark,
         "circle-stroke-width": 2,
         "circle-stroke-opacity": 0.9,
@@ -244,12 +236,7 @@ export const MAP_STYLES = {
       type: "circle",
       _featureIdProp: "INTERSECTION_ID",
       paint: {
-        "circle-radius": {
-          stops: [
-            [10, 1],
-            [20, 12],
-          ],
-        },
+        "circle-radius": pointsCircleRadiusStops,
         "circle-stroke-opacity": 0,
         "circle-color": COLORS.black,
         "circle-opacity": 0,
@@ -284,12 +271,7 @@ export const MAP_STYLES = {
       featureIdProp: "id",
       type: "circle",
       paint: {
-        "circle-radius": {
-          stops: [
-            [10, 1],
-            [20, 12],
-          ],
-        },
+        "circle-radius": pointsCircleRadiusStops,
         "circle-stroke-color": COLORS.blueDark,
         "circle-stroke-width": 2,
         "circle-stroke-opacity": 0.9,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapUtils.js
@@ -68,6 +68,7 @@ export const ProjectComponentsSourcesAndLayers = ({
   linkMode,
   clickedComponent,
   componentFeatureCollection,
+  isDrawing,
 }) => {
   // This is a temporary to get data into the map sources
   const {
@@ -79,8 +80,10 @@ export const ProjectComponentsSourcesAndLayers = ({
   } = data;
 
   const isViewingComponents = !isEditingComponent && !clickedComponent;
-  const isEditingLines = isEditingComponent && linkMode === "lines";
-  const isEditingPoints = isEditingComponent && linkMode === "points";
+  const isEditingLines =
+    isEditingComponent && linkMode === "lines" && !isDrawing;
+  const isEditingPoints =
+    isEditingComponent && linkMode === "points" && !isDrawing;
   const shouldShowMutedFeatures = clickedComponent || isEditingComponent;
 
   return (


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10403

Adds the draw tools to the components map refactor

Questions/concerns:

- there is some cross-activity when clicking a segment or point from CTN layers near a drawn line or point (capture below). The `clickBuffer` parameter of the draw tools could be updated to avoid this but I also don't want to make it super hard to click drawn features if we drop that too low.
![clickLines](https://user-images.githubusercontent.com/37249039/198742954-1062cd30-970c-4075-aaf6-f76d666ffc39.gif)


## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://md-10403-draw-tools--atd-moped-main.netlify.app/moped/ or test locally

**Steps to test:**
1. Go to a new or existing project's **Map** tab and then click **New Component**
2. Choose component type **Access Control - Driveway Closure**
3. Zoom until you see the dashed lines of the CTN layer
4. Click the line drawing icon in the top right just above the trash can icon
5. You should see:
   a. the dashed lines of the CTN line layer disappear
   b. the cursor turn into a crosshair
6. Draw a line and complete the line by clicking twice in the last vertex. The vertices of the line should still be circled in green showing that the line is currently active in the draw tools
7. While still active, click the line and hold while dragging it and you should see the location of the drawn line update when you release your click
8. Click away from the line and the green circles should disappear and the dashed CTN line layer should reappear
9. Select a couple of segments from the CTN line layer and click **Save** - you will see the new component shown on the map in magenta
10. Repeat the above steps with the point component type called **Bike Box**
11. While drawing the point component, you should see the features of the first line component shown as muted with a gray color
12. After creating and saving a point type component, highlight each new component by clicking on the boxes in the left sidebar
13. You should see the highlighted component features highlighted in blue on the map and the other components muted with a gray color

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
