### PR TITLE
refines project components activity log events

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1615,23 +1615,47 @@
         insert:
           columns: '*'
         update:
-          columns:
-            - component_id
-            - project_component_id
-            - project_id
-            - description
-            - name
-            - is_deleted
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 0
         timeout_sec: 60
-      webhook_from_env: MOPED_API_EVENTS_URL
+      webhook_from_env: HASURA_ENDPOINT
       headers:
-        - name: MOPED_API_APIKEY
-          value_from_env: MOPED_API_APIKEY
-        - name: MOPED_API_EVENT_NAME
-          value: activity_log
+        - name: x-hasura-admin-secret
+          value_from_env: ACTIVITY_LOG_API_SECRET
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "variables": {
+                "object": {
+                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_type":  {{ $body.table.name }},
+                  "activity_id": {{ $body.id }},
+                  "record_project_id": {{ $body.event.data.new.project_id }},
+                  "record_data": {"event": {{ $body.event }}},
+                  "description": [{"newSchema": "true"}],
+                  "operation_type": {{ $body.event.op }},
+                  "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
+                },
+                "updated_at": {{$body.created_at}},
+                "project_id": {{$body.event.data.new.project_id}}
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        version: 2
+      cleanup_config:
+        batch_size: 10000
+        clean_invocation_logs: false
+        clear_older_than: 168
+        paused: true
+        schedule: 0 0 * * *
+        timeout: 60
 - table:
     name: moped_proj_components_subcomponents
     schema: public
@@ -3216,17 +3240,7 @@
         insert:
           columns: '*'
         update:
-          columns:
-            - is_current_phase
-            - date_added
-            - subphase_id
-            - phase_description
-            - project_id
-            - phase_start
-            - is_deleted
-            - phase_end
-            - project_phase_id
-            - phase_id
+          columns: '*'
       retry_conf:
         interval_sec: 10
         num_retries: 0

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -521,6 +521,7 @@ export const PROJECT_ACTIVITY_LOG = gql`
     moped_components(order_by: {component_id: asc}) {
       component_id
       component_name
+      component_subtype
     }
     activity_log_lookup_tables: moped_activity_log(
       where: { record_project_id: { _eq: $projectId } }

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -518,6 +518,10 @@ export const PROJECT_ACTIVITY_LOG = gql`
       id
       name
     }
+    moped_components(order_by: {component_id: asc}) {
+      component_id
+      component_name
+    }
     activity_log_lookup_tables: moped_activity_log(
       where: { record_project_id: { _eq: $projectId } }
       distinct_on: record_type

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -1,0 +1,60 @@
+import RoomOutlinedIcon from "@material-ui/icons/RoomOutlined";
+import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
+
+export const formatComponentsActivity = (change, componentList) => {
+  const entryMap = ProjectActivityLogTableMaps["moped_proj_components"];
+
+  const changeIcon = <RoomOutlinedIcon />;
+  const component =
+    componentList[change.record_data.event.data.new.component_id];
+  const componentText = {
+    text: component,
+    style: "boldText",
+  };
+
+  // add a new component
+  if (change.description.length === 0) {
+    return {
+      changeIcon,
+      changeText: [{ text: "Added a component: ", style: null }, componentText],
+    };
+  }
+
+  // delete an existing component
+  if (change.description[0].field === "is_deleted") {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Removed a component: ", style: null },
+        componentText,
+      ],
+    };
+  }
+
+  // Multiple fields in the moped_proj_components table can be updated at once
+  // We list the fields changed in the activity log, this gathers the fields changed
+  const newRecord = change.record_data.event.data.new;
+  const oldRecord = change.record_data.event.data.old;
+
+  let changes = [];
+
+  // loop through fields to check for differences, push label onto changes Array
+  Object.keys(newRecord).forEach((field) => {
+    if (newRecord[field] !== oldRecord[field]) {
+      changes.push(entryMap.fields[field]?.label);
+    }
+  });
+
+  return {
+    changeIcon,
+    changeText: [
+      { text: "Edited ", style: null },
+      componentText,
+      { text: " by updating the ", style: null },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ],
+  };
+};

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -16,7 +16,7 @@ export const formatMilestonesActivity = (change, milestoneList) => {
           text: milestoneList[change.record_data.event.data.new.milestone_id],
           style: "boldText",
         },
