### PR TITLE
Always show dev environment alert banner except in production

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -82,10 +82,10 @@ const TopBar = ({ className, ...rest }) => {
 
   return (
     <AppBar className={clsx(classes.root, className)} elevation={2} {...rest}>
-      {process.env.REACT_APP_HASURA_ENV === "staging" && (
+      {process.env.REACT_APP_HASURA_ENV !== "production" && (
         // If in staging environment, display info alert
         <Alert severity="info">
-          Welcome to Moped Staging. This environment is for testing purposes.
+          This is a Moped development environment for testing purposes.
         </Alert>
       )}
       <Toolbar>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10786

## Testing

Test locally and [deploy preview](https://deploy-preview-878--atd-moped-main.netlify.app/).

**Steps to test:**
Verify the alert banner displays.

<img width="550" alt="Screen Shot 2022-11-15 at 8 46 51 PM" src="https://user-images.githubusercontent.com/14793120/202063532-f3937017-5f1b-478d-8eef-bdea75998554.png">

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
