### PR TITLE
Script to add moped user ID to old activity log entries

### DIFF
--- a/moped-database/config/.gitignore
+++ b/moped-database/config/.gitignore
@@ -1,6 +1,5 @@
 *.*
 !.gitignore
-!primary_key_map.json
 !hasura.local.yaml
 !hasura_cluster_template.json
 !README.md

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -461,13 +461,6 @@ export const PROJECT_ACTIVITY_LOG = gql`
       description
       operation_type
       record_data
-      moped_user {
-        first_name
-        last_name
-        picture
-        email
-        user_id
-      }
       updated_by_user {
         first_name
         last_name

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectTypesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectTypesActivity.js
@@ -1,6 +1,7 @@
 export const formatProjectTypesActivity = (change, projectTypeList) => {
-
-  const changeIcon = <span className="material-symbols-outlined">summarize</span>
+  const changeIcon = (
+    <span className="material-symbols-outlined">summarize</span>
+  );
   const projectType =
     projectTypeList[change.record_data.event.data.new.project_type_id];
   const displayText = {
@@ -31,4 +32,10 @@ export const formatProjectTypesActivity = (change, projectTypeList) => {
       ],
     };
   }
+
+  // Fallback text for other updates. Catches old updates before database refactoring. (status_id etc)
+  return {
+    changeIcon,
+    changeText: [{ text: "Updated ", style: null }, displayText],
+  };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -235,15 +235,8 @@ const ProjectActivityLog = () => {
                           <Box p={0}>
                             <CDNAvatar
                               className={classes.avatarSmall}
-                              // until we update the events in the activity log to use the user id
-                              // instead of the cognito id, we have to check both places
-                              src={
-                                change?.moped_user?.picture ??
-                                change?.updated_by_user?.picture
-                              }
-                              initials={getInitials(
-                                change?.moped_user ?? change?.updated_by_user
-                              )}
+                              src={change?.updated_by_user?.picture}
+                              initials={getInitials(change?.updated_by_user)}
                               // todo: do we want this to not be always gray if its just the initials?
                               userColor={null}
                             />
@@ -253,9 +246,7 @@ const ProjectActivityLog = () => {
                             flexGrow={1}
                             className={classes.avatarName}
                           >
-                            {getUserFullName(
-                              change?.moped_user ?? change?.updated_by_user
-                            )}
+                            {getUserFullName(change?.updated_by_user)}
                           </Box>
                         </Box>
                       </TableCell>

--- a/moped-toolbox/backfill_user_id/run.py
+++ b/moped-toolbox/backfill_user_id/run.py
@@ -1,0 +1,147 @@
+"""Updates the `added_by` column of moped_project records based on the `moped_activity_log`.
+This script can safely be run repeatedly as needed."""
+
+import argparse
+import json
+import requests
+from secrets import HASURA_AUTH
+
+
+ACTIVITY_LOG_TODO_QUERY = """
+query ActivityWithNoUser {
+  moped_activity_log(where: {updated_by_user_id: {_is_null: true}}) {
+    activity_id
+    updated_by
+  }
+}
+"""
+
+MOPED_USERS_QUERY = """
+query AllMopedUsers {
+  moped_users {
+    first_name
+    last_name
+    user_id
+    cognito_user_id
+  }
+}
+"""
+
+UPDATE_ACTIVITY_USER_MUTATION = """
+mutation UpdateActivityUserId($activity_id: uuid!, $updated_by_user_id: Int!) {
+  update_moped_activity_log_by_pk(
+    pk_columns: {activity_id: $activity_id},
+    _set: {updated_by_user_id: $updated_by_user_id}
+    ){
+    updated_by_user_id
+  }
+}
+
+"""
+
+
+def make_hasura_request(*, query, variables, env):
+    """Fetch data from hasura
+
+    Args:
+        query (str): the hasura query
+        variables : variables needed in the query
+        env (str): the environment name, which will be used to access secrets
+
+    Raises:
+        ValueError: If no data is returned
+
+    Returns:
+        dict: Hasura JSON response data
+    """
+    admin_secret = HASURA_AUTH["hasura_graphql_admin_secret"][env]
+    endpoint = HASURA_AUTH["hasura_graphql_endpoint"][env]
+    headers = {
+        "X-Hasura-Admin-Secret": admin_secret,
+        "content-type": "application/json",
+    }
+    payload = {"query": query, "variables": variables}
+    res = requests.post(endpoint, json=payload, headers=headers)
+    res.raise_for_status()
+    data = res.json()
+    try:
+        return data["data"]
+    except KeyError:
+        raise ValueError(data)
+
+
+def make_user_dict(users):
+    user_dict = {}
+    for u in users:
+        if u["cognito_user_id"] is None:
+            continue
+        user_dict[u["cognito_user_id"]] = u["user_id"]
+    return user_dict
+
+
+def main(env):
+    activities = make_hasura_request(query=ACTIVITY_LOG_TODO_QUERY, env=env, variables=None)[
+        "moped_activity_log"
+    ]
+    users = make_hasura_request(query=MOPED_USERS_QUERY, env=env, variables=None)[
+        "moped_users"
+    ]
+
+    cognito_lookup = make_user_dict(users)
+
+    ready = []
+    unable_to_process = []
+    missing_ids = []
+
+    for activity in activities:
+        activity_id = activity["activity_id"]
+        updated_by_cognito_id = activity["updated_by"]
+        try:
+            user_id = cognito_lookup[updated_by_cognito_id]
+            ready.append({"activity_id": activity_id, "updated_by_user_id": user_id})
+        except KeyError:
+            unable_to_process.append({"activity_id": activity_id, "cognito_id": updated_by_cognito_id})
+            if updated_by_cognito_id not in missing_ids:
+                missing_ids.append(updated_by_cognito_id)
+
+    print(unable_to_process)
+
+    counts = {
+        "updated": 0,
+        "todo": len(ready),
+        "unable_to_process": len(unable_to_process),
+    }
+
+    print(counts)
+
+    for entry in ready:
+        make_hasura_request(
+            query=UPDATE_ACTIVITY_USER_MUTATION,
+            variables={"activity_id": entry["activity_id"], "updated_by_user_id": entry["updated_by_user_id"]},
+            env=env,
+        )
+        counts["updated"] += 1
+        counts["todo"] -= 1
+        print(counts)
+
+    # print("Writing inoperable projects to 'log.json'")
+
+    # with open("log.json", "w") as fout:
+    #     json.dump(unable_to_process, fout, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-e",
+        "--env",
+        type=str,
+        choices=["local", "staging", "prod"],
+        default="local",
+        help=f"Environment",
+    )
+
+    args = parser.parse_args()
+
+    main(args.env)

--- a/moped-toolbox/backfill_user_id/run.py
+++ b/moped-toolbox/backfill_user_id/run.py
@@ -1,4 +1,6 @@
-"""Updates the `added_by` column of moped_project records based on the `moped_activity_log`.
+"""
+Updates activity log entries that are missing user IDs.
+Checks the cognito ID and updates with corresponding user ID.
 This script can safely be run repeatedly as needed."""
 
 import argparse
@@ -77,6 +79,9 @@ def make_hasura_request(*, query, variables, env):
 
 
 def make_user_dict(users):
+    """
+    Makes a dictionary of users, key is cognito ID, value is user ID
+    """
     user_dict = {}
     for u in users:
         if u["cognito_user_id"] is None:
@@ -97,7 +102,6 @@ def main(env):
 
     ready = []
     unable_to_process = []
-    missing_ids = []
 
     for activity in activities:
         activity_id = activity["activity_id"]

--- a/moped-toolbox/backfill_user_id/secrets_template.py
+++ b/moped-toolbox/backfill_user_id/secrets_template.py
@@ -1,0 +1,8 @@
+HASURA_AUTH = {
+    "hasura_graphql_endpoint": {
+        "local": "http://localhost:8080/v1/graphql",
+    },
+    "hasura_graphql_admin_secret": {
+        "local": "hasurapassword",
+    },
+}


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11513

Before the activity log refactor, we used to associate changes with a users's Cognito ID. However when we deactivate a user, we delete their cognito ID, so the activity log ends up saying "Unknown User"

![Screenshot 2023-02-27 at 5 20 59 PM](https://user-images.githubusercontent.com/12474808/221925434-e46632bb-2234-4c9d-8345-077902219c70.png)

This PR backfills all of the entries with a user's ID, which doesn't get deleted even when a user is deactivated. When I was testing against prod data locally, I found 4 cognito IDs that are not in the prod database. I went through the logs and tracked who the IDs belong to so we can backfill those in prod. 

Any missing IDs in staging will just stay as "Unknown User". 

While I was testing I found a WSOD bug on one of the projects.  (https://mobility.austin.gov/moped/projects/216?tab=activity_log) I patched that in this PR. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-988--atd-moped-main.netlify.app/moped/projects/1657?tab=activity_log 
This will show Unknown User for everything, since I've removed references to the cognito ID in the code, but haven't run the script against staging. 

**Steps to test:**

Running the script locally on the local db won't find any entries to update, since locally we use the user id and not the cognito ID. You can test by downloading a copy of the prod data and running the `run.py` script in `/moped-toolbox/backfill_user_id/`

I tested it locally that way and the way you know it really worked is activities from last year render with the users name and not Unknown. 

![Screenshot 2023-02-28 at 9 26 08 AM](https://user-images.githubusercontent.com/12474808/221926280-bb4ecdd4-d75b-40f0-a8c8-6d202d39534f.png)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
