### PR TITLE
Refactor activity log text formatting

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -10,61 +10,83 @@ export const formatFundingActivity = (
   const entryMap = ProjectActivityLogTableMaps["moped_proj_funding"];
 
   const changeIcon = <MonetizationOnOutlinedIcon />;
-  const changeText = [];
 
   // add a new funding source
   if (change.description.length === 0) {
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeText.push({ text: "Added ", style: null });
-      changeText.push({
-        text: fundingSources[
-          change.record_data.event.data.new.funding_source_id
+      return {
+        changeIcon,
+        changeText: [
+          { text: "Added ", style: null },
+          {
+            text: fundingSources[
+              change.record_data.event.data.new.funding_source_id
+            ],
+            style: "boldText",
+          },
+          { text: " as a new funding source.", style: null },
         ],
-        style: "boldText",
-      });
-      changeText.push({ text: " as a new funding source.", style: null });
+      };
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeText.push({ text: "Added ", style: null });
-      changeText.push({
-        text: fundingPrograms[
-          change.record_data.event.data.new.funding_program_id
+      return {
+        changeIcon,
+        changeText: [
+          { text: "Added ", style: null },
+          {
+            text: fundingPrograms[
+              change.record_data.event.data.new.funding_program_id
+            ],
+            style: "boldText",
+          },
+          { text: " as a new funding source.", style: null },
         ],
-        style: "boldText",
-      });
-      changeText.push({ text: " as a new funding source.", style: null });
+      };
     } else {
-      changeText.push({ text: "Added a new funding source", style: null });
+      return {
+        changeIcon,
+        changeText: [{ text: "Added a new funding source", style: null }],
+      };
     }
-
-    return { changeIcon, changeText };
   }
 
   // delete an existing record
   if (change.description[0].field === "is_deleted") {
-    // if the added record has a funding source, use that as the change value
+    // if the deleted record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeText.push({ text: "Deleted a funding source: ", style: null });
-      changeText.push({
-        text: fundingSources[
-          change.record_data.event.data.new.funding_source_id
+      return {
+        changeIcon,
+        changeText: [
+          { text: "Deleted a funding source: ", style: null },
+          {
+            text: fundingSources[
+              change.record_data.event.data.new.funding_source_id
+            ],
+            style: "boldText",
+          },
         ],
-        style: "boldText",
-      });
+      };
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeText.push({ text: "Deleted a funding source: ", style: null });
-      changeText.push({
-        text: fundingPrograms[
-          change.record_data.event.data.new.funding_program_id
+      return {
+        changeIcon,
+        changeText: [
+          { text: "Deleted a funding source: ", style: null },
+          {
+            text: fundingPrograms[
+              change.record_data.event.data.new.funding_program_id
+            ],
+            style: "boldText",
+          },
         ],
-        style: "boldText",
-      });
+      };
     } else {
-          changeText.push({ text: "Deleted a funding source", style: null });
+      return {
+        changeIcon,
+        changeText: [{ text: "Deleted a funding source.", style: null }],
+      };
     }
-    return { changeIcon, changeText };
   }
 
   // Multiple fields in the moped_proj_funding table can be updated at once
@@ -86,14 +108,17 @@ export const formatFundingActivity = (
     }
   });
 
-  changeText.push({
-    text: "Edited a funding source by updating the ",
-    style: null,
-  });
-  changeText.push({
-    text: changes.join(", "),
-    style: "boldText",
-  });
-
-  return { changeIcon, changeText };
+  return {
+    changeIcon,
+    changeText: [
+      {
+        text: "Edited a funding source by updating the ",
+        style: null,
+      },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ],
+  };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -14,7 +14,6 @@ export const formatFundingActivity = (
 
   // add a new funding source
   if (change.description.length === 0) {
-    changeText = [{ text: "Added a new funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
       changeText.push({ text: "Added ", style: null });
@@ -35,13 +34,15 @@ export const formatFundingActivity = (
         style: "boldText",
       });
       changeText.push({ text: " as a new funding source.", style: null });
+    } else {
+      changeText.push({ text: "Added a new funding source", style: null });
     }
+
     return { changeIcon, changeText };
   }
 
   // delete an existing record
   if (change.description[0].field === "is_deleted") {
-    changeText = [{ text: "Deleted a funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
       changeText.push({ text: "Deleted a funding source: ", style: null });
@@ -60,6 +61,8 @@ export const formatFundingActivity = (
         ],
         style: "boldText",
       });
+    } else {
+          changeText.push({ text: "Deleted a funding source", style: null });
     }
     return { changeIcon, changeText };
   }

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -10,46 +10,66 @@ export const formatFundingActivity = (
   const entryMap = ProjectActivityLogTableMaps["moped_proj_funding"];
 
   const changeIcon = <MonetizationOnOutlinedIcon />;
-  let changeDescription = "Project funding updated";
-  let changeValue = "";
+  let changeText = [{ text: "Project funding updated", style: null }];
 
   // add a new funding source
   if (change.description.length === 0) {
-    changeDescription = "Added a new funding source";
+    changeText = [{ text: "Added a new funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeValue =
-        fundingSources[change.record_data.event.data.new.funding_source_id];
+      changeText = [
+        { text: "Added ", style: null },
+        {
+          text: fundingSources[
+            change.record_data.event.data.new.funding_source_id
+          ],
+          style: "boldText",
+        },
+        { text: " as a new funding source." },
+      ];
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeValue =
-        fundingPrograms[change.record_data.event.data.new.funding_program_id];
+      changeText = [
+        { text: "Added ", style: null },
+        {
+          text: fundingPrograms[
+            change.record_data.event.data.new.funding_program_id
+          ],
+          style: "boldText",
+        },
+        { text: " as a new funding source." },
+      ];
     }
-    // if we have a change value, tack on a : at the end
-    if (changeValue) {
-      changeDescription = "Added a new funding source: ";
-    }
-    // if there isnt a funding source or program added, then default to ""
-    return { changeIcon, changeDescription, changeValue };
+    return { changeIcon, changeText };
   }
 
   // delete an existing record
   if (change.description[0].field === "is_deleted") {
-    changeDescription = "Deleted a funding source";
+    changeText = [{ text: "Deleted a funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeValue =
-        fundingSources[change.record_data.event.data.new.funding_source_id];
+      changeText = [
+        { text: "Deleted a funding source: ", style: null },
+        {
+          text: fundingSources[
+            change.record_data.event.data.new.funding_source_id
+          ],
+          style: "boldText",
+        },
+      ];
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeValue =
-        fundingPrograms[change.record_data.event.data.new.funding_program_id];
+      changeText = [
+        { text: "Deleted a funding source: ", style: null },
+        {
+          text: fundingPrograms[
+            change.record_data.event.data.new.funding_program_id
+          ],
+          style: "boldText",
+        },
+      ];
     }
-    // if we have a change value, tack on a : at the end
-    if (changeValue) {
-      changeDescription = "Deleted a funding source: ";
-    }
-    return { changeIcon, changeDescription, changeValue };
+    return { changeIcon, changeText };
   }
 
   // Multiple fields in the moped_proj_funding table can be updated at once
@@ -71,8 +91,13 @@ export const formatFundingActivity = (
     }
   });
 
-  changeDescription = "Edited a funding source ";
-  changeValue = changes.join(", ");
+  changeText = [
+    { text: "Edited a funding source by updating the ", style: null },
+    {
+      text: changes.join(", "),
+      style: "boldText",
+    },
+  ];
 
-  return { changeIcon, changeDescription, changeValue };
+  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -64,10 +64,10 @@ export const formatFundingActivity = (
     // typeof(null) === "object", check that field is not null before checking if object
     if (!!newRecord[field] && typeof newRecord[field] === "object") {
       if (!isEqual(newRecord[field], oldRecord[field])) {
-        changes.push(entryMap.fields[field].label);
+        changes.push(entryMap.fields[field]?.label);
       }
     } else if (newRecord[field] !== oldRecord[field]) {
-      changes.push(entryMap.fields[field].label);
+      changes.push(entryMap.fields[field]?.label);
     }
   });
 

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -10,35 +10,31 @@ export const formatFundingActivity = (
   const entryMap = ProjectActivityLogTableMaps["moped_proj_funding"];
 
   const changeIcon = <MonetizationOnOutlinedIcon />;
-  let changeText = [{ text: "Project funding updated", style: null }];
+  const changeText = [];
 
   // add a new funding source
   if (change.description.length === 0) {
     changeText = [{ text: "Added a new funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeText = [
-        { text: "Added ", style: null },
-        {
-          text: fundingSources[
-            change.record_data.event.data.new.funding_source_id
-          ],
-          style: "boldText",
-        },
-        { text: " as a new funding source." },
-      ];
+      changeText.push({ text: "Added ", style: null });
+      changeText.push({
+        text: fundingSources[
+          change.record_data.event.data.new.funding_source_id
+        ],
+        style: "boldText",
+      });
+      changeText.push({ text: " as a new funding source.", style: null });
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeText = [
-        { text: "Added ", style: null },
-        {
-          text: fundingPrograms[
-            change.record_data.event.data.new.funding_program_id
-          ],
-          style: "boldText",
-        },
-        { text: " as a new funding source." },
-      ];
+      changeText.push({ text: "Added ", style: null });
+      changeText.push({
+        text: fundingPrograms[
+          change.record_data.event.data.new.funding_program_id
+        ],
+        style: "boldText",
+      });
+      changeText.push({ text: " as a new funding source.", style: null });
     }
     return { changeIcon, changeText };
   }
@@ -48,26 +44,22 @@ export const formatFundingActivity = (
     changeText = [{ text: "Deleted a funding source", style: null }];
     // if the added record has a funding source, use that as the change value
     if (change.record_data.event.data.new.funding_source_id) {
-      changeText = [
-        { text: "Deleted a funding source: ", style: null },
-        {
-          text: fundingSources[
-            change.record_data.event.data.new.funding_source_id
-          ],
-          style: "boldText",
-        },
-      ];
+      changeText.push({ text: "Deleted a funding source: ", style: null });
+      changeText.push({
+        text: fundingSources[
+          change.record_data.event.data.new.funding_source_id
+        ],
+        style: "boldText",
+      });
       // if not, then check if theres a funding program
     } else if (change.record_data.event.data.new.funding_program_id) {
-      changeText = [
-        { text: "Deleted a funding source: ", style: null },
-        {
-          text: fundingPrograms[
-            change.record_data.event.data.new.funding_program_id
-          ],
-          style: "boldText",
-        },
-      ];
+      changeText.push({ text: "Deleted a funding source: ", style: null });
+      changeText.push({
+        text: fundingPrograms[
+          change.record_data.event.data.new.funding_program_id
+        ],
+        style: "boldText",
+      });
     }
     return { changeIcon, changeText };
   }
@@ -91,13 +83,14 @@ export const formatFundingActivity = (
     }
   });
 
