### PR TITLE
refines project phases activity log events

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3231,12 +3231,35 @@
         interval_sec: 10
         num_retries: 0
         timeout_sec: 60
-      webhook_from_env: MOPED_API_EVENTS_URL
+      webhook_from_env: HASURA_ENDPOINT
       headers:
-        - name: MOPED_API_APIKEY
-          value_from_env: MOPED_API_APIKEY
-        - name: MOPED_API_EVENT_NAME
-          value: activity_log
+        - name: x-hasura-admin-secret
+          value_from_env: ACTIVITY_LOG_API_SECRET
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "variables": {
+                "object": {
+                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_type":  {{ $body.table.name }},
+                  "activity_id": {{ $body.id }},
+                  "record_project_id": {{ $body.event.data.new.project_id }},
+                  "record_data": {"event": {{ $body.event }}},
+                  "description": [{"newSchema": "true"}],
+                  "operation_type": {{ $body.event.op }},
+                  "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
+                },
+                "updated_at": {{$body.created_at}},
+                "project_id": {{$body.event.data.new.project_id}}
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        version: 2
       cleanup_config:
         batch_size: 10000
         clean_invocation_logs: false

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3216,17 +3216,7 @@
         insert:
           columns: '*'
         update:
-          columns:
-            - is_current_phase
-            - date_added
-            - subphase_id
-            - phase_description
-            - project_id
-            - phase_start
-            - is_deleted
-            - phase_end
-            - project_phase_id
-            - phase_id
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 0

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -486,6 +486,10 @@ export const PROJECT_ACTIVITY_LOG = gql`
       phase_id
       phase_name
     }
+    moped_subphases {
+      subphase_id
+      subphase_name
+    }
     moped_milestones {
       milestone_id
       milestone_name

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -6,6 +6,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
 
   const changeIcon = <EventNoteIcon />;
 
+  const subphaseObject = {
+    text: ` - ${subphaseList[change.record_data.event.data.new.subphase_id]}`,
+    style: "boldText",
+  };
+
   // add a new phase
   if (change.description.length === 0) {
     return {
@@ -16,16 +21,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
           text: phaseList[change.record_data.event.data.new.phase_id],
           style: "boldText",
         },
-        // include subphase name if a subphase exists
+        // include subphase name if one exists
         ...(subphaseList[change.record_data.event.data.new.subphase_id]
-          ? [
-              {
-                text: ` - ${
-                  subphaseList[change.record_data.event.data.new.subphase_id]
-                }`,
-                style: "boldText",
-              },
-            ]
+          ? [subphaseObject]
           : []),
         { text: " as a new phase.", style: null },
       ],
@@ -42,16 +40,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
           text: phaseList[change.record_data.event.data.new.phase_id],
           style: "boldText",
         },
-        // include subphase name if a subphase exists
+        // include subphase name if one exists
         ...(subphaseList[change.record_data.event.data.new.subphase_id]
-          ? [
-              {
-                text: ` - ${
-                  subphaseList[change.record_data.event.data.new.subphase_id]
-                }`,
-                style: "boldText",
-              },
-            ]
+          ? [subphaseObject]
           : []),
       ],
     };
@@ -79,16 +70,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
         text: phaseList[change.record_data.event.data.new.phase_id],
         style: "boldText",
       },
-      // include subphase name if a subphase exists
+      // include subphase name if one exists
       ...(subphaseList[change.record_data.event.data.new.subphase_id]
-        ? [
-            {
-              text: ` - ${
-                subphaseList[change.record_data.event.data.new.subphase_id]
-              }`,
-              style: "boldText",
-            },
-          ]
+        ? [subphaseObject]
         : []),
       { text: " by updating the ", style: null },
       {

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -5,11 +5,14 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_phases"];
 
   const changeIcon = <EventNoteIcon />;
-  const phaseId = change.record_data.event.data.new.phase_id
-  const subphaseId = change.record_data.event.data.new.subphase_id
-
-  const subphaseObject = {
-    text: ` - ${subphaseList[subphaseId]}`,
+  const phase = phaseList[change.record_data.event.data.new.phase_id];
+  const subphase = subphaseList[change.record_data.event.data.new.subphase_id];
+  const phaseText = {
+    text: phase,
+    style: "boldText",
+  };
+  const subphaseText = {
+    text: ` - ${subphase}`,
     style: "boldText",
   };
 
@@ -19,14 +22,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       changeIcon,
       changeText: [
         { text: "Added ", style: null },
-        {
-          text: phaseList[phaseId],
-          style: "boldText",
-        },
+        phaseText,
         // include subphase name if one exists
-        ...(subphaseList[subphaseId]
-          ? [subphaseObject]
-          : []),
+        ...(subphase ? [subphaseText] : []),
         { text: " as a new phase.", style: null },
       ],
     };
@@ -38,14 +36,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       changeIcon,
       changeText: [
         { text: "Deleted the phase ", style: null },
-        {
-          text: phaseList[phaseId],
-          style: "boldText",
-        },
+        phaseText,
         // include subphase name if one exists
-        ...(subphaseList[subphaseId]
-          ? [subphaseObject]
-          : []),
+        ...(subphase ? [subphaseText] : []),
       ],
     };
   }
@@ -68,14 +61,9 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
     changeIcon,
     changeText: [
       { text: "Edited the phase ", style: null },
-      {
-        text: phaseList[phaseId],
-        style: "boldText",
-      },
+      phaseText,
       // include subphase name if one exists
-      ...(subphaseList[subphaseId]
-        ? [subphaseObject]
-        : []),
+      ...(subphase ? [subphaseText] : []),
       { text: " by updating the ", style: null },
       {
         text: changes.join(", "),

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -5,9 +5,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_phases"];
 
   const changeIcon = <EventNoteIcon />;
+  const phaseId = change.record_data.event.data.new.phase_id
+  const subphaseId = change.record_data.event.data.new.subphase_id
 
   const subphaseObject = {
-    text: ` - ${subphaseList[change.record_data.event.data.new.subphase_id]}`,
+    text: ` - ${subphaseList[subphaseId]}`,
     style: "boldText",
   };
 
@@ -18,11 +20,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       changeText: [
         { text: "Added ", style: null },
         {
-          text: phaseList[change.record_data.event.data.new.phase_id],
+          text: phaseList[phaseId],
           style: "boldText",
         },
         // include subphase name if one exists
-        ...(subphaseList[change.record_data.event.data.new.subphase_id]
+        ...(subphaseList[subphaseId]
           ? [subphaseObject]
           : []),
         { text: " as a new phase.", style: null },
@@ -37,11 +39,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       changeText: [
         { text: "Deleted the phase ", style: null },
         {
-          text: phaseList[change.record_data.event.data.new.phase_id],
+          text: phaseList[phaseId],
           style: "boldText",
         },
         // include subphase name if one exists
-        ...(subphaseList[change.record_data.event.data.new.subphase_id]
+        ...(subphaseList[subphaseId]
           ? [subphaseObject]
           : []),
       ],
@@ -67,11 +69,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
     changeText: [
       { text: "Edited the phase ", style: null },
       {
-        text: phaseList[change.record_data.event.data.new.phase_id],
+        text: phaseList[phaseId],
         style: "boldText",
       },
       // include subphase name if one exists
-      ...(subphaseList[change.record_data.event.data.new.subphase_id]
+      ...(subphaseList[subphaseId]
         ? [subphaseObject]
         : []),
       { text: " by updating the ", style: null },

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -1,0 +1,100 @@
+import EventNoteIcon from "@material-ui/icons/EventNote";
+import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
+
+export const formatPhasesActivity = (change, phaseList, subphaseList) => {
+  const entryMap = ProjectActivityLogTableMaps["moped_proj_phases"];
+
+  const changeIcon = <EventNoteIcon />;
+
+  // add a new phase
+  if (change.description.length === 0) {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Added ", style: null },
+        {
+          text: phaseList[change.record_data.event.data.new.phase_id],
+          style: "boldText",
+        },
+        // include subphase name if a subphase exists
+        ...(subphaseList[change.record_data.event.data.new.subphase_id]
+          ? [
+              {
+                text: ` - ${
+                  subphaseList[change.record_data.event.data.new.subphase_id]
+                }`,
+                style: "boldText",
+              },
+            ]
+          : []),
+        { text: " as a new phase.", style: null },
+      ],
+    };
+  }
+
+  // delete an existing phase
+  if (change.description[0].field === "is_deleted") {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Deleted the phase ", style: null },
+        {
+          text: phaseList[change.record_data.event.data.new.phase_id],
+          style: "boldText",
+        },
+        // include subphase name if a subphase exists
+        ...(subphaseList[change.record_data.event.data.new.subphase_id]
+          ? [
+              {
+                text: ` - ${
+                  subphaseList[change.record_data.event.data.new.subphase_id]
+                }`,
+                style: "boldText",
+              },
+            ]
+          : []),
+      ],
+    };
+  }
+
+  // Multiple fields in the moped_proj_funding table can be updated at once
+  // We list the fields changed in the activity log, this gathers the fields changed
+  const newRecord = change.record_data.event.data.new;
+  const oldRecord = change.record_data.event.data.old;
+
+  let changes = [];
+
+  // loop through fields to check for differences, push label onto changes Array
+  Object.keys(newRecord).forEach((field) => {
+    if (newRecord[field] !== oldRecord[field]) {
+      changes.push(entryMap.fields[field]?.label);
+    }
+  });
+
+  return {
+    changeIcon,
+    changeText: [
+      { text: "Edited the phase ", style: null },
+      {
+        text: phaseList[change.record_data.event.data.new.phase_id],
+        style: "boldText",
+      },
+      // include subphase name if a subphase exists
+      ...(subphaseList[change.record_data.event.data.new.subphase_id]
+        ? [
+            {
+              text: ` - ${
+                subphaseList[change.record_data.event.data.new.subphase_id]
+              }`,
+              style: "boldText",
+            },
+          ]
+        : []),
+      { text: " by updating the ", style: null },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ],
+  };
+};

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -1,6 +1,7 @@
 import { formatProjectActivity } from "./activityLogFormatters/mopedProjectActivity";
 import { formatTagsActivity } from "./activityLogFormatters/mopedTagsActivity";
 import { formatFundingActivity } from "./activityLogFormatters/mopedFundingActivity";
+import { formatPhasesActivity } from "./activityLogFormatters/mopedPhasesActivity";
 import { formatMilestonesActivity } from "./activityLogFormatters/mopedMilestonesActivity";
 import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersActivity";
 
@@ -30,7 +31,9 @@ export const formatActivityLogEntry = (change, lookupData) => {
     case "moped_proj_tags":
       return formatTagsActivity(change, lookupData.tagList);
     case "moped_proj_funding":
-      return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms);
+      return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms, "phase");
+    case "moped_proj_phases":
+      return formatPhasesActivity(change, lookupData.phaseList, lookupData.subphaseList);
     case "moped_proj_milestones":
       return formatMilestonesActivity(change, lookupData.milestoneList);
     case "moped_proj_partners":

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -5,7 +5,6 @@ import { formatPhasesActivity } from "./activityLogFormatters/mopedPhasesActivit
 import { formatMilestonesActivity } from "./activityLogFormatters/mopedMilestonesActivity";
 import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersActivity";
 
-
 export const formatActivityLogEntry = (change, lookupData) => {
   const changeText = [
       {text: "Project was updated", style: null}
@@ -31,7 +30,7 @@ export const formatActivityLogEntry = (change, lookupData) => {
     case "moped_proj_tags":
       return formatTagsActivity(change, lookupData.tagList);
     case "moped_proj_funding":
-      return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms, "phase");
+      return formatFundingActivity(change, lookupData.fundingSources, lookupData.fundingPrograms);
     case "moped_proj_phases":
       return formatPhasesActivity(change, lookupData.phaseList, lookupData.subphaseList);
     case "moped_proj_milestones":

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -78,12 +78,13 @@ const useLookupTables = (data) =>
 
     lookupData.userList = {};
     lookupData.phaseList = {};
+    lookupData.subphaseList = {};
     lookupData.tagList = {};
     lookupData.entityList = {};
     lookupData.fundingSources = {};
     lookupData.fundingPrograms = {};
     lookupData.fundingStatus = {};
-    lookupData.milestoneList ={};
+    lookupData.milestoneList = {};
     lookupData.publicProcessStatusList = {};
 
     if (data) {
@@ -92,6 +93,10 @@ const useLookupTables = (data) =>
       });
       data["moped_phases"].forEach((phase) => {
         lookupData.phaseList[`${phase.phase_id}`] = phase.phase_name;
+      });
+      data["moped_subphases"].forEach((subphase) => {
+        lookupData.subphaseList[`${subphase.subphase_id}`] =
+          subphase.subphase_name;
       });
       data["moped_tags"].forEach((tag) => {
         lookupData.tagList[`${tag.id}`] = tag.name;
@@ -112,10 +117,12 @@ const useLookupTables = (data) =>
           fundStatus.funding_status_name;
       });
       data["moped_milestones"].forEach((milestone) => {
-        lookupData.milestoneList[`${milestone.milestone_id}`] = milestone.milestone_name;
-      })
+        lookupData.milestoneList[`${milestone.milestone_id}`] =
+          milestone.milestone_name;
+      });
       data["moped_public_process_statuses"].forEach((publicProcessStatus) => {
-        lookupData.publicProcessStatusList[`${publicProcessStatus.id}`] = publicProcessStatus.name;
+        lookupData.publicProcessStatusList[`${publicProcessStatus.id}`] =
+          publicProcessStatus.name;
       });
     }
 
@@ -238,8 +245,10 @@ const ProjectActivityLog = () => {
               </TableHead>
               <TableBody>
                 {activityLogData.map((change) => {
-                  const { changeIcon, changeText } =
-                    formatActivityLogEntry(change, lookupData);
+                  const { changeIcon, changeText } = formatActivityLogEntry(
+                    change,
+                    lookupData
+                  );
                   return (
                     <TableRow key={change.activity_id}>
                       <TableCell
@@ -293,8 +302,9 @@ const ProjectActivityLog = () => {
                           "moped_project",
                           "moped_proj_tags",
                           "moped_proj_funding",
+                          "moped_proj_phases",
                           "moped_proj_milestones",
-                          "moped_proj_partners"
+                          "moped_proj_partners",
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -335,104 +335,58 @@ export const ProjectActivityLogTableMaps = {
     label: "Phases",
     fields: {
       phase_order: {
-        icon: "",
         label: "order",
-        type: "int4",
       },
       phase_id: {
-        icon: "",
         label: "phase",
-        type: "integer",
-        lookup: {
-          table: "moped_phases",
-          fieldLabel: "phase_id",
-          fieldValues: ["phase_name"],
-        },
       },
       phase_description: {
-        icon: "",
         label: "description",
-        type: "text",
       },
       completion_percentage: {
-        icon: "",
         label: "completion percentage",
-        type: "int4",
       },
       phase_status: {
-        icon: "",
         label: "status",
-        type: "text",
       },
       phase_privacy: {
-        icon: "",
         label: "privacy",
-        type: "bool",
       },
       phase_start: {
-        icon: "",
         label: "start date",
-        type: "date",
       },
       phase_end: {
-        icon: "",
         label: "end date",
-        type: "date",
       },
       phase_priority: {
-        icon: "",
         label: "priority",
-        type: "int4",
       },
       is_current_phase: {
-        icon: "",
         label: "current phase marker",
-        type: "bool",
       },
       completed: {
-        icon: "",
         label: "completed",
-        type: "bool",
       },
       project_id: {
-        icon: "",
         label: "project ID",
-        type: "int4",
       },
       started_by_user_id: {
-        icon: "",
         label: "started by user ID",
-        type: "int4",
       },
       completed_by_user_id: {
-        icon: "",
         label: "completed by user ID",
-        type: "int4",
       },
       date_added: {
-        icon: "",
         label: "date added",
-        type: "timestamptz",
       },
       project_phase_id: {
-        icon: "",
         label: "ID",
-        type: "int4",
       },
       is_deleted: {
-        icon: "",
         label: "is deleted",
-        data_type: "boolean",
       },
       subphase_id: {
-        icon: "",
-        label: "subphase ID",
-        type: "integer",
-        lookup: {
-          table: "moped_subphases",
-          fieldLabel: "subphase_id",
-          fieldValues: ["subphase_name"],
-        },
+        label: "subphase",
       },
     },
   },


### PR DESCRIPTION
this pr refines phases and subphase activity log events using REST connectors

## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11279

## Testing
**URL to test:** 
https://deploy-preview-953--atd-moped-main.netlify.app/moped/

**Steps to test:**
- add, edit and remove a phase with a subphase and a phase without a subphase while noting the activity log updates
- the changes should be reflected in the activity log with the subphase listed where appropriate

Create event
```markdown
Added **<phase-name> - <subphase-name-if-exists>** as a new phase
```
Edit event

```markdown
Edited the phase **<phase-name> - <subphase-name-if-exists>** by updating the <comma-separated-field names>
```

Delete event 
```markdown
Removed the phase **<phase-name> - <subphase-name-if-exists>**
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
