### PR TITLE
Adds DB support for public process status

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3970,6 +3970,31 @@
         - name: MOPED_API_EVENT_NAME
           value: activity_log
 - table:
+    name: moped_public_process_status
+    schema: public
+  select_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - id
+          - slug
+          - name
+        filter: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - id
+          - slug
+          - name
+        filter: {}
+    - role: moped-viewer
+      permission:
+        columns:
+          - id
+          - slug
+          - name
+        filter: {}
+- table:
     name: moped_subcomponents
     schema: public
   insert_permissions:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3345,6 +3345,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
     - role: moped-editor
       permission:
         check: {}
@@ -3376,6 +3377,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
   select_permissions:
     - role: moped-admin
       permission:
@@ -3407,6 +3409,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
         filter: {}
         allow_aggregations: true
     - role: moped-editor
@@ -3439,6 +3442,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
@@ -3471,6 +3475,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
         filter: {}
         allow_aggregations: true
   update_permissions:
@@ -3504,6 +3509,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
         filter: {}
         check: {}
     - role: moped-editor
@@ -3536,6 +3542,7 @@
           - updated_at
           - project_uuid
           - is_deleted
+          - public_process_status_id
         filter: {}
         check: {}
   event_triggers:

--- a/moped-database/migrations/1672774236734_create_table_public_moped_public_process_status/down.sql
+++ b/moped-database/migrations/1672774236734_create_table_public_moped_public_process_status/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."moped_public_process_status";

--- a/moped-database/migrations/1672774236734_create_table_public_moped_public_process_status/up.sql
+++ b/moped-database/migrations/1672774236734_create_table_public_moped_public_process_status/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "public"."moped_public_process_status" ("id" serial NOT NULL, "name" text NOT NULL UNIQUE, "slug" text NOT NULL UNIQUE, PRIMARY KEY ("id") );COMMENT ON TABLE "public"."moped_public_process_status" IS E'lookup table of public process statuses';

--- a/moped-database/migrations/1672776463774_insert_public_process_statuses/down.sql
+++ b/moped-database/migrations/1672776463774_insert_public_process_statuses/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM moped_public_process_status where 1=1;

--- a/moped-database/migrations/1672776463774_insert_public_process_statuses/up.sql
+++ b/moped-database/migrations/1672776463774_insert_public_process_statuses/up.sql
@@ -1,0 +1,6 @@
+INSERT INTO moped_public_process_status (name, slug) VALUES 
+    ('Unknown', 'unknown'),
+    ('Needed', 'needed'),
+    ('Not needed', 'not_needed'),
+    ('In progress', 'in_progress'),
+    ('Complete', 'complete');

--- a/moped-database/migrations/1672776840767_alter_table_public_moped_project_add_column_public_process_status_id/down.sql
+++ b/moped-database/migrations/1672776840767_alter_table_public_moped_project_add_column_public_process_status_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_project" drop column "public_process_status_id" cascade;

--- a/moped-database/migrations/1672776840767_alter_table_public_moped_project_add_column_public_process_status_id/up.sql
+++ b/moped-database/migrations/1672776840767_alter_table_public_moped_project_add_column_public_process_status_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."moped_project" add column "public_process_status_id" integer
+ not null default '1';

--- a/moped-database/migrations/1672776894714_set_fk_public_moped_project_public_process_status_id/down.sql
+++ b/moped-database/migrations/1672776894714_set_fk_public_moped_project_public_process_status_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_project" drop constraint "moped_project_public_process_status_id_fkey";

--- a/moped-database/migrations/1672776894714_set_fk_public_moped_project_public_process_status_id/up.sql
+++ b/moped-database/migrations/1672776894714_set_fk_public_moped_project_public_process_status_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_project"
+  add constraint "moped_project_public_process_status_id_fkey"
+  foreign key ("public_process_status_id")
+  references "public"."moped_public_process_status"
+  ("id") on update set null on delete set null;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11096

This PR implements DB support for tracking public process status in Moped. There is an [epic issue](https://github.com/cityofaustin/atd-data-tech/issues/10832) which captures the front-end Editor work which is outside the scope of this PR.

This is not WIP, but I'd like to hold off on merging until we get MUG feedback.

## Testing
**URL to test:** local

**Steps to test:**
1. Start the hasura cluster
2. Navigate to `localhost:8080` and observe the `moped_public_process_status` table with the following records:

```
id, name, key
1, Unknown, unknown
2, Needed, needed
3, Not needed, not_needed
4, In progress, in_progress
5, Complete, complete
```
3. Navigate to the `moped_project` table and observe all three seed records are populated with the default value `1` for the `public_process_status_id` column.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
