### PR TITLE
Normalize project notes author tracking

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2503,6 +2503,13 @@
 - table:
     name: moped_proj_notes
     schema: public
+  object_relationships:
+    - name: moped_project
+      using:
+        foreign_key_constraint_on: project_id
+    - name: moped_user
+      using:
+        foreign_key_constraint_on: added_by_user_id
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-database/migrations/1672415599589_set_note_added_by_user_id/down.sql
+++ b/moped-database/migrations/1672415599589_set_note_added_by_user_id/down.sql
@@ -1,0 +1,2 @@
+-- we can't undo this migration
+select 0;

--- a/moped-database/migrations/1672415599589_set_note_added_by_user_id/up.sql
+++ b/moped-database/migrations/1672415599589_set_note_added_by_user_id/up.sql
@@ -1,0 +1,7 @@
+UPDATE moped_proj_notes
+SET added_by_user_id = moped_users.user_id
+FROM moped_users 
+WHERE
+    added_by_user_id = 1
+    AND
+    moped_proj_notes.added_by = moped_users.first_name || ' ' || moped_users.last_name;

--- a/moped-database/migrations/1672420074371_set_fk_public_moped_proj_notes_added_by_user_id/down.sql
+++ b/moped-database/migrations/1672420074371_set_fk_public_moped_proj_notes_added_by_user_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_proj_notes" drop constraint "moped_proj_notes_added_by_user_id_fkey";

--- a/moped-database/migrations/1672420074371_set_fk_public_moped_proj_notes_added_by_user_id/up.sql
+++ b/moped-database/migrations/1672420074371_set_fk_public_moped_proj_notes_added_by_user_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_proj_notes"
+  add constraint "moped_proj_notes_added_by_user_id_fkey"
+  foreign key ("added_by_user_id")
+  references "public"."moped_users"
+  ("user_id") on update cascade on delete set null;

--- a/moped-editor/src/queries/comments.js
+++ b/moped-editor/src/queries/comments.js
@@ -6,8 +6,10 @@ export const COMMENTS_QUERY = gql`
       where: $projectNoteConditions
       order_by: { date_created: desc }
     ) {
-      added_by
-      added_by_user_id
+      moped_user {
+        first_name
+        last_name
+      }
       project_note
       project_id
       date_created

--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -28,7 +28,10 @@ export const DASHBOARD_QUERY = gql`
           where: { project_note_type: { _eq: 2 }, is_deleted: { _eq: false } }
           order_by: { date_created: desc }
         ) {
-          added_by
+          moped_user {
+            first_name
+            last_name
+          }
           project_note_type
           project_note
         }

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -60,8 +60,10 @@ export const SUMMARY_QUERY = gql`
       ) {
         project_note_id
         project_note
-        added_by
-        added_by_user_id
+        moped_user {
+          first_name
+          last_name
+        }
         date_created
       }
       moped_project_types(where: { is_deleted: { _eq: false } }) {
@@ -692,28 +694,6 @@ export const PROJECT_SUMMARY_STATUS_UPDATE_INSERT = gql`
     insert_moped_proj_notes(objects: $statusUpdate) {
       affected_rows
       __typename
-    }
-  }
-`;
-
-/**
- * Updates the status update
- */
-export const PROJECT_SUMMARY_STATUS_UPDATE_UPDATE = gql`
-  mutation ProjectStatusUpdateUpdate(
-    $project_note_id: Int_comparison_exp = {}
-    $project_note: String = ""
-    $added_by: bpchar = ""
-  ) {
-    update_moped_proj_notes(
-      where: { project_note_id: $project_note_id }
-      _set: {
-        project_note: $project_note
-        added_by: $added_by
-        project_note_type: 2
-      }
-    ) {
-      affected_rows
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -175,7 +175,6 @@ const ProjectComments = (props) => {
       variables: {
         objects: [
           {
-            added_by: getUserFullName(userSessionData),
             project_note: DOMPurify.sanitize(noteText),
             project_id: projectId,
             added_by_user_id: Number(userSessionData.user_id),
@@ -342,7 +341,7 @@ const ProjectComments = (props) => {
                                   component={"span"}
                                   className={classes.commentorText}
                                 >
-                                  {item.added_by}
+                                  {getUserFullName(item.moped_user)}
                                 </Typography>
                                 <Typography
                                   component={"span"}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -5,6 +5,7 @@ import parse from "html-react-parser";
 
 import { makeUSExpandedFormDateFromTimeStampTZ } from "../../../../utils/dateAndTime";
 import DashboardStatusModal from "src/views/dashboard/DashboardStatusModal";
+import { getUserFullName } from "src/utils/userNames";
 
 /**
  * ProjectSummaryStatusUpdate Component
@@ -18,7 +19,9 @@ import DashboardStatusModal from "src/views/dashboard/DashboardStatusModal";
 const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const statusUpdate = data.moped_project[0].moped_proj_notes[0]?.project_note;
   const projectName = data.moped_project[0].project_name;
-  const addedBy = data.moped_project[0].moped_proj_notes[0]?.added_by;
+  const addedByUser = data.moped_project[0].moped_proj_notes[0]?.moped_user;
+  const addedBy = getUserFullName(addedByUser);
+
   const dateCreated = makeUSExpandedFormDateFromTimeStampTZ(
     data.moped_project[0].moped_proj_notes[0]?.date_created
   ).toUpperCase();


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/9644

Here's another patch I want to get squared away ahead of the access migration.

## Testing
**URL to test:** Local only 

**Steps to test:**

To test the migrations:

1. Follow all the steps to [load production](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-MIQvl_rKnZ_-wHRdp4J/dev-guides/how-tos/how-to-load-production-data-into-a-local-instance) data into your local instance.
2. Connect to the prod read replica, and observe that `added_by_user_text` and  `added_by_user_name` do not match when you run this query:

```sql
select mpn.project_note_id, mpn.date_created, mpn.added_by as added_by_user_text, mu.first_name || ' ' || mu.last_name as added_by_user_name
from moped_proj_notes mpn
left join moped_users mu on mpn.added_by_user_id = mu.user_id
where mpn.date_created < '2022-07-15';
```

3. Run the same query against your local instance. in all cases, `added_by_user_text` should match `added_by_user_name`. The migrations were successful!

You will not be able to test the Moped editor after loading in production data, because our local user (id = 1) does not exist in the production database that you replicated locally. You'll receive an error if you try to create a new comment or status update.

To test the editor:

1. Stop the hasura cluster and start it again.

2. Start the Moped Editor. Inspect comments and status update to verify the comment author name is rendering correctly. 

3. Create and edit comments as well. You should do this in these places:

- Project comments tab
- Project summary status update
- Status update column from the Dashboard page

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
