### PR TITLE
Set initial map extent from existing project components

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useMutation, useQuery } from "@apollo/client";
 import { useParams } from "react-router";
 import { makeStyles } from "@material-ui/core/styles";
@@ -121,6 +121,34 @@ export default function MapView({ projectName, projectStatuses }) {
       },
     }
   );
+
+  const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
+
+  useEffect(() => {
+    if (!data || hasMapZoomedInitially) return;
+
+    if (data.project_geography.length === 0) {
+      setHasMapZoomedInitially(true);
+    }
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: data.project_geography,
+    };
+
+    const bboxOfAllFeatures = bbox(featureCollection);
+    mapRef.current.fitBounds(bboxOfAllFeatures, {
+      maxZoom: 19,
+      padding: {
+        top: 75,
+        bottom: 75,
+        left: 75,
+        right: 75,
+      },
+    });
+
+    setHasMapZoomedInitially(true);
+  }, [data, hasMapZoomedInitially]);
 
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -33,6 +33,7 @@ import {
 } from "./utils/makeFeatures";
 import { makeComponentFeatureCollectionsMap } from "./utils/makeData";
 import { getDrawId } from "./utils/features";
+import { fitBoundsOptions } from "./mapSettings";
 
 const drawerWidth = 350;
 
@@ -137,15 +138,7 @@ export default function MapView({ projectName, projectStatuses }) {
     };
 
     const bboxOfAllFeatures = bbox(featureCollection);
-    mapRef.current.fitBounds(bboxOfAllFeatures, {
-      maxZoom: 19,
-      padding: {
-        top: 75,
-        bottom: 75,
-        left: 75,
-        right: 75,
-      },
-    });
+    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions);
 
     setHasMapZoomedInitially(true);
   }, [data, hasMapZoomedInitially]);
@@ -159,16 +152,7 @@ export default function MapView({ projectName, projectStatuses }) {
     // close the map projectFeature map popup
     setClickedProjectFeature(null);
     // move the map
-    mapRef.current?.fitBounds(bbox(featureCollection), {
-      maxZoom: 19,
-      // accounting for fixed top bar
-      padding: {
-        top: 75,
-        bottom: 75,
-        left: 75,
-        right: 75,
-      },
-    });
+    mapRef.current?.fitBounds(bbox(featureCollection), fitBoundsOptions);
   };
 
   const onSaveComponent = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -19,7 +19,7 @@ import EditModeDialog from "./EditModeDialog";
 import ComponentMapToolbar from "./ComponentMapToolbar";
 import ComponentListItem from "./ComponentListItem";
 import DraftComponentListItem from "./DraftComponentListItem";
-import { useAppBarHeight } from "./utils/map";
+import { useAppBarHeight, useZoomToExistingComponents } from "./utils/map";
 import {
   ADD_PROJECT_COMPONENT,
   GET_PROJECT_COMPONENTS,
@@ -123,25 +123,7 @@ export default function MapView({ projectName, projectStatuses }) {
     }
   );
 
