### PR TITLE
Create script to backfill who created a project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ hasura_cluster.json
 hasura_cluster_template.json
 
 # Secrets used in moped toolbox scripts
-moped-toolbox/*secrets.py
+secrets.py
 
 # Logs
 logs

--- a/moped-toolbox/backfill_added_by/run.py
+++ b/moped-toolbox/backfill_added_by/run.py
@@ -34,7 +34,7 @@ query ProjectInsertActivities {
 }
 """
 
-ACTIVE_MOPED_USERS_QUERY = """
+MOPED_USERS_QUERY = """
 query AllMopedUsers {
   moped_users {
     first_name
@@ -108,7 +108,6 @@ def main(env):
         logs = [l for l in activities if l["record_project_id"] == proj["project_id"]]
         if not logs:
             # some projects are missing logs - presumably to due SQS/event handler failures
-            # print(f"WARNING: No logs found for project #{proj_id}")
             if proj["date_added"].startswith("2022-02-10"):
                 # this is an AMD project migrated on 2 Feb 2022
                 ready.append({"project_id": proj_id, "added_by": amd_user_id})
@@ -128,6 +127,7 @@ def main(env):
                 ready.append({"project_id": proj_id, "added_by": amd_user_id})
                 continue
             elif log["updated_by"]:
+                # we logged a cognito user ID but it is no longer associated with a user in the DB
                 unable_to_process.append(
                     {"project_id": proj_id, "reason": "unknown cognito user ID"}
                 )

--- a/moped-toolbox/backfill_added_by/run.py
+++ b/moped-toolbox/backfill_added_by/run.py
@@ -164,7 +164,7 @@ def main(env):
     print("Writing inoperable projects to 'log.json'")
 
     with open("log.json", "w") as fout:
-        json.dump(unable_to_process, fout)
+        json.dump(unable_to_process, fout, indent=2)
 
 
 if __name__ == "__main__":

--- a/moped-toolbox/backfill_added_by/run.py
+++ b/moped-toolbox/backfill_added_by/run.py
@@ -92,7 +92,7 @@ def main(env):
         query=ACTIVITY_LOG_LOOKUP_QUERY, env=env, variables=None
     )["moped_activity_log"]
     users = make_hasura_request(
-        query=ACTIVE_MOPED_USERS_QUERY, env=env, variables=None
+        query=MOPED_USERS_QUERY, env=env, variables=None
     )["moped_users"]
 
     # we will attribute AMD projects to ivonne if no user info is available

--- a/moped-toolbox/backfill_added_by/run.py
+++ b/moped-toolbox/backfill_added_by/run.py
@@ -1,3 +1,6 @@
+"""Updates the `added_by` column of moped_project records based on the `moped_activity_log`.
+This script can safely be run repeatedly as needed."""
+
 import argparse
 import json
 import requests

--- a/moped-toolbox/backfill_added_by/run.py
+++ b/moped-toolbox/backfill_added_by/run.py
@@ -1,0 +1,179 @@
+import argparse
+import json
+import requests
+from secrets import HASURA_AUTH
+
+
+PROJECTS_TODO_QUERY = """
+query ProjectsWithNoAddedBy {
+  moped_project(
+    where: {
+      _and: {
+        added_by: {_is_null: true},
+        is_deleted: {_eq: false}
+      }
+    },
+    order_by: { project_id: asc }) {
+    project_id
+    added_by
+    date_added
+  }
+}
+"""
+
+ACTIVITY_LOG_LOOKUP_QUERY = """
+query ProjectInsertActivities {
+  moped_activity_log(where: {_and: {operation_type: {_eq: "INSERT"}, record_type: {_eq: "moped_project"}}}) {
+    record_project_id
+    record_type
+    updated_by
+    moped_user {
+      user_id
+    }
+  }
+}
+"""
+
+ACTIVE_MOPED_USERS_QUERY = """
+query AllMopedUsers {
+  moped_users {
+    first_name
+    last_name
+    user_id
+    cognito_user_id
+  }
+}
+"""
+
+UPDATE_PROJECT_ADDED_BY_MUTATION = """
+mutation UpdateProjectAddedBy($project_id: Int!, $added_by: Int!) {
+  update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {added_by: $added_by}) {
+    added_by
+  }
+}
+"""
+
+
+def make_hasura_request(*, query, variables, env):
+    """Fetch data from hasura
+
+    Args:
+        query (str): the hasura query
+        env (str): the environment name, which will be used to acces secrets
+
+    Raises:
+        ValueError: If no data is returned
+
+    Returns:
+        dict: Hasura JSON response data
+    """
+    admin_secret = HASURA_AUTH["hasura_graphql_admin_secret"][env]
+    endpoint = HASURA_AUTH["hasura_graphql_endpoint"][env]
+    headers = {
+        "X-Hasura-Admin-Secret": admin_secret,
+        "content-type": "application/json",
+    }
+    payload = {"query": query, "variables": variables}
+    res = requests.post(endpoint, json=payload, headers=headers)
+    res.raise_for_status()
+    data = res.json()
+    try:
+        return data["data"]
+    except KeyError:
+        raise ValueError(data)
+
+
+def main(env):
+    counts = {"updated": 0, "todo": 0, "unable_to_process": 0}
+    projects = make_hasura_request(query=PROJECTS_TODO_QUERY, env=env, variables=None)[
+        "moped_project"
+    ]
+    activities = make_hasura_request(
+        query=ACTIVITY_LOG_LOOKUP_QUERY, env=env, variables=None
+    )["moped_activity_log"]
+    users = make_hasura_request(
+        query=ACTIVE_MOPED_USERS_QUERY, env=env, variables=None
+    )["moped_users"]
+
+    # we will attribute AMD projects to ivonne if no user info is available
+    amd_user_id = next(user for user in users if user["first_name"].lower() == "ivonne")
+    if not amd_user_id:
+        raise Exception("Unable to find default AMD user")
+
+    ready = []
+    unable_to_process = []
+
+    for proj in projects:
+        proj_id = proj["project_id"]
+        logs = [l for l in activities if l["record_project_id"] == proj["project_id"]]
+        if not logs:
+            # some projects are missing logs - presumably to due SQS/event handler failures
+            # print(f"WARNING: No logs found for project #{proj_id}")
+            if proj["date_added"].startswith("2022-02-10"):
+                # this is an AMD project migrated on 2 Feb 2022
+                ready.append({"project_id": proj_id, "added_by": amd_user_id})
+                continue
+            else:
+                unable_to_process.append(
+                    {"project_id": proj_id, "reason": "no 'insert' event log found"}
+                )
+                continue
+        # ignore extra logs (there may be dupes due to SQS/event handler bug )
+        log = logs[0]
+        user = log["moped_user"]
+
+        if not user:
+            if proj["date_added"].startswith("2022-02-10"):
+                # this is an AMD project migrated on 2 Feb 2022 - it was created without a session token so no user ID was logged
+                ready.append({"project_id": proj_id, "added_by": amd_user_id})
+                continue
+            elif log["updated_by"]:
+                unable_to_process.append(
+                    {"project_id": proj_id, "reason": "unknown cognito user ID"}
+                )
+                continue
+            else:
+                unable_to_process.append(
+                    {"project_id": proj_id, "reason": "no user data"}
+                )
+                continue
+        # this project is ready to go
+        user_id = user["user_id"]
+        ready.append({"project_id": proj_id, "added_by": user_id})
+
+    counts["unable_to_process"] = len(unable_to_process)
+    counts["todo"] = len(ready)
+
+    print(counts)
+
+    for proj in ready:
+        make_hasura_request(
+            query=UPDATE_PROJECT_ADDED_BY_MUTATION,
+            variables={"project_id": proj["project_id"], "added_by": proj["added_by"]},
+            env=env,
+        )
+        counts["updated"] += 1
+        counts["todo"] -= 1
+        print(counts)
+
+    print("Writing failed projects to 'log.json'")
+
+    with open("log.json", "w") as fout:
+        json.dump(unable_to_process, fout)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-e",
+        "--env",
+        type=str,
+        choices=["local", "staging", "prod"],
+        default="local",
+        help=f"Environment",
+    )
+
+    args = parser.parse_args()
+
+    main(args.env)

--- a/moped-toolbox/backfill_added_by/secrets_template.py
+++ b/moped-toolbox/backfill_added_by/secrets_template.py
@@ -1,0 +1,8 @@
+HASURA_AUTH = {
+    "hasura_graphql_endpoint": {
+        "local": "http://localhost:8080/v1/graphql",
+    },
+    "hasura_graphql_admin_secret": {
+        "local": "DuMmyApiKeyHFVOVto19otC1wX6sP2N0VSKrCD70L10B7Sm525ZR6L672i2F79M9!",
+    },
+}


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10724

This script populates a project's `added_by` column based on the cognito user ID captured in the activity log. There's a grab bag of edge cases which are not covered, but are documented in the code. 

~In production, there will be 40 projects for which we cannot automatically find the `added_by` user ID. We can refine this script to use other project data to determine the author, or we can fix these projects manually/ad-hoc. I decided to leave it outside the scope of this script for now.~

Edit: after [some sleuthing](https://austininnovation.slack.com/archives/CNUEPKLB1/p1667967766423399?thread_ts=1667944441.541699&cid=CNUEPKLB1), we'll have just 3 projects in prod for which we cannot automatically assign an `added_by` value. 

The script outputs `log.json` which identifies the reason we cannot update a given project.

## Testing
**URL to test:** local

**Steps to test:**
1. Start the hasura cluster and editor
2. From the project list, sort on the "Created By" column and observe that all rows are blank
3. Activate a python env with `requests` installed
4. Navigate to `moped-toolbox/backfill_added_by`
5. `python run.py -e local`
6. Refresh the Moped Editor, sort on the "Created By" column, and observe that five rows are populated, including project ID 225 ("Tilly Test") - created by Tilly
7. run `cat log.json` to view the JSON output of five additional projects which were not updated for various reasons



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
