### PR TITLE
Fix simultaneous draw and select on component create and reset `isDraw` state on create/edit cancel

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -61,12 +61,13 @@ export default function TheMap({
   linkMode,
   setIsFetchingFeatures,
   featureCollectionsByComponentId,
+  isDrawing,
+  setIsDrawing,
 }) {
   const [cursor, setCursor] = useState("grab");
 
   const [bounds, setBounds] = useState();
   const [basemapKey, setBasemapKey] = useState("streets");
-  const [isDrawing, setIsDrawing] = useState(false);
   const projectComponentsFeatureCollection =
     useAllComponentsFeatureCollection(components);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -79,6 +79,9 @@ export default function MapView({ projectName, projectStatuses }) {
   /* tracks the loading state of AGOL feature service fetching */
   const [isFetchingFeatures, setIsFetchingFeatures] = useState(false);
 
+  /* tracks the drawing state of the map */
+  const [isDrawing, setIsDrawing] = useState(false);
+
   const {
     data,
     refetch: refetchProjectComponents,
@@ -109,6 +112,7 @@ export default function MapView({ projectName, projectStatuses }) {
     setClickedComponent,
     setLinkMode,
     refetchProjectComponents,
+    setIsDrawing,
   });
 
   const {
@@ -124,6 +128,7 @@ export default function MapView({ projectName, projectStatuses }) {
     setClickedComponent,
     setLinkMode,
     refetchProjectComponents,
+    setIsDrawing,
   });
 
   const { isDeletingComponent, setIsDeletingComponent, onDeleteComponent } =

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -266,6 +266,8 @@ export default function MapView({ projectName, projectStatuses }) {
               setIsFetchingFeatures={setIsFetchingFeatures}
               linkMode={linkMode}
               featureCollectionsByComponentId={featureCollectionsByComponentId}
+              isDrawing={isDrawing}
+              setIsDrawing={setIsDrawing}
             />
           </div>
           <CreateComponentModal

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
@@ -129,6 +129,7 @@ export const useCreateComponent = ({
   setClickedComponent,
   setLinkMode,
   refetchProjectComponents,
+  setIsDrawing,
 }) => {
   const [createState, createDispatch] = useReducer(createReducer, {
     isCreatingComponent: false,
@@ -146,6 +147,7 @@ export const useCreateComponent = ({
   const onCancelComponentCreate = () => {
     createDispatch({ type: "cancel_create" });
     setLinkMode(null);
+    setIsDrawing(false);
   };
 
   const onSaveDraftComponent = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
@@ -53,6 +53,7 @@ const createReducer = (state, action) => {
       };
     case "add_drawn_features":
       const newDrawnFeatures = action.payload;
+
       const featuresWithAdditions = [
         ...state.draftComponent.features,
         ...newDrawnFeatures,
@@ -63,7 +64,11 @@ const createReducer = (state, action) => {
         features: [...state.draftComponent.features, ...newDrawnFeatures],
       };
 
-      action.callback(featuresWithAdditions);
+      // We only want drawn features to be fed into the map draw tools
+      const drawToolsFeatureOverrides = featuresWithAdditions.filter(
+        (feature) => getDrawId(feature)
+      );
+      action.callback(drawToolsFeatureOverrides);
 
       return { ...state, draftComponent: newDraftComponent };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -222,6 +222,7 @@ export const useUpdateComponent = ({
   setClickedComponent,
   setLinkMode,
   refetchProjectComponents,
+  setIsDrawing,
 }) => {
   const [editState, editDispatch] = useReducer(editReducer, {
     isEditingComponent: false,
@@ -410,6 +411,7 @@ export const useUpdateComponent = ({
   const onCancelComponentMapEdit = () => {
     editDispatch({ type: "cancel_map_edit" });
     setLinkMode(null);
+    setIsDrawing(false);
   };
 
   return {


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11053
https://github.com/cityofaustin/atd-data-tech/issues/10865

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
preview link on the way or local

**Steps to test:**
TBD

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
