### PR TITLE
Reset draft component on exit edit mode dialog

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -11,6 +11,7 @@ import { useDoesDraftEditComponentHaveFeatures } from "./features";
 import { UPDATE_COMPONENT_FEATURES } from "src/queries/components";
 
 const editReducer = (state, action) => {
+  console.log("STATE", state, action)
   switch (action.type) {
     case "start_edit":
       const draftEditComponent = action.payload;
@@ -37,6 +38,7 @@ const editReducer = (state, action) => {
         ...state,
         showEditModeDialog: false,
         isEditingComponent: false,
+        draftEditComponent: null,
       };
     case "cancel_attributes_edit":
       return {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -11,7 +11,6 @@ import { useDoesDraftEditComponentHaveFeatures } from "./features";
 import { UPDATE_COMPONENT_FEATURES } from "src/queries/components";
 
 const editReducer = (state, action) => {
-  console.log("STATE", state, action)
   switch (action.type) {
     case "start_edit":
       const draftEditComponent = action.payload;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11231

## Testing
**URL to test:**  Local or [Netlify](https://deploy-preview-943--atd-moped-main.netlify.app/) 😎 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Create a bike lane component
2. Click on the component in the sidebar, then click the "edit" button
3. When the "What do you want to edit?" dialog opens, close it (or click away) without selecting "attributes" or "map"
4. Click anywhere on the map to "unfocus" from this component
5. Observe that you can still see this component on the map ✅ 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