-  const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
-
-  useEffect(() => {
-    if (!data || hasMapZoomedInitially) return;
-
-    if (data.project_geography.length === 0) {
-      setHasMapZoomedInitially(true);
-    }
-
-    const featureCollection = {
-      type: "FeatureCollection",
-      features: data.project_geography,
-    };
-
-    const bboxOfAllFeatures = bbox(featureCollection);
-    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions);
-
-    setHasMapZoomedInitially(true);
-  }, [data, hasMapZoomedInitially]);
+  useZoomToExistingComponents(mapRef, data);
 
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import { useMutation, useQuery } from "@apollo/client";
 import { useParams } from "react-router";
 import { makeStyles } from "@material-ui/core/styles";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -134,7 +134,10 @@ export default function MapView({ projectName, projectStatuses }) {
     // close the map projectFeature map popup
     setClickedProjectFeature(null);
     // move the map
-    mapRef.current?.fitBounds(bbox(featureCollection), fitBoundsOptions);
+    mapRef.current?.fitBounds(
+      bbox(featureCollection),
+      fitBoundsOptions.zoomToClickedComponent
+    );
   };
 
   const onSaveComponent = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -28,8 +28,8 @@ export const SOURCES = {
 };
 
 export const initialViewState = {
-  latitude: 30.28,
-  longitude: -97.74,
+  latitude: 30.2747,
+  longitude: -97.7406,
   zoom: 15,
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -30,17 +30,18 @@ export const SOURCES = {
 export const initialViewState = {
   latitude: 30.2747,
   longitude: -97.7406,
-  zoom: 15,
+  zoom: 12,
 };
 
 export const fitBoundsOptions = {
-  maxZoom: 19,
-  // accounting for fixed top bar
-  padding: {
-    top: 75,
-    bottom: 75,
-    left: 75,
-    right: 75,
+  zoomToExtent: {
+    maxZoom: 15,
+    // accounting for fixed top bar
+    padding: 200,
+  },
+  zoomToClickedComponent: {
+    maxZoom: 19,
+    padding: 200,
   },
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -33,6 +33,17 @@ export const initialViewState = {
   zoom: 15,
 };
 
+export const fitBoundsOptions = {
+  maxZoom: 19,
+  // accounting for fixed top bar
+  padding: {
+    top: 75,
+    bottom: 75,
+    left: 75,
+    right: 75,
+  },
+};
+
 /**
  * @see https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters
  */

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { makeStyles, useMediaQuery, useTheme } from "@material-ui/core";
 import booleanIntersects from "@turf/boolean-intersects";
 import circle from "@turf/circle";
@@ -8,6 +8,8 @@ import {
   Timeline as TimelineIcon,
 } from "@material-ui/icons";
 import { MAP_STYLES } from "../mapStyleSettings";
+import { fitBoundsOptions } from "../mapSettings";
+import bbox from "@turf/bbox";
 
 /**
  * Iterate through the map styles config to create an array of interactive layers
@@ -170,3 +172,25 @@ export const useSubcomponentOptions = (component) =>
 
     return options;
   }, [component]);
+
+export const useZoomToExistingComponents = (mapRef, data) => {
+  const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
+
+  useEffect(() => {
+    if (!data || hasMapZoomedInitially) return;
+
+    if (data.project_geography.length === 0) {
+      setHasMapZoomedInitially(true);
+    }
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: data.project_geography,
+    };
+
+    const bboxOfAllFeatures = bbox(featureCollection);
+    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions);
+
+    setHasMapZoomedInitially(true);
+  }, [data, hasMapZoomedInitially]);
+};

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -198,5 +198,5 @@ export const useZoomToExistingComponents = (mapRef, data) => {
     mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions);
 
     setHasMapZoomedInitially(true);
-  }, [data, hasMapZoomedInitially]);
+  }, [data, hasMapZoomedInitially, mapRef]);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -184,6 +184,7 @@ export const useZoomToExistingComponents = (mapRef, data) => {
 
   useEffect(() => {
     if (!data || hasMapZoomedInitially) return;
+    if (!mapRef?.current) return;
 
     if (data.project_geography.length === 0) {
       setHasMapZoomedInitially(true);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -187,6 +187,7 @@ export const useZoomToExistingComponents = (mapRef, data) => {
 
     if (data.project_geography.length === 0) {
       setHasMapZoomedInitially(true);
+      return;
     }
 
     const featureCollection = {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -173,6 +173,12 @@ export const useSubcomponentOptions = (component) =>
     return options;
   }, [component]);
 
+/**
+ * Use Mapbox fitBounds to zoom to existing project components feature collection
+ * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
+ * @param {Object} data - Data returned from the moped_components query
+ * @param {Array} data.project_geography - Array of existing component features
+ */
 export const useZoomToExistingComponents = (mapRef, data) => {
   const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -197,7 +197,7 @@ export const useZoomToExistingComponents = (mapRef, data) => {
     };
 
     const bboxOfAllFeatures = bbox(featureCollection);
-    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions);
+    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions.zoomToExtent);
 
     setHasMapZoomedInitially(true);
   }, [data, hasMapZoomedInitially, mapRef]);


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10426

This PR updates the components map to zoom to a bounding box that has all of a project's component features within. If there are no existing components, the map initializes to its default coordinates and zoom.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://md-10426-zoom-on-load--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to https://md-10426-zoom-on-load--atd-moped-main.netlify.app/moped/projects/156?tab=summary
2. Go to the **Map** tab and you should see the map zoom to the existing components
3. You can also create a new project to see the default zoom, add some components, and then leave and revisit the **Map** tab to see the zoom on load

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
