### PR TITLE
updates project partner activity log entries

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2874,8 +2874,8 @@
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
                 },
-                  "updated_at": {{$body.created_at}},
-                  "project_id": {{$body.event.data.new.project_id}}
+                "updated_at": {{$body.created_at}},
+                "project_id": {{$body.event.data.new.project_id}}
               }
             }
         method: POST

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2848,24 +2848,47 @@
         insert:
           columns: '*'
         update:
-          columns:
-            - added_by
-            - entity_id
-            - is_deleted
-            - project_id
-            - proj_partner_id
-            - partner_name
-            - date_added
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 0
         timeout_sec: 60
-      webhook_from_env: MOPED_API_EVENTS_URL
+      webhook_from_env: HASURA_ENDPOINT
       headers:
-        - name: MOPED_API_APIKEY
-          value_from_env: MOPED_API_APIKEY
-        - name: MOPED_API_EVENT_NAME
-          value: activity_log
+        - name: x-hasura-admin-secret
+          value_from_env: ACTIVITY_LOG_API_SECRET
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "variables": {
+                "object": {
+                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_type":  {{ $body.table.name }},
+                  "activity_id": {{ $body.id }},
+                  "record_project_id": {{ $body.event.data.new.project_id }},
+                  "record_data": {"event": {{ $body.event }}},
+                  "description": [{"newSchema": "true"}],
+                  "operation_type": {{ $body.event.op }},
+                  "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
+                },
+                  "updated_at": {{$body.created_at}},
+                  "project_id": {{$body.event.data.new.project_id}}
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        version: 2
+      cleanup_config:
+        batch_size: 10000
+        clean_invocation_logs: false
+        clear_older_than: 168
+        paused: true
+        schedule: 0 0 * * *
+        timeout: 60
 - table:
     name: moped_proj_personnel
     schema: public

--- a/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
@@ -1,0 +1,21 @@
+import GroupOutlined from "@material-ui/icons/GroupOutlined";
+
+export const formatPartnersActivity = (change, entityList) => {
+  const changeIcon = <GroupOutlined />;
+  let changeDescription = "Project partners updated";
+  let changeValue = ""
+
+  console.log(change.record_data.event.data.new);
+
+  // Adding a new partner
+  if (change.description.length === 0) {
+    changeDescription = "Added project partner "
+    changeValue = entityList[change.record_data.event.data.new.entity_id]
+  } else {
+    // Soft deleting a partner is the only update a user can do (is_deleted is set to true)
+    changeDescription = "Removed project partner "
+    changeValue = entityList[change.record_data.event.data.new.entity_id]
+  }
+
+  return { changeIcon, changeDescription, changeValue };
+};

--- a/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
@@ -5,8 +5,6 @@ export const formatPartnersActivity = (change, entityList) => {
   let changeDescription = "Project partners updated";
   let changeValue = ""
 
-  console.log(change.record_data.event.data.new);
-
   // Adding a new partner
   if (change.description.length === 0) {
     changeDescription = "Added project partner "

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -1,6 +1,7 @@
 import { formatProjectActivity } from "./activityLogFormatters/mopedProjectActivity";
 import { formatTagsActivity } from "./activityLogFormatters/mopedTagsActivity";
 import { formatFundingActivity } from "./activityLogFormatters/mopedFundingActivity";
+import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersActivity";
 
 export const formatActivityLogEntry = (change, lookupData) => {
   const changeDescription = "Project was updated";
@@ -16,6 +17,8 @@ export const formatActivityLogEntry = (change, lookupData) => {
       return formatTagsActivity(change, lookupData.tagList);
     case "moped_proj_funding":
       return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms);
+    case "moped_proj_partners":
+      return formatPartnersActivity(change, lookupData.entityList);
     default:
       return { changeIcon, changeDescription, changeValue };
   }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -285,6 +285,7 @@ const ProjectActivityLog = () => {
                           "moped_project",
                           "moped_proj_tags",
                           "moped_proj_funding",
+                          "moped_proj_partners"
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}


### PR DESCRIPTION
this pr updates the activity log to use REST connectors for 'project partners' activity log updates. it also updates the formatting of how these updates are displayed in the activity log.

## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11167

## Testing
**URL to test:** 

[11167_refine_partners_activity_log_events--atd-moped-main.netlify.app/moped/](https://11167_refine_partners_activity_log_events--atd-moped-main.netlify.app/moped/)

**Steps to test:**
- go to a project summary page
- add one or more project partners using the dropdown
- check the activity log to see that the activity is reflected (you may have to refresh the page)
- repeat the previous steps by deleting one or more project partners
- repeat the previous steps by adding one or more new partners and removing one or more existing ones

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
