### PR TITLE
sets default project list sort and displays arrow

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -86,6 +86,9 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    * This overrides MaterialTable props and determines how
    * the table is sorted when the page loads. Must remain consistent
    * with the sorting order passed in from ProjectsListViewQueryConf.
+   * @property {string} column - The column name in graphql to sort by
+   * @property {integer} columnId - The column id in graphql to sort by
+   * @property {string} order - Either "asc" or "desc" or ""
    */
   const defaultSortingProperties = {
     column: "updated_at",
@@ -96,10 +99,8 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
   /**
    * Stores the column name and the order to order by
    * @type {Object} sort
-   * @property {string} column - The column name in graphql to sort by
-   * @property {string} order - Either "asc" or "desc" or "" (default: "")
    * @function setSort - Sets the state of sort
-   * @default {{value: "", column: ""}}
+   * @default {defaultSortingProperties}
    */
   const [sort, setSort] = useState(defaultSortingProperties);
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -82,6 +82,18 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
   });
 
   /**
+   * The default sorting properties applied to the table.
+   * This overrides MaterialTable props and determines how
+   * the table is sorted when the page loads. Must remain consistent
+   * with the sorting order passed in from ProjectsListViewQueryConf.
+   */
+  const defaultSortingProperties = {
+    column: "updated_at",
+    columnId: 8,
+    order: "desc",
+  };
+
+  /**
    * Stores the column name and the order to order by
    * @type {Object} sort
    * @property {string} column - The column name in graphql to sort by
@@ -89,11 +101,7 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    * @function setSort - Sets the state of sort
    * @default {{value: "", column: ""}}
    */
-  const [sort, setSort] = useState({
-    column: "updated_at",
-    columnId: 8,
-    order: "desc",
-  });
+  const [sort, setSort] = useState(defaultSortingProperties);
 
   /**
    * Stores the string to search for and the column to search against
@@ -179,9 +187,7 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    * Query Management
    */
   // Manage the ORDER BY clause of our query
-  if (sort.column !== "" && sort.order !== "") {
-    query.setOrder(sort.column, sort.order);
-  }
+  query.setOrder(sort.column, sort.order);
 
   // Set limit, offset based on pagination state
   if (query.config.showPagination) {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -90,8 +90,8 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    * @default {{value: "", column: ""}}
    */
   const [sort, setSort] = useState({
-    column: "project_id",
-    columnId: 0,
+    column: "updated_at",
+    columnId: 8,
     order: "desc",
   });
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -624,18 +624,14 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
                         />
                       );
                     },
-                    Header: (props) => {
-                      console.log(props);
-                      console.log(sort);
-                      return (
-                        <MTableHeader
-                          {...props}
-                          onOrderChange={handleTableHeaderClick}
-                          orderBy={sort.columnId}
-                          orderDirection={sort.order}
-                        />
-                      );
-                    },
+                    Header: (props) => (
+                      <MTableHeader
+                        {...props}
+                        onOrderChange={handleTableHeaderClick}
+                        orderBy={sort.columnId}
+                        orderDirection={sort.order}
+                      />
+                    ),
                     Body: (props) => {
                       // see PR #639 https://github.com/cityofaustin/atd-moped/pull/639 for context
                       // we have configured MT to use local data but are technically using remote data

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -90,8 +90,9 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    * @default {{value: "", column: ""}}
    */
   const [sort, setSort] = useState({
-    column: "",
-    order: "",
+    column: "project_id",
+    columnId: 0,
+    order: "desc",
   });
 
   /**
@@ -530,25 +531,20 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
     query.clearOrderBy();
     const columnName = columns[columnId]?.field;
 
-    // If both column and order are empty...
-    if (sort.order === "" && sort.column === "") {
-      // First time sort is applied
-      setSort({
-        order: "asc",
-        column: columnName,
-      });
-    } else if (sort.column === columnName) {
-      // Else if the current sortColumn is the same as the new
+    if (sort.column === columnName) {
+      // If the current sortColumn is the same as the new
       // then invert values and repeat sort on column
       setSort({
         order: sort.order === "desc" ? "asc" : "desc",
         column: columnName,
+        columnId: columnId,
       });
     } else if (sort.column !== columnName) {
-      // Sort different column after initial sort, then reset
+      // Sort different column in same order as previous column
       setSort({
-        order: "desc",
+        order: sort.order,
         column: columnName,
+        columnId: columnId,
       });
     }
   };
@@ -628,13 +624,18 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
                         />
                       );
                     },
-                    Header: (props) => (
-                      <MTableHeader
-                        {...props}
-                        onOrderChange={handleTableHeaderClick}
-                        orderDirection={sort.order}
-                      />
-                    ),
+                    Header: (props) => {
+                      console.log(props);
+                      console.log(sort);
+                      return (
+                        <MTableHeader
+                          {...props}
+                          onOrderChange={handleTableHeaderClick}
+                          orderBy={sort.columnId}
+                          orderDirection={sort.order}
+                        />
+                      );
+                    },
                     Body: (props) => {
                       // see PR #639 https://github.com/cityofaustin/atd-moped/pull/639 for context
                       // we have configured MT to use local data but are technically using remote data


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10671

this fixes the bug where the column sorting icon on the projects list view only appeared on hover. it's also a step toward completing https://github.com/cityofaustin/atd-data-tech/issues/10538

in order to do this, i had to hardcode a default sorting order, so i used  the existing default (descending by date modified) set `ProjectsListViewQueryConf`. ultimately, we would populate the new default using url parameters from the previous session. i thought it made sense to always have a column sorted since this is what it will ultimately be like when the sorting is persistent. also, it used to be that if you click a column name a third time, the arrow disappears and the table is sorted back to default. i thought this was unnecessary and inconsistent with having a persistent icon, so i simplified the behavior.

https://deploy-preview-884--atd-moped-main.netlify.app/

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-884--atd-moped-main.netlify.app/

**Steps to test:**
- go to the projects list page
- the columns should be sorted descending by date modified by default with an arrow indicating the order
- click the date modified column, the order should swap
- click another column, it should be sorted in the same order
- click it again, the order should swap

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