-        { text: " as a new milestone.", style: null },
+        { text: " as a new milestone", style: null },
       ],
     };
   }

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -25,7 +25,7 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
         phaseText,
         // include subphase name if one exists
         ...(subphase ? [subphaseText] : []),
-        { text: " as a new phase.", style: null },
+        { text: " as a new phase", style: null },
       ],
     };
   }

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -4,6 +4,7 @@ import { formatFundingActivity } from "./activityLogFormatters/mopedFundingActiv
 import { formatPhasesActivity } from "./activityLogFormatters/mopedPhasesActivity";
 import { formatMilestonesActivity } from "./activityLogFormatters/mopedMilestonesActivity";
 import { formatPartnersActivity } from "./activityLogFormatters/mopedPartnersActivity";
+import { formatComponentsActivity } from "./activityLogFormatters/mopedComponentsActivity";
 
 export const formatActivityLogEntry = (change, lookupData) => {
   const changeText = [
@@ -37,6 +38,8 @@ export const formatActivityLogEntry = (change, lookupData) => {
       return formatMilestonesActivity(change, lookupData.milestoneList);
     case "moped_proj_partners":
       return formatPartnersActivity(change, lookupData.entityList);
+    case "moped_proj_components":
+      return formatComponentsActivity(change, lookupData.componentList);
     default:
       return { changeIcon, changeText };
   }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -126,8 +126,11 @@ const useLookupTables = (data) =>
           publicProcessStatus.name;
       });
       data["moped_components"].forEach((component) => {
-        lookupData.componentList[`${component.component_id}`] =
-          component.component_name;
+        lookupData.componentList[`${component.component_id}`] = `${
+          component.component_name
+        }${
+          component.component_subtype ? ` - ${component.component_subtype}` : ""
+        }`;
       });
     }
 
@@ -310,7 +313,7 @@ const ProjectActivityLog = () => {
                           "moped_proj_phases",
                           "moped_proj_milestones",
                           "moped_proj_partners",
-                          "moped_proj_components"
+                          "moped_proj_components",
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -86,6 +86,7 @@ const useLookupTables = (data) =>
     lookupData.fundingStatus = {};
     lookupData.milestoneList = {};
     lookupData.publicProcessStatusList = {};
+    lookupData.componentList = {};
 
     if (data) {
       data["moped_users"].forEach((user) => {
@@ -123,6 +124,10 @@ const useLookupTables = (data) =>
       data["moped_public_process_statuses"].forEach((publicProcessStatus) => {
         lookupData.publicProcessStatusList[`${publicProcessStatus.id}`] =
           publicProcessStatus.name;
+      });
+      data["moped_components"].forEach((component) => {
+        lookupData.componentList[`${component.component_id}`] =
+          component.component_name;
       });
     }
 
@@ -305,6 +310,7 @@ const ProjectActivityLog = () => {
                           "moped_proj_phases",
                           "moped_proj_milestones",
                           "moped_proj_partners",
+                          "moped_proj_components"
                         ].includes(change.record_type) ? (
                           <ProjectActivityEntry
                             changeIcon={changeIcon}

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -394,34 +394,22 @@ export const ProjectActivityLogTableMaps = {
     label: "Component",
     fields: {
       project_id: {
-        icon: "",
         label: "ID",
-        data_type: "int4",
       },
       project_component_id: {
-        icon: "",
         label: "component ID",
-        data_type: "int4",
       },
       component_id: {
-        icon: "",
         label: "component ID",
-        data_type: "integer",
       },
       name: {
-        icon: "",
         label: "name",
-        data_type: "text",
       },
       description: {
-        icon: "",
         label: "description",
-        data_type: "text",
       },
       is_deleted: {
-        icon: "",
         label: "is deleted",
-        data_type: "boolean",
       },
     },
   },


### PR DESCRIPTION
this pr refines components activity log events using REST connectors.

note: reflecting component feature changes in the activity log is outside the scope of this issue, that will be addressed in the future.

## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10806

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-954--atd-moped-main.netlify.app/

**Steps to test:**
- add, edit and remove a component while noting the activity log updates
- the changes should be reflected in the activity log

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
