### PR TITLE
relates project notes to current phase and displays badge

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2512,6 +2512,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2524,6 +2525,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2536,6 +2538,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2549,6 +2552,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2562,6 +2566,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2576,6 +2581,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id
@@ -2589,6 +2595,7 @@
           - added_by_user_id
           - date_created
           - is_deleted
+          - phase_id
           - project_id
           - project_note
           - project_note_id

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2503,6 +2503,16 @@
 - table:
     name: moped_proj_notes
     schema: public
+  object_relationships:
+    - name: moped_phases
+      using:
+        manual_configuration:
+          column_mapping:
+            phase_id: phase_id
+          insertion_order: null
+          remote_table:
+            name: moped_phases
+            schema: public
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2504,15 +2504,9 @@
     name: moped_proj_notes
     schema: public
   object_relationships:
-    - name: moped_phases
+    - name: moped_phase
       using:
-        manual_configuration:
-          column_mapping:
-            phase_id: phase_id
-          insertion_order: null
-          remote_table:
-            name: moped_phases
-            schema: public
+        foreign_key_constraint_on: phase_id
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
+++ b/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
@@ -1,2 +1,2 @@
--- drop phase_id from moped_proj_notes table
+-- drop phase_id from moped_proj_notes
 alter table "public"."moped_proj_notes" drop column "phase_id" cascade;

--- a/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
+++ b/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
@@ -1,4 +1,2 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."moped_proj_notes" add column "phase_id" integer
---  null;
+-- drop phase_id from moped_proj_notes table
+alter table "public"."moped_proj_notes" drop column "phase_id" cascade;

--- a/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
+++ b/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."moped_proj_notes" add column "phase_id" integer
+--  null;

--- a/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/up.sql
+++ b/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/up.sql
@@ -1,2 +1,3 @@
+-- add nullable phase_id column of type integer to moped_proj_notes
 alter table "public"."moped_proj_notes" add column "phase_id" integer
  null;

--- a/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/up.sql
+++ b/moped-database/migrations/1672772477585_alter_table_public_moped_proj_notes_add_column_phase_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."moped_proj_notes" add column "phase_id" integer
+ null;

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/down.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_proj_notes" drop constraint "moped_proj_notes_phase_id_fkey";

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/down.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/down.sql
@@ -1,1 +1,2 @@
+-- drop foreign key constraint on moped_proj_notes phase_id
 alter table "public"."moped_proj_notes" drop constraint "moped_proj_notes_phase_id_fkey";

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
@@ -1,3 +1,4 @@
+-- create foreign key relationship between moped_proj_notes and moped_phases on phase_id
 alter table "public"."moped_proj_notes"
   add constraint "moped_proj_notes_phase_id_fkey"
   foreign key ("phase_id")

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
@@ -3,4 +3,4 @@ alter table "public"."moped_proj_notes"
   add constraint "moped_proj_notes_phase_id_fkey"
   foreign key ("phase_id")
   references "public"."moped_phases"
-  ("phase_id") on update cascade;
+  ("phase_id") on update cascade on delete set null;

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."moped_proj_notes"
+  add constraint "moped_proj_notes_phase_id_fkey"
+  foreign key ("phase_id")
+  references "public"."moped_phases"
+  ("phase_id") on update cascade on delete cascade;

--- a/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
+++ b/moped-database/migrations/1672851579949_set_fk_public_moped_proj_notes_phase_id/up.sql
@@ -3,4 +3,4 @@ alter table "public"."moped_proj_notes"
   add constraint "moped_proj_notes_phase_id_fkey"
   foreign key ("phase_id")
   references "public"."moped_phases"
-  ("phase_id") on update cascade on delete cascade;
+  ("phase_id") on update cascade;

--- a/moped-editor/src/queries/comments.js
+++ b/moped-editor/src/queries/comments.js
@@ -14,6 +14,9 @@ export const COMMENTS_QUERY = gql`
       project_note_id
       project_note_type
       is_deleted
+      moped_phases {
+        phase_name
+      }
     }
   }
 `;

