### PR TITLE
Enhancements to project summary fields

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.6.9",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -65,6 +65,7 @@ const useStyles = makeStyles((theme) => ({
       borderRadius: theme.spacing(0.5),
       cursor: "pointer",
     },
+    overflowWrap: "break-word",
   },
   fieldAuthor: {
     marginRight: ".25rem",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -10,8 +10,7 @@ import { NavLink as RouterLink } from "react-router-dom";
  * @constructor
  */
 const ProjectSummaryParentProjectLink = ({ data, classes }) => {
-  const parentProjectId =
-    data?.moped_project?.[0]?.parent_project_id;
+  const parentProjectId = data?.moped_project?.[0]?.parent_project_id;
   const parentProjectName = data?.moped_project[0].moped_project.project_name;
 
   return (
@@ -21,13 +20,18 @@ const ProjectSummaryParentProjectLink = ({ data, classes }) => {
         display="flex"
         justifyContent="flex-start"
         className={classes.fieldBox}
+        alignItems="center"
       >
         <RouterLink
           id="projectKnackSyncLink"
           className={"MuiTypography-body1"}
           to={`/moped/projects/${parentProjectId}`}
         >
-          <Typography variant={"inherit"} color={"primary"}>
+          <Typography
+            className={classes.fieldLabelText}
+            variant={"inherit"}
+            color={"primary"}
+          >
             {parentProjectName}
           </Typography>
         </RouterLink>


### PR DESCRIPTION
## Associated issues

Fixes cityofaustin/atd-data-tech/issues/10754

## Testing
**URL to test:** 

https://deploy-preview-909--atd-moped-main.netlify.app


**Steps to test:**
1. Go to the project summary page for a new or existing project that has a parent project.
2. Ensure that the parent project field is now aligned with the rest of the fields.
3. Update the description and website fields to have very longgggggggg strings. The strings should now break and wrap when not editing.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
