### PR TITLE
Use an alert banner component and fix padding in local env

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
+++ b/moped-editor/src/layouts/DashboardLayout/DashboardLayout.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
     overflow: "hidden",
     // If in staging environment, add extra padding
     // to make room for staging environment info alert
-    paddingTop: process.env.REACT_APP_HASURA_ENV === "staging" ? 114 : 64,
+    paddingTop: process.env.REACT_APP_HASURA_ENV !== "production" ? 114 : 64,
   },
   contentContainer: {
     display: "flex",

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -21,7 +21,7 @@ import NavLink from "src/components/NavLink";
 
 const getAlertBannerSeverity = (env) => {
   // show an orange banner on local
-  // show blue on staging, netlify, test, ...not production 
+  // show blue on staging, netlify, test, ...not production
   switch (env) {
     case "local":
       return "warning";
@@ -37,7 +37,8 @@ const EnvAlertBanner = () => {
   }
   return (
     <Alert severity={getAlertBannerSeverity(env)}>
-      This is a {env} environment for testing purposes.
+      This is a <span style={{ fontWeight: "bold" }}>{env}</span> environment
+      for testing purposes.
     </Alert>
   );
 };

--- a/moped-editor/src/layouts/DashboardLayout/TopBar.js
+++ b/moped-editor/src/layouts/DashboardLayout/TopBar.js
@@ -19,6 +19,29 @@ import DropdownMenu from "./NavBar/DropdownMenu";
 import NavigationSearchInput from "./NavBar/NavigationSearchInput";
 import NavLink from "src/components/NavLink";
 
+const getAlertBannerSeverity = (env) => {
+  // show an orange banner on local
+  // show blue on staging, netlify, test, ...not production 
+  switch (env) {
+    case "local":
+      return "warning";
+    default:
+      return "info";
+  }
+};
+
+const EnvAlertBanner = () => {
+  const env = process.env.REACT_APP_HASURA_ENV;
+  if (env === "production") {
+    return null;
+  }
+  return (
+    <Alert severity={getAlertBannerSeverity(env)}>
+      This is a {env} environment for testing purposes.
+    </Alert>
+  );
+};
+
 const useStyles = makeStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.background.paper,
@@ -82,12 +105,7 @@ const TopBar = ({ className, ...rest }) => {
 
   return (
     <AppBar className={clsx(classes.root, className)} elevation={2} {...rest}>
-      {process.env.REACT_APP_HASURA_ENV !== "production" && (
-        // If in staging environment, display info alert
-        <Alert severity="info">
-          This is a Moped development environment for testing purposes.
-        </Alert>
-      )}
+      <EnvAlertBanner />
       <Toolbar>
         <RouterLink to="/moped">
           <Logo />
@@ -118,13 +136,13 @@ const TopBar = ({ className, ...rest }) => {
           <NavigationSearchInput />
         </Hidden>
         <Hidden smDown>
-        <Box>
-          <DropdownMenu
-            handleDropdownClick={handleDropdownClick}
-            handleDropdownClose={handleDropdownClose}
-            dropdownAnchorEl={dropdownAnchorEl}
-          />
-        </Box>
+          <Box>
+            <DropdownMenu
+              handleDropdownClick={handleDropdownClick}
+              handleDropdownClose={handleDropdownClose}
+              dropdownAnchorEl={dropdownAnchorEl}
+            />
+          </Box>
         </Hidden>
         <Hidden mdUp>
           <MobileDropdownMenu />


### PR DESCRIPTION
https://austininnovation.slack.com/archives/CNUEPKLB1/p1668810204891789

Punting on an environment-specific favicon - but this adds an orange banner in local and shows the env name in the banner.

URL to test: Local and [Netlify](https://deploy-preview-886--atd-moped-main.netlify.app/moped/projects)

Steps to test:
1. Check it out

<img width="480" alt="Screen Shot 2022-11-21 at 3 03 17 PM" src="https://user-images.githubusercontent.com/14793120/203148026-1effee48-c3c1-42ed-a9ee-4e19a982f4f5.png">

<img width="433" alt="Screen Shot 2022-11-21 at 3 05 46 PM" src="https://user-images.githubusercontent.com/14793120/203148498-11c76573-b9b9-458d-83a2-f29ae20ae6e2.png">

