### PR TITLE
Show fund source or program in activity log funding edits

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -7,9 +7,9 @@ const getFundingSourceIdText = (newRecord, fundingSources, fundingPrograms) => {
     return;
   }
   if (newRecord.funding_source_id) {
-    return fundingSources[newRecord.funding_source_id];
+    return fundingSources?.[newRecord.funding_source_id];
   } else if (newRecord.funding_program_id) {
-    return fundingPrograms[newRecord.funding_program_id];
+    return fundingPrograms?.[newRecord.funding_program_id];
   } else {
     return;
   }
@@ -78,7 +78,6 @@ export const formatFundingActivity = (
 
   // Multiple fields in the moped_proj_funding table can be updated at once
   // We list the fields changed in the activity log, this gathers the fields changed
-
   let changes = [];
 
   // loop through fields to check for differences, push label onto changes Array

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -2,6 +2,19 @@ import MonetizationOnOutlinedIcon from "@material-ui/icons/MonetizationOnOutline
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 import { isEqual } from "lodash";
 
+const getFundingSourceIdText = (newRecord, fundingSources, fundingPrograms) => {
+  if (!newRecord || !fundingSources || !fundingPrograms) {
+    return;
+  }
+  if (newRecord.funding_source_id) {
+    return fundingSources[newRecord.funding_source_id];
+  } else if (newRecord.funding_program_id) {
+    return fundingPrograms[newRecord.funding_program_id];
+  } else {
+    return;
+  }
+};
+
 export const formatFundingActivity = (
   change,
   fundingSources,
@@ -11,33 +24,25 @@ export const formatFundingActivity = (
 
   const changeIcon = <MonetizationOnOutlinedIcon />;
 
+  const newRecord = change.record_data.event.data.new;
+  const oldRecord = change.record_data.event.data.old;
+
+  const fundingSourceText = getFundingSourceIdText(
+    newRecord,
+    fundingSources,
+    fundingPrograms
+  );
+
   // add a new funding source
   if (change.description.length === 0) {
     // if the added record has a funding source, use that as the change value
-    if (change.record_data.event.data.new.funding_source_id) {
+    if (fundingSourceText) {
       return {
         changeIcon,
         changeText: [
           { text: "Added ", style: null },
           {
-            text: fundingSources[
-              change.record_data.event.data.new.funding_source_id
-            ],
-            style: "boldText",
-          },
-          { text: " as a new funding source.", style: null },
-        ],
-      };
-      // if not, then check if theres a funding program
-    } else if (change.record_data.event.data.new.funding_program_id) {
-      return {
-        changeIcon,
-        changeText: [
-          { text: "Added ", style: null },
-          {
-            text: fundingPrograms[
-              change.record_data.event.data.new.funding_program_id
-            ],
+            text: fundingSourceText,
             style: "boldText",
           },
           { text: " as a new funding source.", style: null },
@@ -50,33 +55,15 @@ export const formatFundingActivity = (
       };
     }
   }
-
   // delete an existing record
   if (change.description[0].field === "is_deleted") {
-    // if the deleted record has a funding source, use that as the change value
-    if (change.record_data.event.data.new.funding_source_id) {
+    if (fundingSourceText) {
       return {
         changeIcon,
         changeText: [
           { text: "Deleted a funding source: ", style: null },
           {
-            text: fundingSources[
-              change.record_data.event.data.new.funding_source_id
-            ],
-            style: "boldText",
-          },
-        ],
-      };
-      // if not, then check if theres a funding program
-    } else if (change.record_data.event.data.new.funding_program_id) {
-      return {
-        changeIcon,
-        changeText: [
-          { text: "Deleted a funding source: ", style: null },
-          {
-            text: fundingPrograms[
-              change.record_data.event.data.new.funding_program_id
-            ],
+            text: fundingSourceText,
             style: "boldText",
           },
         ],
@@ -91,8 +78,6 @@ export const formatFundingActivity = (
 
   // Multiple fields in the moped_proj_funding table can be updated at once
   // We list the fields changed in the activity log, this gathers the fields changed
-  const newRecord = change.record_data.event.data.new;
-  const oldRecord = change.record_data.event.data.old;
 
   let changes = [];
 
@@ -108,9 +93,28 @@ export const formatFundingActivity = (
     }
   });
 
-  return {
-    changeIcon,
-    changeText: [
+  let changeText;
+  if (fundingSourceText) {
+    changeText = [
+      {
+        text: "Edited funding source ",
+        style: null,
+      },
+      {
+        text: fundingSourceText,
+        style: "boldText",
+      },
+      {
+        text: " by updating the ",
+        style: null,
+      },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ];
+  } else {
+    changeText = [
       {
         text: "Edited a funding source by updating the ",
         style: null,
@@ -119,6 +123,11 @@ export const formatFundingActivity = (
         text: changes.join(", "),
         style: "boldText",
       },
-    ],
+    ];
+  }
+
+  return {
+    changeIcon,
+    changeText,
   };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -45,7 +45,7 @@ export const formatFundingActivity = (
             text: fundingSourceText,
             style: "boldText",
           },
-          { text: " as a new funding source.", style: null },
+          { text: " as a new funding source", style: null },
         ],
       };
     } else {
@@ -71,7 +71,7 @@ export const formatFundingActivity = (
     } else {
       return {
         changeIcon,
-        changeText: [{ text: "Deleted a funding source.", style: null }],
+        changeText: [{ text: "Deleted a funding source", style: null }],
       };
     }
   }


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11560

AMD raised a question about this during our most recent demo. IIRC Chia had suggested we implement this in the first place but I said no there's no time.

## Testing
**URL to test:** [Netlify](https://deploy-preview-986--atd-moped-main.netlify.app/)

**Steps to test:**
1. Add a funding source to a project with the "Source" column populated.
2. Edit the funding source amount.
3. Verify the activity log renders the edit by including the name of the funding source you selected.
4. Repeat, but populate the "Program" column instead of the "Source" column.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
