### PR TITLE
Use REST connector endpoint for project milestones

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2581,36 +2581,47 @@
         insert:
           columns: '*'
         update:
-          columns:
-            - completed
-            - is_current_milestone
-            - milestone_id
-            - milestone_privacy
-            - milestone_end
-            - milestone_estimate
-            - milestone_start
-            - completed_by_user_id
-            - completion_percentage
-            - milestone_order
-            - milestone_priority
-            - project_id
-            - project_milestone_id
-            - started_by_user_id
-            - milestone_date_type
-            - milestone_description
-            - milestone_status
-            - date_added
-            - is_deleted
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 0
         timeout_sec: 60
-      webhook_from_env: MOPED_API_EVENTS_URL
+      webhook_from_env: HASURA_ENDPOINT
       headers:
-        - name: MOPED_API_APIKEY
-          value_from_env: MOPED_API_APIKEY
-        - name: MOPED_API_EVENT_NAME
-          value: activity_log
+        - name: x-hasura-admin-secret
+          value_from_env: ACTIVITY_LOG_API_SECRET
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+                            "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+                            "variables": {
+                                "object": {
+                                    "record_id": {{ $body.event.data.new.project_id }},
+                                    "record_type":  {{ $body.table.name }},
+                                    "activity_id": {{ $body.id }},
+                                    "record_project_id": {{ $body.event.data.new.project_id }},
+                                    "record_data": {"event": {{ $body.event }}},
+                                    "description": [{"newSchema": "true"}],
+                                    "operation_type": {{ $body.event.op }},
+                                    "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
+                                },
+                                "updated_at": {{$body.created_at}},
+                                "project_id": {{$body.event.data.new.project_id}}
+                            }
+                        }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        version: 2
+      cleanup_config:
+        batch_size: 10000
+        clean_invocation_logs: false
+        clear_older_than: 168
+        paused: true
+        schedule: 0 0 * * *
+        timeout: 60
 - table:
     name: moped_proj_notes
     schema: public