-  changeText = [
-    { text: "Edited a funding source by updating the ", style: null },
-    {
-      text: changes.join(", "),
-      style: "boldText",
-    },
-  ];
+  changeText.push({
+    text: "Edited a funding source by updating the ",
+    style: null,
+  });
+  changeText.push({
+    text: changes.join(", "),
+    style: "boldText",
+  });
 
   return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -5,29 +5,34 @@ export const formatMilestonesActivity = (change, milestoneList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];
 
   const changeIcon = <EventNoteIcon />;
-  const changeText = [];
 
   // add a new milestone
   if (change.description.length === 0) {
-    changeText.push({ text: "Added ", style: null });
-    changeText.push({
-      text: milestoneList[change.record_data.event.data.new.milestone_id],
-      style: "boldText",
-    });
-    changeText.push({ text: " as a new milestone.", style: null });
-
-    return { changeIcon, changeText };
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Added ", style: null },
+        {
+          text: milestoneList[change.record_data.event.data.new.milestone_id],
+          style: "boldText",
+        },
+        { text: " as a new milestone.", style: null },
+      ],
+    };
   }
 
   // delete an existing milestone
   if (change.description[0].field === "is_deleted") {
-    changeText.push({ text: "Deleted the milestone ", style: null });
-    changeText.push({
-      text: milestoneList[change.record_data.event.data.new.milestone_id],
-      style: "boldText",
-    });
-
-    return { changeIcon, changeText };
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Deleted the milestone ", style: null },
+        {
+          text: milestoneList[change.record_data.event.data.new.milestone_id],
+          style: "boldText",
+        },
+      ],
+    };
   }
 
   // Multiple fields in the moped_proj_funding table can be updated at once
