### PR TITLE
renders only one delete modal

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -101,7 +101,8 @@ const ProjectComments = (props) => {
   const [commentId, setCommentId] = useState(null);
   const [displayNotes, setDisplayNotes] = useState([]);
   const [noteType, setNoteType] = useState(isStatusEditModal ? 2 : 0);
-  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] =
+    useState(false);
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   // if component is being used in edit modal from dashboard
@@ -312,104 +313,100 @@ const ProjectComments = (props) => {
               <CircularProgress />
             ) : displayNotes.length > 0 ? (
               <List className={classes.root}>
-                {displayNotes.map((item, i) => {
-                  const isNotLastItem = i < displayNotes.length - 1;
-                  /**
-                   * Only allow the user who wrote the status to edit it
-                   */
-                  const editableComment =
-                    userSessionData.user_id === item.added_by_user_id;
-                  return (
-                    <React.Fragment key={item.project_note_id}>
-                      <ListItem alignItems="flex-start">
-                        <ListItemAvatar>
-                          <Avatar />
-                        </ListItemAvatar>
-                        <ListItemText
-                          className={
-                            editableComment ? classes.editableComment : ""
-                          }
-                          primary={
-                            <>
-                              <Typography
-                                component={"span"}
-                                className={classes.commentorText}
-                              >
-                                {item.added_by}
-                              </Typography>
-                              <Typography
-                                component={"span"}
-                                className={classes.commentDate}
-                              >
-                                {` - ${makeUSExpandedFormDateFromTimeStampTZ(
-                                  item.date_created
-                                )} ${makeHourAndMinutesFromTimeStampTZ(
-                                  item.date_created
-                                )}`}
-                              </Typography>
-                              <Typography
-                                component={"span"}
-                                className={classes.noteType}
-                              >
-                                {` ${projectNoteTypes[item.project_note_type]}`}
-                              </Typography>
-                            </>
-                          }
-                          secondary={
-                            commentId === item.project_note_id ? (
-                              <CommentInputQuill
-                                noteText={noteText}
-                                setNoteText={setNoteText}
-                                editingComment={editingComment}
-                                commentAddLoading={commentAddLoading}
-                                commentAddSuccess={commentAddSuccess}
-                                submitNewComment={submitNewComment}
-                                submitEditComment={submitEditComment}
-                                cancelCommentEdit={cancelCommentEdit}
-                              />
-                            ) : (
-                              <Typography
-                                component={"span"}
-                                className={"noteBody"}
-                              >
-                                {parse(item.project_note)}
-                              </Typography>
-                            )
-                          }
-                        />
-                        {
-                          // show edit/delete icons if comment authored by logged in user
-                          // or user is admin
-                          editableComment && (
-                            <ListItemSecondaryAction
-                              className={classes.editControls}
-                            >
-                              {commentId !== item.project_note_id && (
-                                <IconButton
-                                  edge="end"
-                                  aria-label="edit"
-                                  onClick={() =>
-                                    editComment(i, item.project_note_id)
-                                  }
+                <DeleteConfirmationModal
+                  type="comment"
+                  submitDelete={() => submitDeleteComment(deleteConfirmationId)}
+                  isDeleteConfirmationOpen={isDeleteConfirmationOpen}
+                  setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+                >
+                  {displayNotes.map((item, i) => {
+                    const isNotLastItem = i < displayNotes.length - 1;
+                    /**
+                     * Only allow the user who wrote the status to edit it
+                     */
+                    const editableComment =
+                      userSessionData.user_id === item.added_by_user_id;
+                    return (
+                      <React.Fragment key={item.project_note_id}>
+                        <ListItem alignItems="flex-start">
+                          <ListItemAvatar>
+                            <Avatar />
+                          </ListItemAvatar>
+                          <ListItemText
+                            className={
+                              editableComment ? classes.editableComment : ""
+                            }
+                            primary={
+                              <>
+                                <Typography
+                                  component={"span"}
+                                  className={classes.commentorText}
                                 >
-                                  <EditIcon
-                                    className={classes.editDeleteButtons}
-                                  />
-                                </IconButton>
-                              )}
-                              {!editingComment && (
-                                <DeleteConfirmationModal
-                                  type="comment"
-                                  submitDelete={() =>
-                                    submitDeleteComment(deleteConfirmationId)
-                                  }
-                                  isDeleteConfirmationOpen={
-                                    isDeleteConfirmationOpen
-                                  }
-                                  setIsDeleteConfirmationOpen={
-                                    setIsDeleteConfirmationOpen
-                                  }
+                                  {item.added_by}
+                                </Typography>
+                                <Typography
+                                  component={"span"}
+                                  className={classes.commentDate}
                                 >
+                                  {` - ${makeUSExpandedFormDateFromTimeStampTZ(
+                                    item.date_created
+                                  )} ${makeHourAndMinutesFromTimeStampTZ(
+                                    item.date_created
+                                  )}`}
+                                </Typography>
+                                <Typography
+                                  component={"span"}
+                                  className={classes.noteType}
+                                >
+                                  {` ${
+                                    projectNoteTypes[item.project_note_type]
+                                  }`}
+                                </Typography>
+                              </>
+                            }
+                            secondary={
+                              commentId === item.project_note_id ? (
+                                <CommentInputQuill
+                                  noteText={noteText}
+                                  setNoteText={setNoteText}
+                                  editingComment={editingComment}
+                                  commentAddLoading={commentAddLoading}
+                                  commentAddSuccess={commentAddSuccess}
+                                  submitNewComment={submitNewComment}
+                                  submitEditComment={submitEditComment}
+                                  cancelCommentEdit={cancelCommentEdit}
+                                />
+                              ) : (
+                                <Typography
+                                  component={"span"}
+                                  className={"noteBody"}
+                                >
+                                  {parse(item.project_note)}
+                                </Typography>
+                              )
+                            }
+                          />
+                          {
+                            // show edit/delete icons if comment authored by logged in user
+                            // or user is admin
+                            editableComment && (
+                              <ListItemSecondaryAction
+                                className={classes.editControls}
+                              >
+                                {commentId !== item.project_note_id && (
+                                  <IconButton
+                                    edge="end"
+                                    aria-label="edit"
+                                    onClick={() =>
+                                      editComment(i, item.project_note_id)
+                                    }
+                                  >
+                                    <EditIcon
+                                      className={classes.editDeleteButtons}
+                                    />
+                                  </IconButton>
+                                )}
+                                {!editingComment && (
                                   <IconButton
                                     edge="end"
                                     aria-label="delete"
@@ -421,16 +418,16 @@ const ProjectComments = (props) => {
                                       className={classes.editDeleteButtons}
                                     />
                                   </IconButton>
-                                </DeleteConfirmationModal>
-                              )}
-                            </ListItemSecondaryAction>
-                          )
-                        }
-                      </ListItem>
-                      {isNotLastItem && <Divider component="li" />}
-                    </React.Fragment>
-                  );
-                })}
+                                )}
+                              </ListItemSecondaryAction>
+                            )
+                          }
+                        </ListItem>
+                        {isNotLastItem && <Divider component="li" />}
+                      </React.Fragment>
+                    );
+                  })}
+                </DeleteConfirmationModal>
               </List>
             ) : (
               <Typography className={classes.emptyState}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -65,7 +65,8 @@ const useStyles = makeStyles((theme) => ({
 const TagsSection = ({ projectId }) => {
   const [addTagMode, setAddTagMode] = useState(false);
   const [newTagList, setNewTagList] = useState([]);
-  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] =
+    useState(false);
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   const { loading, error, data, refetch } = useQuery(TAGS_QUERY, {
@@ -156,22 +157,22 @@ const TagsSection = ({ projectId }) => {
           </Button>
         </Toolbar>
         <Box component={"ul"} className={classes.chipContainer}>
-          {data.moped_proj_tags.map((tag) => (
-            <li key={tag.id}>
-              <DeleteConfirmationModal
-                type="tag"
-                submitDelete={() => handleTagDelete(deleteConfirmationId)}
-                isDeleteConfirmationOpen={isDeleteConfirmationOpen}
-                setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
-              >
+          <DeleteConfirmationModal
+            type="tag"
+            submitDelete={() => handleTagDelete(deleteConfirmationId)}
+            isDeleteConfirmationOpen={isDeleteConfirmationOpen}
+            setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+          >
+            {data.moped_proj_tags.map((tag) => (
+              <li key={tag.id}>
                 <Chip
                   label={tag.moped_tag.name}
                   onDelete={() => handleDeleteOpen(tag)}
                   className={classes.chip}
                 />
-              </DeleteConfirmationModal>
-            </li>
-          ))}
+              </li>
+            ))}
+          </DeleteConfirmationModal>
           {addTagMode && (
             <Box
               display="flex"


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10751

this pr moves the delete confirmation modal out of the scope within which tags, comments and status updates are iterated

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-896--atd-moped-main.netlify.app/

**Steps to test:**
- add five or more tags to any project
- delete one of the tags
- the delete confirmation modal background should be a normal opacity
- delete the tag and confirm the correct tag was deleted
- the opacity should not change as you delete tags
- repeat this step on the comments tab and in the status update modal (adding multiple comments/updates and deleting them)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
