### PR TITLE
Bump Hasura test instances to v2.15.1

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -20,7 +20,11 @@ services:
             - MOPED_API_EVENTS_URL=http://localhost:5000/events
             - MOPED_API_APIKEY=DuMmyApiKeyHFVOVto19otC1wX6sP2N0VSKrCD70L10B7Sm525ZR6L672i2F79M9!
         command: ["graphql-engine", "serve",  "--enable-console"]
-
+        healthcheck:
+            test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
+            interval: 2s
+            timeout: 1s
+            retries: 10
 
 # There is a volume which is common
 volumes:

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -352,7 +352,6 @@ def create_task_definition(slug, api_endpoint):
                     {"containerPort": 8080, "hostPort": 8080, "protocol": "tcp"}
                 ],
                 "essential": True,
-                "healthCheck": { "command": ["CMD-SHELL", "curl -f http://localhost:8080/healthz || exit 1"]},
                 "environment": [
                     {"name": "HTTP_PORT", "value": "8080"},
                     {"name": "HASURA_GRAPHQL_ENABLE_CONSOLE", "value": "true"},

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -352,6 +352,7 @@ def create_task_definition(slug, api_endpoint):
                     {"containerPort": 8080, "hostPort": 8080, "protocol": "tcp"}
                 ],
                 "essential": True,
+                "healthCheck": { "command": ["CMD-SHELL", "curl -f http://localhost:8080/healthz || exit 1"]},
                 "environment": [
                     {"name": "HTTP_PORT", "value": "8080"},
                     {"name": "HASURA_GRAPHQL_ENABLE_CONSOLE", "value": "true"},

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -344,7 +344,7 @@ def create_task_definition(slug, api_endpoint):
         containerDefinitions=[
             {
                 "name": "graphql-engine",
-                "image": "hasura/graphql-engine:v2.7.0",
+                "image": "hasura/graphql-engine:v2.15.1",
                 # "image": "mendhak/http-https-echo:latest",
                 "cpu": 256,
                 "memory": 512,

--- a/moped-etl/prefect/tasks/ecs.py
+++ b/moped-etl/prefect/tasks/ecs.py
@@ -277,6 +277,7 @@ def remove_route53_cname_for_validation(parameters):
         },
     )
 
+
 @task(name="Create EC2 ELB Listeners")
 def create_load_balancer_listener(
     load_balancer, target_group, certificate, ready_for_listeners
@@ -352,6 +353,16 @@ def create_task_definition(slug, api_endpoint):
                     {"containerPort": 8080, "hostPort": 8080, "protocol": "tcp"}
                 ],
                 "essential": True,
+                # see: https://github.com/hasura/graphql-engine/issues/1532#issuecomment-1161637925
+                "healthCheck": {
+                    "command": [
+                        "CMD-SHELL",
+                        "timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1",
+                    ],
+                    "interval": 2,
+                    "retries": 10,
+                    "imeout": 1,
+                },
                 "environment": [
                     {"name": "HTTP_PORT", "value": "8080"},
                     {"name": "HASURA_GRAPHQL_ENABLE_CONSOLE", "value": "true"},
@@ -370,11 +381,13 @@ def create_task_definition(slug, api_endpoint):
                     },
                     {
                         "name": "HASURA_GRAPHQL_JWT_SECRET",
-                        "value":'{"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}'
+                        "value": '{"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}',
                     },
                     {
                         "name": "HASURA_ENDPOINT",
-                        "value": "https://" + shared.form_graphql_endpoint_hostname(graphql_endpoint) + "/v1/graphql",
+                        "value": "https://"
+                        + shared.form_graphql_endpoint_hostname(graphql_endpoint)
+                        + "/v1/graphql",
                     },
                     #  This depends on the Moped API endpoint returned from API commission tasks, add /events/ to end
                     {


### PR DESCRIPTION
## Associated issues
Our test instances are lagging behind local, staging, and prod. I'm also hoping this clears an issue where Hasura occasionally crashes after replacing metadata.

I also noticed that we don't define a health check, which I think will help the container service restart more quickly if it fails. We don't use autoscaling, but I think the health check is a precursor for auto scaling.


## Testing
**URL to test:** 
[This test instance](https://4838-jc-migrate-access-db--atd-moped-main.netlify.app/moped/projects) is running these changes.

**Steps to test:**
i need to learn from Chia + Frank on how to test this. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
