### PR TITLE
bump local graphql-engine version

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.7'
 services:
     hasura:
-        image: hasura/graphql-engine:v2.11.2
+        image: hasura/graphql-engine:v2.15.1
         restart: always
         depends_on:
             - moped-pgsql


### PR DESCRIPTION
## Associated issues

_none_

Our version of `graphql-engine` is getting a little long in the tooth @ 3 months old. I'd like to bump the version up to the latest and greatest while that change is still pretty small and easy to digest. 

This PR, while including a change to the local environment, is really a stand-in for the small change in the AWS configuration that will bring our ECS cluster up to date by updating the docker image that is run. Approving this PR indicates your support for moving forward with that update.

Unless anyone is opposed, I'd like to make the change to the staging ECS cluster, so it can be tested as part of the next moped formal testing. @johnclary, I'll touch base with you tomorrow after this has a day to simmer to see if that's suitable.

## Testing

Local testing for this one. To test, fire up the local database and app, and just see if you can break it. It's testing the aptitude of the updated graphql-engine to be the graphql endpoint for the app, so pretty much anything and everything is on the table in terms of valid testing. 

## _Nota Bene_

Tiny fire under us to get the test-deployment work merged .. 🕯️ .. There would be a line in that flow that needs to be updated by the intent of this PR, but we just don't have the file in `main` yet. 😢🐼

---
#### Ship list
- [ ] Product manager approved

