### PR TITLE
Simplify map color styles

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapStyleSettings.js
@@ -47,10 +47,10 @@ export const MAP_STYLES = {
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
-        "circle-stroke-color": COLORS.pinkBright,
+        "circle-stroke-color": COLORS.bluePrimary,
         "circle-stroke-width": 2,
         "circle-stroke-opacity": 0.9,
-        "circle-color": COLORS.pinkLight,
+        "circle-color": COLORS.blueLight,
         "circle-opacity": 0.9,
       },
     },
@@ -67,7 +67,7 @@ export const MAP_STYLES = {
           "case",
           ["boolean", ["feature-state", "hover"], false],
           COLORS.pinkDark,
-          COLORS.pinkBright,
+          COLORS.bluePrimary,
         ],
       },
       layout: {


### PR DESCRIPTION
## Associated issues

We currently have four map feature colors:
- Default / not editing: `#fc0885` 
- Focused component / still not editing: `#1276D1`
- Focused component + editing: `#ffb300`
- Not focused / not being edited components: `#a6a2a2`

When not editing, I don't think we should use a distinct color for focused vs not focused. It's a bit confusing. As much as I love `#fc0885`, i think we can nix it and just use our primary blue. This PR switches things like so:

- Default / not editing: `#1276D1`
- Focused component / still not editing: `#1276D1`
- Focused component + editing: `#ffb300`
- Not focused / not being edited components: `#a6a2a2`

## Testing
**URL to test:**  [Netlify](https://deploy-preview-945--atd-moped-main.netlify.app/)

**Steps to test:**
1. Create a bunch of point and line components.
2. Focus, unfocus, and edit the components.
3. Observe: no more fuchsia 😭 
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
