### PR TITLE
Disable "Continue" button when the create component form isn't complete

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -3,7 +3,7 @@ import { useQuery } from "@apollo/client";
 import { Controller, useForm } from "react-hook-form";
 import { Button, Grid, TextField } from "@material-ui/core";
 import { CheckCircle } from "@material-ui/icons";
-import { Autocomplete } from "@material-ui/lab";
+import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import SignalComponentAutocomplete from "../SignalComponentAutocomplete";
 import {
@@ -20,46 +20,6 @@ const defaultFormValues = {
   signal: null,
 };
 
-const ControlledAutocomplete = ({
-  id,
-  options,
-  renderOption,
-  name,
-  control,
-  label,
-  autoFocus = false,
-  multiple = false,
-  disabled,
-}) => (
-  <Controller
-    id={id}
-    name={name}
-    control={control}
-    render={({ onChange, value, ref }) => (
-      <Autocomplete
-        options={options}
-        multiple={multiple}
-        getOptionLabel={(option) => option?.label || ""}
-        getOptionSelected={(option, value) => option?.value === value?.value}
-        renderOption={renderOption}
-        value={value}
-        disabled={disabled}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            inputRef={ref}
-            size="small"
-            label={label}
-            variant="outlined"
-            autoFocus={autoFocus}
-          />
-        )}
-        onChange={(_event, option) => onChange(option)}
-      />
-    )}
-  />
-);
-
 const ComponentForm = ({
   formButtonText,
   onSave,
@@ -68,9 +28,10 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
-  const { register, handleSubmit, control, watch, setValue } = useForm({
-    defaultValues: defaultFormValues,
-  });
+  const { register, handleSubmit, control, watch, setValue, formState } =
+    useForm({
+      defaultValues: defaultFormValues,
+    });
 
   // Get and format component and subcomponent options
   const { data: optionsData, loading: areOptionsLoading } = useQuery(
@@ -165,6 +126,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
+            disabled={!formState.isValid}
           >
             {isSignalComponent ? "Save" : formButtonText}
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
 import { Controller, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
 import { Button, Grid, TextField } from "@material-ui/core";
 import { CheckCircle } from "@material-ui/icons";
 import { ControlledAutocomplete } from "./utils/form";
@@ -12,6 +13,7 @@ import {
   useSubcomponentOptions,
   useInitialValuesOnAttributesEdit,
 } from "./utils/form";
+import * as yup from "yup";
 
 const defaultFormValues = {
   component: null,
@@ -19,6 +21,13 @@ const defaultFormValues = {
   description: "",
   signal: null,
 };
+
+const validationSchema = yup.object().shape({
+  component: yup.object().required(),
+  subcomponents: yup.array(),
+  description: yup.string(),
+  signal: yup.object(),
+});
 
 const ComponentForm = ({
   formButtonText,
@@ -31,6 +40,7 @@ const ComponentForm = ({
   const { register, handleSubmit, control, watch, setValue, formState } =
     useForm({
       defaultValues: defaultFormValues,
+      resolver: yupResolver(validationSchema),
     });
 
   // Get and format component and subcomponent options

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -24,9 +24,9 @@ const defaultFormValues = {
 
 const validationSchema = yup.object().shape({
   component: yup.object().required(),
-  subcomponents: yup.array(),
+  subcomponents: yup.array().optional(),
   description: yup.string(),
-  signal: yup.object(),
+  signal: yup.object().optional(),
 });
 
 const ComponentForm = ({
@@ -37,11 +37,18 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
-  const { register, handleSubmit, control, watch, setValue, formState } =
-    useForm({
-      defaultValues: defaultFormValues,
-      resolver: yupResolver(validationSchema),
-    });
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    setValue,
+    formState: { isValid },
+  } = useForm({
+    defaultValues: defaultFormValues,
+    mode: "onChange",
+    resolver: yupResolver(validationSchema),
+  });
 
   // Get and format component and subcomponent options
   const { data: optionsData, loading: areOptionsLoading } = useQuery(
@@ -136,7 +143,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={!formState.isValid}
+            disabled={!isValid}
           >
             {isSignalComponent ? "Save" : formButtonText}
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -26,7 +26,11 @@ const validationSchema = yup.object().shape({
   component: yup.object().required(),
   subcomponents: yup.array().optional(),
   description: yup.string(),
-  signal: yup.object().optional(),
+  // Signal field is required if the selected component inserts into the feature_signals table
+  signal: yup.object().when("component", {
+    is: (val) => val?.data?.feature_layer?.internal_table === "feature_signals",
+    then: yup.object().required(),
+  }),
 });
 
 const ComponentForm = ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,5 +1,7 @@
 import { useMemo, useEffect } from "react";
-import { Icon, makeStyles } from "@material-ui/core";
+import { Autocomplete } from "@material-ui/lab";
+import { Controller } from "react-hook-form";
+import { Icon, makeStyles, TextField } from "@material-ui/core";
 import {
   RoomOutlined as RoomOutlinedIcon,
   Timeline as TimelineIcon,
@@ -135,3 +137,43 @@ export const ComponentOptionWithIcon = ({ option }) => {
     </>
   );
 };
+
+export const ControlledAutocomplete = ({
+  id,
+  options,
+  renderOption,
+  name,
+  control,
+  label,
+  autoFocus = false,
+  multiple = false,
+  disabled,
+}) => (
+  <Controller
+    id={id}
+    name={name}
+    control={control}
+    render={({ onChange, value, ref }) => (
+      <Autocomplete
+        options={options}
+        multiple={multiple}
+        getOptionLabel={(option) => option?.label || ""}
+        getOptionSelected={(option, value) => option?.value === value?.value}
+        renderOption={renderOption}
+        value={value}
+        disabled={disabled}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            inputRef={ref}
+            size="small"
+            label={label}
+            variant="outlined"
+            autoFocus={autoFocus}
+          />
+        )}
+        onChange={(_event, option) => onChange(option)}
+      />
+    )}
+  />
+);


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11124

This PR disables the **Continue** (or **Save** when creating a signal component) button in the modals that appears when creating a new component or when editing an existing component's attributes.

Button is disabled when:
- form does not have required fields complete
   - for non-signal components: the component type field is required
   - for signal components: the component type and signal fields are required
- the edit attributes modal is open but no edit has been made yet

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local for now

**Steps to test:**
1. Go to a new or existing project's **Map** tab
2. Click **New Component** and notice that the **Continue** button in the modal is greyed out and you can't click it
3. Add a Description and notice that the button is still greyed out
4. Choose a non-signal **Component Type** and the **Continue** button will turn blue and active
5. Finish creating the component and save it
6. Now create another component but this time select **Signal - PHB** from the type dropdown
7. Notice that the **Save** button is greyed out
8. Select a signal from the **Signal** dropdown and see the **Save** button turn blue and active and then click it
9. Last, edit the attributes of the non-signal component that you created and notice that the **Save** button is greyed out
10. Update the description and see that the button turns blue and active
11. Save the update

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
