### PR TITLE
Patches transpose geomtery script to align with front-end changes

### DIFF
--- a/moped-toolbox/populate_geometry_transform/Dockerfile
+++ b/moped-toolbox/populate_geometry_transform/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get install -y python3 python3-pip aptitude magic-wormhole vim python3-p
 WORKDIR /tmp
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip install -r requirements.txt
-WORKDIR /root/app
+WORKDIR /app

--- a/moped-toolbox/populate_geometry_transform/README.md
+++ b/moped-toolbox/populate_geometry_transform/README.md
@@ -1,0 +1,22 @@
+# transpose component geometries
+
+## local run
+
+1. Start the Hasura cluster [with production data](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-MIQvl_rKnZ_-wHRdp4J/dev-guides/how-tos/how-to-load-production-data-into-a-local-instance).
+
+2. Build the docker image
+
+```
+$ docker build -t geomtransform .
+```
+
+3. Run the script, mounting your local copy of this directory into the container.
+
+`DB_HOST`
+`DB_USER`
+`DB_PASSWORD`
+`DB_NAME`
+
+```
+$ docker run -it --rm -v "$(pwd)":/app geomtransform python3 transpose_geometry.py
+```

--- a/moped-toolbox/populate_geometry_transform/README.md
+++ b/moped-toolbox/populate_geometry_transform/README.md
@@ -12,11 +12,6 @@ $ docker build -t geomtransform .
 
 3. Run the script, mounting your local copy of this directory into the container.
 
-`DB_HOST`
-`DB_USER`
-`DB_PASSWORD`
-`DB_NAME`
-
 ```
 $ docker run -it --rm -v "$(pwd)":/app geomtransform python3 transpose_geometry.py
 ```

--- a/moped-toolbox/populate_geometry_transform/docker-compose.yml
+++ b/moped-toolbox/populate_geometry_transform/docker-compose.yml
@@ -4,4 +4,4 @@ services:
     build: .
     command: ["tail", "-f", "/dev/null"]
     volumes:
-      - .:/root/app
+      - .:/app

--- a/moped-toolbox/populate_geometry_transform/transpose_geometry.py
+++ b/moped-toolbox/populate_geometry_transform/transpose_geometry.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 #  docker run -it --rm -v "$(pwd)":/app geomtransform /bin/bash
 
-from operator import truediv
 import os
 
 import psycopg2
@@ -61,12 +60,6 @@ def remove_deprecated_fields(fields, values):
     deprecated_fields = [
         "source_layer",
         "project_extent_id",
-        # "symbol",
-        # "line_type",
-        # "ctn_segment_id",
-        # "to_address_max",
-        # "from_address_min",
-        # "full_street_name"
     ]
     for f in deprecated_fields:
         try:


### PR DESCRIPTION
## Associated issues
- In service of https://github.com/cityofaustin/atd-data-tech/issues/11186

## Summary of changes
- adds special handling of `feature_signals` features which no longer have a `source_layer` or `project_extent_id` column
- excludes deleted `moped_proj_features` from processing. a few of these were throwing errors due to corrupted geometries. i think it's safe to just exclude them but i'm curious what y'all think
- makes a small change to the Dockerfile and compose which was giving me problems when trying to mount a volume with `docker run`
- adds a short README for running the script with `docker run`. 


## Testing
**URL to test:** Local
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
- See [readme](https://github.com/cityofaustin/atd-moped/blob/6341232d7000208e445a8a44ac88a60e78c4d767/moped-toolbox/populate_geometry_transform/README.md)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