--- a/moped-editor/src/queries/comments.js
+++ b/moped-editor/src/queries/comments.js
@@ -15,6 +15,7 @@ export const COMMENTS_QUERY = gql`
       project_note_type
       is_deleted
       moped_phases {
+        phase_key
         phase_name
       }
     }

--- a/moped-editor/src/queries/comments.js
+++ b/moped-editor/src/queries/comments.js
@@ -14,7 +14,7 @@ export const COMMENTS_QUERY = gql`
       project_note_id
       project_note_type
       is_deleted
-      moped_phases {
+      moped_phase {
         phase_key
         phase_name
       }

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -81,6 +81,7 @@ export const SUMMARY_QUERY = gql`
       }
       moped_proj_phases(where: { is_current_phase: { _eq: true } }) {
         moped_phase {
+          phase_id
           phase_name
           phase_key
         }

--- a/moped-editor/src/views/dashboard/DashboardStatusModal.js
+++ b/moped-editor/src/views/dashboard/DashboardStatusModal.js
@@ -15,7 +15,7 @@ import ProjectComments from "../projects/projectView/ProjectComments";
 const DashboardStatusModal = ({
   projectId,
   projectName,
-  data,
+  currentPhaseId,
   modalParent,
   statusUpdate,
   queryRefetch,
@@ -68,7 +68,7 @@ const DashboardStatusModal = ({
           <ProjectComments
             modal
             projectId={projectId}
-            data={data}
+            currentPhaseId={currentPhaseId}
             closeModalDialog={handleDialogClose}
           />
         </DialogContent>

--- a/moped-editor/src/views/dashboard/DashboardStatusModal.js
+++ b/moped-editor/src/views/dashboard/DashboardStatusModal.js
@@ -15,6 +15,7 @@ import ProjectComments from "../projects/projectView/ProjectComments";
 const DashboardStatusModal = ({
   projectId,
   projectName,
+  data,
   modalParent,
   statusUpdate,
   queryRefetch,
@@ -67,6 +68,7 @@ const DashboardStatusModal = ({
           <ProjectComments
             modal
             projectId={projectId}
+            data={data}
             closeModalDialog={handleDialogClose}
           />
         </DialogContent>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -370,8 +370,8 @@ const ProjectComments = (props) => {
                                   component={"span"}
                                 >
                                   <ProjectStatusBadge
-                                    phaseKey={mopedProjNotes[i].moped_phases.phase_key}
-                                    phaseName={mopedProjNotes[i].moped_phases.phase_name}
+                                    phaseKey={mopedProjNotes[i]?.moped_phases.phase_key}
+                                    phaseName={mopedProjNotes[i]?.moped_phases.phase_name}
                                     comment
                                   />
                                 </Typography>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -123,6 +123,7 @@ const ProjectComments = (props) => {
   });
 
   const mopedProjNotes = data?.moped_proj_notes;
+  console.log(mopedProjNotes);
 
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {
     onCompleted() {
@@ -370,8 +371,8 @@ const ProjectComments = (props) => {
                                   component={"span"}
                                 >
                                   <ProjectStatusBadge
-                                    phaseKey={mopedProjNotes[i]?.moped_phases.phase_key}
-                                    phaseName={mopedProjNotes[i]?.moped_phases.phase_name}
+                                    phaseKey={mopedProjNotes[i]?.moped_phase?.phase_key}
+                                    phaseName={mopedProjNotes[i]?.moped_phase?.phase_name}
                                     comment
                                   />
                                 </Typography>

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -92,6 +92,9 @@ const projectNoteTypes = ["", "Internal Note", "Status Update"];
 
 const ProjectComments = (props) => {
   const isStatusEditModal = props.modal;
+  const currentPhaseId =
+    props.currentPhaseId ??
+    props.data?.moped_project[0]?.moped_proj_phases[0]?.moped_phase.phase_id;
   let { projectId } = useParams();
   const classes = useStyles();
   const userSessionData = getSessionDatabaseData();
@@ -123,7 +126,6 @@ const ProjectComments = (props) => {
   });
 
   const mopedProjNotes = data?.moped_proj_notes;
-  console.log(mopedProjNotes);
 
   const [addNewComment] = useMutation(ADD_PROJECT_COMMENT, {
     onCompleted() {
@@ -182,9 +184,7 @@ const ProjectComments = (props) => {
             project_id: projectId,
             added_by_user_id: Number(userSessionData.user_id),
             project_note_type: isStatusEditModal ? 2 : 1,
-            phase_id:
-              props.data?.moped_project[0]?.moped_proj_phases[0]?.moped_phase
-                .phase_id,
+            phase_id: currentPhaseId,
           },
         ],
       },
@@ -367,15 +367,20 @@ const ProjectComments = (props) => {
                                     projectNoteTypes[item.project_note_type]
                                   }`}
                                 </Typography>
