### PR TITLE
Add new potential and construction subphases

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4182,23 +4182,6 @@
     - name: moped_phase
       using:
         foreign_key_constraint_on: related_phase_id
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - subphase_id
-          - subphase_name
-          - subphase_description
-          - related_phase_id
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - related_phase_id
-          - subphase_id
-          - subphase_description
-          - subphase_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -4224,25 +4207,6 @@
           - subphase_description
           - subphase_name
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - related_phase_id
-          - subphase_id
-          - subphase_description
-          - subphase_name
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - related_phase_id
-          - subphase_id
-          - subphase_description
-          - subphase_name
-        filter: {}
-        check: null
 - table:
     name: moped_tags
     schema: public

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4190,52 +4190,37 @@
           - subphase_id
           - subphase_name
           - subphase_description
-          - subphase_order
-          - subphase_average_length
-          - required_subphase
           - related_phase_id
     - role: moped-editor
       permission:
         check: {}
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
   select_permissions:
     - role: moped-admin
       permission:
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
         filter: {}
     - role: moped-editor
       permission:
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
         filter: {}
     - role: moped-viewer
       permission:
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
         filter: {}
@@ -4243,11 +4228,8 @@
     - role: moped-admin
       permission:
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
         filter: {}
@@ -4255,11 +4237,8 @@
     - role: moped-editor
       permission:
         columns:
-          - required_subphase
           - related_phase_id
-          - subphase_average_length
           - subphase_id
-          - subphase_order
           - subphase_description
           - subphase_name
         filter: {}

--- a/moped-database/migrations/1680198069231_drop_moped_subphase_columns/down.sql
+++ b/moped-database/migrations/1680198069231_drop_moped_subphase_columns/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE moped_subphases
+    ADD COLUMN subphase_order integer unique,
+    ADD COLUMN subphase_average_length integer NULL,
+    ADD COLUMN required_subphase boolean NULL;

--- a/moped-database/migrations/1680198069231_drop_moped_subphase_columns/up.sql
+++ b/moped-database/migrations/1680198069231_drop_moped_subphase_columns/up.sql
@@ -1,0 +1,5 @@
+-- drop unused columns
+ALTER TABLE moped_subphases
+    DROP COLUMN subphase_order,
+    DROP COLUMN subphase_average_length,
+    DROP COLUMN required_subphase;

--- a/moped-database/migrations/1680199250609_add_new_subphases/down.sql
+++ b/moped-database/migrations/1680199250609_add_new_subphases/down.sql
@@ -1,3 +1,3 @@
-DELETE FROM moped_subphases WHERE subphase_name = 'Requested by partner';
-DELETE FROM moped_subphases WHERE subphase_name = 'Fiber/Communications';
-DELETE FROM moped_subphases WHERE subphase_name = 'Detection/CCTV';
+DELETE FROM moped_subphases WHERE subphase_name = 'Requested by partner' and subphase_id = 25;
+DELETE FROM moped_subphases WHERE subphase_name = 'Detection/CCTV' and subphase_id = 26;
+DELETE FROM moped_subphases WHERE subphase_name = 'Fiber/Communications' and subphase_id = 27;

--- a/moped-database/migrations/1680199250609_add_new_subphases/down.sql
+++ b/moped-database/migrations/1680199250609_add_new_subphases/down.sql
@@ -1,0 +1,3 @@
+DELETE FROM moped_subphases WHERE subphase_name = 'Requested by partner';
+DELETE FROM moped_subphases WHERE subphase_name = 'Fiber/Communications';
+DELETE FROM moped_subphases WHERE subphase_name = 'Detection/CCTV';

--- a/moped-database/migrations/1680199250609_add_new_subphases/up.sql
+++ b/moped-database/migrations/1680199250609_add_new_subphases/up.sql
@@ -1,0 +1,4 @@
+INSERT INTO moped_subphases (subphase_name, subphase_description, related_phase_id) VALUES
+    ('Requested by partner','The project has been requested by a partner division or agency and is being evaluated', 1),
+    ('Detection/CCTV','Construction activities related to vehicle detection and/or CCTV camera installation', 9),
+    ('Fiber/Communications','Construction activities related to fiber optic cable and/or communications equipment', 9);

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -250,7 +250,7 @@ export const TIMELINE_QUERY = gql`
       phase_id
       phase_name
       phase_order
-      moped_subphases {
+      moped_subphases(order_by: { subphase_name: asc }) {
         subphase_name
         subphase_id
       }
@@ -260,6 +260,7 @@ export const TIMELINE_QUERY = gql`
       order_by: {
         phase_start: desc
         moped_phase: { phase_order: desc }
+        moped_subphase: { subphase_name: asc }
       }
     ) {
       project_phase_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -260,7 +260,6 @@ export const TIMELINE_QUERY = gql`
       order_by: {
         phase_start: desc
         moped_phase: { phase_order: desc }
-        moped_subphase: { subphase_order: desc }
       }
     ) {
       project_phase_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -250,7 +250,7 @@ export const TIMELINE_QUERY = gql`
       phase_id
       phase_name
       phase_order
-      moped_subphases(order_by: { subphase_order: asc }) {
+      moped_subphases {
         subphase_name
         subphase_id
       }

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -7,11 +7,10 @@ export const TABLE_LOOKUPS_QUERY = gql`
       phase_name
       phase_description
       phase_order
-      moped_subphases(order_by: { subphase_order: asc }) {
+      moped_subphases {
         subphase_id
         subphase_description
         subphase_name
-        subphase_order
       }
     }
     moped_milestones(order_by: { milestone_id: asc }) {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11859

## Testing

Database changes, so test locally

**Steps to test:**

spin up database and editor, there are three new subphases with ids 25, 26, 27. 

checking the https://localhost:3000/moped/dev/lookups lookup page you can see one new one in potential phase and two new ones in the construction phase

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
