### PR TITLE
Wrap project name in project list and change default visible columns

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -158,7 +158,7 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
     project_partner: false,
     ecapris_subproject_id: false,
     updated_at: false,
-    project_feature: false, // signal_ids
+    project_feature: true, // signal_ids
     task_order: true,
     type_name: true,
     funding_source_name: true,
@@ -299,7 +299,8 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
         position: "sticky",
         left: 0,
         backgroundColor: "white",
-        whiteSpace: "noWrap",
+        minWidth: "20rem",
+        // whiteSpace: "noWrap",
         zIndex: 1,
       },
     },
@@ -378,6 +379,7 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
       field: "project_feature",
       hidden: hiddenColumns["project_feature"],
       sorting: false,
+      cellStyle: { maxWidth: "20rem" },
       render: (entry) => {
         if (!entry?.project_feature) {
           return "-";
@@ -443,7 +445,7 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
       field: "project_note",
       hidden: hiddenColumns["project_note"],
       emptyValue: "-",
-      cellStyle: { minWidth: 300 },
+      cellStyle: { maxWidth: "30rem" },
       render: (entry) => parse(String(entry.project_note)),
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -58,6 +58,34 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
+ * Default column display (if no config in local storage)
+ */
+const DEFAULT_HIDDEN_COLS = {
+  project_id: false,
+  project_name: false,
+  current_phase: false,
+  project_team_members: true,
+  project_lead: false,
+  project_sponsor: false,
+  project_partner: true,
+  ecapris_subproject_id: false,
+  updated_at: false,
+  project_feature: true, // signal_ids
+  task_order: true,
+  type_name: true,
+  funding_source_name: true,
+  project_note: true,
+  construction_start_date: false,
+  completion_end_date: false,
+  project_inspector: true,
+  project_designer: true,
+  contractors: true,
+  contract_numbers: true,
+  project_tags: false,
+  added_by: true,
+};
+
+/**
  * GridTable Search Capability plus Material Table
  * @param {Object} query - The GraphQL query configuration
  * @param {String} searchTerm - The initial term
@@ -148,34 +176,8 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
    */
   const [filters, setFilter] = useState(getFilterQuery() || {});
 
-  const defaultHiddenColumns = {
-    project_id: false,
-    project_name: false,
-    current_phase: false,
-    project_team_members: false,
-    project_lead: false,
-    project_sponsor: false,
-    project_partner: false,
-    ecapris_subproject_id: false,
-    updated_at: false,
-    project_feature: true, // signal_ids
-    task_order: true,
-    type_name: true,
-    funding_source_name: true,
-    project_note: true,
-    construction_start_date: false,
-    completion_end_date: false,
-    project_inspector: true,
-    project_designer: true,
-    contractors: false,
-    contract_numbers: false,
-    project_tags: false,
-    added_by: true,
-  };
-
   const [hiddenColumns, setHiddenColumns] = useState(
-    JSON.parse(localStorage.getItem("mopedColumnConfig")) ??
-      defaultHiddenColumns
+    JSON.parse(localStorage.getItem("mopedColumnConfig")) ?? DEFAULT_HIDDEN_COLS
   );
 
   const toggleColumnConfig = (field, hiddenState) => {
@@ -300,7 +302,6 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
         left: 0,
         backgroundColor: "white",
         minWidth: "20rem",
-        // whiteSpace: "noWrap",
         zIndex: 1,
       },
     },

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -380,7 +380,6 @@ const ProjectsListViewTable = ({ query, searchTerm }) => {
       field: "project_feature",
       hidden: hiddenColumns["project_feature"],
       sorting: false,
-      cellStyle: { maxWidth: "20rem" },
       render: (entry) => {
         if (!entry?.project_feature) {
           return "-";

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -1,18 +1,7 @@
 import React from "react";
 import Link from "@material-ui/core/Link";
-import OpenInNewIcon from "@material-ui/icons/OpenInNew";
-import { makeStyles } from "@material-ui/core/styles";
-
-const useStyles = makeStyles((theme) => ({
-  openInNewIcon: {
-    fontSize: "16px",
-    verticalAlign: "middle",
-    paddingBottom: "1px",
-  },
-}));
 
 const RenderSignalLink = ({ signals }) => {
-  const classes = useStyles();
   return (
     <span>
       {signals.map((signal, index) => (

--- a/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
+++ b/moped-editor/src/views/projects/signalProjectTable/RenderSignalLink.js
@@ -3,7 +3,7 @@ import Link from "@material-ui/core/Link";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   openInNewIcon: {
     fontSize: "16px",
     verticalAlign: "middle",
@@ -24,7 +24,6 @@ const RenderSignalLink = ({ signals }) => {
               rel="noopener noreferrer"
             >
               {signal.signal_id}
-              <OpenInNewIcon className={classes.openInNewIcon} />
             </Link>
           ) : (
             signal.signal_id


### PR DESCRIPTION
## Associated issues
I was wrong to remove project name wrapping in the first place. I surrender 🏳️
- https://github.com/cityofaustin/atd-data-tech/issues/11500

## Testing
**URL to test:**  [Netlify](https://deploy-preview-981--atd-moped-main.netlify.app/moped/session/signin)

**Steps to test:**
1. Create a project with a very long name. See name wrap in project list.
2. To test the column config, use your debug console to delete the `mopedColumnConfig` from local storage.
3. Confirm the default visibility matches [here](https://github.com/cityofaustin/atd-data-tech/issues/11500).

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
