### PR TITLE
Adds autofocus to various form inputs

### DIFF
--- a/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
+++ b/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
@@ -192,11 +192,11 @@ const FileUploadDialogSingle = props => {
         <Grid container>
           <Grid item xs={12} md={12}>
             <TextField
+              autoFocus
               className={classes.textField}
               id="standard-multiline-flexible"
               placeholder={"File name"}
               multiline={false}
-              rowsMax={1}
               value={null}
               onChange={handleFileNameChange}
               fullWidth
@@ -261,7 +261,7 @@ const FileUploadDialogSingle = props => {
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCancel} color="primary" autoFocus>
+        <Button onClick={handleCancel} color="primary">
           Cancel
         </Button>
         <Button

--- a/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
+++ b/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
@@ -17,7 +17,7 @@ import FileUpload from "./FileUpload";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   title: {
     padding: "0rem 0 2rem 0",
   },
@@ -40,7 +40,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const FileUploadDialogSingle = props => {
+const FileUploadDialogSingle = (props) => {
   const classes = useStyles();
 
   /**
@@ -62,7 +62,7 @@ const FileUploadDialogSingle = props => {
    * Logic that needs to be run after the file has been uploaded to S3
    * @param {string} fileKey - The name of the file in S3
    */
-  const handleOnFileProcessed = fileKey => {
+  const handleOnFileProcessed = (fileKey) => {
     setFileKey(fileKey);
   };
 
@@ -81,7 +81,7 @@ const FileUploadDialogSingle = props => {
    * Handles the file name changes
    * @param {Object} e - The event object
    */
-  const handleFileNameChange = e => {
+  const handleFileNameChange = (e) => {
     setFileName(e.target.value);
   };
 
@@ -89,7 +89,7 @@ const FileUploadDialogSingle = props => {
    * Handles the file description changes
    * @param {Object} e - The event object
    */
-  const handleFileDescriptionChange = e => {
+  const handleFileDescriptionChange = (e) => {
     setFileDescription(e.target.value);
   };
 
@@ -97,7 +97,7 @@ const FileUploadDialogSingle = props => {
    * Handles the file type changes
    * @param {Object} e - The event object
    */
-  const handleFileTypeChange = e => {
+  const handleFileTypeChange = (e) => {
     setFileType(e.target.value);
   };
 
@@ -145,7 +145,7 @@ const FileUploadDialogSingle = props => {
    * @param {any} value - The value in question
    * @return {number}
    */
-  const fieldLength = value => {
+  const fieldLength = (value) => {
     if (value !== null && typeof value === "string") {
       return value.length;
     }

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -27,6 +27,7 @@ const DefineProjectForm = ({
           {!fromSignalAsset && (
             <TextField
               required
+              autoFocus
               label="Project name"
               name="project_name"
               variant="standard"

--- a/moped-editor/src/views/projects/projectView/CommentInputQuill.js
+++ b/moped-editor/src/views/projects/projectView/CommentInputQuill.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import { Box, Button, Container, Grid } from "@material-ui/core";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
@@ -14,7 +14,7 @@ const quillModules = {
   ],
 };
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     width: "100%",
     backgroundColor: theme.palette.background.paper,
@@ -37,6 +37,12 @@ const CommentInputQuill = ({
   cancelCommentEdit,
 }) => {
   const classes = useStyles();
+  const ref = useRef();
+
+  useEffect(() => {
+    // autofocuses the quill input
+    ref?.current.focus();
+  }, []);
 
   return (
     <Container>
@@ -48,6 +54,7 @@ const CommentInputQuill = ({
               value={noteText}
               onChange={setNoteText}
               modules={quillModules}
+              ref={ref}
             />
           </Box>
         </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
@@ -85,6 +85,7 @@ const ProjectContractsTable = () => {
       title: "Contractor",
       field: "contractor",
       width: "20%",
+      // we use this custom component in order to autofocus the input
       editComponent: (props) => (
         <TextField
           {...props}

--- a/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectContractsTable.js
@@ -8,6 +8,7 @@ import {
   CircularProgress,
   Snackbar,
   Typography,
+  TextField,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 import {
@@ -84,6 +85,13 @@ const ProjectContractsTable = () => {
       title: "Contractor",
       field: "contractor",
       width: "20%",
+      editComponent: (props) => (
+        <TextField
+          {...props}
+          onChange={(e) => props.onChange(e.target.value)}
+          autoFocus
+        />
+      ),
     },
     {
       title: "Contract #",
@@ -178,9 +186,7 @@ const ProjectContractsTable = () => {
           },
           body: {
             emptyDataSourceMessage: (
-              <Typography variant="body1">
-                No contracts to display
-              </Typography>
+              <Typography variant="body1">No contracts to display</Typography>
             ),
           },
         }}

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -158,6 +158,7 @@ const StaffForm = ({
         <Grid item xs={12} md={6}>
           <TextField
             fullWidth
+            autoFocus
             name="first_name"
             id="first-name"
             label="First Name"


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/9144

## Testing
[Netlify](https://deploy-preview-904--atd-moped-main.netlify.app/moped/projects)

**Steps to test:**
Observe the input autofocusing in these places:
1. New project form: project name
2. New contract row in contracts table: contractor column
3. File upload - file name
4. Comments (from Dashboard, project summary, or comments tab): the comment input
5. Add/edit staff form: first name

I tried to apply autofocus in these two places, but it just wouldn't take (despite using patterns we have elsewhere):

- ❌ Milestones table
- ❌ Funding table


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
