### PR TITLE
fixes disappearing component bug

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useUpdateComponent.js
@@ -47,6 +47,7 @@ const editReducer = (state, action) => {
         ...state,
         showEditAttributesDialog: false,
         isEditingComponent: false,
+        draftEditComponent: null,
       };
     case "cancel_map_edit":
       return {


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11668

this took some digging to figure out but it turned out to be a one-line fix! there is a conditional in `ProjectSourcesAndLayers` which is based on a piece of state called `draftEditComponent` that filters out any layers that are currently being edited. this was filtering out the feature which the user had just edited using the edit attributes modal. this was because the command that is fired when you update features in `EditAttributesModal` (called `cancel_attributes_edit`, which lives in `useUpdateComponent`) was missing a line that sets `draftEditComponent` to `null`. adding this missing state change fixes the problem!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1000--atd-moped-main.netlify.app/

**Steps to test:**
- Create/save a new component.
- Edit the components attributes by updating the component description.
- After saving your changes, click on the map near your component.
- The component should NOT disappear!

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