@@ -44,16 +49,19 @@ export const formatMilestonesActivity = (change, milestoneList) => {
     }
   });
 
-  changeText.push({ text: "Edited the milestone ", style: null });
-  changeText.push({
-    text: milestoneList[change.record_data.event.data.new.milestone_id],
-    style: "boldText",
-  });
-  changeText.push({ text: " by updating the ", style: null });
-  changeText.push({
-    text: changes.join(", "),
-    style: "boldText",
-  });
-
-  return { changeIcon, changeText };
+  return {
+    changeIcon,
+    changeText: [
+      { text: "Edited the milestone ", style: null },
+      {
+        text: milestoneList[change.record_data.event.data.new.milestone_id],
+        style: "boldText",
+      },
+      { text: " by updating the ", style: null },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ],
+  };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -1,30 +1,37 @@
-import EventNoteIcon from '@material-ui/icons/EventNote';
+import EventNoteIcon from "@material-ui/icons/EventNote";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 
-export const formatMilestonesActivity = (
-  change,
-  milestoneList
-) => {
+export const formatMilestonesActivity = (change, milestoneList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];
 
   const changeIcon = <EventNoteIcon />;
-  let changeDescription = "Project milestone updated";
-  let changeValue = "";
+  let changeText = [{ text: "Project milestone updated", style: null }];
 
   // add a new milestone
   if (change.description.length === 0) {
-    changeDescription = "Added a new milestone: ";
-    changeValue = milestoneList[change.record_data.event.data.new.milestone_id]
+    changeText = [
+      { text: "Added ", style: null },
+      {
+        text: milestoneList[change.record_data.event.data.new.milestone_id],
+        style: "boldText",
+      },
+      { text: " as a new milestone.", style: null },
+    ];
 
-    return { changeIcon, changeDescription, changeValue };
+    return { changeIcon, changeText };
   }
 
   // delete an existing milestone
   if (change.description[0].field === "is_deleted") {
-    changeDescription = "Deleted the milestone: ";
-    changeValue = milestoneList[change.record_data.event.data.new.milestone_id];
+    changeText = [
+      { text: "Deleted the milestone ", style: null },
+      {
+        text: milestoneList[change.record_data.event.data.new.milestone_id],
+        style: "boldText",
+      },
+    ];
 
-    return { changeIcon, changeDescription, changeValue };
+    return { changeIcon, changeText };
   }
 
   // Multiple fields in the moped_proj_funding table can be updated at once
@@ -32,18 +39,27 @@ export const formatMilestonesActivity = (
   const newRecord = change.record_data.event.data.new;
   const oldRecord = change.record_data.event.data.old;
 
-  console.log(newRecord, oldRecord)
-
   let changes = [];
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-      changes.push(entryMap.fields[field].label);
-    })
+    if (newRecord[field] !== oldRecord[field]) {
+      changes.push(entryMap.fields[field]?.label);
+    }
+  });
 
-  // todo: add the milestone name
-  changeDescription = "Edited a milestone's ";
-  changeValue = changes.join(", ");
+  changeText = [
+    { text: "Edited the milestone ", style: null },
+    {
+      text: milestoneList[change.record_data.event.data.new.milestone_id],
+      style: "boldText",
+    },
+    { text: " by updating the ", style: null },
+    {
+      text: changes.join(", "),
+      style: "boldText",
+    },
+  ];
 
-  return { changeIcon, changeDescription, changeValue };
+  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -5,32 +5,27 @@ export const formatMilestonesActivity = (change, milestoneList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];
 
   const changeIcon = <EventNoteIcon />;
-  let changeText = [{ text: "Project milestone updated", style: null }];
+  const changeText = [];
 
   // add a new milestone
   if (change.description.length === 0) {
-    changeText = [
-      { text: "Added ", style: null },
-      {
-        text: milestoneList[change.record_data.event.data.new.milestone_id],
-        style: "boldText",
-      },
-      { text: " as a new milestone.", style: null },
-    ];
-
+    changeText.push({ text: "Added ", style: null });
+    changeText.push({
+      text: milestoneList[change.record_data.event.data.new.milestone_id],
+      style: "boldText",
+    });
+    changeText.push({ text: " as a new milestone.", style: null });
 
     return { changeIcon, changeText };
   }
 
   // delete an existing milestone
   if (change.description[0].field === "is_deleted") {
-    changeText = [
-      { text: "Deleted the milestone ", style: null },
-      {
-        text: milestoneList[change.record_data.event.data.new.milestone_id],
-        style: "boldText",
-      },
-    ];
+    changeText.push({ text: "Deleted the milestone ", style: null });
+    changeText.push({
+      text: milestoneList[change.record_data.event.data.new.milestone_id],
+      style: "boldText",
+    });
 
     return { changeIcon, changeText };
   }
@@ -49,18 +44,16 @@ export const formatMilestonesActivity = (change, milestoneList) => {
     }
   });
 
