### PR TITLE
Fix comment edit style

### DIFF
--- a/moped-editor/src/views/projects/projectView/CommentInputQuill.js
+++ b/moped-editor/src/views/projects/projectView/CommentInputQuill.js
@@ -24,6 +24,9 @@ const useStyles = makeStyles((theme) => ({
     position: "relative",
     color: theme.palette.secondary.dark,
   },
+  quillText: {
+    color: theme.palette.text.primary,
+  },
 }));
 
 const CommentInputQuill = ({
@@ -48,7 +51,7 @@ const CommentInputQuill = ({
     <Container>
       <Grid container direction="column" spacing={1}>
         <Grid item xs={12} sm={12}>
-          <Box pt={2}>
+          <Box className={classes.quillText} pt={2}>
             <ReactQuill
               theme="snow"
               value={noteText}

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -79,7 +79,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: "25px",
   },
   editDeleteButtons: {
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.primary,
   },
   chip: {
     margin: theme.spacing(0.5),

--- a/moped-editor/src/views/projects/projectView/ProjectComments.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComments.js
@@ -79,7 +79,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: "25px",
   },
   editDeleteButtons: {
-    color: "#000000",
+    color: theme.palette.text.secondary,
   },
   chip: {
     margin: theme.spacing(0.5),


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11126

This PR updates the `CommentInputQuill` component to set the style of text in it React Quill text box. It was previously inheriting from MUI styles which led to inconsistent styling depending on its wrapper.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-951--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to the following places to create or edit a comment or status update and make sure the input text color matches our [`theme.palette.text.primary` color](https://www.google.com/search?q=%23212121):
   - Project summary > Status update
   - Project summary > Comments tab > New comment
   - Project summary > Comments tab > Edit existing comment
   - Dashboard > My Projects > Status update
   - Dashboard > Following > Status update

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
