### PR TITLE
Update project search to handle eCapris ID as text

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -172,13 +172,12 @@ export const ProjectsListViewQueryConf = {
           url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${value}`}
         />
       ),
-      type: "number",
+      type: "string",
       search: {
         label: "Search by eCapris subproject ID",
-        operator: "_eq",
-        quoted: false,
+        operator: "_ilike",
+        quoted: true,
         envelope: "%{VALUE}%",
-        invalidValueDefault: 0,
       },
     },
     updated_at: {


### PR DESCRIPTION
I broke the project search via #992. To see for your yourself, login to staging and try to search for a project using the top nav or the search box on the project list. It will fail :/

This patch fixes the search config for `ecapris_subproject_id`.

## Testing
**URL to test:** [Netlfiy](https://deploy-preview-997--atd-moped-main.netlify.app/moped/projects)

**Steps to test:**
1. Put the value `7333.001` into the global search in Moped's top nav. You should see a handful of projects in the drop-down menu appear. Click on one. Great!
2. From the project list page, put the same value, `7333.001`, into the search input above the project list. Again, you should see a handful of results.

That's all 😅 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
