### PR TITLE
Repairs db-docs build action

### DIFF
--- a/moped-database/schemaspy/generate-pk-map.py
+++ b/moped-database/schemaspy/generate-pk-map.py
@@ -14,7 +14,8 @@ def make_update() -> dict:
         url="http://localhost:8080/v1/query",
         headers={
             "Accept": "*/*",
-            "content-type": "application/json"
+            "content-type": "application/json",
+            "X-Hasura-Admin-Secret": "hasurapassword",
         },
         json={
             "type": "run_sql",


### PR DESCRIPTION
Our DB docs github action is failing. Technically, the docs are actually being deployed successfully, but the secondary step of generating a primary key map is failing, here: https://github.com/cityofaustin/atd-moped/actions/runs/3802004783/jobs/6467061851.

Note that we'll be able to deprecate this primary key map once we completely migrate our activity log to REST connectors.

## Associated issues
- None :/ 

## Testing
**URL to test:** Local

**Steps to test:**
1. Start the Hasura cluster
2. From a python environment with `requests` installed, run the python script

```shell
# moped-database/schemaspy/
$ python generate-pk-map.py
```
3. The script will print a JSON string of all Moped table names with each table's primary key column name.

```python
{"moped_activity_log": "activity_id", "moped_city_fiscal_years": "id", "moped_components": "component_id", "moped_department": "department_id", "moped_entity": "entity_id", "moped_fund_programs": "funding_program_id", "moped_fund_sources": "funding_source_id", "moped_fund_status": "funding_status_id", "moped_funds": "id", "moped_milestones": "milestone_id", "moped_organization": "organization_id", "moped_phases": "phase_id", "moped_proj_components": "project_component_id", "moped_proj_components_subcomponents": "component_subcomponent_id", "moped_proj_contract": "id", "moped_proj_entities": "entity_list_id", "moped_proj_features": "feature_id", "moped_proj_financials": "financials_id", "moped_proj_fiscal_years": "id", "moped_proj_funding": "proj_funding_id", "moped_proj_milestones": "project_milestone_id", "moped_proj_notes": "project_note_id", "moped_proj_partners": "proj_partner_id", "moped_proj_personnel": "project_personnel_id", "moped_proj_personnel_roles": "id", "moped_proj_phases": "project_phase_id", "moped_proj_tags": "id", "moped_project": "project_id", "moped_project_files": "project_file_id", "moped_project_roles": "project_role_id", "moped_project_types": "id", "moped_subcomponents": "subcomponent_id", "moped_subphases": "subphase_id", "moped_tags": "id", "moped_types": "type_id", "moped_user_followed_projects": "id", "moped_users": "user_id", "moped_workgroup": "workgroup_id"}
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
