### PR TITLE
add phase_id to dashboard summary query

### DIFF
--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -48,6 +48,7 @@ export const DASHBOARD_QUERY = gql`
           moped_phase {
             phase_name
             phase_key
+            phase_id
           }
         }
         moped_proj_milestones(where: { is_deleted: { _eq: false } }) {


### PR DESCRIPTION
This is a follow-up patch to https://github.com/cityofaustin/atd-moped/pull/929#pullrequestreview-1237676588

## Testing
**URL to test:** [Netlify](https://deploy-preview-930--atd-moped-main.netlify.app/) or local

**Steps to test:**
1. Follow a project who's current phase is not "Unknown".
2. Navigate to the dashboard view and switch to the "Following" tab of the projects table. Click into the status column to add a status update.
3. Click back into the status update modal to verify that the status you created renders with a status badge that matches the project's status badge. 

#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
