### PR TITLE
Patch regression in components query to show existing component phases

### DIFF
--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -42,6 +42,9 @@ export const GET_PROJECT_COMPONENTS = gql`
     project_component_id
     component_id
     description
+    phase_id
+    subphase_id
+    completion_date
     project_id
     moped_components {
       component_name
@@ -57,6 +60,18 @@ export const GET_PROJECT_COMPONENTS = gql`
     }
     moped_proj_components_subcomponents(where: { is_deleted: { _eq: false } }) {
       subcomponent_id
+    }
+    moped_phase {
+      phase_id
+      phase_name
+      moped_subphases {
+        subphase_id
+        subphase_name
+      }
+    }
+    moped_subphase {
+      subphase_id
+      subphase_name
     }
     feature_street_segments(where: { is_deleted: { _eq: false } }) {
       id


### PR DESCRIPTION
## Associated issues
This patches a small regression that happened when we merged John, Tilly, and my code that touched the project components queries. Existing phases are not showing properly because the components query wasn't fetching that data to populate the form.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Go to https://moped.austinmobility.io/moped/projects/1924?tab=map and edit the attributes of **Bike Lane - Climbing** component
2. It will seem like there is not a component phase (the switch is off) but there are values for phase, subphase, and completion date in the database
3. Go to https://deploy-preview-989--atd-moped-main.netlify.app/moped/projects/1924?tab=map and edit the same component's attributes
4. You will see that it has an existing phase, subphase, and completion date
   - Planned
   - Study in progress
   - 03/16/2023

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
