### PR TITLE
sets project list view paging to 100

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -241,6 +241,6 @@ export const ProjectsListViewQueryConf = {
   },
   or: null,
   and: null,
-  limit: 25,
+  limit: 100,
   offset: 0,
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -538,6 +538,13 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
     query.clearOrderBy();
     const columnName = columns[columnId]?.field;
 
+    // Resets pagination to 0 when user clicks a header to display most relevant results
+    setPagination({
+      limit: query.limit,
+      offset: query.offset,
+      page: 0,
+    });
+
     if (sort.column === columnName) {
       // If the current sortColumn is the same as the new
       // then invert values and repeat sort on column


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10885

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-890--atd-moped-main.netlify.app/moped/

**Steps to test:**
- go to project list view, you should see 100 projects displayed sorted in descending order by date modified
- click the page forward button to see the rest of the records
- click a different column header, the table should rerender on page 1 with the top 100 records that match the column you clicked, in descending order
- go to the next page, you should see the remaining records according to the sort you applied
- reverse the sort, you should be taken back to the top 100 records (page 1) in ascending order according to the header you clicked

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
