### PR TITLE
Bump hasura to v2.20.1

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.7'
 services:
     hasura:
-        image: hasura/graphql-engine:v2.17.1
+        image: hasura/graphql-engine:v2.20.1
         restart: always
         depends_on:
             - moped-pgsql


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11749

See the [v2.20 release notes](https://github.com/hasura/graphql-engine/releases/tag/v2.20.0) - this version includes a security patch as well.

## Testing
**URL to test:** Local
1. Start the Hasura cluster and editor

Full testing will be captured by our v1.20 release testing.



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
