### PR TITLE
Add graphql endpoint variable to task definition

### DIFF
--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -96,7 +96,7 @@ def drain_service(slug):
 
 
 # with Flow("Moped Test Instance Commission") as test_commission:
-with Flow("Moped Test Instance Commission", executor=executor) as test_commission:
+with Flow("Moped Test Instance Commission") as test_commission:
     branch = Parameter("branch", default="feature-branch-name", required=True)
     database_seed_source = Parameter(
         "database_seed_source", default="seed", required=True
@@ -104,6 +104,7 @@ with Flow("Moped Test Instance Commission", executor=executor) as test_commissio
     do_migrations = Parameter("do_migrations", default=True, required=True)
 
     slug = slug_branch_name(branch)
+    print(slug)
 
     ## Get github checkout
 

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -95,8 +95,10 @@ def drain_service(slug):
     return drained_service
 
 
+# change the Flow's name below when testing, otherwise registering your test flow
+# will overwrite the production flow
 # with Flow("Moped Test Instance Commission") as test_commission:
-with Flow("Moped Test Instance Commission") as test_commission:
+with Flow("Moped Test Instance Commission test") as test_commission:
     branch = Parameter("branch", default="feature-branch-name", required=True)
     database_seed_source = Parameter(
         "database_seed_source", default="seed", required=True
@@ -375,10 +377,5 @@ with Flow("Moped Test Instance Decommission") as test_decommission:
 
 
 if __name__ == "__main__":
-    branch = "refactor-user-activation-and-main"
-
+    # this could be another place to change for a test flow, project_name="Moped staging"
     test_commission.register(project_name="Moped")
-    # test_decommission.register(project_name="Moped")
-
-    # test_commission.run(branch=branch, database_seed_source="staging")
-    # test_decommission.run(branch=branch)

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -96,9 +96,9 @@ def drain_service(slug):
 
 
 # change the Flow's name below when testing, otherwise registering your test flow
-# will overwrite the production flow
-# with Flow("Moped Test Instance Commission") as test_commission:
-with Flow("Moped Test Instance Commission test") as test_commission:
+# will overwrite the production flow ex:
+# with Flow("Moped Test Instance Commission test") as test_commission:
+with Flow("Moped Test Instance Commission") as test_commission:
     branch = Parameter("branch", default="feature-branch-name", required=True)
     database_seed_source = Parameter(
         "database_seed_source", default="seed", required=True

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -379,3 +379,4 @@ with Flow("Moped Test Instance Decommission") as test_decommission:
 if __name__ == "__main__":
     # this could be another place to change for a test flow, project_name="Moped staging"
     test_commission.register(project_name="Moped")
+    # test_decommission.register(project_name="Moped")

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -269,12 +269,12 @@ with Flow("Moped Test Instance Commission test") as test_commission:
 
     ## Commission the Activity Log
 
-    commission_activity_log_command = activity_log.create_activity_log_command(
-        slug=slug, upstream_tasks=[git_repo_checked_out]
-    )
-    deploy_activity_log = activity_log.create_activity_log_task(
-        command=commission_activity_log_command
-    )
+    # commission_activity_log_command = activity_log.create_activity_log_command(
+    #     slug=slug, upstream_tasks=[git_repo_checked_out]
+    # )
+    # deploy_activity_log = activity_log.create_activity_log_task(
+    #     command=commission_activity_log_command
+    # )
 
     ## Apply Migrations, metadata and optional seed data
     graphql_endpoint = "https://" + migrations.get_graphql_engine_hostname(slug=slug)

--- a/moped-etl/prefect/moped_test_create_flow.py
+++ b/moped-etl/prefect/moped_test_create_flow.py
@@ -104,7 +104,6 @@ with Flow("Moped Test Instance Commission") as test_commission:
     do_migrations = Parameter("do_migrations", default=True, required=True)
 
     slug = slug_branch_name(branch)
-    print(slug)
 
     ## Get github checkout
 

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -277,7 +277,6 @@ def remove_route53_cname_for_validation(parameters):
         },
     )
 
-
 @task(name="Create EC2 ELB Listeners")
 def create_load_balancer_listener(
     load_balancer, target_group, certificate, ready_for_listeners
@@ -324,6 +323,7 @@ def create_load_balancer_listener(
 def create_task_definition(slug, api_endpoint):
     basename = slug["basename"]
     database = slug["database"]
+    graphql_endpoint = slug["graphql_endpoint"]
     logger.info("Adding task definition")
     ecs = boto3.client("ecs", region_name=AWS_DEFAULT_REGION)
 
@@ -361,8 +361,13 @@ def create_task_definition(slug, api_endpoint):
                         "value": HASURA_GRAPHQL_DATABASE_URL,
                     },
                     {
+                        #"name": "HASURA_GRAPHQL_ADMIN_SECRET",
                         "name": "HASURA_ADMIN_SECRET",
                         "value": shared.generate_access_key(basename),
+                    },
+                    {
+                        "name": "HASURA_ENDPOINT",
+                        "value": "https://" + shared.form_graphql_endpoint_hostname(graphql_endpoint) + "/v1/graphql",
                     },
                     #  This depends on the Moped API endpoint returned from API commission tasks, add /events/ to end
                     {

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -361,9 +361,12 @@ def create_task_definition(slug, api_endpoint):
                         "value": HASURA_GRAPHQL_DATABASE_URL,
                     },
                     {
-                        #"name": "HASURA_GRAPHQL_ADMIN_SECRET",
-                        "name": "HASURA_ADMIN_SECRET",
+                        "name": "HASURA_GRAPHQL_ADMIN_SECRET",
                         "value": shared.generate_access_key(basename),
+                    },
+                    {
+                        "name": "HASURA_GRAPHQL_JWT_SECRET",
+                        "value":'{"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}'
                     },
                     {
                         "name": "HASURA_ENDPOINT",

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -365,6 +365,10 @@ def create_task_definition(slug, api_endpoint):
                         "value": shared.generate_access_key(basename),
                     },
                     {
+                        "name": "ACTIVITY_LOG_API_SECRET",
+                        "value": shared.generate_access_key(basename),
+                    },
+                    {
                         "name": "HASURA_GRAPHQL_JWT_SECRET",
                         "value":'{"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}'
                     },


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/10600
and a bonus! https://github.com/cityofaustin/atd-data-tech/issues/10887

associated moped PR: https://github.com/cityofaustin/atd-moped/pull/883
associated prefect PR: https://github.com/cityofaustin/atd-prefect/pull/42

I need to add the endpoint for the graphql requests for the REST connector to work. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

https://cloud.prefect.io/dts/flow/7672e429-8787-45ba-8406-6e01fef0d416

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
