### PR TITLE
Prevent saving of map edits if there are no map features

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.6.9",
@@ -49,8 +49,6 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-error-boundary": "^3.1.4",
-        "react-error-overlay": "^6.0.11",
         "react-feather": "^2.0.10",
         "react-filepond": "^7.1.2",
         "react-helmet": "^6.1.0",
@@ -27529,21 +27527,6 @@
         "react": ">= 0.14.7"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -53143,14 +53126,6 @@
       "resolved": "https://registry.npmjs.org/react-double-scrollbar/-/react-double-scrollbar-0.0.15.tgz",
       "integrity": "sha512-dLz3/WBIpgFnzFY0Kb4aIYBMT2BWomHuW2DH6/9jXfS6/zxRRBUFQ04My4HIB7Ma7QoRBpcy8NtkPeFgcGBpgg==",
       "requires": {}
-    },
-    "react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
     },
     "react-error-overlay": {
       "version": "6.0.11",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -80,8 +80,6 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-error-boundary": "^3.1.4",
-    "react-error-overlay": "^6.0.11",
     "react-feather": "^2.0.10",
     "react-filepond": "^7.1.2",
     "react-helmet": "^6.1.0",

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -117,6 +117,12 @@ export const SUMMARY_QUERY = gql`
       project_id
       user_id
     }
+    project_geography(
+      where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
+    ) {
+      geometry: geography
+      attributes
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents.js
@@ -17,7 +17,6 @@ import {
   IconButton,
 } from "@material-ui/core";
 
-import { ErrorBoundary } from "react-error-boundary";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 import ProjectComponentsMapView from "./ProjectComponentsMapView";
 import { createFeatureCollectionFromProjectFeatures } from "../../../utils/mapHelpers";
@@ -32,7 +31,7 @@ import ProjectComponentsMapEdit from "./ProjectComponentsMapEdit";
 import Alert from "@material-ui/lab/Alert";
 import { ArrowForwardIos } from "@material-ui/icons";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
     backgroundColor: theme.palette.background.paper,
@@ -69,9 +68,8 @@ const ProjectComponents = () => {
   const { projectId } = useParams();
   const classes = useStyles();
 
-  const [selectedProjectComponent, setSelectedProjectComponent] = useState(
-    null
-  );
+  const [selectedProjectComponent, setSelectedProjectComponent] =
+    useState(null);
   const [mapError, setMapError] = useState(false);
   const [componentEditMode, setComponentEditMode] = useState(false);
 
@@ -103,7 +101,7 @@ const ProjectComponents = () => {
    * Handles logic whenever a component is clicked, refreshes whatever is in memory and re-renders
    * @param clickedComponent - The component in question
    */
-  const handleComponentClick = clickedComponent =>
+  const handleComponentClick = (clickedComponent) =>
     setSelectedProjectComponent(clickedComponent);
 
   /**
@@ -164,118 +162,104 @@ const ProjectComponents = () => {
         />
       )}
       {!componentEditMode && (
-        <ErrorBoundary
-          FallbackComponent={({ error, resetErrorBoundary }) => (
-            <ProjectSummaryMapFallback
-              error={error}
-              resetErrorBoundary={resetErrorBoundary}
-              projectId={projectId}
-              refetchProjectDetails={refetch}
-              mapData={projectFeatureCollection}
-            />
-          )}
-          onReset={() => setMapError(false)}
-          resetKeys={[mapError]}
+        <ProjectComponentsMapView
+          projectFeatureCollection={
+            selectedProjectComponent
+              ? selectedComponentFeatureCollection
+              : projectFeatureCollection
+          }
+          noPadding
         >
-          <ProjectComponentsMapView
-            projectFeatureCollection={
-              selectedProjectComponent
-                ? selectedComponentFeatureCollection
-                : projectFeatureCollection
-            }
-            noPadding
+          <Button
+            className={classes.componentButtonAddNew}
+            onClick={handleAddNewComponentClick}
+            variant="outlined"
+            color="default"
+            size={"large"}
+            startIcon={<Icon>add</Icon>}
+            fullWidth
           >
-            <Button
-              className={classes.componentButtonAddNew}
-              onClick={handleAddNewComponentClick}
-              variant="outlined"
-              color="default"
-              size={"large"}
-              startIcon={<Icon>add</Icon>}
-              fullWidth
-            >
-              Add new component
-            </Button>
-            {componentsAvailable && (
-              <ClickAwayListener onClickAway={handleComponentClickAway}>
-                <List className={classes.root}>
-                  {data.moped_proj_components.map(
-                    (projectComponent, compIndex) => {
-                      const projComponentId =
-                        projectComponent.project_component_id;
-                      return (
-                        <ListItem
-                          key={"mcListItem-" + projComponentId}
-                          role={undefined}
-                          dense
-                          button
-                          onClick={() => handleComponentClick(projectComponent)}
-                          className={
-                            projComponentId ===
-                            selectedProjectComponent?.project_component_id
-                              ? classes.componentItemBlue
-                              : classes.componentItem
-                          }
-                        >
-                          <ListItemIcon>
-                            <Checkbox
-                              edge="start"
-                              className={classes.listItemCheckbox}
-                              checked={
-                                projComponentId ===
-                                selectedProjectComponent?.project_component_id
-                              }
-                              tabIndex={-1}
-                              disableRipple
-                              inputProps={{ "aria-labelledby": null }}
-                            />
-                          </ListItemIcon>
-                          <ListItemText
-                            id={"mcListItemText-" + projComponentId}
-                            primary={
-                              projectComponent?.moped_components?.component_name
+            Add new component
+          </Button>
+          {componentsAvailable && (
+            <ClickAwayListener onClickAway={handleComponentClickAway}>
+              <List className={classes.root}>
+                {data.moped_proj_components.map(
+                  (projectComponent, compIndex) => {
+                    const projComponentId =
+                      projectComponent.project_component_id;
+                    return (
+                      <ListItem
+                        key={"mcListItem-" + projComponentId}
+                        role={undefined}
+                        dense
+                        button
+                        onClick={() => handleComponentClick(projectComponent)}
+                        className={
+                          projComponentId ===
+                          selectedProjectComponent?.project_component_id
+                            ? classes.componentItemBlue
+                            : classes.componentItem
+                        }
+                      >
+                        <ListItemIcon>
+                          <Checkbox
+                            edge="start"
+                            className={classes.listItemCheckbox}
+                            checked={
+                              projComponentId ===
+                              selectedProjectComponent?.project_component_id
                             }
-                            secondary={
-                              (projectComponent?.moped_components
-                                ?.component_subtype ?? "") +
-                              [
-                                ...new Set(
-                                  projectComponent.moped_proj_components_subcomponents.map(
-                                    mpcs =>
-                                      mpcs.moped_subcomponent.subcomponent_name
-                                  )
-                                ),
-                              ]
-                                .sort()
-                                .join(", ")
-                            }
+                            tabIndex={-1}
+                            disableRipple
+                            inputProps={{ "aria-labelledby": null }}
                           />
-                          <ListItemSecondaryAction
-                            onClick={() => {
-                              handleComponentClick(projectComponent);
-                              handleComponentDetailsClick();
-                            }}
-                          >
-                            <IconButton edge="end" aria-label="comments">
-                              <ArrowForwardIos
-                                className={classes.listItemSecondaryAction}
-                              />
-                            </IconButton>
-                          </ListItemSecondaryAction>
-                        </ListItem>
-                      );
-                    }
-                  )}
-                </List>
-              </ClickAwayListener>
-            )}
-            {!componentsAvailable && (
-              <Alert severity="info">
-                There aren't any components for this project.
-              </Alert>
-            )}
-          </ProjectComponentsMapView>
-        </ErrorBoundary>
+                        </ListItemIcon>
+                        <ListItemText
+                          id={"mcListItemText-" + projComponentId}
+                          primary={
+                            projectComponent?.moped_components?.component_name
+                          }
+                          secondary={
+                            (projectComponent?.moped_components
+                              ?.component_subtype ?? "") +
+                            [
+                              ...new Set(
+                                projectComponent.moped_proj_components_subcomponents.map(
+                                  (mpcs) =>
+                                    mpcs.moped_subcomponent.subcomponent_name
+                                )
+                              ),
+                            ]
+                              .sort()
+                              .join(", ")
+                          }
+                        />
+                        <ListItemSecondaryAction
+                          onClick={() => {
+                            handleComponentClick(projectComponent);
+                            handleComponentDetailsClick();
+                          }}
+                        >
+                          <IconButton edge="end" aria-label="comments">
+                            <ArrowForwardIos
+                              className={classes.listItemSecondaryAction}
+                            />
+                          </IconButton>
+                        </ListItemSecondaryAction>
+                      </ListItem>
+                    );
+                  }
+                )}
+              </List>
+            </ClickAwayListener>
+          )}
+          {!componentsAvailable && (
+            <Alert severity="info">
+              There aren't any components for this project.
+            </Alert>
+          )}
+        </ProjectComponentsMapView>
       )}
     </ApolloErrorHandler>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -201,13 +201,10 @@ export default function TheMap({
             feature?.properties?.[sourceFeatureId] !== featureUniqueId // From CTN layers
         );
 
-        const isAtLeastOneFeatureRemaining = filteredFeatures.length > 0;
-        return isAtLeastOneFeatureRemaining
-          ? {
-              ...currentComponent,
-              [tableToInsert]: filteredFeatures,
-            }
-          : currentComponent;
+        return {
+          ...currentComponent,
+          [tableToInsert]: filteredFeatures,
+        };
       }
     };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -271,7 +271,6 @@ export default function TheMap({
       onMouseLeave={onMouseLeave}
       onMoveEnd={onMoveEnd}
       onClick={onClick}
-      boxZoom={false}
       cursor={cursor}
       mapStyle={basemaps[basemapKey].mapStyle}
       {...mapParameters}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -117,6 +117,7 @@ export default function MapView({ projectName, projectStatuses }) {
     onSaveEditedComponent,
     onCancelComponentMapEdit,
     onEditFeatures,
+    doesDraftEditComponentHaveFeatures,
   } = useUpdateComponent({
     components,
     clickedComponent,
@@ -212,7 +213,7 @@ export default function MapView({ projectName, projectStatuses }) {
                   }
                   onSave={onSaveEditedComponent}
                   onCancel={onCancelComponentMapEdit}
-                  saveButtonDisabled={false}
+                  saveButtonDisabled={!doesDraftEditComponentHaveFeatures}
                   saveButtonText="Save Edit"
                 />
               )}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -53,6 +53,7 @@ export const fitBoundsOptions = {
 export const mapParameters = {
   touchPitch: false,
   dragRotate: false,
+  boxZoom: false,
   maxBounds: [
     [-99, 29],
     [-96, 32],

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/features.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/features.js
@@ -1,6 +1,7 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { getIntersectionLabel } from "./map";
+import { getAllComponentFeatures } from "./makeFeatureCollections";
 
 export const useComponentFeatureCollectionFromMap = (
   component,
@@ -172,4 +173,25 @@ export const useExistingDrawnFeatures = ({
       });
     }
   }, [linkMode, draftEditComponent, drawControlsRef]);
+};
+
+export const useDoesDraftEditComponentHaveFeatures = (draftEditComponent) => {
+  const [
+    doesDraftEditComponentHaveFeatures,
+    setDoesDraftEditComponentHaveFeatures,
+  ] = useState(false);
+
+  useEffect(() => {
+    if (draftEditComponent === null) return;
+
+    const allDraftComponentFeatures =
+      getAllComponentFeatures(draftEditComponent);
+    const doesComponentHaveFeatures = Boolean(
+      allDraftComponentFeatures.length > 0
+    );
+
+    setDoesDraftEditComponentHaveFeatures(doesComponentHaveFeatures);
+  }, [draftEditComponent]);
+
+  return doesDraftEditComponentHaveFeatures;
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/features.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/features.js
@@ -175,6 +175,11 @@ export const useExistingDrawnFeatures = ({
   }, [linkMode, draftEditComponent, drawControlsRef]);
 };
 
+/**
+ * Track whether a draft edit component has features or not
+ * @param {Object} draftEditComponent - the draft component storing feature edits
+ * @returns {Boolean} - does the draft component have features
+ */
 export const useDoesDraftEditComponentHaveFeatures = (draftEditComponent) => {
   const [
     doesDraftEditComponentHaveFeatures,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -2,6 +2,18 @@ import { useMemo } from "react";
 import { featureTableFieldMap } from "./makeFeatures";
 
 /**
+ * Take a project_geography record and return a valid GeoJSON feature
+ * TODO: We should look into returning GeoJSON features directly from the DB
+ * @param {Object} record - project_geography record from GET_PROJECT_COMPONENTS query
+ * @returns {Object} - GeoJSON feature
+ */
+export const makeFeatureFromProjectGeographyRecord = (record) => ({
+  type: "Feature",
+  properties: { ...record.attributes },
+  geometry: record.geometry,
+});
+
+/**
  * Create an object map of component feature collections by component id
  * Ex. { 1: { type: "FeatureCollection", features: [...] } }
  * @param {Object} data - data returned by GET_PROJECT_COMPONENTS query
@@ -15,12 +27,7 @@ export const useComponentFeatureCollectionsMap = (data) =>
 
     data.project_geography.forEach((component) => {
       const currentComponentId = component.component_id;
-
-      const currentFeature = {
-        type: "Feature",
-        properties: { ...component.attributes },
-        geometry: component.geometry,
-      };
+      const currentFeature = makeFeatureFromProjectGeographyRecord(component);
 
       if (!componentGeographyMap[currentComponentId]) {
         componentGeographyMap[currentComponentId] = {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -41,6 +41,12 @@ export const useComponentFeatureCollectionsMap = (data) =>
     return componentGeographyMap;
   }, [data]);
 
+/**
+ * Component features are returned as arrays for each feature type table.
+ * We can use the featureTableFieldMap to unpack the component object.
+ * @param {Object} component - component object from GET_PROJECT_COMPONENTS query
+ * @returns {Array} - array of all component features
+ */
 export const getAllComponentFeatures = (component) => {
   const allComponentFeatures = [];
 
@@ -49,9 +55,15 @@ export const getAllComponentFeatures = (component) => {
       allComponentFeatures.push(component[key]);
   });
 
+  // Flatten array of arrays containing features from each feature table
   return allComponentFeatures.flat();
 };
 
+/**
+ * Take a component object and return a GeoJSON FeatureCollection of all component features
+ * @param {Object} component - component object from GET_PROJECT_COMPONENTS query
+ * @returns {Object} - GeoJSON FeatureCollection of all component features
+ */
 export const useComponentFeatureCollection = (component) =>
   useMemo(() => {
     if (component === null)
@@ -75,7 +87,11 @@ export const useComponentFeatureCollection = (component) =>
     };
   }, [component]);
 
-// returns geojson of features across all components
+/**
+ * Take all project components and return a GeoJSON FeatureCollection of all components features
+ * @param {Array} components - all components returned by GET_PROJECT_COMPONENTS query
+ * @returns {Object} - GeoJSON FeatureCollection of all components features
+ */
 export const useAllComponentsFeatureCollection = (components) =>
   useMemo(() => {
     if (components === null || components.length === 0)
@@ -84,17 +100,15 @@ export const useAllComponentsFeatureCollection = (components) =>
         features: [],
       };
 
-    const allComponentfeatures = [];
+    const allComponentsFeatures = [];
 
     components.forEach((component) => {
-      Object.keys(featureTableFieldMap).forEach((key) => {
-        if (component.hasOwnProperty(key))
-          allComponentfeatures.push(component[key]);
-      });
+      const allComponentFeatures = getAllComponentFeatures(component);
+      allComponentsFeatures.push(allComponentFeatures);
     });
 
     // Make features valid GeoJSON by adding type and properties attributes
-    const geoJsonFeatures = allComponentfeatures.flat().map((component) => ({
+    const geoJsonFeatures = allComponentsFeatures.flat().map((component) => ({
       ...component,
       type: "Feature",
       properties: {},

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -49,7 +49,7 @@ export const getAllComponentFeatures = (component) => {
       allComponentFeatures.push(component[key]);
   });
 
-  return allComponentFeatures;
+  return allComponentFeatures.flat();
 };
 
 export const useComponentFeatureCollection = (component) =>
@@ -62,13 +62,8 @@ export const useComponentFeatureCollection = (component) =>
 
     const allComponentFeatures = getAllComponentFeatures(component);
 
-    Object.keys(featureTableFieldMap).forEach((key) => {
-      if (component.hasOwnProperty(key))
-        allComponentFeatures.push(component[key]);
-    });
-
     // Make features valid GeoJSON by adding type and properties attributes
-    const geoJsonFeatures = allComponentFeatures.flat().map((component) => ({
+    const geoJsonFeatures = allComponentFeatures.map((component) => ({
       ...component,
       type: "Feature",
       properties: {},

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -41,6 +41,17 @@ export const useComponentFeatureCollectionsMap = (data) =>
     return componentGeographyMap;
   }, [data]);
 
+export const getAllComponentFeatures = (component) => {
+  const allComponentFeatures = [];
+
+  Object.keys(featureTableFieldMap).forEach((key) => {
+    if (component.hasOwnProperty(key))
+      allComponentFeatures.push(component[key]);
+  });
+
+  return allComponentFeatures;
+};
+
 export const useComponentFeatureCollection = (component) =>
   useMemo(() => {
     if (component === null)
@@ -49,7 +60,7 @@ export const useComponentFeatureCollection = (component) =>
         features: [],
       };
 
-    const allComponentFeatures = [];
+    const allComponentFeatures = getAllComponentFeatures(component);
 
     Object.keys(featureTableFieldMap).forEach((key) => {
       if (component.hasOwnProperty(key))

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useState } from "react";
+import { useReducer } from "react";
 import { useMutation } from "@apollo/client";
 import {
   makeLineStringFeatureInsertionData,
@@ -7,7 +7,7 @@ import {
   makeDrawnPointsInsertionData,
   addComponentIdForUpdate,
 } from "./makeFeatures";
-import { getAllComponentFeatures } from "./makeFeatureCollections";
+import { useDoesDraftEditComponentHaveFeatures } from "./features";
 import { UPDATE_COMPONENT_FEATURES } from "src/queries/components";
 
 const editReducer = (state, action) => {
@@ -232,23 +232,8 @@ export const useUpdateComponent = ({
     drawnPointFeatureUpdates: [],
   });
 
-  const [
-    doesDraftEditComponentHaveFeatures,
-    setDoesDraftEditComponentHaveFeatures,
-  ] = useState(false);
-
-  useEffect(() => {
-    if (editState.draftEditComponent === null) return;
-
-    const allDraftComponentFeatures = getAllComponentFeatures(
-      editState.draftEditComponent
-    );
-    const doesComponentHaveFeatures = Boolean(
-      allDraftComponentFeatures.length > 0
-    );
-
-    setDoesDraftEditComponentHaveFeatures(doesComponentHaveFeatures);
-  }, [editState.draftEditComponent]);
+  const doesDraftEditComponentHaveFeatures =
+    useDoesDraftEditComponentHaveFeatures(editState.draftEditComponent);
 
   const [updateComponentFeatures] = useMutation(UPDATE_COMPONENT_FEATURES);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -1,4 +1,4 @@
-import { useReducer } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { useMutation } from "@apollo/client";
 import {
   makeLineStringFeatureInsertionData,
@@ -7,6 +7,7 @@ import {
   makeDrawnPointsInsertionData,
   addComponentIdForUpdate,
 } from "./makeFeatures";
+import { getAllComponentFeatures } from "./makeFeatureCollections";
 import { UPDATE_COMPONENT_FEATURES } from "src/queries/components";
 
 const editReducer = (state, action) => {
@@ -231,6 +232,24 @@ export const useUpdateComponent = ({
     drawnPointFeatureUpdates: [],
   });
 
+  const [
+    doesDraftEditComponentHaveFeatures,
+    setDoesDraftEditComponentHaveFeatures,
+  ] = useState(false);
+
+  useEffect(() => {
+    if (editState.draftEditComponent === null) return;
+
+    const allDraftComponentFeatures = getAllComponentFeatures(
+      editState.draftEditComponent
+    );
+    const doesComponentHaveFeatures = Boolean(
+      allDraftComponentFeatures.length > 0
+    );
+
+    setDoesDraftEditComponentHaveFeatures(doesComponentHaveFeatures);
+  }, [editState.draftEditComponent]);
+
   const [updateComponentFeatures] = useMutation(UPDATE_COMPONENT_FEATURES);
 
   const onEditFeatures = () => {
@@ -414,5 +433,6 @@ export const useUpdateComponent = ({
     onSaveEditedComponent,
     onCancelComponentMapEdit,
     onEditFeatures,
+    doesDraftEditComponentHaveFeatures,
   };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -3,16 +3,10 @@ import { useParams } from "react-router-dom";
 
 import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
-import { createProjectFeatureCollection } from "src/utils/projectComponentHelpers";
 
 import { Grid, CardContent, CircularProgress } from "@material-ui/core";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
-/*
-  Error Handler and Fallback Component
-*/
-import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
-import { ErrorBoundary } from "react-error-boundary";
 import ProjectSummaryProjectEntity from "./ProjectSummaryProjectEntity";
 import ProjectSummaryProjectPartners from "./ProjectSummaryProjectPartners";
 
@@ -28,7 +22,6 @@ import ProjectSummaryWorkOrders from "./ProjectSummaryWorkOrders";
 import ProjectSummaryWorkAssignmentID from "./ProjectSummaryWorkAssignID";
 import ProjectSummaryInterimID from "./ProjectSummaryInterimID";
 
-import { countFeatures } from "../../../../utils/mapHelpers";
 import SubprojectsTable from "./SubprojectsTable";
 import TagsSection from "./TagsSection";
 
@@ -122,7 +115,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
   const { projectId } = useParams();
   const classes = useStyles();
 
-  const [mapError, setMapError] = useState(false);
   const [snackbarState, setSnackbarState] = useState(false);
 
   /**
@@ -140,28 +132,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
 
   if (loading) return <CircularProgress />;
   if (error) return `Error! ${error.message}`;
-
-  const projectComponents = data?.moped_project[0]?.moped_proj_components || [];
-  const projectFeatureCollection =
-    createProjectFeatureCollection(projectComponents);
-
-  const renderMap = () => {
-    if (countFeatures(projectFeatureCollection) < 1) {
-      return (
-        <ProjectSummaryMapFallback
-          projectId={projectId}
-          refetchProjectDetails={refetch}
-          mapData={projectFeatureCollection}
-        />
-      );
-    } else {
-      return (
-        <ProjectSummaryMap
-          projectFeatureCollection={projectFeatureCollection}
-        />
-      );
-    }
-  };
 
   return (
     <ApolloErrorHandler errors={error}>
@@ -294,23 +264,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                {projectFeatureCollection && (
-                  <ErrorBoundary
-                    FallbackComponent={({ error, resetErrorBoundary }) => (
-                      <ProjectSummaryMapFallback
-                        error={error}
-                        resetErrorBoundary={resetErrorBoundary}
-                        projectId={projectId}
-                        refetchProjectDetails={refetch}
-                        mapData={projectFeatureCollection}
-                      />
-                    )}
-                    onReset={() => setMapError(false)}
-                    resetKeys={[mapError]}
-                  >
-                    {renderMap()}
-                  </ErrorBoundary>
-                )}
+                <ProjectSummaryMap data={data} />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
@@ -4,7 +4,7 @@ import { Box, Button, Card, makeStyles } from "@material-ui/core";
 
 import { Link } from "react-router-dom";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     fontSize: "0.875rem",
     fontWeight: 500,
@@ -40,25 +40,17 @@ const useStyles = makeStyles(theme => ({
 }));
 
 /**
- * Renders a fallback component that shows the user whenever there is a map error.
- * @param {object} error - provided by ErrorBoundary component, contains error details.
- * @param {object} mapData - The map data with errors to show in the console for debugging
+ * Renders a fallback component
  * @return {JSX.Element}
  * @constructor
  */
-const ProjectSummaryMapFallback = ({ error, mapData }) => {
+const ProjectSummaryMapFallback = () => {
   const classes = useStyles();
-
-  /**
-   * Log whatever error there may be
-   */
-  console.debug("MapDataError: ", error);
-  console.debug("MapData: ", mapData);
 
   return (
     <Box>
       <Card className={classes.card} color="secondary">
-        <img 
+        <img
           className={classes.mapPlaceholderImg}
           alt="Map Unavailable"
           src={`${process.env.PUBLIC_URL}/static/images/map_unavailable.png`}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
@@ -1,0 +1,44 @@
+import { Source, Layer } from "react-map-gl";
+import { MAP_STYLES } from "../ProjectComponents/mapStyleSettings";
+import { useFeatureTypes } from "../ProjectComponents/utils/map";
+
+/**
+ * Component that renders feature collection of all components features in a project
+ * All layers are set to show below basemap street labels using beforeId = "street-labels"
+ * @param {Object} projectFeatureCollection - GeoJSON feature collection with all project features
+ * @returns JSX.Element
+ */
+const ProjectSummaryMapSourcesAndLayers = ({ projectFeatureCollection }) => {
+  const projectLines = useFeatureTypes(projectFeatureCollection, "line");
+  const projectPoints = useFeatureTypes(projectFeatureCollection, "point");
+
+  return (
+    <>
+      <Source
+        id="project-lines"
+        type="geojson"
+        data={projectLines}
+        promoteId="id"
+      >
+        <Layer
+          beforeId="street-labels"
+          {...MAP_STYLES["project-lines"].layerProps}
+        />
+      </Source>
+
+      <Source
+        id="project-points"
+        type="geojson"
+        data={projectPoints}
+        promoteId="id"
+      >
+        <Layer
+          beforeId="street-labels"
+          {...MAP_STYLES["project-points"].layerProps}
+        />
+      </Source>
+    </>
+  );
+};
+
+export default ProjectSummaryMapSourcesAndLayers;


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10991

This PR updates the edit component map flow to enable removing all features from a component and to disable the **Save Edit** button when that happens. The button enables again when another feature is added.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local or https://md-10991-prevent-save--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Create a new project and then add a new line or point component
2. Add some features and then save it
3. Edit the component that you just created and delete every feature by deselecting or using the trash can on drawn features
4. You should see the **Save Edit** button disable when you have no features left
5. Select a feature from the map or drawn one
6. The **Save Edit** button should be enabled again and you can save the update

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
