### PR TITLE
[Enhancement] Update activity log formatting for Knack project ID

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1657,7 +1657,7 @@
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
               "variables": {
                 "object": {
-                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_id": {{ $body.event.data.new.project_component_id }},
                   "record_type":  {{ $body.table.name }},
                   "activity_id": {{ $body.id }},
                   "record_project_id": {{ $body.event.data.new.project_id }},
@@ -2421,7 +2421,7 @@
                             "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
                             "variables": {
                                 "object": {
-                                    "record_id": {{ $body.event.data.new.project_id }},
+                                    "record_id": {{ $body.event.data.new.proj_funding_id }},
                                     "record_type":  {{ $body.table.name }},
                                     "activity_id": {{ $body.id }},
                                     "record_project_id": {{ $body.event.data.new.project_id }},
@@ -2647,7 +2647,7 @@
                             "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
                             "variables": {
                                 "object": {
-                                    "record_id": {{ $body.event.data.new.project_id }},
+                                    "record_id": {{ $body.event.data.new.project_milestone_id }},
                                     "record_type":  {{ $body.table.name }},
                                     "activity_id": {{ $body.id }},
                                     "record_project_id": {{ $body.event.data.new.project_id }},
@@ -2932,7 +2932,7 @@
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
               "variables": {
                 "object": {
-                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_id": {{ $body.event.data.new.proj_partner_id }},
                   "record_type":  {{ $body.table.name }},
                   "activity_id": {{ $body.id }},
                   "record_project_id": {{ $body.event.data.new.project_id }},
@@ -3197,7 +3197,7 @@
                             "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",
                             "variables": {
                                 "object": {
-                                    "record_id": {{ $body.event.data.new.project_personnel_id }},
+                                    "record_id": {{ $body.event.data.new.id }},
                                     "record_type":  {{ $body.table.name }},
                                     "activity_id": {{ $body.id }},
                                     "record_data": { "event": {{ $body.event }}},
@@ -3356,7 +3356,7 @@
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
               "variables": {
                 "object": {
-                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_id": {{ $body.event.data.new.project_phase_id }},
                   "record_type":  {{ $body.table.name }},
                   "activity_id": {{ $body.id }},
                   "record_project_id": {{ $body.event.data.new.project_id }},
@@ -3462,9 +3462,9 @@
         update:
           columns:
             - id
+            - is_deleted
             - project_id
             - tag_id
-            - is_deleted
       retry_conf:
         interval_sec: 10
         num_retries: 0
@@ -3481,7 +3481,7 @@
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
               "variables": {
                 "object": {
-                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_id": {{ $body.event.data.new.id }},
                   "record_type":  {{ $body.table.name }},
                   "activity_id": {{ $body.id }},
                   "record_project_id": {{ $body.event.data.new.project_id }},
@@ -4291,7 +4291,7 @@
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
               "variables": {
                 "object": {
-                  "record_id": {{ $body.event.data.new.project_id }},
+                  "record_id": {{ $body.event.data.new.id }},
                   "record_type":  {{ $body.table.name }},
                   "activity_id": {{ $body.id }},
                   "record_project_id": {{ $body.event.data.new.project_id }},

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3462,9 +3462,9 @@
         update:
           columns:
             - id
-            - is_deleted
             - project_id
             - tag_id
+            - is_deleted
       retry_conf:
         interval_sec: 10
         num_retries: 0

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -96,6 +96,22 @@ export const formatProjectActivity = (change, lookupList) => {
       };
     }
 
+    if (changedField === "knack_project_id") {
+      return {
+        changeIcon,
+        changeText: [
+          {
+            text: "Synchronized this project with the ",
+            style: null,
+          },
+          {
+            text: "Data Tracker",
+            style: "boldText",
+          },
+        ],
+      };
+    }
+
     // the update can be rendered as a string
     const changeValue =
       // check truthiness to prevent rendering String(null) as "null"


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11281
<img width="731" alt="Screen Shot 2023-02-02 at 11 39 46 AM" src="https://user-images.githubusercontent.com/12474808/216400695-6f36e860-4738-46a6-ad25-1e3a234b4d27.png">


I also used this PR to fix the "record_id" that is being stored in activity log entries. John pointed out that I was using the project_id as the record_id when really it should be the id of the record that is being updated/changed. 


## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-965--atd-moped-main.netlify.app/moped/projects/1866?tab=activity_log

**Steps to test:**

You can see the updated activity log entry in the link above. 
To test, add a signal and click the synchronize with data tracker link from the summary page. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
