### PR TITLE
Re-implement project summary map

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.6.9",
@@ -49,8 +49,6 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-error-boundary": "^3.1.4",
-        "react-error-overlay": "^6.0.11",
         "react-feather": "^2.0.10",
         "react-filepond": "^7.1.2",
         "react-helmet": "^6.1.0",
@@ -27529,21 +27527,6 @@
         "react": ">= 0.14.7"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -53143,14 +53126,6 @@
       "resolved": "https://registry.npmjs.org/react-double-scrollbar/-/react-double-scrollbar-0.0.15.tgz",
       "integrity": "sha512-dLz3/WBIpgFnzFY0Kb4aIYBMT2BWomHuW2DH6/9jXfS6/zxRRBUFQ04My4HIB7Ma7QoRBpcy8NtkPeFgcGBpgg==",
       "requires": {}
-    },
-    "react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
     },
     "react-error-overlay": {
       "version": "6.0.11",

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -80,8 +80,6 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-error-boundary": "^3.1.4",
-    "react-error-overlay": "^6.0.11",
     "react-feather": "^2.0.10",
     "react-filepond": "^7.1.2",
     "react-helmet": "^6.1.0",

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -117,6 +117,13 @@ export const SUMMARY_QUERY = gql`
       project_id
       user_id
     }
+    project_geography(
+      where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
+    ) {
+      geometry: geography
+      component_id
+      attributes
+    }
   }
 `;
 

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -121,7 +121,6 @@ export const SUMMARY_QUERY = gql`
       where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
     ) {
       geometry: geography
-      component_id
       attributes
     }
   }

--- a/moped-editor/src/views/projects/projectView/ProjectComponents.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents.js
@@ -17,7 +17,6 @@ import {
   IconButton,
 } from "@material-ui/core";
 
-import { ErrorBoundary } from "react-error-boundary";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 import ProjectComponentsMapView from "./ProjectComponentsMapView";
 import { createFeatureCollectionFromProjectFeatures } from "../../../utils/mapHelpers";
@@ -32,7 +31,7 @@ import ProjectComponentsMapEdit from "./ProjectComponentsMapEdit";
 import Alert from "@material-ui/lab/Alert";
 import { ArrowForwardIos } from "@material-ui/icons";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
     backgroundColor: theme.palette.background.paper,
@@ -69,9 +68,8 @@ const ProjectComponents = () => {
   const { projectId } = useParams();
   const classes = useStyles();
 
-  const [selectedProjectComponent, setSelectedProjectComponent] = useState(
-    null
-  );
+  const [selectedProjectComponent, setSelectedProjectComponent] =
+    useState(null);
   const [mapError, setMapError] = useState(false);
   const [componentEditMode, setComponentEditMode] = useState(false);
 
@@ -103,7 +101,7 @@ const ProjectComponents = () => {
    * Handles logic whenever a component is clicked, refreshes whatever is in memory and re-renders
    * @param clickedComponent - The component in question
    */
-  const handleComponentClick = clickedComponent =>
+  const handleComponentClick = (clickedComponent) =>
     setSelectedProjectComponent(clickedComponent);
 
   /**
@@ -164,118 +162,104 @@ const ProjectComponents = () => {
         />
       )}
       {!componentEditMode && (
-        <ErrorBoundary
-          FallbackComponent={({ error, resetErrorBoundary }) => (
-            <ProjectSummaryMapFallback
-              error={error}
-              resetErrorBoundary={resetErrorBoundary}
-              projectId={projectId}
-              refetchProjectDetails={refetch}
-              mapData={projectFeatureCollection}
-            />
-          )}
-          onReset={() => setMapError(false)}
-          resetKeys={[mapError]}
+        <ProjectComponentsMapView
+          projectFeatureCollection={
+            selectedProjectComponent
+              ? selectedComponentFeatureCollection
+              : projectFeatureCollection
+          }
+          noPadding
         >
-          <ProjectComponentsMapView
-            projectFeatureCollection={
-              selectedProjectComponent
-                ? selectedComponentFeatureCollection
-                : projectFeatureCollection
-            }
-            noPadding
+          <Button
+            className={classes.componentButtonAddNew}
+            onClick={handleAddNewComponentClick}
+            variant="outlined"
+            color="default"
+            size={"large"}
+            startIcon={<Icon>add</Icon>}
+            fullWidth
           >
-            <Button
-              className={classes.componentButtonAddNew}
-              onClick={handleAddNewComponentClick}
-              variant="outlined"
-              color="default"
-              size={"large"}
-              startIcon={<Icon>add</Icon>}
-              fullWidth
-            >
-              Add new component
-            </Button>
-            {componentsAvailable && (
-              <ClickAwayListener onClickAway={handleComponentClickAway}>
-                <List className={classes.root}>
-                  {data.moped_proj_components.map(
-                    (projectComponent, compIndex) => {
-                      const projComponentId =
-                        projectComponent.project_component_id;
-                      return (
-                        <ListItem
-                          key={"mcListItem-" + projComponentId}
-                          role={undefined}
-                          dense
-                          button
-                          onClick={() => handleComponentClick(projectComponent)}
-                          className={
-                            projComponentId ===
-                            selectedProjectComponent?.project_component_id
-                              ? classes.componentItemBlue
-                              : classes.componentItem
-                          }
-                        >
-                          <ListItemIcon>
-                            <Checkbox
-                              edge="start"
-                              className={classes.listItemCheckbox}
-                              checked={
-                                projComponentId ===
-                                selectedProjectComponent?.project_component_id
-                              }
-                              tabIndex={-1}
-                              disableRipple
-                              inputProps={{ "aria-labelledby": null }}
-                            />
-                          </ListItemIcon>
-                          <ListItemText
-                            id={"mcListItemText-" + projComponentId}
-                            primary={
-                              projectComponent?.moped_components?.component_name
+            Add new component
+          </Button>
+          {componentsAvailable && (
+            <ClickAwayListener onClickAway={handleComponentClickAway}>
+              <List className={classes.root}>
+                {data.moped_proj_components.map(
+                  (projectComponent, compIndex) => {
+                    const projComponentId =
+                      projectComponent.project_component_id;
+                    return (
+                      <ListItem
+                        key={"mcListItem-" + projComponentId}
+                        role={undefined}
+                        dense
+                        button
+                        onClick={() => handleComponentClick(projectComponent)}
+                        className={
+                          projComponentId ===
+                          selectedProjectComponent?.project_component_id
+                            ? classes.componentItemBlue
+                            : classes.componentItem
+                        }
+                      >
+                        <ListItemIcon>
+                          <Checkbox
+                            edge="start"
+                            className={classes.listItemCheckbox}
+                            checked={
+                              projComponentId ===
+                              selectedProjectComponent?.project_component_id
                             }
-                            secondary={
-                              (projectComponent?.moped_components
-                                ?.component_subtype ?? "") +
-                              [
-                                ...new Set(
-                                  projectComponent.moped_proj_components_subcomponents.map(
-                                    mpcs =>
-                                      mpcs.moped_subcomponent.subcomponent_name
-                                  )
-                                ),
-                              ]
-                                .sort()
-                                .join(", ")
-                            }
+                            tabIndex={-1}
+                            disableRipple
+                            inputProps={{ "aria-labelledby": null }}
                           />
-                          <ListItemSecondaryAction
-                            onClick={() => {
-                              handleComponentClick(projectComponent);
-                              handleComponentDetailsClick();
-                            }}
-                          >
-                            <IconButton edge="end" aria-label="comments">
-                              <ArrowForwardIos
-                                className={classes.listItemSecondaryAction}
-                              />
-                            </IconButton>
-                          </ListItemSecondaryAction>
-                        </ListItem>
-                      );
-                    }
-                  )}
-                </List>
-              </ClickAwayListener>
-            )}
-            {!componentsAvailable && (
-              <Alert severity="info">
-                There aren't any components for this project.
-              </Alert>
-            )}
-          </ProjectComponentsMapView>
-        </ErrorBoundary>
+                        </ListItemIcon>
+                        <ListItemText
+                          id={"mcListItemText-" + projComponentId}
+                          primary={
+                            projectComponent?.moped_components?.component_name
+                          }
+                          secondary={
+                            (projectComponent?.moped_components
+                              ?.component_subtype ?? "") +
+                            [
+                              ...new Set(
+                                projectComponent.moped_proj_components_subcomponents.map(
+                                  (mpcs) =>
+                                    mpcs.moped_subcomponent.subcomponent_name
+                                )
+                              ),
+                            ]
+                              .sort()
+                              .join(", ")
+                          }
+                        />
+                        <ListItemSecondaryAction
+                          onClick={() => {
+                            handleComponentClick(projectComponent);
+                            handleComponentDetailsClick();
+                          }}
+                        >
+                          <IconButton edge="end" aria-label="comments">
+                            <ArrowForwardIos
+                              className={classes.listItemSecondaryAction}
+                            />
+                          </IconButton>
+                        </ListItemSecondaryAction>
+                      </ListItem>
+                    );
+                  }
+                )}
+              </List>
+            </ClickAwayListener>
+          )}
+          {!componentsAvailable && (
+            <Alert severity="info">
+              There aren't any components for this project.
+            </Alert>
+          )}
+        </ProjectComponentsMapView>
       )}
     </ApolloErrorHandler>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -271,7 +271,6 @@ export default function TheMap({
       onMouseLeave={onMouseLeave}
       onMoveEnd={onMoveEnd}
       onClick={onClick}
-      boxZoom={false}
       cursor={cursor}
       mapStyle={basemaps[basemapKey].mapStyle}
       {...mapParameters}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -53,6 +53,7 @@ export const fitBoundsOptions = {
 export const mapParameters = {
   touchPitch: false,
   dragRotate: false,
+  boxZoom: false,
   maxBounds: [
     [-99, 29],
     [-96, 32],

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -2,6 +2,18 @@ import { useMemo } from "react";
 import { featureTableFieldMap } from "./makeFeatures";
 
 /**
+ * Take a project_geography record and return a valid GeoJSON feature
+ * TODO: We should look into returning GeoJSON features directly from the DB
+ * @param {Object} record - project_geography record from GET_PROJECT_COMPONENTS query
+ * @returns {Object} - GeoJSON feature
+ */
+export const makeFeatureFromProjectGeographyRecord = (record) => ({
+  type: "Feature",
+  properties: { ...record.attributes },
+  geometry: record.geometry,
+});
+
+/**
  * Create an object map of component feature collections by component id
  * Ex. { 1: { type: "FeatureCollection", features: [...] } }
  * @param {Object} data - data returned by GET_PROJECT_COMPONENTS query
@@ -15,12 +27,7 @@ export const useComponentFeatureCollectionsMap = (data) =>
 
     data.project_geography.forEach((component) => {
       const currentComponentId = component.component_id;
-
-      const currentFeature = {
-        type: "Feature",
-        properties: { ...component.attributes },
-        geometry: component.geometry,
-      };
+      const currentFeature = makeFeatureFromProjectGeographyRecord(component);
 
       if (!componentGeographyMap[currentComponentId]) {
         componentGeographyMap[currentComponentId] = {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -97,7 +97,8 @@ export const useZoomToExistingComponents = (mapRef, data) => {
   const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
 
   useEffect(() => {
-    if (!data || hasMapZoomedInitially) return;
+    if (!data) return;
+    if (hasMapZoomedInitially) return;
     if (!mapRef?.current) return;
 
     if (data.project_geography.length === 0) {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -97,8 +97,7 @@ export const useZoomToExistingComponents = (mapRef, data) => {
   const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
 
   useEffect(() => {
-    if (!data) return;
-    if (hasMapZoomedInitially) return;
+    if (!data || hasMapZoomedInitially) return;
     if (!mapRef?.current) return;
 
     if (data.project_geography.length === 0) {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -116,7 +116,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
   const { projectId } = useParams();
   const classes = useStyles();
 
-  const [mapError, setMapError] = useState(false);
   const [snackbarState, setSnackbarState] = useState(false);
 
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -8,11 +8,6 @@ import { createProjectFeatureCollection } from "src/utils/projectComponentHelper
 import { Grid, CardContent, CircularProgress } from "@material-ui/core";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
-/*
-  Error Handler and Fallback Component
-*/
-import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
-import { ErrorBoundary } from "react-error-boundary";
 import ProjectSummaryProjectEntity from "./ProjectSummaryProjectEntity";
 import ProjectSummaryProjectPartners from "./ProjectSummaryProjectPartners";
 
@@ -28,7 +23,6 @@ import ProjectSummaryWorkOrders from "./ProjectSummaryWorkOrders";
 import ProjectSummaryWorkAssignmentID from "./ProjectSummaryWorkAssignID";
 import ProjectSummaryInterimID from "./ProjectSummaryInterimID";
 
-import { countFeatures } from "../../../../utils/mapHelpers";
 import SubprojectsTable from "./SubprojectsTable";
 import TagsSection from "./TagsSection";
 
@@ -144,24 +138,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
   const projectComponents = data?.moped_project[0]?.moped_proj_components || [];
   const projectFeatureCollection =
     createProjectFeatureCollection(projectComponents);
-
-  const renderMap = () => {
-    if (countFeatures(projectFeatureCollection) < 1) {
-      return (
-        <ProjectSummaryMapFallback
-          projectId={projectId}
-          refetchProjectDetails={refetch}
-          mapData={projectFeatureCollection}
-        />
-      );
-    } else {
-      return (
-        <ProjectSummaryMap
-          projectFeatureCollection={projectFeatureCollection}
-        />
-      );
-    }
-  };
 
   return (
     <ApolloErrorHandler errors={error}>
@@ -294,20 +270,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                {/* {projectFeatureCollection && (
-                  <ErrorBoundary
-                    FallbackComponent={({ error }) => (
-                      <ProjectSummaryMapFallback
-                        error={error}
-                        mapData={projectFeatureCollection}
-                      />
-                    )}
-                    onReset={() => setMapError(false)}
-                    resetKeys={[mapError]}
-                  >
-                    {renderMap()}
-                  </ErrorBoundary>
-                )} */}
                 <ProjectSummaryMap
                   projectFeatureCollection={projectFeatureCollection}
                 />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -294,14 +294,11 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                {projectFeatureCollection && (
+                {/* {projectFeatureCollection && (
                   <ErrorBoundary
-                    FallbackComponent={({ error, resetErrorBoundary }) => (
+                    FallbackComponent={({ error }) => (
                       <ProjectSummaryMapFallback
                         error={error}
-                        resetErrorBoundary={resetErrorBoundary}
-                        projectId={projectId}
-                        refetchProjectDetails={refetch}
                         mapData={projectFeatureCollection}
                       />
                     )}
@@ -310,7 +307,10 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   >
                     {renderMap()}
                   </ErrorBoundary>
-                )}
+                )} */}
+                <ProjectSummaryMap
+                  projectFeatureCollection={projectFeatureCollection}
+                />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -3,7 +3,6 @@ import { useParams } from "react-router-dom";
 
 import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
-import { createProjectFeatureCollection } from "src/utils/projectComponentHelpers";
 
 import { Grid, CardContent, CircularProgress } from "@material-ui/core";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
@@ -133,10 +132,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
 
   if (loading) return <CircularProgress />;
   if (error) return `Error! ${error.message}`;
-
-  const projectComponents = data?.moped_project[0]?.moped_proj_components || [];
-  const projectFeatureCollection =
-    createProjectFeatureCollection(projectComponents);
 
   return (
     <ApolloErrorHandler errors={error}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -269,9 +269,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                <ProjectSummaryMap
-                  projectFeatureCollection={projectFeatureCollection}
-                />
+                <ProjectSummaryMap data={data} />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,6 +1,7 @@
 import React, { useRef, useCallback, useState } from "react";
 import Map, { NavigationControl } from "react-map-gl";
-import { Box, makeStyles } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
 import "mapbox-gl/dist/mapbox-gl.css";
 
 import {
@@ -53,49 +54,45 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   );
 
   /**
-   * Let's throw an error intentionally if there are no features for a project.
-   */
-  if (featureCount < 1) {
-    // Throw an error if this component was called without features to render.
-    throw Error("Map error: Cannot render or edit maps with no features");
-  }
-
-  /**
    * If we do have features, proceed to render map.
    */
   return (
     <Box>
-      <Map
-        /* Current state of viewport */
-        {...viewport}
-        /* Object reference to this object */
-        ref={mapRef}
-        maxZoom={20}
-        style={{ width: "100%", height: "60vh" }}
-        /* Access Key */
-        mapboxAccessToken={MAPBOX_TOKEN}
-        onRender={fitMapToFeatureCollectionOnRender}
-        /* Get the IDs from the layerConfigs object to set as interactive in the summary map */
-        /* If specified: Pointer event callbacks will only query the features under the pointer of these layers.
+      {featureCount > 1 ? (
+        <Map
+          /* Current state of viewport */
+          {...viewport}
+          /* Object reference to this object */
+          ref={mapRef}
+          maxZoom={20}
+          style={{ width: "100%", height: "60vh" }}
+          /* Access Key */
+          mapboxAccessToken={MAPBOX_TOKEN}
+          onRender={fitMapToFeatureCollectionOnRender}
+          /* Get the IDs from the layerConfigs object to set as interactive in the summary map */
+          /* If specified: Pointer event callbacks will only query the features under the pointer of these layers.
               The getCursor callback will receive isHovering: true when hover over features of these layers */
-        interactiveLayerIds={getSummaryMapInteractiveIds(
-          projectFeatureCollection
-        )}
-        /* Gets and sets data from a map feature used to populate and place a tooltip */
-        onMouseMove={handleLayerHover}
-        /* Updates state of viewport on zoom, scroll, and other events */
-        onMove={(e) => handleViewportChange(e.viewState)}
-        mapStyle={basemaps.streets}
-      >
-        {/* Draw Navigation controls with specific styles */}
-        <NavigationControl showCompass={false} position="bottom-right" />
-        {/*
+          interactiveLayerIds={getSummaryMapInteractiveIds(
+            projectFeatureCollection
+          )}
+          /* Gets and sets data from a map feature used to populate and place a tooltip */
+          onMouseMove={handleLayerHover}
+          /* Updates state of viewport on zoom, scroll, and other events */
+          onMove={(e) => handleViewportChange(e.viewState)}
+          mapStyle={basemaps.streets}
+        >
+          {/* Draw Navigation controls with specific styles */}
+          <NavigationControl showCompass={false} position="bottom-right" />
+          {/*
           If there is GeoJSON data, create sources and layers for
           each source layer in the project's GeoJSON FeatureCollection
         */}
-        {projectFeatureCollection &&
-          createSummaryMapLayers(projectFeatureCollection)}
-      </Map>
+          {projectFeatureCollection &&
+            createSummaryMapLayers(projectFeatureCollection)}
+        </Map>
+      ) : (
+        <ProjectSummaryMapFallback mapData={projectFeatureCollection} />
+      )}
     </Box>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -39,7 +39,7 @@ const ProjectSummaryMap = ({ data }) => {
       features: [],
     };
 
-    if (!data?.project_geography) return;
+    if (!data?.project_geography) return featureCollection;
 
     const projectGeographyGeoJSONFeatures = data.project_geography.map(
       (feature) => makeFeatureFromProjectGeographyRecord(feature)

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -63,6 +63,7 @@ const ProjectSummaryMap = ({ data }) => {
           style={{ width: "100%", height: "60vh" }}
           mapStyle={basemaps.streets.mapStyle}
           {...mapParameters}
+          cooperativeGestures={true}
         >
           <BasemapSpeedDial
             basemapKey={basemapKey}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useMemo } from "react";
 import MapGL from "react-map-gl";
 import { Box } from "@material-ui/core";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
@@ -10,23 +10,39 @@ import {
   mapParameters,
   initialViewState,
 } from "../ProjectComponents/mapSettings";
-import { countFeatures } from "../../../../utils/mapHelpers";
+import { makeFeatureFromProjectGeographyRecord } from "../ProjectComponents/utils/makeFeatureCollections";
 import "mapbox-gl/dist/mapbox-gl.css";
 
-const ProjectSummaryMap = ({ projectFeatureCollection }) => {
+const ProjectSummaryMap = ({ data }) => {
   const mapRef = useRef();
   const [basemapKey, setBasemapKey] = useState("streets");
+  console.log(data);
 
-  const featureCount = countFeatures(projectFeatureCollection);
+  const projectFeatureCollection = useMemo(() => {
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [],
+    };
+
+    if (!data?.project_geography) return;
+
+    const projectGeographyGeoJSONFeatures = data.project_geography.map(
+      (feature) => makeFeatureFromProjectGeographyRecord(feature)
+    );
+
+    return { ...featureCollection, features: projectGeographyGeoJSONFeatures };
+  }, [data]);
+
+  const areThereComponentFeatures =
+    projectFeatureCollection.features.length > 0;
 
   // TODO:
-  // 1. Add project geography to summary query? Or add here so we only fetch once?
   // 3. Use useZoomToExistingComponents hook to zoom to project geography
   // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
 
   return (
     <Box>
-      {featureCount > 1 ? (
+      {areThereComponentFeatures ? (
         <MapGL
           ref={mapRef}
           initialViewState={initialViewState}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -13,12 +13,6 @@ import {
 import { countFeatures } from "../../../../utils/mapHelpers";
 import "mapbox-gl/dist/mapbox-gl.css";
 
-// See https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
-import mapboxgl from "mapbox-gl";
-mapboxgl.workerClass =
-  // eslint-disable-next-line import/no-webpack-loader-syntax
-  require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
-
 const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   const mapRef = useRef();
   const [basemapKey, setBasemapKey] = useState("streets");

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,18 +1,20 @@
-import React, { useRef, useCallback, useState } from "react";
-import Map, { NavigationControl } from "react-map-gl";
+import React, { useRef } from "react";
+import MapGL from "react-map-gl";
 import { Box } from "@material-ui/core";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
+import {
+  basemaps,
+  mapParameters,
+  initialViewState,
+} from "../ProjectComponents/mapSettings";
+import { countFeatures } from "../../../../utils/mapHelpers";
 import "mapbox-gl/dist/mapbox-gl.css";
 
-import {
-  createSummaryMapLayers,
-  getSummaryMapInteractiveIds,
-  MAPBOX_TOKEN,
-  countFeatures,
-  useFeatureCollectionToFitBounds,
-  basemaps,
-  mapConfig,
-} from "../../../../utils/mapHelpers";
+// See https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
+import mapboxgl from "mapbox-gl";
+mapboxgl.workerClass =
+  // eslint-disable-next-line import/no-webpack-loader-syntax
+  require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
 
 const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   const mapRef = useRef();
@@ -25,62 +27,19 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
   // 5. Update map so it has same limitations as the project map (no zooming out past a certain point, etc)
 
-  const [viewport, setViewport] = useState(mapConfig.mapInit);
-  /**
-   * Make use of a custom hook that fits to a provided feature collection.
-   */
-  const { fitMapToFeatureCollectionOnRender } = useFeatureCollectionToFitBounds(
-    mapRef,
-    projectFeatureCollection,
-    true,
-    100
-  );
-
-  /**
-   * Updates viewport on zoom, scroll, and other events
-   * @param {Object} updatedViewPort - Mapbox object that stores properties of the map view
-   */
-  const handleViewportChange = useCallback(
-    (viewport) =>
-      setViewport((prevViewport) => ({ ...prevViewport, ...viewport })),
-    [setViewport]
-  );
-
   /**
    * If we do have features, proceed to render map.
    */
   return (
     <Box>
       {featureCount > 1 ? (
-        <Map
-          /* Current state of viewport */
-          {...viewport}
-          /* Object reference to this object */
+        <MapGL
           ref={mapRef}
-          maxZoom={20}
+          initialViewState={initialViewState}
           style={{ width: "100%", height: "60vh" }}
-          /* Access Key */
-          mapboxAccessToken={MAPBOX_TOKEN}
-          onRender={fitMapToFeatureCollectionOnRender}
-          /* Get the IDs from the layerConfigs object to set as interactive in the summary map */
-          /* If specified: Pointer event callbacks will only query the features under the pointer of these layers.
-              The getCursor callback will receive isHovering: true when hover over features of these layers */
-          interactiveLayerIds={getSummaryMapInteractiveIds(
-            projectFeatureCollection
-          )}
-          /* Updates state of viewport on zoom, scroll, and other events */
-          onMove={(e) => handleViewportChange(e.viewState)}
-          mapStyle={basemaps.streets}
-        >
-          {/* Draw Navigation controls with specific styles */}
-          <NavigationControl showCompass={false} position="bottom-right" />
-          {/*
-          If there is GeoJSON data, create sources and layers for
-          each source layer in the project's GeoJSON FeatureCollection
-        */}
-          {projectFeatureCollection &&
-            createSummaryMapLayers(projectFeatureCollection)}
-        </Map>
+          mapStyle={basemaps.streets.mapStyle}
+          {...mapParameters}
+        />
       ) : (
         <ProjectSummaryMapFallback mapData={projectFeatureCollection} />
       )}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -23,6 +23,7 @@ const useMapRef = () => {
   const [mapRefState, setMapRefState] = useState(null);
   const mapRef = useCallback((mapInstance) => {
     if (mapInstance !== null) {
+      // Store instance as the value of current just like a ref would
       setMapRefState({ current: mapInstance });
     }
   }, []);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -7,8 +7,6 @@ import {
   createSummaryMapLayers,
   getSummaryMapInteractiveIds,
   MAPBOX_TOKEN,
-  mapStyles,
-  renderTooltip,
   countFeatures,
   useHoverLayer,
   useFeatureCollectionToFitBounds,
@@ -16,16 +14,7 @@ import {
   mapConfig,
 } from "../../../../utils/mapHelpers";
 
-const useStyles = makeStyles({
-  locationCountText: {
-    fontSize: "0.875rem",
-    fontWeight: 500,
-  },
-  toolTip: mapStyles.toolTipStyles,
-});
-
 const ProjectSummaryMap = ({ projectFeatureCollection }) => {
-  const classes = useStyles();
   const mapRef = useRef();
   const featureCount = countFeatures(projectFeatureCollection);
 
@@ -106,8 +95,6 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
         */}
         {projectFeatureCollection &&
           createSummaryMapLayers(projectFeatureCollection)}
-        {/* Draw tooltip on feature hover */}
-        {renderTooltip(featureText, hoveredCoords, classes.toolTip)}
       </Map>
     </Box>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -29,6 +29,13 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   const mapRef = useRef();
   const featureCount = countFeatures(projectFeatureCollection);
 
+  // TODO:
+  // 1. Add project geography to summary query? Or add here so we only fetch once?
+  // 2. Update map to use the project
+  // 3. Use useZoomToExistingComponents hook to zoom to project geography
+  // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
+  // 5. Update map so it has same limitations as the project map (no zooming out past a certain point, etc)
+
   /**
    * Make use of a custom hook that returns a vector tile layer hover event handler
    * and the details to place and populate a tooltip.

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,8 +1,10 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import MapGL from "react-map-gl";
 import { Box } from "@material-ui/core";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
-import ProjectSourcesAndLayers from "../ProjectComponents/ProjectSourcesAndLayers";
+import BaseMapSourceAndLayers from "../ProjectComponents/BaseMapSourceAndLayers";
+import BasemapSpeedDial from "../ProjectComponents/BasemapSpeedDial";
+import ProjectSummaryMapSourcesAndLayers from "./ProjectSummaryMapSourcesAndLayers";
 import {
   basemaps,
   mapParameters,
@@ -19,18 +21,15 @@ mapboxgl.workerClass =
 
 const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   const mapRef = useRef();
+  const [basemapKey, setBasemapKey] = useState("streets");
+
   const featureCount = countFeatures(projectFeatureCollection);
 
   // TODO:
   // 1. Add project geography to summary query? Or add here so we only fetch once?
-  // 2. Update map to use the project geography
   // 3. Use useZoomToExistingComponents hook to zoom to project geography
   // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
-  // 5. Update map so it has same limitations as the project map (no zooming out past a certain point, etc)
 
-  /**
-   * If we do have features, proceed to render map.
-   */
   return (
     <Box>
       {featureCount > 1 ? (
@@ -41,16 +40,13 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
           mapStyle={basemaps.streets.mapStyle}
           {...mapParameters}
         >
-          <ProjectSourcesAndLayers
-            isCreatingComponent={isCreatingComponent}
-            isEditingComponent={isEditingComponent}
-            isDrawing={isDrawing}
-            linkMode={linkMode}
-            clickedComponent={clickedComponent}
-            projectComponentsFeatureCollection={
-              projectComponentsFeatureCollection
-            }
-            draftEditComponent={draftEditComponent}
+          <BasemapSpeedDial
+            basemapKey={basemapKey}
+            setBasemapKey={setBasemapKey}
+          />
+          <BaseMapSourceAndLayers basemapKey={basemapKey} />
+          <ProjectSummaryMapSourcesAndLayers
+            projectFeatureCollection={projectFeatureCollection}
           />
         </MapGL>
       ) : (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -9,7 +9,6 @@ import {
   getSummaryMapInteractiveIds,
   MAPBOX_TOKEN,
   countFeatures,
-  useHoverLayer,
   useFeatureCollectionToFitBounds,
   basemaps,
   mapConfig,
@@ -25,12 +24,6 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
   // 3. Use useZoomToExistingComponents hook to zoom to project geography
   // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
   // 5. Update map so it has same limitations as the project map (no zooming out past a certain point, etc)
-
-  /**
-   * Make use of a custom hook that returns a vector tile layer hover event handler
-   * and the details to place and populate a tooltip.
-   */
-  const { handleLayerHover, featureText, hoveredCoords } = useHoverLayer();
 
   const [viewport, setViewport] = useState(mapConfig.mapInit);
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -20,7 +20,7 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
 
   // TODO:
   // 1. Add project geography to summary query? Or add here so we only fetch once?
-  // 2. Update map to use the project
+  // 2. Update map to use the project geography
   // 3. Use useZoomToExistingComponents hook to zoom to project geography
   // 4. Update useZoomToExistingComponents to take project geography as a arg instead of data
   // 5. Update map so it has same limitations as the project map (no zooming out past a certain point, etc)
@@ -68,8 +68,6 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
           interactiveLayerIds={getSummaryMapInteractiveIds(
             projectFeatureCollection
           )}
-          /* Gets and sets data from a map feature used to populate and place a tooltip */
-          onMouseMove={handleLayerHover}
           /* Updates state of viewport on zoom, scroll, and other events */
           onMove={(e) => handleViewportChange(e.viewState)}
           mapStyle={basemaps.streets}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import MapGL from "react-map-gl";
 import { Box } from "@material-ui/core";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
+import ProjectSourcesAndLayers from "../ProjectComponents/ProjectSourcesAndLayers";
 import {
   basemaps,
   mapParameters,
@@ -39,7 +40,19 @@ const ProjectSummaryMap = ({ projectFeatureCollection }) => {
           style={{ width: "100%", height: "60vh" }}
           mapStyle={basemaps.streets.mapStyle}
           {...mapParameters}
-        />
+        >
+          <ProjectSourcesAndLayers
+            isCreatingComponent={isCreatingComponent}
+            isEditingComponent={isEditingComponent}
+            isDrawing={isDrawing}
+            linkMode={linkMode}
+            clickedComponent={clickedComponent}
+            projectComponentsFeatureCollection={
+              projectComponentsFeatureCollection
+            }
+            draftEditComponent={draftEditComponent}
+          />
+        </MapGL>
       ) : (
         <ProjectSummaryMapFallback mapData={projectFeatureCollection} />
       )}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
@@ -4,7 +4,7 @@ import { Box, Button, Card, makeStyles } from "@material-ui/core";
 
 import { Link } from "react-router-dom";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     fontSize: "0.875rem",
     fontWeight: 500,
@@ -41,24 +41,17 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Renders a fallback component that shows the user whenever there is a map error.
- * @param {object} error - provided by ErrorBoundary component, contains error details.
  * @param {object} mapData - The map data with errors to show in the console for debugging
  * @return {JSX.Element}
  * @constructor
  */
-const ProjectSummaryMapFallback = ({ error, mapData }) => {
+const ProjectSummaryMapFallback = () => {
   const classes = useStyles();
-
-  /**
-   * Log whatever error there may be
-   */
-  console.debug("MapDataError: ", error);
-  console.debug("MapData: ", mapData);
 
   return (
     <Box>
       <Card className={classes.card} color="secondary">
-        <img 
+        <img
           className={classes.mapPlaceholderImg}
           alt="Map Unavailable"
           src={`${process.env.PUBLIC_URL}/static/images/map_unavailable.png`}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapFallback.js
@@ -40,8 +40,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
- * Renders a fallback component that shows the user whenever there is a map error.
- * @param {object} mapData - The map data with errors to show in the console for debugging
+ * Renders a fallback component
  * @return {JSX.Element}
  * @constructor
  */

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
@@ -1,22 +1,16 @@
 import { Source, Layer } from "react-map-gl";
-import { MAP_STYLES } from "./mapStyleSettings";
+import { MAP_STYLES } from "../ProjectComponents/mapStyleSettings";
 import { useFeatureTypes } from "../ProjectComponents/utils/map";
 
 /**
  * Component that renders feature collection of all components features in a project
  * All layers are set to show below basemap street labels using beforeId = "street-labels"
- * @param {Object} projectComponentsFeatureCollection - GeoJSON feature collection with all project features
+ * @param {Object} projectFeatureCollection - GeoJSON feature collection with all project features
  * @returns JSX.Element
  */
-const ProjectSourcesAndLayers = ({ projectComponentsFeatureCollection }) => {
-  const projectLines = useFeatureTypes(
-    projectComponentsFeatureCollection,
-    "line"
-  );
-  const projectPoints = useFeatureTypes(
-    projectComponentsFeatureCollection,
-    "point"
-  );
+const ProjectSummaryMapSourcesAndLayers = ({ projectFeatureCollection }) => {
+  const projectLines = useFeatureTypes(projectFeatureCollection, "line");
+  const projectPoints = useFeatureTypes(projectFeatureCollection, "point");
 
   return (
     <>
@@ -47,4 +41,4 @@ const ProjectSourcesAndLayers = ({ projectComponentsFeatureCollection }) => {
   );
 };
 
-export default ProjectSourcesAndLayers;
+export default ProjectSummaryMapSourcesAndLayers;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
@@ -1,0 +1,50 @@
+import { Source, Layer } from "react-map-gl";
+import { MAP_STYLES } from "./mapStyleSettings";
+import { useFeatureTypes } from "../ProjectComponents/utils/map";
+
+/**
+ * Component that renders feature collection of all components features in a project
+ * All layers are set to show below basemap street labels using beforeId = "street-labels"
+ * @param {Object} projectComponentsFeatureCollection - GeoJSON feature collection with all project features
+ * @returns JSX.Element
+ */
+const ProjectSourcesAndLayers = ({ projectComponentsFeatureCollection }) => {
+  const projectLines = useFeatureTypes(
+    projectComponentsFeatureCollection,
+    "line"
+  );
+  const projectPoints = useFeatureTypes(
+    projectComponentsFeatureCollection,
+    "point"
+  );
+
+  return (
+    <>
+      <Source
+        id="project-lines"
+        type="geojson"
+        data={projectLines}
+        promoteId="id"
+      >
+        <Layer
+          beforeId="street-labels"
+          {...MAP_STYLES["project-lines"].layerProps}
+        />
+      </Source>
+
+      <Source
+        id="project-points"
+        type="geojson"
+        data={projectPoints}
+        promoteId="id"
+      >
+        <Layer
+          beforeId="street-labels"
+          {...MAP_STYLES["project-points"].layerProps}
+        />
+      </Source>
+    </>
+  );
+};
+
+export default ProjectSourcesAndLayers;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
@@ -12,8 +12,6 @@ const ProjectSummaryMapSourcesAndLayers = ({ projectFeatureCollection }) => {
   const projectLines = useFeatureTypes(projectFeatureCollection, "line");
   const projectPoints = useFeatureTypes(projectFeatureCollection, "point");
 
-  console.log("projectLines", projectLines);
-
   return (
     <>
       <Source

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMapSourcesAndLayers.js
@@ -12,6 +12,8 @@ const ProjectSummaryMapSourcesAndLayers = ({ projectFeatureCollection }) => {
   const projectLines = useFeatureTypes(projectFeatureCollection, "line");
   const projectPoints = useFeatureTypes(projectFeatureCollection, "point");
 
+  console.log("projectLines", projectLines);
+
   return (
     <>
       <Source


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/10995
https://github.com/cityofaustin/atd-data-tech/issues/10689

This PR updates the project summary map to show features that come from the `project_geography` view. I also updated the map to use some of the same config and patterns as the components map. I removed the `ErrorBoundary` component from the summary view since it isn't a pattern that we've used elsewhere in the app. Definitely up for debate because having those can be handy, but I think that if we remove it then I should remove the package for it as well.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local or https://md-10995-summary-map--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Create a new project and, when you reach the summary page, notice that the fallback component with the map and scooter are showing instead of the summary map'
2. Click the "Add Components" button in the fallback and use the map to add some components with features of point and line type
3. Go back to the summary page, and you should see all of the component features that you added and the map should zoom to them just like in the components map
4. Try out the speed dial selector in the bottom right of the summary map and switch between street and aerial

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