--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.6.9",

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -478,6 +478,10 @@ export const PROJECT_ACTIVITY_LOG = gql`
       phase_id
       phase_name
     }
+    moped_milestones {
+      milestone_id
+      milestone_name
+    }
     moped_tags(order_by: { name: asc }) {
       name
       id

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -1,10 +1,7 @@
-import EventNoteIcon from '@material-ui/icons/EventNote';
+import EventNoteIcon from "@material-ui/icons/EventNote";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 
-export const formatMilestonesActivity = (
-  change,
-  milestoneList
-) => {
+export const formatMilestonesActivity = (change, milestoneList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];
 
   const changeIcon = <EventNoteIcon />;
@@ -14,7 +11,7 @@ export const formatMilestonesActivity = (
   // add a new milestone
   if (change.description.length === 0) {
     changeDescription = "Added a new milestone: ";
-    changeValue = milestoneList[change.record_data.event.data.new.milestone_id]
+    changeValue = milestoneList[change.record_data.event.data.new.milestone_id];
 
     return { changeIcon, changeDescription, changeValue };
   }
@@ -32,14 +29,14 @@ export const formatMilestonesActivity = (
   const newRecord = change.record_data.event.data.new;
   const oldRecord = change.record_data.event.data.old;
 
-  console.log(newRecord, oldRecord)
-
   let changes = [];
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-      changes.push(entryMap.fields[field].label);
-    })
+    if (newRecord[field] !== oldRecord[field]) {
+      changes.push(entryMap.fields[field]?.label);
+    }
+  });
 
   // todo: add the milestone name
   changeDescription = "Edited a milestone's ";

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -1,0 +1,49 @@
+import EventNoteIcon from '@material-ui/icons/EventNote';
+import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
+
+export const formatMilestonesActivity = (
+  change,
+  milestoneList
+) => {
+  const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];
+
+  const changeIcon = <EventNoteIcon />;
+  let changeDescription = "Project milestone updated";
+  let changeValue = "";
+
+  // add a new milestone
+  if (change.description.length === 0) {
+    changeDescription = "Added a new milestone: ";
+    changeValue = milestoneList[change.record_data.event.data.new.milestone_id]
+
+    return { changeIcon, changeDescription, changeValue };
+  }
+
+  // delete an existing milestone
+  if (change.description[0].field === "is_deleted") {
+    changeDescription = "Deleted the milestone: ";
+    changeValue = milestoneList[change.record_data.event.data.new.milestone_id];
+
+    return { changeIcon, changeDescription, changeValue };
+  }
+
+  // Multiple fields in the moped_proj_funding table can be updated at once
+  // We list the fields changed in the activity log, this gathers the fields changed
+  const newRecord = change.record_data.event.data.new;
+  const oldRecord = change.record_data.event.data.old;
+
+  console.log(newRecord, oldRecord)
+
+  let changes = [];
+
+  // loop through fields to check for differences, push label onto changes Array
+  Object.keys(newRecord).forEach((field) => {
+      changes.push(entryMap.fields[field].label);
+    })
+
+  // todo: add the milestone name
+  changeDescription = "Edited a milestone's ";
+  changeValue = changes.join(", ");
+
+  return { changeIcon, changeDescription, changeValue };
+};

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -24,7 +24,7 @@ export const formatMilestonesActivity = (change, milestoneList) => {
     return { changeIcon, changeDescription, changeValue };
   }
 
-  // Multiple fields in the moped_proj_funding table can be updated at once
+  // Multiple fields in the milestones table can be updated at once
   // We list the fields changed in the activity log, this gathers the fields changed
   const newRecord = change.record_data.event.data.new;
   const oldRecord = change.record_data.event.data.old;

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -1,6 +1,7 @@
 import { formatProjectActivity } from "./activityLogFormatters/mopedProjectActivity";
 import { formatTagsActivity } from "./activityLogFormatters/mopedTagsActivity";
 import { formatFundingActivity } from "./activityLogFormatters/mopedFundingActivity";
+import { formatMilestonesActivity } from "./activityLogFormatters/mopedMilestonesActivity";
 
 export const formatActivityLogEntry = (change, lookupData) => {
   const changeDescription = "Project was updated";
@@ -16,6 +17,8 @@ export const formatActivityLogEntry = (change, lookupData) => {
       return formatTagsActivity(change, lookupData.tagList);
     case "moped_proj_funding":
       return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms);
+    case "moped_proj_milestones":
+      return formatMilestonesActivity(change, lookupData.milestoneList);
     default:
       return { changeIcon, changeDescription, changeValue };
   }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -83,6 +83,7 @@ const useLookupTables = (data) =>
     lookupData.fundingSources = {};
     lookupData.fundingPrograms = {};
     lookupData.fundingStatus = {};
+    lookupData.milestoneList ={};
 
     if (data) {
       data["moped_users"].forEach((user) => {
@@ -109,6 +110,9 @@ const useLookupTables = (data) =>
         lookupData.fundingStatus[`${fundStatus.funding_status_id}`] =
           fundStatus.funding_status_name;
       });
+      data["moped_milestones"].forEach((milestone) => {
+        lookupData.milestoneList[`${milestone.milestone_id}`] = milestone.milestone_name;
+      })
     }
 
     return lookupData;
@@ -285,6 +289,7 @@ const ProjectActivityLog = () => {
                           "moped_project",
                           "moped_proj_tags",
                           "moped_proj_funding",
+                          "moped_proj_milestones"
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -289,7 +289,7 @@ const ProjectActivityLog = () => {
                           "moped_project",
                           "moped_proj_tags",
                           "moped_proj_funding",
-                          "moped_proj_milestones"
+                          "moped_proj_milestones",
                           "moped_proj_partners"
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -118,104 +118,64 @@ export const ProjectActivityLogTableMaps = {
     label: "Milestone",
     fields: {
       milestone_end: {
-        icon: "",
         label: "end date",
-        type: "date",
       },
       project_id: {
-        icon: "",
         label: "project ID",
-        type: "int4",
       },
       project_milestone_id: {
-        icon: "",
         label: "ID",
-        type: "int4",
       },
       completed: {
-        icon: "",
         label: "completion",
-        type: "bool",
       },
       is_current_milestone: {
-        icon: "",
         label: "current milestone marker",
-        type: "bool",
       },
       milestone_order: {
-        icon: "",
         label: "order",
-        type: "int4",
       },
       milestone_description: {
-        icon: "",
         label: "description",
-        type: "text",
       },
       milestone_name: {
-        icon: "",
         label: "name",
-        type: "text",
       },
       date_added: {
-        icon: "",
         label: "date added",
-        type: "timestamptz",
       },
       milestone_privacy: {
-        icon: "",
         label: "privacy flag",
-        type: "bool",
       },
       milestone_start: {
-        icon: "",
         label: "start date",
-        type: "date",
       },
       completion_percentage: {
-        icon: "",
         label: "completion percentage",
-        type: "integer",
       },
       milestone_status: {
-        icon: "",
         label: "status",
-        type: "text",
       },
       milestone_priority: {
-        icon: "",
         label: "priority",
-        type: "integer",
       },
       milestone_date_type: {
-        icon: "",
         label: "date type",
-        type: "text",
       },
       milestone_related_phase_id: {
-        icon: "",
         label: "related phase ID",
-        type: "integer",
       },
       started_by_user_id: {
-        icon: "",
         label: "started by user ID",
-        type: "integer",
       },
       completed_by_user_id: {
-        icon: "",
         label: "completed by user ID",
-        type: "integer",
       },
       milestone_estimate: {
-        icon: "",
-        label: "milestone estimate",
-        type: "timestampz",
+        label: "completion estimate",
       },
       is_deleted: {
-        icon: "",
         label: "is deleted",
-        data_type: "boolean",
       },
     },
   },


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11092

## Testing
**URL to test:** 
https://deploy-preview-950--atd-moped-main.netlify.app/moped/projects/1912?tab=activity_log

**Steps to test:**

From the timeline tab, add a new milestone to a project. "Added a new milestone: Cabinet set"
Edit a milestone's fields, you should the fields listed out, like:  "Edited a milestone's completion, description"
Delete a milestone. 


you may notice that what is presented here in the activity log doesn't match what John's mockups are in the issue. I've refactored the activity log work to look more like what the issues are requesting. That PR is here: https://github.com/cityofaustin/atd-moped/pull/949

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
