### PR TITLE
Add tooltips to project summary fields to define lead, sponsor, and partners

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -204,6 +204,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   classes={classes}
                   snackbarHandle={snackbarHandle}
                   entityName="Lead"
+                  tooltipText="Division, department, or organization responsible for successful project implementation"
                 />
               </Grid>
               <Grid item xs={12}>
@@ -214,6 +215,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   classes={classes}
                   snackbarHandle={snackbarHandle}
                   entityName="Sponsor"
+                  tooltipText="Division, department, or organization who is the main contributor of funds for the project"
                 />
               </Grid>
               <Grid item xs={12}>
@@ -223,6 +225,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   refetch={refetch}
                   classes={classes}
                   snackbarHandle={snackbarHandle}
+                  tooltipText="Other internal or external workgroups participating in the project"
                 />
               </Grid>
               <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -19,6 +19,7 @@ const ProjectSummaryLabel = ({
   tooltipText,
 }) => {
   return (
+    // the tooltip will not appear if the `title` is empty
     <Tooltip placement="bottom-start" title={tooltipText || ""}>
       <Typography
         className={className ?? classes.fieldLabelText}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Typography } from "@material-ui/core";
+import { Tooltip, Typography } from "@material-ui/core";
 
 /**
  *
@@ -16,9 +16,10 @@ const ProjectSummaryLabel = ({
   onClickEdit,
   className,
   spanClassName,
+  tooltipText,
 }) => {
   return (
-    <>
+    <Tooltip placement="bottom-start" title={tooltipText || ""}>
       <Typography
         className={className ?? classes.fieldLabelText}
         onClick={onClickEdit}
@@ -35,7 +36,7 @@ const ProjectSummaryLabel = ({
         {/* Otherwise, render the input on one line */}
         {!Array.isArray(text) && <span className={spanClassName}>{text}</span>}
       </Typography>