-  changeText = [
-    { text: "Edited the milestone ", style: null },
-    {
-      text: milestoneList[change.record_data.event.data.new.milestone_id],
-      style: "boldText",
-    },
-    { text: " by updating the ", style: null },
-    {
-      text: changes.join(", "),
-      style: "boldText",
-    },
-  ];
+  changeText.push({ text: "Edited the milestone ", style: null });
+  changeText.push({
+    text: milestoneList[change.record_data.event.data.new.milestone_id],
+    style: "boldText",
+  });
+  changeText.push({ text: " by updating the ", style: null });
+  changeText.push({
+    text: changes.join(", "),
+    style: "boldText",
+  });
 
   return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
@@ -2,18 +2,27 @@ import GroupOutlined from "@material-ui/icons/GroupOutlined";
 
 export const formatPartnersActivity = (change, entityList) => {
   const changeIcon = <GroupOutlined />;
-  let changeDescription = "Project partners updated";
-  let changeValue = ""
+  let changeText = [{ text: "Project partners updated", style: null }];
 
   // Adding a new partner
   if (change.description.length === 0) {
-    changeDescription = "Added project partner "
-    changeValue = entityList[change.record_data.event.data.new.entity_id]
+    changeText = [
+      { text: "Added project partner ", style: null },
+      {
+        text: entityList[change.record_data.event.data.new.entity_id],
+        style: "boldText",
+      },
+    ];
   } else {
     // Soft deleting a partner is the only update a user can do (is_deleted is set to true)
-    changeDescription = "Removed project partner "
-    changeValue = entityList[change.record_data.event.data.new.entity_id]
+    changeText = [
+      { text: "Removed project partner ", style: null },
+      {
+        text: entityList[change.record_data.event.data.new.entity_id],
+        style: "boldText",
+      },
+    ];
   }
 
-  return { changeIcon, changeDescription, changeValue };
+  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
@@ -2,26 +2,22 @@ import GroupOutlined from "@material-ui/icons/GroupOutlined";
 
 export const formatPartnersActivity = (change, entityList) => {
   const changeIcon = <GroupOutlined />;
-  let changeText = [{ text: "Project partners updated", style: null }];
+  const changeText = [];
 
   // Adding a new partner
   if (change.description.length === 0) {
-    changeText = [
-      { text: "Added project partner ", style: null },
-      {
-        text: entityList[change.record_data.event.data.new.entity_id],
-        style: "boldText",
-      },
-    ];
+    changeText.push({ text: "Added project partner ", style: null });
+    changeText.push({
+      text: entityList[change.record_data.event.data.new.entity_id],
+      style: "boldText",
+    });
   } else {
     // Soft deleting a partner is the only update a user can do (is_deleted is set to true)
-    changeText = [
-      { text: "Removed project partner ", style: null },
-      {
-        text: entityList[change.record_data.event.data.new.entity_id],
-        style: "boldText",
-      },
-    ];
+    changeText.push({ text: "Removed project partner ", style: null });
+    changeText.push({
+      text: entityList[change.record_data.event.data.new.entity_id],
+      style: "boldText",
+    });
   }
 
   return { changeIcon, changeText };

--- a/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPartnersActivity.js
@@ -2,23 +2,30 @@ import GroupOutlined from "@material-ui/icons/GroupOutlined";
 
 export const formatPartnersActivity = (change, entityList) => {
   const changeIcon = <GroupOutlined />;
-  const changeText = [];
 
   // Adding a new partner
   if (change.description.length === 0) {
-    changeText.push({ text: "Added project partner ", style: null });
-    changeText.push({
-      text: entityList[change.record_data.event.data.new.entity_id],
-      style: "boldText",
-    });
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Added project partner ", style: null },
+        {
+          text: entityList[change.record_data.event.data.new.entity_id],
+          style: "boldText",
+        },
+      ],
+    };
   } else {
     // Soft deleting a partner is the only update a user can do (is_deleted is set to true)
-    changeText.push({ text: "Removed project partner ", style: null });
-    changeText.push({
-      text: entityList[change.record_data.event.data.new.entity_id],
-      style: "boldText",
-    });
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Removed project partner ", style: null },
+        {
+          text: entityList[change.record_data.event.data.new.entity_id],
+          style: "boldText",
+        },
+      ],
+    };
   }
