### PR TITLE
Moped projects being duplicated in the Data Tracker

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryKnackDataTrackerSync.js
@@ -191,16 +191,17 @@ const ProjectSummaryKnackDataTrackerSync = ({
             project_id: project.project_id,
             knack_id: knackRecord.record.id,
           },
-        });
-      })
-      .then(() => refetch()) // ask the application to update its status from our graphql endpoint
-      .then(() => {
-        // End of the chain; advise the user of success
-        snackbarHandle(
-          true,
-          "Success: Project data synchronized with Data Tracker",
-          "success"
-        );
+        })
+          // ask the application to update its status from our graphql endpoint
+          .then(() => refetch())
+          .then(() =>
+            // End of the chain; advise the user of success
+            snackbarHandle(
+              true,
+              "Success: Project data synchronized with Data Tracker",
+              "success"
+            )
+          );
       })
       .catch((error) => {
         // Failure, alert the user that we've encountered an error


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11224

The project summary UI wasn't always updating after a project was sync'd with Knack successfully and opened the door to duplicate syncs after the first one succeeded. It seems that, in the original chaining, sometimes the code would move forward to the `refetch` call before the mutation to update the project completed. The `refetch` would return stale data and miss the update, and the UI would not reflect the accurate Knack sync state.

This updates the promise chaining to refetch data and show the snack bar only after the Moped record successfully updates and after the Knack update request succeeds. I know, it is a mouthful. 😅 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local only 💻 

**Steps to test:**
1. Use the same test steps from https://github.com/cityofaustin/atd-moped/pull/939
2. Sync multiple projects and make sure the Project Summary page updates as shown below each and every time the **Success** snackbar appears. Goal is to try to break it. I've tried about 5 or so.

<img width="374" alt="Screenshot 2023-01-24 at 12 36 54 PM" src="https://user-images.githubusercontent.com/37249039/214379963-a1d72457-7ff9-424d-bddc-59b37173cdfb.png">

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- ~[ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
