### PR TITLE
Hides the note status badge if it has no `phase_id`

### DIFF
--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -18,6 +18,7 @@ export const DASHBOARD_QUERY = gql`
           moped_phase {
             phase_name
             phase_key
+            phase_id
           }
         }
         moped_proj_milestones(where: { is_deleted: { _eq: false } }) {

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -144,6 +144,8 @@ const DashboardView = () => {
         project.project.moped_proj_phases?.[0]?.moped_phase.phase_name;
       project["phase_key"] =
         project.project.moped_proj_phases?.[0]?.moped_phase.phase_key;
+      project["current_phase_id"] =
+        project.project.moped_proj_phases?.[0]?.moped_phase.phase_id;
       /**
        * Get percentage of milestones completed
        */
@@ -231,6 +233,7 @@ const DashboardView = () => {
         <DashboardStatusModal
           projectId={entry.project_id}
           projectName={entry.project.project_name}
+          currentPhaseId={entry.current_phase_id}
           modalParent="dashboard"
           statusUpdate={entry.status_update}
           queryRefetch={refetch}

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -328,6 +328,8 @@ const ProjectComments = (props) => {
                 >
                   {displayNotes.map((item, i) => {
                     const isNotLastItem = i < displayNotes.length - 1;
+                    const phaseKey = item.moped_phase?.phase_key;
+                    const phaseName = item.moped_phase?.phase_name;
                     /**
                      * Only allow the user who wrote the status to edit it
                      */
@@ -369,20 +371,16 @@ const ProjectComments = (props) => {
                                     projectNoteTypes[item.project_note_type]
                                   }`}
                                 </Typography>
-                                  <Typography component={"span"}>
+                                <Typography component={"span"}>
+                                  {phaseKey && phaseName && (
                                     <ProjectStatusBadge
-                                      phaseKey={
-                                        displayNotes[i]?.moped_phase
-                                          ?.phase_key
-                                      }
-                                      phaseName={
-                                        displayNotes[i]?.moped_phase
-                                          ?.phase_name
-                                      }
+                                      phaseKey={phaseKey}
+                                      phaseName={phaseName}
                                       condensed
                                       leftMargin
                                     />
-                                  </Typography>
+                                  )}
+                                </Typography>
                               </>
                             }
                             secondary={

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -372,6 +372,7 @@ const ProjectComments = (props) => {
                                   }`}
                                 </Typography>
                                 <Typography component={"span"}>
+                                  {/* only show note's status badge if the note has a phase_id */}
                                   {phaseKey && phaseName && (
                                     <ProjectStatusBadge
                                       phaseKey={phaseKey}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -18,7 +18,8 @@ import DashboardStatusModal from "src/views/dashboard/DashboardStatusModal";
 const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const statusUpdate = data.moped_project[0].moped_proj_notes[0]?.project_note;
   const projectName = data.moped_project[0].project_name;
-  const currentPhaseId = data.moped_project[0].moped_proj_phases[0]?.moped_phase.phase_id
+  const currentPhaseId =
+    data.moped_project[0].moped_proj_phases[0]?.moped_phase.phase_id;
   const addedBy = data.moped_project[0].moped_proj_notes[0]?.added_by;
   const dateCreated = makeUSExpandedFormDateFromTimeStampTZ(
     data.moped_project[0].moped_proj_notes[0]?.date_created


### PR DESCRIPTION
This PR does two things:
1. Fixes a bug where `phase_id` was not being set for notes added through the dashboard status modal
2. Causes the note's status badge to be hidden if the note has no `phase_id`. See discussion about that [here](https://austininnovation.slack.com/archives/CNUEPKLB1/p1672929622935829).

## Testing
**URL to test:** [Netlify](https://deploy-preview-929--atd-moped-main.netlify.app/moped/projects) or local

**Steps to test:**
1. Navigate to a project that has comments and a current phase, e.g. project ID [1700](https://deploy-preview-929--atd-moped-main.netlify.app/moped/projects/1700?tab=comments)
3. On the comments tab, observe that the status badge does not render for comments created before January 2023
4. Add a comment to the project - observe that the comment's status badge renders and matches the project's status badge
5. Navigate to a project that has no current phase, e.g. project id [1905](https://deploy-preview-929--atd-moped-main.netlify.app/moped/projects/1905)
6. Add a comment to this project—observe that no status badge renders on the comment

☝️ "follow" these projects and repeat these steps from the Dashboard view.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