-
-  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -5,20 +5,26 @@ export const formatProjectActivity = (change, entityList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_project"];
   let changeDescription = "Project updated";
   let changeIcon = <span className="material-symbols-outlined">summarize</span>;
-  let changeValue = "";
+  let changeText = [{ text: "Project updated", style: null }];
 
   const changeData = change.record_data.event.data;
 
   // Project creation
   if (change.description.length === 0) {
-    changeDescription = "Created project as ";
-    changeValue = changeData.new.project_name;
+    changeText = [
+      { text: "Created project as ", style: null },
+      { text: changeData.new.project_name, style: "boldText" },
+    ];
     changeIcon = <BeenhereOutlinedIcon />;
-    return { changeIcon, changeDescription, changeValue };
+    return { changeIcon, changeText };
   }
 
   // the field that was changed in the activity
   const changedField = change.description[0].field;
+
+  if (!changedField) {
+    return { changeIcon, changeText };
+  }
 
   // need to use a lookup table
   if (entryMap.fields[changedField]?.lookup) {
@@ -29,40 +35,68 @@ export const formatProjectActivity = (change, entityList) => {
       changeData.old === 0 ||
       changeData.old[changedField] === 0
     ) {
-      changeDescription = `Added "${
-        entityList[change.description[0].new]
-      }" as `;
-      changeValue = entryMap.fields[changedField].label;
-      return { changeIcon, changeDescription, changeValue };
+      changeText = [
+        {
+          text: `Added "${entityList[change.description[0].new]}" as `,
+          style: null,
+        },
+        { text: entryMap.fields[changedField].label, style: "boldText" },
+      ];
+
+      return { changeIcon, changeText };
     }
 
     // if the new field is null or undefined, its because something was removed
     if (!entityList[changeData.new[changedField]]) {
-      changeDescription = `Removed ${entryMap.fields[changedField].label} `;
-      changeValue = "";
-      return { changeIcon, changeDescription, changeValue };
+      changeText = [
+        {
+          text: `Removed ${entryMap.fields[changedField].label} `,
+          style: null,
+        },
+      ];
+      return { changeIcon, changeText };
     }
 
     // Changing a field, but need to use lookup table to display
-    changeDescription = `Changed ${entryMap.fields[changedField].label} to `;
-    changeValue = entityList[changeData.new[changedField]];
-  } else {
+    changeText = [
+      {
+        text: `Changed "${entryMap.fields[changedField].label}" to `,
+        style: null,
+      },
+      { text: entityList[changeData.new[changedField]], style: "boldText" },
+    ];
+  }
+  // we dont need the lookup table
+  else {
     // If the update is an object, show just the field name that was updated.
     if (typeof changeData.new[changedField] === "object") {
-      changeDescription = `Changed ${entryMap.fields[changedField].label}`;
-      changeValue = "";
-      return { changeIcon, changeDescription, changeValue };
+      changeText = [
+        {
+          text: `Changed ${entryMap.fields[changedField].label} `,
+          style: null,
+        },
+      ];
+      return { changeIcon, changeText };
     }
 
     // the update can be rendered as a string
-    changeDescription = `
-          Changed ${entryMap.fields[changedField].label}
-          to `;
-    changeValue =
-      changeData.new[changedField].length > 0
+    const changeValue =
+      String(changeData.new[changedField]).length > 0
         ? changeData.new[changedField]
         : "(none)";
-  }
 
-  return { changeIcon, changeDescription, changeValue };
+    changeText = [
+      {
+        text: `
+          Changed ${entryMap.fields[changedField].label}
+          to `,
+        style: null,
+      },
+      {
+        text: changeValue,
+        style: "boldText",
+      },
+    ];
+  }
+  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -4,16 +4,14 @@ import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/Pr
 export const formatProjectActivity = (change, entityList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_project"];
   let changeIcon = <span className="material-symbols-outlined">summarize</span>;
-  let changeText = [{ text: "Project updated", style: null }];
+  let changeText = [];
 
   const changeData = change.record_data.event.data;
 
   // Project creation
   if (change.description.length === 0) {
-    changeText = [
-      { text: "Created project as ", style: null },
-      { text: changeData.new.project_name, style: "boldText" },
-    ];
+    changeText.push({ text: "Created project as ", style: null });
+    changeText.push({ text: changeData.new.project_name, style: "boldText" });
     changeIcon = <BeenhereOutlinedIcon />;
     return { changeIcon, changeText };
   }
@@ -22,6 +20,7 @@ export const formatProjectActivity = (change, entityList) => {
   const changedField = change.description[0].field;
 
   if (!changedField) {
+    changeText.push({ text: "Project updated", style: null });
     return { changeIcon, changeText };
   }
 
@@ -34,47 +33,45 @@ export const formatProjectActivity = (change, entityList) => {
       changeData.old === 0 ||
       changeData.old[changedField] === 0
     ) {
-      changeText = [
-        {
-          text: `Added "${entityList[change.description[0].new]}" as `,
-          style: null,
-        },
-        { text: entryMap.fields[changedField].label, style: "boldText" },
-      ];
+      changeText.push({
+        text: `Added "${entityList[change.description[0].new]}" as `,
+        style: null,
+      });
+      changeText.push({
+        text: entryMap.fields[changedField].label,
+        style: "boldText",
+      });
 
       return { changeIcon, changeText };
     }
 
     // if the new field is null or undefined, its because something was removed
     if (!entityList[changeData.new[changedField]]) {
-      changeText = [
-        {
-          text: `Removed ${entryMap.fields[changedField].label} `,
-          style: null,
-        },
-      ];
+      changeText.push({
+        text: `Removed ${entryMap.fields[changedField].label} `,
+        style: null,
+      });
       return { changeIcon, changeText };
     }
 
     // Changing a field, but need to use lookup table to display
-    changeText = [
-      {
-        text: `Changed "${entryMap.fields[changedField].label}" to `,
-        style: null,
-      },
-      { text: entityList[changeData.new[changedField]], style: "boldText" },
-    ];
+    changeText.push({
+      text: `Changed "${entryMap.fields[changedField].label}" to `,
+      style: null,
+    });
+    changeText.push({
+      text: entityList[changeData.new[changedField]],
+      style: "boldText",
+    });
   }
   // we dont need the lookup table
   else {
     // If the update is an object, show just the field name that was updated.
     if (typeof changeData.new[changedField] === "object") {
-      changeText = [
-        {
-          text: `Changed ${entryMap.fields[changedField].label} `,
-          style: null,
-        },
-      ];
+      changeText.push({
+        text: `Changed ${entryMap.fields[changedField].label} `,
+        style: null,
+      });
       return { changeIcon, changeText };
     }
 
@@ -84,18 +81,16 @@ export const formatProjectActivity = (change, entityList) => {
         ? changeData.new[changedField]
         : "(none)";
 
-    changeText = [
-      {
-        text: `
+    changeText.push({
+      text: `
           Changed ${entryMap.fields[changedField].label}
           to `,
-        style: null,
-      },
-      {
-        text: changeValue,
-        style: "boldText",
-      },
-    ];
+      style: null,
+    });
+    changeText.push({
+      text: changeValue,
+      style: "boldText",
+    });
   }
   return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -95,9 +95,12 @@ export const formatProjectActivity = (change, lookupList) => {
         ],
       };
     }
+    console.log(changeData.new[changedField])
 
     // the update can be rendered as a string
     const changeValue =
+      // check truthiness to prevent rendering String(null) as "null"
+      !!changeData.new[changedField] &&
       String(changeData.new[changedField]).length > 0
         ? changeData.new[changedField]
         : "(none)";

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -34,7 +34,7 @@ export const formatProjectActivity = (change, lookupList) => {
       changeData.old[changedField] === 0
     ) {
       changeText.push({
-        text: `Added "${entityList[change.description[0].new]}" as `,
+        text: `Added "${lookupList[change.description[0].new]}" as `,
         style: null,
       });
       changeText.push({
@@ -46,7 +46,7 @@ export const formatProjectActivity = (change, lookupList) => {
     }
 
     // if the new field is null or undefined, its because something was removed
-    if (!entityList[changeData.new[changedField]]) {
+    if (!lookupList[changeData.new[changedField]]) {
       changeText.push({
         text: `Removed ${entryMap.fields[changedField].label} `,
         style: null,
@@ -60,7 +60,7 @@ export const formatProjectActivity = (change, lookupList) => {
       style: null,
     });
     changeText.push({
-      text: entityList[changeData.new[changedField]],
+      text: lookupList[changeData.new[changedField]],
       style: "boldText",
     });
   }

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -4,24 +4,29 @@ import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/Pr
 export const formatProjectActivity = (change, lookupList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_project"];
   let changeIcon = <span className="material-symbols-outlined">summarize</span>;
-  let changeText = [];
 
   const changeData = change.record_data.event.data;
 
   // Project creation
   if (change.description.length === 0) {
-    changeText.push({ text: "Created project as ", style: null });
-    changeText.push({ text: changeData.new.project_name, style: "boldText" });
     changeIcon = <BeenhereOutlinedIcon />;
-    return { changeIcon, changeText };
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Created project as ", style: null },
+        { text: changeData.new.project_name, style: "boldText" },
+      ],
+    };
   }
 
   // the field that was changed in the activity
   const changedField = change.description[0].field;
 
   if (!changedField) {
-    changeText.push({ text: "Project updated", style: null });
-    return { changeIcon, changeText };
+    return {
+      changeIcon,
+      changeText: [{ text: "Project updated", style: null }],
+    };
   }
 
   // need to use a lookup table
@@ -33,46 +38,62 @@ export const formatProjectActivity = (change, lookupList) => {
       changeData.old === 0 ||
       changeData.old[changedField] === 0
     ) {
-      changeText.push({
-        text: `Added "${lookupList[change.description[0].new]}" as `,
-        style: null,
-      });
-      changeText.push({
-        text: entryMap.fields[changedField].label,
-        style: "boldText",
-      });
-
-      return { changeIcon, changeText };
+      return {
+        changeIcon,
+        changeText: [
+          {
+            text: `Added "${lookupList[change.description[0].new]}" as `,
+            style: null,
+          },
+          {
+            text: entryMap.fields[changedField].label,
+            style: "boldText",
+          },
+        ],
+      };
     }
 
     // if the new field is null or undefined, its because something was removed
     if (!lookupList[changeData.new[changedField]]) {
-      changeText.push({
-        text: `Removed ${entryMap.fields[changedField].label} `,
-        style: null,
-      });
-      return { changeIcon, changeText };
+      return {
+        changeIcon,
+        changeText: [
+          {
+            text: `Removed ${entryMap.fields[changedField].label} `,
+            style: null,
+          },
+        ],
+      };
     }
 
     // Changing a field, but need to use lookup table to display
-    changeText.push({
-      text: `Changed "${entryMap.fields[changedField].label}" to `,
-      style: null,
-    });
-    changeText.push({
-      text: lookupList[changeData.new[changedField]],
-      style: "boldText",
-    });
+    return {
+      changeIcon,
+      changeText: [
+        {
+          text: `Changed "${entryMap.fields[changedField].label}" to `,
+          style: null,
+        },
+        {
+          text: lookupList[changeData.new[changedField]],
+          style: "boldText",
+        },
+      ],
+    };
   }
   // we dont need the lookup table
   else {
     // If the update is an object, show just the field name that was updated.
     if (typeof changeData.new[changedField] === "object") {
-      changeText.push({
-        text: `Changed ${entryMap.fields[changedField].label} `,
-        style: null,
-      });
-      return { changeIcon, changeText };
+      return {
+        changeIcon,
+        changeText: [
+          {
+            text: `Changed ${entryMap.fields[changedField].label} `,
+            style: null,
+          },
+        ],
+      };
     }
 
     // the update can be rendered as a string
@@ -80,17 +101,20 @@ export const formatProjectActivity = (change, lookupList) => {
       String(changeData.new[changedField]).length > 0
         ? changeData.new[changedField]
         : "(none)";
-
-    changeText.push({
-      text: `
+    return {
+      changeIcon,
+      changeText: [
+        {
+          text: `
           Changed ${entryMap.fields[changedField].label}
           to `,
-      style: null,
-    });
-    changeText.push({
-      text: changeValue,
-      style: "boldText",
-    });
+          style: null,
+        },
+        {
+          text: changeValue,
+          style: "boldText",
+        },
+      ],
+    };
   }
-  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -42,7 +42,7 @@ export const formatProjectActivity = (change, lookupList) => {
         changeIcon,
         changeText: [
           {
-            text: `Added "${lookupList[change.description[0].new]}" as `,
+            text: `Added ${lookupList[change.description[0].new]} as `,
             style: null,
           },
           {
@@ -71,7 +71,7 @@ export const formatProjectActivity = (change, lookupList) => {
       changeIcon,
       changeText: [
         {
-          text: `Changed "${entryMap.fields[changedField].label}" to `,
+          text: `Changed ${entryMap.fields[changedField].label} to `,
           style: null,
         },
         {

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -3,7 +3,6 @@ import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/Pr
 
 export const formatProjectActivity = (change, entityList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_project"];
-  let changeDescription = "Project updated";
   let changeIcon = <span className="material-symbols-outlined">summarize</span>;
   let changeText = [{ text: "Project updated", style: null }];
 

--- a/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
@@ -2,23 +2,30 @@ import LocalOfferOutlinedIcon from "@material-ui/icons/LocalOfferOutlined";
 
 export const formatTagsActivity = (change, tagList) => {
   const changeIcon = <LocalOfferOutlinedIcon />;
-  let changeText = [];
 
   // Adding a new tag
   if (change.description.length === 0) {
-    changeText.push({ text: "Project tagged with ", style: null });
-    changeText.push({
-      text: tagList[change.record_data.event.data.new.tag_id],
-      style: "boldText",
-    });
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Project tagged with ", style: null },
+        {
+          text: tagList[change.record_data.event.data.new.tag_id],
+          style: "boldText",
+        },
+      ],
+    };
   } else {
     // Soft deleting a tag is the only update a user can do (is_deleted is set to true)
-    changeText.push({ text: "Project tag deleted  ", style: null });
-    changeText.push({
-      text: tagList[change.record_data.event.data.new.tag_id],
-      style: "boldText",
-    });
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Project tag deleted  ", style: null },
+        {
+          text: tagList[change.record_data.event.data.new.tag_id],
+          style: "boldText",
+        },
+      ],
+    };
   }
-
-  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
@@ -2,26 +2,22 @@ import LocalOfferOutlinedIcon from "@material-ui/icons/LocalOfferOutlined";
 
 export const formatTagsActivity = (change, tagList) => {
   const changeIcon = <LocalOfferOutlinedIcon />;
-  let changeText = [{ text: "Project tags updated", style: null }];
+  let changeText = [];
 
   // Adding a new tag
   if (change.description.length === 0) {
-    changeText = [
-      { text: "Project tagged with ", style: null },
-      {
-        text: tagList[change.record_data.event.data.new.tag_id],
-        style: "boldText",
-      },
-    ];
+    changeText.push({ text: "Project tagged with ", style: null });
+    changeText.push({
+      text: tagList[change.record_data.event.data.new.tag_id],
+      style: "boldText",
+    });
   } else {
     // Soft deleting a tag is the only update a user can do (is_deleted is set to true)
-    changeText = [
-      { text: "Project tag deleted  ", style: null },
-      {
-        text: tagList[change.record_data.event.data.new.tag_id],
-        style: "boldText",
-      },
-    ];
+    changeText.push({ text: "Project tag deleted  ", style: null });
+    changeText.push({
+      text: tagList[change.record_data.event.data.new.tag_id],
+      style: "boldText",
+    });
   }
 
   return { changeIcon, changeText };

--- a/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedTagsActivity.js
@@ -2,18 +2,27 @@ import LocalOfferOutlinedIcon from "@material-ui/icons/LocalOfferOutlined";
 
 export const formatTagsActivity = (change, tagList) => {
   const changeIcon = <LocalOfferOutlinedIcon />;
-  let changeDescription = "Project tags updated";
-  let changeValue = ""
+  let changeText = [{ text: "Project tags updated", style: null }];
 
   // Adding a new tag
   if (change.description.length === 0) {
-    changeDescription = "Project tagged with "
-    changeValue = tagList[change.record_data.event.data.new.tag_id]
+    changeText = [
+      { text: "Project tagged with ", style: null },
+      {
+        text: tagList[change.record_data.event.data.new.tag_id],
+        style: "boldText",
+      },
+    ];
   } else {
     // Soft deleting a tag is the only update a user can do (is_deleted is set to true)
-    changeDescription = "Project tag deleted "
-    changeValue = tagList[change.record_data.event.data.new.tag_id]
+    changeText = [
+      { text: "Project tag deleted  ", style: null },
+      {
+        text: tagList[change.record_data.event.data.new.tag_id],
+        style: "boldText",
+      },
+    ];
   }
 
-  return { changeIcon, changeDescription, changeValue };
+  return { changeIcon, changeText };
 };

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -8,6 +8,9 @@ import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersAct
 export const formatActivityLogEntry = (change, lookupData) => {
   const changeDescription = "Project was updated";
   const changeValue = "";
+  const changeText = [
+      {text: "Project was updated", textClassname: null}
+    ];
   const changeIcon = (
     <span className="material-symbols-outlined">summarize</span>
   );
@@ -24,6 +27,6 @@ export const formatActivityLogEntry = (change, lookupData) => {
     case "moped_proj_partners":
       return formatPartnersActivity(change, lookupData.entityList);
     default:
-      return { changeIcon, changeDescription, changeValue };
+      return { changeIcon, changeDescription, changeValue, changeText };
   }
 };

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -6,10 +6,8 @@ import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersAct
 
 
 export const formatActivityLogEntry = (change, lookupData) => {
-  const changeDescription = "Project was updated";
-  const changeValue = "";
   const changeText = [
-      {text: "Project was updated", textClassname: null}
+      {text: "Project was updated", style: null}
     ];
   const changeIcon = (
     <span className="material-symbols-outlined">summarize</span>
@@ -27,6 +25,6 @@ export const formatActivityLogEntry = (change, lookupData) => {
     case "moped_proj_partners":
       return formatPartnersActivity(change, lookupData.entityList);
     default:
-      return { changeIcon, changeDescription, changeValue, changeText };
+      return { changeIcon, changeText };
   }
 };

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -14,8 +14,26 @@ const ProjectActivityEntry = ({
   changeIcon,
   changeDescription,
   changeValue,
+  changeText,
 }) => {
   const classes = useStyles();
+
+  if (changeText) {
+    return (
+      <Box display="flex" p={0}>
+        <Box p={0}>{changeIcon}</Box>
+        <Box p={0} flexGrow={1}>
+          <Typography variant="body2" className={classes.entryText}>
+            {changeText.map((changeObject) => (
+              <span className={classes[changeObject.style]}>
+                {changeObject.text}
+              </span>
+            ))}
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box display="flex" p={0}>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -25,8 +25,8 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
         <Typography variant="body2" className={classes.entryText}>
           {
             // maps through the array of objects and applies specified style to the text
-            changeText.map((changeObject) => (
-              <span className={classes[changeObject.style]}>
+            changeText.map((changeObject, index) => (
+              <span className={classes[changeObject.style]} key={index}>
                 {changeObject.text}
               </span>
             ))

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -12,19 +12,20 @@ const useStyles = makeStyles((theme) => ({
 
 const ProjectActivityEntry = ({ changeIcon, changeText }) => {
   const classes = useStyles();
-
-  <Box display="flex" p={0}>
-    <Box p={0}>{changeIcon}</Box>
-    <Box p={0} flexGrow={1}>
-      <Typography variant="body2" className={classes.entryText}>
-        {changeText.map((changeObject) => (
-          <span className={classes[changeObject.style]}>
-            {changeObject.text}
-          </span>
-        ))}
-      </Typography>
+  return (
+    <Box display="flex" p={0}>
+      <Box p={0}>{changeIcon}</Box>
+      <Box p={0} flexGrow={1}>
+        <Typography variant="body2" className={classes.entryText}>
+          {changeText.map((changeObject) => (
+            <span className={classes[changeObject.style]}>
+              {changeObject.text}
+            </span>
+          ))}
+        </Typography>
+      </Box>
     </Box>
-  </Box>;
+  );
 };
 
 export default ProjectActivityEntry;

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -10,6 +10,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+/**
+ * One row/entry in the project activity log
+ * @param {changeIcon} Material UI icon component
+ * @param {changeText} - Array of objects of the shape:
+ *  {text: String to display, style: String name of style or null}
+ */
 const ProjectActivityEntry = ({ changeIcon, changeText }) => {
   const classes = useStyles();
   return (
@@ -17,11 +23,14 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
       <Box p={0}>{changeIcon}</Box>
       <Box p={0} flexGrow={1}>
         <Typography variant="body2" className={classes.entryText}>
-          {changeText.map((changeObject) => (
-            <span className={classes[changeObject.style]}>
-              {changeObject.text}
-            </span>
-          ))}
+          {
+            // maps through the array of objects and applies specified style to the text
+            changeText.map((changeObject) => (
+              <span className={classes[changeObject.style]}>
+                {changeObject.text}
+              </span>
+            ))
+          }
         </Typography>
       </Box>
     </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -10,44 +10,21 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ProjectActivityEntry = ({
-  changeIcon,
-  changeDescription,
-  changeValue,
-  changeText,
-}) => {
+const ProjectActivityEntry = ({ changeIcon, changeText }) => {
   const classes = useStyles();
 
-  if (changeText) {
-    return (
-      <Box display="flex" p={0}>
-        <Box p={0}>{changeIcon}</Box>
-        <Box p={0} flexGrow={1}>
-          <Typography variant="body2" className={classes.entryText}>
-            {changeText.map((changeObject) => (
-              <span className={classes[changeObject.style]}>
-                {changeObject.text}
-              </span>
-            ))}
-          </Typography>
-        </Box>
-      </Box>
-    );
-  }
-
-  return (
-    <Box display="flex" p={0}>
-      <Box p={0}>{changeIcon}</Box>
-      <Box p={0} flexGrow={1}>
-        <Typography variant="body2" className={classes.entryText}>
-          {changeDescription}
-          {!!changeValue && (
-            <span className={classes.boldText}>{changeValue}</span>
-          )}
-        </Typography>
-      </Box>
+  <Box display="flex" p={0}>
+    <Box p={0}>{changeIcon}</Box>
+    <Box p={0} flexGrow={1}>
+      <Typography variant="body2" className={classes.entryText}>
+        {changeText.map((changeObject) => (
+          <span className={classes[changeObject.style]}>
+            {changeObject.text}
+          </span>
+        ))}
+      </Typography>
     </Box>
-  );
+  </Box>;
 };
 
 export default ProjectActivityEntry;

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -234,7 +234,7 @@ const ProjectActivityLog = () => {
               </TableHead>
               <TableBody>
                 {activityLogData.map((change) => {
-                  const { changeIcon, changeDescription, changeValue } =
+                  const { changeIcon, changeDescription, changeValue, changeText } =
                     formatActivityLogEntry(change, lookupData);
                   return (
                     <TableRow key={change.activity_id}>
@@ -296,6 +296,7 @@ const ProjectActivityLog = () => {
                             changeIcon={changeIcon}
                             changeDescription={changeDescription}
                             changeValue={changeValue}
+                            changeText={changeText}
                           />
                         ) : (
                           <Box display="flex" p={0}>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -234,7 +234,7 @@ const ProjectActivityLog = () => {
               </TableHead>
               <TableBody>
                 {activityLogData.map((change) => {
-                  const { changeIcon, changeDescription, changeValue, changeText } =
+                  const { changeIcon, changeText } =
                     formatActivityLogEntry(change, lookupData);
                   return (
                     <TableRow key={change.activity_id}>
@@ -294,8 +294,6 @@ const ProjectActivityLog = () => {
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}
-                            changeDescription={changeDescription}
-                            changeValue={changeValue}
                             changeText={changeText}
                           />
                         ) : (

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -123,6 +123,9 @@ export const ProjectActivityLogTableMaps = {
       project_id: {
         label: "project ID",
       },
+      milestone_id: {
+        label: "id"
+      },
       project_milestone_id: {
         label: "ID",
       },


### PR DESCRIPTION
## Associated issues

No specific issue per se, but looking at activity log issues like the milestones one (https://github.com/cityofaustin/atd-data-tech/issues/11092), the current way in main to represent activity log updates, i.e., changeDescription and changeValue, was limiting how updates could be formatted. 

This refactoring doesn't tie us down to only two strings and opens the door for more flexibility. 

also this https://github.com/cityofaustin/atd-data-tech/issues/11233 (ecapris is stored as a number, and you cant find the lengths of numbers)

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

Test locally until its parent PR (milesontes) is approved and merged. 

**Steps to test:**
 This updates all of the existing activity log formatters
* funding
* milestones
* partners
* project
* tags

Add / edit / delete records on the funding table, milestones. 
update a project's information on the summary page (be sure to test ecapris and interim project id) as well as tags, project partners and public process status. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