-                                <Typography
-                                  component={"span"}
-                                >
-                                  <ProjectStatusBadge
-                                    phaseKey={mopedProjNotes[i]?.moped_phase?.phase_key}
-                                    phaseName={mopedProjNotes[i]?.moped_phase?.phase_name}
-                                    comment
-                                  />
-                                </Typography>
+                                  <Typography component={"span"}>
+                                    <ProjectStatusBadge
+                                      phaseKey={
+                                        displayNotes[i]?.moped_phase
+                                          ?.phase_key
+                                      }
+                                      phaseName={
+                                        displayNotes[i]?.moped_phase
+                                          ?.phase_name
+                                      }
+                                      condensed
+                                      leftMargin
+                                    />
+                                  </Typography>
                               </>
                             }
                             secondary={

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -27,6 +27,7 @@ import parse from "html-react-parser";
 import DOMPurify from "dompurify";
 import CommentInputQuill from "./CommentInputQuill";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
+import ProjectStatusBadge from "./ProjectStatusBadge";
 
 import "./ProjectComments.css";
 
@@ -364,6 +365,15 @@ const ProjectComments = (props) => {
                                   {` ${
                                     projectNoteTypes[item.project_note_type]
                                   }`}
+                                </Typography>
+                                <Typography
+                                  component={"span"}
+                                >
+                                  <ProjectStatusBadge
+                                    phaseKey={mopedProjNotes[i].moped_phases.phase_key}
+                                    phaseName={mopedProjNotes[i].moped_phases.phase_name}
+                                    comment
+                                  />
                                 </Typography>
                               </>
                             }

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -180,6 +180,9 @@ const ProjectComments = (props) => {
             project_id: projectId,
             added_by_user_id: Number(userSessionData.user_id),
             project_note_type: isStatusEditModal ? 2 : 1,
+            phase_id:
+              props.data?.moped_project[0]?.moped_proj_phases[0]?.moped_phase
+                .phase_id,
           },
         ],
       },

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -92,6 +92,8 @@ const projectNoteTypes = ["", "Internal Note", "Status Update"];
 
 const ProjectComments = (props) => {
   const isStatusEditModal = props.modal;
+  // use currentPhaseId if passed down from ProjectSummaryStatusUpdate component,
+  // otherwise use data passed from ProjectView
   const currentPhaseId =
     props.currentPhaseId ??
     props.data?.moped_project[0]?.moped_proj_phases[0]?.moped_phase.phase_id;

--- a/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
+++ b/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
@@ -165,15 +165,8 @@ const useChipStyles = makeStyles((theme) => ({
     backgroundColor: ({ phaseKey }) =>
       getStyle(theme, phaseKey ?? "").background,
   },
-  comment: {
+  leftMargin: {
     marginLeft: "1rem",
-    fontWeight: "500",
-    fontSize: "12px",
-    borderRadius: "2rem",
-    height: "1.75rem",
-    // Find background color
-    backgroundColor: ({ phaseKey }) =>
-      getStyle(theme, phaseKey ?? "").background,
   },
 }));
 
@@ -189,7 +182,7 @@ const ProjectStatusBadge = ({
   phaseKey,
   phaseName,
   condensed = false,
-  comment = false,
+  leftMargin = false,
   clickable = false,
 }) => {
   const classes = useStyles();
@@ -211,7 +204,7 @@ const ProjectStatusBadge = ({
         iconClasses.root,
         clickable && classes.clickableChip,
         condensed ? chipClasses.condensed : chipClasses.root,
-        comment ? chipClasses.comment : chipClasses.root
+        leftMargin && chipClasses.leftMargin
       )}
       icon={<ChipIcon className={iconClasses.root} />}
       label={phaseName || defaultLabel}

--- a/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
+++ b/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
@@ -165,6 +165,16 @@ const useChipStyles = makeStyles((theme) => ({
     backgroundColor: ({ phaseKey }) =>
       getStyle(theme, phaseKey ?? "").background,
   },
+  comment: {
+    marginLeft: "1rem",
+    fontWeight: "500",
+    fontSize: "12px",
+    borderRadius: "2rem",
+    height: "1.75rem",
+    // Find background color
+    backgroundColor: ({ phaseKey }) =>
+      getStyle(theme, phaseKey ?? "").background,
+  },
 }));
 
 /**
@@ -179,6 +189,7 @@ const ProjectStatusBadge = ({
   phaseKey,
   phaseName,
   condensed = false,
+  comment = false,
   clickable = false,
 }) => {
   const classes = useStyles();
@@ -199,7 +210,8 @@ const ProjectStatusBadge = ({
       className={clsx(
         iconClasses.root,
         clickable && classes.clickableChip,
-        condensed ? chipClasses.condensed : chipClasses.root
+        condensed ? chipClasses.condensed : chipClasses.root,
+        comment ? chipClasses.comment : chipClasses.root
       )}
       icon={<ChipIcon className={iconClasses.root} />}
       label={phaseName || defaultLabel}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -36,6 +36,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
         <DashboardStatusModal
           projectId={projectId}
           projectName={projectName}
+          data={data}
           modalParent="summary"
           statusUpdate={statusUpdate}
           queryRefetch={refetch}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -18,6 +18,7 @@ import DashboardStatusModal from "src/views/dashboard/DashboardStatusModal";
 const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const statusUpdate = data.moped_project[0].moped_proj_notes[0]?.project_note;
   const projectName = data.moped_project[0].project_name;
+  const currentPhaseId = data.moped_project[0].moped_proj_phases[0]?.moped_phase.phase_id
   const addedBy = data.moped_project[0].moped_proj_notes[0]?.added_by;
   const dateCreated = makeUSExpandedFormDateFromTimeStampTZ(
     data.moped_project[0].moped_proj_notes[0]?.date_created
@@ -36,7 +37,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
         <DashboardStatusModal
           projectId={projectId}
           projectName={projectName}
-          data={data}
+          currentPhaseId={currentPhaseId}
           modalParent="summary"
           statusUpdate={statusUpdate}
           queryRefetch={refetch}


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10679
fixes https://github.com/cityofaustin/atd-data-tech/issues/11082

this pr stores the current phase of a project in the `moped_proj_notes` and table and displays it next to the associated status update or project comment. next pr will allow users to edit the associated phase!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
[10679_relate_project_notes_to_current_phase--atd-moped-main.netlify.app/moped/](https://10679_relate_project_notes_to_current_phase--atd-moped-main.netlify.app/moped/)

**Steps to test:**
- create a new project
- add a status update named 'potential' (for easier tracking during testing)
- the new status update should appear with the 'potential' badge next to it (the modal will close automatically)
- add a comment with the same name
- the new comment should appear with the 'potential' badge next to it
- change the current phase under the 'timeline' tab
- add a new status update with the name of that phase
- check to make sure the badge reflects the update
- repeat the last pairs of steps with a comment
- delete a comment and/or status update, the appropriate ones should be deleted and the rest should persist

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