-    </>
+    </Tooltip>
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectEntity.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectEntity.js
@@ -37,6 +37,7 @@ const ProjectSummaryProjectEntity = ({
   classes,
   snackbarHandle,
   entityName,
+  tooltipText,
 }) => {
   const entityList = data?.moped_entity ?? [];
   const noneSponsor = entityList.find((e) => e.entity_id === 0);
@@ -136,6 +137,7 @@ const ProjectSummaryProjectEntity = ({
             text={sponsor?.entity_name || ""}
             classes={classes}
             onClickEdit={() => setEditMode(true)}
+            tooltipText={tooltipText}
           />
         )}
       </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -5,7 +5,6 @@ import {
   Grid,
   Icon,
   Input,
-  Tooltip,
   ListItemText,
   MenuItem,
   Select,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -124,74 +124,72 @@ const ProjectSummaryProjectPartners = ({
   };
 
   return (
-    <>
-      <Grid item xs={12} className={classes.fieldGridItem}>
-        <Typography className={classes.fieldLabel}>Partners</Typography>
-        <Box
-          display="flex"
-          justifyContent="flex-start"
-          className={classes.fieldBox}
-        >
-          {editMode && (
-            <>
-              <Select
-                id={`moped-project-summary-partner-select-${projectId}`}
-                multiple
-                value={selectedEntities}
-                onChange={handleChange}
-                input={<Input autoFocus />}
-                renderValue={(entity_ids) =>
-                  entity_ids.map((e) => entityDict[e]).join(", ")
-                }
-                /*
+    <Grid item xs={12} className={classes.fieldGridItem}>
+      <Typography className={classes.fieldLabel}>Partners</Typography>
+      <Box
+        display="flex"
+        justifyContent="flex-start"
+        className={classes.fieldBox}
+      >
+        {editMode && (
+          <>
+            <Select
+              id={`moped-project-summary-partner-select-${projectId}`}
+              multiple
+              value={selectedEntities}
+              onChange={handleChange}
+              input={<Input autoFocus />}
+              renderValue={(entity_ids) =>
+                entity_ids.map((e) => entityDict[e]).join(", ")
+              }
+              /*
                 There appears to be a problem with MenuProps in version 4.x (which is fixed in 5.0),
                 this is fixed by overriding the function "getContentAnchorEl".
                     Source: https://github.com/mui-org/material-ui/issues/19245#issuecomment-620488016
               */
-                MenuProps={{
-                  getContentAnchorEl: () => null,
-                  style: {
-                    maxHeight: 500,
-                    width: 450,
-                  },
-                }}
-                className={classes.fieldSelectItem}
-              >
-                {entityList.map((entity) => (
-                  <MenuItem key={entity.entity_id} value={entity.entity_id}>
-                    <Checkbox
-                      checked={selectedEntities.includes(entity.entity_id)}
-                      color={"primary"}
-                    />
-                    <ListItemText primary={entity.entity_name} />
-                  </MenuItem>
-                ))}
-              </Select>
-              <Icon
-                className={classes.editIconConfirm}
-                onClick={handleProjectPartnersSave}
-              >
-                check
-              </Icon>
-              <Icon
-                className={classes.editIconConfirm}
-                onClick={handleProjectPartnersClose}
-              >
-                close
-              </Icon>
-            </>
-          )}
-          {!editMode && (
-            <ProjectSummaryLabel
-              text={selectedEntities.map((e) => entityDict[e])}
-              classes={classes}
-              onClickEdit={() => setEditMode(true)}
-              tooltipText={tooltipText}
-            />
-          )}
-        </Box>
-      </Grid>
-    </>
+              MenuProps={{
+                getContentAnchorEl: () => null,
+                style: {
+                  maxHeight: 500,
+                  width: 450,
+                },
+              }}
+              className={classes.fieldSelectItem}
+            >
+              {entityList.map((entity) => (
+                <MenuItem key={entity.entity_id} value={entity.entity_id}>
+                  <Checkbox
+                    checked={selectedEntities.includes(entity.entity_id)}
+                    color={"primary"}
+                  />
+                  <ListItemText primary={entity.entity_name} />
+                </MenuItem>
+              ))}
+            </Select>
+            <Icon
+              className={classes.editIconConfirm}
+              onClick={handleProjectPartnersSave}
+            >
+              check
+            </Icon>
+            <Icon
+              className={classes.editIconConfirm}
+              onClick={handleProjectPartnersClose}
+            >
+              close
+            </Icon>
+          </>
+        )}
+        {!editMode && (
+          <ProjectSummaryLabel
+            text={selectedEntities.map((e) => entityDict[e])}
+            classes={classes}
+            onClickEdit={() => setEditMode(true)}
+            tooltipText={tooltipText}
+          />
+        )}
+      </Box>
+    </Grid>
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -5,6 +5,7 @@ import {
   Grid,
   Icon,
   Input,
+  Tooltip,
   ListItemText,
   MenuItem,
   Select,
@@ -31,6 +32,7 @@ const ProjectSummaryProjectPartners = ({
   refetch,
   classes,
   snackbarHandle,
+  tooltipText,
 }) => {
   /**
    * Helper initial state lists
@@ -123,71 +125,74 @@ const ProjectSummaryProjectPartners = ({
   };
 
   return (
-    <Grid item xs={12} className={classes.fieldGridItem}>
-      <Typography className={classes.fieldLabel}>Partners</Typography>
-      <Box
-        display="flex"
-        justifyContent="flex-start"
-        className={classes.fieldBox}
-      >
-        {editMode && (
-          <>
-            <Select
-              id={`moped-project-summary-partner-select-${projectId}`}
-              multiple
-              value={selectedEntities}
-              onChange={handleChange}
-              input={<Input autoFocus />}
-              renderValue={(entity_ids) =>
-                entity_ids.map((e) => entityDict[e]).join(", ")
-              }
-              /*
+    <>
+      <Grid item xs={12} className={classes.fieldGridItem}>
+        <Typography className={classes.fieldLabel}>Partners</Typography>
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+          className={classes.fieldBox}
+        >
+          {editMode && (
+            <>
+              <Select
+                id={`moped-project-summary-partner-select-${projectId}`}
+                multiple
+                value={selectedEntities}
+                onChange={handleChange}
+                input={<Input autoFocus />}
+                renderValue={(entity_ids) =>
+                  entity_ids.map((e) => entityDict[e]).join(", ")
+                }
+                /*
                 There appears to be a problem with MenuProps in version 4.x (which is fixed in 5.0),
                 this is fixed by overriding the function "getContentAnchorEl".
                     Source: https://github.com/mui-org/material-ui/issues/19245#issuecomment-620488016
               */
-              MenuProps={{
-                getContentAnchorEl: () => null,
-                style: {
-                  maxHeight: 500,
-                  width: 450,
-                },
-              }}
-              className={classes.fieldSelectItem}
-            >
-              {entityList.map((entity) => (
-                <MenuItem key={entity.entity_id} value={entity.entity_id}>
-                  <Checkbox
-                    checked={selectedEntities.includes(entity.entity_id)}
-                    color={"primary"}
-                  />
-                  <ListItemText primary={entity.entity_name} />
-                </MenuItem>
-              ))}
-            </Select>
-            <Icon
-              className={classes.editIconConfirm}
-              onClick={handleProjectPartnersSave}
-            >
-              check
-            </Icon>
-            <Icon
-              className={classes.editIconConfirm}
-              onClick={handleProjectPartnersClose}
-            >
-              close
-            </Icon>
-          </>
-        )}
-        {!editMode && (
-          <ProjectSummaryLabel
-            text={selectedEntities.map((e) => entityDict[e])}
-            classes={classes}
-            onClickEdit={() => setEditMode(true)}
-          />
-        )}
-      </Box>
-    </Grid>
+                MenuProps={{
+                  getContentAnchorEl: () => null,
+                  style: {
+                    maxHeight: 500,
+                    width: 450,
+                  },
+                }}
+                className={classes.fieldSelectItem}
+              >
+                {entityList.map((entity) => (
+                  <MenuItem key={entity.entity_id} value={entity.entity_id}>
+                    <Checkbox
+                      checked={selectedEntities.includes(entity.entity_id)}
+                      color={"primary"}
+                    />
+                    <ListItemText primary={entity.entity_name} />
+                  </MenuItem>
+                ))}
+              </Select>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={handleProjectPartnersSave}
+              >
+                check
+              </Icon>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={handleProjectPartnersClose}
+              >
+                close
+              </Icon>
+            </>
+          )}
+          {!editMode && (
+            <ProjectSummaryLabel
+              text={selectedEntities.map((e) => entityDict[e])}
+              classes={classes}
+              onClickEdit={() => setEditMode(true)}
+              tooltipText={tooltipText}
+            />
+          )}
+        </Box>
+      </Grid>
+    </>
   );
 };
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10749

Maybe not the most elegant solution, but this addresses a frequent request from users to add definitions to these fields, particularly now that we also have a project lead.

I also experimented with helper text on the form inputs, but this would require some refactoring, particularly for the partners field. I think my preference would be that these definitions are persistent in fine print on the page at all times rather than on hover.

## Testing
**URL to test:** [Deploy preview](https://deploy-preview-867--atd-moped-main.netlify.app/)

**Steps to test:**
1. Navigate to the project summary page
2. Hover your mouse over the lead, sponsor, and partners field inputs and observe the tooltip appears with a definition of the field:
- **Lead**: Division, department, or organization responsible for successful project implementation
- **Sponsor**: Division, department, or organization who is the main contributor of funds for the project
- **Partners**: Other internal or external workgroups participating in the project

<img width="1014" alt="Screen Shot 2022-11-10 at 12 52 56 PM" src="https://user-images.githubusercontent.com/14793120/201170334-460a5a1e-63f7-4ca7-bcb6-f663906394f2.png">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
