### PR TITLE
Adds Entities to data dictionary

### DIFF
--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -39,5 +39,10 @@ export const TABLE_LOOKUPS_QUERY = gql`
       slug
       type
     }
+    moped_entity(order_by: { entity_name: asc }) {
+      entity_id
+      entity_name
+     
+    }
   }
 `;

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -6,6 +6,7 @@ import { createBrowserHistory } from "history";
 import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
+import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import Button from "@material-ui/core/Button";
@@ -136,30 +137,34 @@ const LookupsView = () => {
                   </Grid>
 
                   <Grid item>
-                    <IconButton
-                      component={Link}
-                      to={createRecordKeyHash(recordType.key)}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        scrollToTable(recordType.key, refs);
-                        history.replace(createRecordKeyHash(recordType.key));
-                      }}
-                    >
-                      <LinkIcon fontSize="small" />
-                    </IconButton>
+                    <Tooltip title="Link to this table">
+                      <IconButton
+                        component={Link}
+                        to={createRecordKeyHash(recordType.key)}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          scrollToTable(recordType.key, refs);
+                          history.replace(createRecordKeyHash(recordType.key));
+                        }}
+                      >
+                        <LinkIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
                   </Grid>
                   <Grid item>
-                    <IconButton
-                      component={Link}
-                      to={"#"}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        scrollToTable("_scroll_to_top", refs);
-                        history.replace("");
-                      }}
-                    >
-                      <ArrowUpwardIcon fontSize="small" />
-                    </IconButton>
+                    <Tooltip title="Return to top of page">
+                      <IconButton
+                        component={Link}
+                        to={"#"}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          scrollToTable("_scroll_to_top", refs);
+                          history.replace("");
+                        }}
+                      >
+                        <ArrowUpwardIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
                   </Grid>
                   <Grid item xs={12}>
                     <RecordTable

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -160,21 +160,6 @@ const LookupsView = () => {
                     >
                       <ArrowUpwardIcon fontSize="small" />
                     </IconButton>
-                    {/* <Button
-                      size="small"
-                      color="primary"
-                      // variant="outlined"
-                      component={Link}
-                      startIcon={<ArrowUpwardIcon />}
-                      to={createRecordKeyHash(recordType.key)}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        scrollToTable("_scroll_to_top", refs);
-                        // history.replace(createRecordKeyHash(recordType.key));
-                      }}
-                    >
-                      Back to top
-                    </Button> */}
                   </Grid>
                   <Grid item xs={12}>
                     <RecordTable

--- a/moped-editor/src/views/dev/LookupsView/index.js
+++ b/moped-editor/src/views/dev/LookupsView/index.js
@@ -10,6 +10,7 @@ import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import Button from "@material-ui/core/Button";
 import LinkIcon from "@material-ui/icons/Link";
+import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
 import { makeStyles } from "@material-ui/styles";
 import Page from "src/components/Page";
 import RecordTable from "./RecordTable";
@@ -62,10 +63,13 @@ const LookupsView = () => {
    * */
   const refs = useMemo(
     () =>
-      SETTINGS.reduce((prev, recordType) => {
-        prev[recordType.key] = createRef();
-        return prev;
-      }, {}),
+      SETTINGS.reduce(
+        (prev, recordType) => {
+          prev[recordType.key] = createRef();
+          return prev;
+        },
+        { _scroll_to_top: createRef() }
+      ),
     []
   );
 
@@ -96,6 +100,7 @@ const LookupsView = () => {
             spacing={3}
             className={classes.topMargin}
             component={Paper}
+            ref={refs._scroll_to_top}
           >
             {SETTINGS.map((recordType) => (
               <Grid item key={recordType.key}>
@@ -129,6 +134,7 @@ const LookupsView = () => {
                   <Grid item>
                     <Typography variant="h2">{recordType.label}</Typography>
                   </Grid>
+
                   <Grid item>
                     <IconButton
                       component={Link}
@@ -141,6 +147,34 @@ const LookupsView = () => {
                     >
                       <LinkIcon fontSize="small" />
                     </IconButton>
+                  </Grid>
+                  <Grid item>
+                    <IconButton
+                      component={Link}
+                      to={"#"}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        scrollToTable("_scroll_to_top", refs);
+                        history.replace("");
+                      }}
+                    >
+                      <ArrowUpwardIcon fontSize="small" />
+                    </IconButton>
+                    {/* <Button
+                      size="small"
+                      color="primary"
+                      // variant="outlined"
+                      component={Link}
+                      startIcon={<ArrowUpwardIcon />}
+                      to={createRecordKeyHash(recordType.key)}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        scrollToTable("_scroll_to_top", refs);
+                        // history.replace(createRecordKeyHash(recordType.key));
+                      }}
+                    >
+                      Back to top
+                    </Button> */}
                   </Grid>
                   <Grid item xs={12}>
                     <RecordTable

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -43,7 +43,7 @@ export const SETTINGS = [
    */
   {
     key: "moped_phases",
-    label: "Moped phases",
+    label: "Phases",
     columns: [
       /**
        * @type { Object } Column definition
@@ -78,7 +78,7 @@ export const SETTINGS = [
   },
   {
     key: "moped_milestones",
-    label: "Moped milestones",
+    label: "Milestones",
     columns: [
       {
         key: "milestone_id",
@@ -105,7 +105,7 @@ export const SETTINGS = [
   },
   {
     key: "moped_components",
-    label: "Moped components",
+    label: "Components",
     columns: [
       /**
        * @type { Object } Column definition
@@ -142,7 +142,7 @@ export const SETTINGS = [
   },
   {
     key: "moped_tags",
-    label: "Project Tags",
+    label: "Tags",
     columns: [
       {
         key: "id",
@@ -159,6 +159,20 @@ export const SETTINGS = [
       {
         key: "slug",
         label: "Slug",
+      },
+    ],
+  },
+  {
+    key: "moped_entity",
+    label: "Entities",
+    columns: [
+      {
+        key: "entity_id",
+        label: "ID",
+      },
+      {
+        key: "entity_name",
+        label: "Name",
       },
     ],
   },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10740

This PR adds `moped_entities` to the data dictionary page, and it also adds an awkward icon button next to each table header which will take you back to the top nav. 

We clearly need to rethink the design of the data dictionary. Some ideas for improvement:
- Use a persistent sidebar nav (like Gitbook) to make it easy to navigate
- Make use of our comments in the DB schema itself to display definitions of tables and fields
- Make it clear to users where these values are used. E.g., the `moped_entities` column is reference by Lead, Sponsor, and Partners, but users will have no idea that's the case.

☝️ i'll put all that in a separate issue

## Testing
**URL to test:** [Deploy preview](https://deploy-preview-853--atd-moped-main.netlify.app/)
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Navigate to `/moped/dev/lookups`
2. Click on the "Entities" nav button
3. Observe that there are entities listed
4. Refresh the page - confirm that the page scrolls back to the entities section
5. Click the up arrow icon to scroll back to the top of the page
6. Click on some other record types to confirm the same scroll behavior is working

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
