### PR TITLE
Zoom to new components after create or edit

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -14,6 +14,8 @@ import {
   UPDATE_SIGNAL_COMPONENT,
 } from "src/queries/components";
 import { knackSignalRecordToFeatureSignalsRecord } from "src/utils/signalComponentHelpers";
+import { zoomMapToFeatureCollection } from "./utils/map";
+import { fitBoundsOptions } from "./mapSettings";
 
 const useStyles = makeStyles((theme) => ({
   dialogTitle: {
@@ -25,12 +27,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const EditComponentModal = ({
+const EditAttributesModal = ({
   showDialog,
   editDispatch,
   componentToEdit,
   refetchProjectComponents,
   setClickedComponent,
+  mapRef,
 }) => {
   const classes = useStyles();
 
@@ -68,6 +71,7 @@ const EditComponentModal = ({
       const signalFromForm = formData.signal;
       const featureSignalRecord =
         knackSignalRecordToFeatureSignalsRecord(signalFromForm);
+
       const signalToInsert = {
         ...featureSignalRecord,
         component_id: projectComponentId,
@@ -89,7 +93,15 @@ const EditComponentModal = ({
           signals: [signalToInsert],
         },
       })
-        .then(() => onComponentSaveSuccess(updatedClickedComponentState))
+        .then(() => {
+          onComponentSaveSuccess(updatedClickedComponentState);
+          // Zoom to the new or existing signal
+          zoomMapToFeatureCollection(
+            mapRef,
+            { type: "FeatureCollection", features: [signalFromForm] },
+            fitBoundsOptions.zoomToClickedComponent
+          );
+        })
         .catch((error) => {
           console.log(error);
         });
@@ -142,4 +154,4 @@ const EditComponentModal = ({
   );
 };
 
-export default EditComponentModal;
+export default EditAttributesModal;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -115,6 +115,7 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
     setLinkMode,
     refetchProjectComponents,
     setIsDrawing,
+    mapRef,
   });
 
   const {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -132,6 +132,7 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
     setLinkMode,
     refetchProjectComponents,
     setIsDrawing,
+    mapRef,
   });
 
   const { isDeletingComponent, setIsDeletingComponent, onDeleteComponent } =

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -305,6 +305,7 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
             componentToEdit={clickedComponent}
             refetchProjectComponents={refetchProjectComponents}
             setClickedComponent={setClickedComponent}
+            mapRef={mapRef}
           />
         </main>
       </div>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -146,6 +146,8 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
 
   useZoomToExistingComponents(mapRef, data);
 
+  // TODO: Make a helper that takes a mapRef and a component and then zooms to it
+  // TODO: We need a feature collection the signal geometry needs to be converted
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {
     const componentId = component.project_component_id;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -11,7 +11,6 @@ import Divider from "@material-ui/core/Divider";
 import ListItem from "@material-ui/core/ListItem";
 import Button from "@material-ui/core/Button";
 import AddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
-import bbox from "@turf/bbox";
 import TheMap from "./TheMap";
 import CreateComponentModal from "./CreateComponentModal";
 import EditAttributesModal from "./EditAttributesModal";
@@ -28,6 +27,7 @@ import { useCreateComponent } from "./utils/useCreateComponent";
 import { useUpdateComponent } from "./utils/useUpdateComponent";
 import { useDeleteComponent } from "./utils/useDeleteComponent";
 import { useToolbarErrorMessage } from "./utils/useToolbarErrorMessage";
+import { zoomMapToFeatureCollection } from "./utils/map";
 
 const drawerWidth = 350;
 
@@ -148,8 +148,6 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
 
   useZoomToExistingComponents(mapRef, data);
 
-  // TODO: Make a helper that takes a mapRef and a component and then zooms to it
-  // TODO: We need a feature collection the signal geometry needs to be converted
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {
     const componentId = component.project_component_id;
@@ -159,8 +157,9 @@ export default function MapView({ projectName, phaseKey, phaseName }) {
     // close the map projectFeature map popup
     setClickedProjectFeature(null);
     // move the map
-    mapRef.current?.fitBounds(
-      bbox(featureCollection),
+    zoomMapToFeatureCollection(
+      mapRef,
+      featureCollection,
       fitBoundsOptions.zoomToClickedComponent
     );
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -88,6 +88,19 @@ export function useAppBarHeight() {
 }
 
 /**
+ * Zoom to a feature collection using Mapbox fitBounds on a map instance
+ * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
+ * @param {Object} featureCollection - GeoJSON feature collection
+ * @param {Object} fitBoundsOptions - Mapbox fitBounds options
+ */
+const zoomMapToBoundingBox = (mapRef, featureCollection, fitBoundsOptions) => {
+  if (!mapRef?.current) return;
+
+  const bboxOfFeatureCollection = bbox(featureCollection);
+  mapRef.current.fitBounds(bboxOfFeatureCollection, fitBoundsOptions);
+};
+
+/**
  * Use Mapbox fitBounds to zoom to existing project components feature collection
  * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
  * @param {Object} data - Data returned from the moped_components query
@@ -110,8 +123,11 @@ export const useZoomToExistingComponents = (mapRef, data) => {
       features: data.project_geography,
     };
 
-    const bboxOfAllFeatures = bbox(featureCollection);
-    mapRef.current.fitBounds(bboxOfAllFeatures, fitBoundsOptions.zoomToExtent);
+    zoomMapToBoundingBox(
+      mapRef,
+      featureCollection,
+      fitBoundsOptions.zoomToExtent
+    );
 
     setHasMapZoomedInitially(true);
   }, [data, hasMapZoomedInitially, mapRef]);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -93,7 +93,11 @@ export function useAppBarHeight() {
  * @param {Object} featureCollection - GeoJSON feature collection
  * @param {Object} fitBoundsOptions - Mapbox fitBounds options
  */
-const zoomMapToBoundingBox = (mapRef, featureCollection, fitBoundsOptions) => {
+export const zoomMapToFeatureCollection = (
+  mapRef,
+  featureCollection,
+  fitBoundsOptions
+) => {
   if (!mapRef?.current) return;
 
   const bboxOfFeatureCollection = bbox(featureCollection);
@@ -123,7 +127,7 @@ export const useZoomToExistingComponents = (mapRef, data) => {
       features: data.project_geography,
     };
 
-    zoomMapToBoundingBox(
+    zoomMapToFeatureCollection(
       mapRef,
       featureCollection,
       fitBoundsOptions.zoomToExtent

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useCreateComponent.js
@@ -192,6 +192,14 @@ export const useCreateComponent = ({
           createDispatch({ type: "save_create" });
           setLinkMode(null);
           setIsDrawing(false);
+          zoomMapToFeatureCollection(
+            mapRef,
+            {
+              type: "FeatureCollection",
+              features: signalComponent.features,
+            },
+            fitBoundsOptions.zoomToClickedComponent
+          );
         });
       })
       .catch((error) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -9,6 +9,9 @@ import {
 } from "./makeFeatures";
 import { useDoesDraftEditComponentHaveFeatures } from "./features";
 import { UPDATE_COMPONENT_FEATURES } from "src/queries/components";
+import { zoomMapToFeatureCollection } from "./map";
+import { useComponentFeatureCollection } from "./makeFeatureCollections";
+import { fitBoundsOptions } from "../mapSettings";
 
 const editReducer = (state, action) => {
   switch (action.type) {
@@ -224,6 +227,7 @@ export const useUpdateComponent = ({
   setLinkMode,
   refetchProjectComponents,
   setIsDrawing,
+  mapRef,
 }) => {
   const [editState, editDispatch] = useReducer(editReducer, {
     isEditingComponent: false,
@@ -236,6 +240,9 @@ export const useUpdateComponent = ({
 
   const doesDraftEditComponentHaveFeatures =
     useDoesDraftEditComponentHaveFeatures(editState.draftEditComponent);
+  const draftEditComponentFeatureCollection = useComponentFeatureCollection(
+    editState.draftEditComponent
+  );
 
   const [updateComponentFeatures] = useMutation(UPDATE_COMPONENT_FEATURES);
 
@@ -403,6 +410,12 @@ export const useUpdateComponent = ({
           setClickedComponent(null);
           editDispatch({ type: "save_edit" });
           setIsDrawing(false);
+
+          zoomMapToFeatureCollection(
+            mapRef,
+            draftEditComponentFeatureCollection,
+            fitBoundsOptions.zoomToClickedComponent
+          );
         });
       })
       .catch((error) => {


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11241

This PR updates the map to pan and zoom to the features of signal and non-signal components when saving on create or edit. I used the same padding that was used for the zoom that happens when you click on a list item's magnifier icon. That felt right, but open to any feedback on all of this. 🙏 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-970--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Add a line or point component (that isn't a signal component) to a project
2. Select or draw some points or lines, drag the map away from the features, and then save
3. The map should zoom to the features in your newly created component
4. Create a signal component (PHB or Traffic) and save
5. The map should zoom to the location of the signal that you selected
6. Edit the non-signal component and save
7. The map should zoom to the updated features of the component
8. Edit the signal component by selecting a signal far from the original one
9. The map should zoom to the updated signal feature

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
