### PR TITLE
adds public process status to activity log

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3711,6 +3711,7 @@
             - knack_project_id
             - fiscal_year
             - work_assignment_id
+            - public_process_status_id
       retry_conf:
         interval_sec: 10
         num_retries: 0

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -506,6 +506,10 @@ export const PROJECT_ACTIVITY_LOG = gql`
       funding_status_id
       funding_status_name
     }
+    moped_public_process_statuses(order_by: {id: asc}) {
+      id
+      name
+    }
     activity_log_lookup_tables: moped_activity_log(
       where: { record_project_id: { _eq: $projectId } }
       distinct_on: record_type

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -1,7 +1,7 @@
 import BeenhereOutlinedIcon from "@material-ui/icons/BeenhereOutlined";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 
-export const formatProjectActivity = (change, entityList) => {
+export const formatProjectActivity = (change, lookupList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_project"];
   let changeDescription = "Project updated";
   let changeIcon = <span className="material-symbols-outlined">summarize</span>;
@@ -30,14 +30,14 @@ export const formatProjectActivity = (change, entityList) => {
       changeData.old[changedField] === 0
     ) {
       changeDescription = `Added "${
-        entityList[change.description[0].new]
+        lookupList[change.description[0].new]
       }" as `;
       changeValue = entryMap.fields[changedField].label;
       return { changeIcon, changeDescription, changeValue };
     }
 
     // if the new field is null or undefined, its because something was removed
-    if (!entityList[changeData.new[changedField]]) {
+    if (!lookupList[changeData.new[changedField]]) {
       changeDescription = `Removed ${entryMap.fields[changedField].label} `;
       changeValue = "";
       return { changeIcon, changeDescription, changeValue };
@@ -45,7 +45,7 @@ export const formatProjectActivity = (change, entityList) => {
 
     // Changing a field, but need to use lookup table to display
     changeDescription = `Changed ${entryMap.fields[changedField].label} to `;
-    changeValue = entityList[changeData.new[changedField]];
+    changeValue = lookupList[changeData.new[changedField]];
   } else {
     // If the update is an object, show just the field name that was updated.
     if (typeof changeData.new[changedField] === "object") {

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -11,13 +11,18 @@ export const formatActivityLogEntry = (change, lookupData) => {
 
   switch (change.record_type) {
     case "moped_project":
+      // if the user is changing the public process status id field,
+      // provide the publicProcessStatustList lookup object
       if (change?.description[0]?.field === "public_process_status_id") {
         return formatProjectActivity(
           change,
           lookupData.publicProcessStatustList
         );
       }
-      return formatProjectActivity(change, lookupData.entityList);
+      // otherwise, provide the entityList lookup object
+      else {
+        return formatProjectActivity(change, lookupData.entityList);
+      }
     case "moped_proj_tags":
       return formatTagsActivity(change, lookupData.tagList);
     case "moped_proj_funding":

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -12,11 +12,11 @@ export const formatActivityLogEntry = (change, lookupData) => {
   switch (change.record_type) {
     case "moped_project":
       // if the user is changing the public process status id field,
-      // provide the publicProcessStatustList lookup object
+      // provide the publicProcessStatusList lookup object
       if (change?.description[0]?.field === "public_process_status_id") {
         return formatProjectActivity(
           change,
-          lookupData.publicProcessStatustList
+          lookupData.publicProcessStatusList
         );
       }
       // otherwise, provide the entityList lookup object

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -11,6 +11,12 @@ export const formatActivityLogEntry = (change, lookupData) => {
 
   switch (change.record_type) {
     case "moped_project":
+      if (change?.description[0]?.field === "public_process_status_id") {
+        return formatProjectActivity(
+          change,
+          lookupData.publicProcessStatustList
+        );
+      }
       return formatProjectActivity(change, lookupData.entityList);
     case "moped_proj_tags":
       return formatTagsActivity(change, lookupData.tagList);

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -83,7 +83,7 @@ const useLookupTables = (data) =>
     lookupData.fundingSources = {};
     lookupData.fundingPrograms = {};
     lookupData.fundingStatus = {};
-    lookupData.publicProcessStatustList = {};
+    lookupData.publicProcessStatusList = {};
 
     if (data) {
       data["moped_users"].forEach((user) => {
@@ -111,7 +111,7 @@ const useLookupTables = (data) =>
           fundStatus.funding_status_name;
       });
       data["moped_public_process_statuses"].forEach((publicProcessStatus) => {
-        lookupData.publicProcessStatustList[`${publicProcessStatus.id}`] = publicProcessStatus.name;
+        lookupData.publicProcessStatusList[`${publicProcessStatus.id}`] = publicProcessStatus.name;
       });
     }
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -83,6 +83,7 @@ const useLookupTables = (data) =>
     lookupData.fundingSources = {};
     lookupData.fundingPrograms = {};
     lookupData.fundingStatus = {};
+    lookupData.publicProcessStatustList = {};
 
     if (data) {
       data["moped_users"].forEach((user) => {
@@ -108,6 +109,9 @@ const useLookupTables = (data) =>
       data["moped_fund_status"].forEach((fundStatus) => {
         lookupData.fundingStatus[`${fundStatus.funding_status_id}`] =
           fundStatus.funding_status_name;
+      });
+      data["moped_public_process_statuses"].forEach((publicProcessStatus) => {
+        lookupData.publicProcessStatustList[`${publicProcessStatus.id}`] = publicProcessStatus.name;
       });
     }
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -34,6 +34,10 @@ export const ProjectActivityLogTableMaps = {
         label: "project sponsor",
         lookup: "moped_entity",
       },
+      public_process_status_id: {
+        label: "project status",
+        lookup: "moped_public_process_statuses"
+      },
       project_website: {
         label: "project website",
       },

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -35,7 +35,7 @@ export const ProjectActivityLogTableMaps = {
         lookup: "moped_entity",
       },
       public_process_status_id: {
-        label: "project status",
+        label: "public process status",
         lookup: "moped_public_process_statuses"
       },
       project_website: {


### PR DESCRIPTION
this pr adds 'public process status' to the activity log. merging this pr will update the [10833_public_process_field_ui](https://github.com/cityofaustin/atd-moped/tree/10833_public_process_field_ui) branch, which will then be ready to merge into main. i'm keeping the standard moped project update icon for this update in the activity log since this is somewhat intangible.

## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11255

## Testing
**URL to test:** 
https://11255_add_public_process_status_to_activity_log--atd-moped-main.netlify.app/moped/

**Steps to test:**
- go to a project summary page and add a public process status
- go to the activity log and refresh to see the update
- remove the public process status and note the change in the activity log

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
