### PR TITLE
Remove status_id filters from signals query

### DIFF
--- a/moped-editor/src/queries/signals.js
+++ b/moped-editor/src/queries/signals.js
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 
-// Status ID 3 is cancelled
 export const SIGNAL_PROJECTS_QUERY = gql`
   query SignalProjectsQuery {
     moped_project(
@@ -12,14 +11,12 @@ export const SIGNAL_PROJECTS_QUERY = gql`
               moped_components: { component_name: { _ilike: "signal" } }
               is_deleted: { _eq: false }
             }
-            status_id: { _is_null: true }
           }
           {
             moped_proj_components: {
               moped_components: { component_name: { _ilike: "signal" } }
               is_deleted: { _eq: false }
             }
-            status_id: { _neq: 3 }
           }
         ]
       }


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7910

## Testing
**URL to test:** Local

**Steps to test:**
1. Start the cluster and editor as usual
2. Navigate to the signals dashboard: `https://localhost:3000/moped/views/signal-projects`
3. Observe that the page loads and there is one project in the table

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
