### PR TITLE
Bump checkout and python-setup actions to node16-based versions

### DIFF
--- a/.github/workflows/atd_moped_api.yml
+++ b/.github/workflows/atd_moped_api.yml
@@ -22,13 +22,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |

--- a/.github/workflows/atd_moped_api.yml
+++ b/.github/workflows/atd_moped_api.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
@@ -56,13 +56,13 @@ jobs:
     name: Build Database
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install CLI Requirements: Heroku, Hasura"
         run: |
@@ -94,13 +94,13 @@ jobs:
     name: Build Activity Log SQS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install CLI Requirements: AWS Cli"
         run: |
@@ -128,13 +128,13 @@ jobs:
     name: Build Moped Test API
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |
@@ -160,13 +160,13 @@ jobs:
     name: Build Moped cognito-at-edge
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |

--- a/.github/workflows/atd_moped_build_stage.yml
+++ b/.github/workflows/atd_moped_build_stage.yml
@@ -18,7 +18,7 @@ jobs:
       # Get the code first
       - name: "Checkout"
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"
@@ -56,7 +56,7 @@ jobs:
     name: Build Database
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"
@@ -94,7 +94,7 @@ jobs:
     name: Build Activity Log SQS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"
@@ -128,7 +128,7 @@ jobs:
     name: Build Moped Test API
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"
@@ -160,7 +160,7 @@ jobs:
     name: Build Moped cognito-at-edge
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_cloudfront_cognito.yml
+++ b/.github/workflows/atd_moped_cloudfront_cognito.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_cloudfront_cognito.yml
+++ b/.github/workflows/atd_moped_cloudfront_cognito.yml
@@ -18,13 +18,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |

--- a/.github/workflows/atd_moped_cognito_hooks_build.yml
+++ b/.github/workflows/atd_moped_cognito_hooks_build.yml
@@ -15,13 +15,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |

--- a/.github/workflows/atd_moped_cognito_hooks_build.yml
+++ b/.github/workflows/atd_moped_cognito_hooks_build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_database.yml
+++ b/.github/workflows/atd_moped_database.yml
@@ -18,13 +18,13 @@ jobs:
     name: Apply Migrations
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli & Hasura CLI"
         run: |

--- a/.github/workflows/atd_moped_database.yml
+++ b/.github/workflows/atd_moped_database.yml
@@ -18,7 +18,7 @@ jobs:
     name: Apply Migrations
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_db_docs.yml
+++ b/.github/workflows/atd_moped_db_docs.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_moped_db_docs.yml
+++ b/.github/workflows/atd_moped_db_docs.yml
@@ -17,13 +17,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install Python Requirements"
         run: |

--- a/.github/workflows/atd_sqs_activity_log.yml
+++ b/.github/workflows/atd_sqs_activity_log.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
           architecture: "x64"

--- a/.github/workflows/atd_sqs_activity_log.yml
+++ b/.github/workflows/atd_sqs_activity_log.yml
@@ -19,13 +19,13 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
           architecture: "x64"
       # Get the code first
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Then install the AWC CLI tools & boto3
       - name: "Install AWS Cli"
         run: |


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/10631

You can read  [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) about why this change is needed.

## Testing

I do not know how to test this :/  

You can browse the release notes:
- [actions/checkout@v3 ](https://github.com/actions/checkout/releases/tag/v3.0.0)
- [actions/setup-python@v4](https://github.com/actions/setup-python/releases/tag/v4.0.0)

What do y'all think about merging to main yolo-style? 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
