### PR TITLE
Add / Update milestones for new AMD templates

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1398,6 +1398,7 @@
           - related_phase_id
           - milestone_description
           - milestone_name
+          - is_deleted
         filter: {}
     - role: moped-editor
       permission:
@@ -1407,6 +1408,7 @@
           - related_phase_id
           - milestone_description
           - milestone_name
+          - is_deleted
         filter: {}
     - role: moped-viewer
       permission:
@@ -1416,6 +1418,7 @@
           - related_phase_id
           - milestone_description
           - milestone_name
+          - is_deleted
         filter: {}
 - table:
     name: moped_organization

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1389,35 +1389,10 @@
           table:
             name: moped_proj_milestones
             schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
   select_permissions:
     - role: moped-admin
       permission:
         columns:
-          - required_milestone
-          - milestone_average_length
           - milestone_id
           - milestone_order
           - related_phase_id
@@ -1427,8 +1402,6 @@
     - role: moped-editor
       permission:
         columns:
-          - required_milestone
-          - milestone_average_length
           - milestone_id
           - milestone_order
           - related_phase_id
@@ -1438,39 +1411,12 @@
     - role: moped-viewer
       permission:
         columns:
-          - required_milestone
-          - milestone_average_length
           - milestone_id
           - milestone_order
           - related_phase_id
           - milestone_description
           - milestone_name
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-        filter: {}
-        check: {}
 - table:
     name: moped_organization
     schema: public

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
@@ -1,12 +1,11 @@
 ALTER TABLE moped_milestones
     DROP COLUMN is_deleted;
 
-
-
+-- add removed columns
 alter table moped_milestones add column "required_milestone" boolean;
 alter table moped_milestones add column "milestone_average_length" integer;
 
-
+-- rename to previous names
 UPDATE moped_milestones SET milestone_name = 'FDU and Task Orders created including Signs and Markings' WHERE milestone_id = 36;
 UPDATE moped_milestones SET milestone_name = 'Contractor DO created' WHERE milestone_id = 40;
 UPDATE moped_milestones SET milestone_name = 'Power has been installed' WHERE milestone_id = 43;

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
@@ -12,3 +12,6 @@ UPDATE moped_milestones SET milestone_name = 'Power has been installed' WHERE mi
 UPDATE moped_milestones SET milestone_name = 'Verification deficiencies have been addressed ' WHERE milestone_id = 50;
 UPDATE moped_milestones SET milestone_name = 'Signal turn on ' WHERE milestone_id = 51;
 UPDATE moped_milestones SET milestone_name = 'Cabinet ready to be set ' WHERE milestone_id = 44;
+
+DELETE FROM moped_milestones WHERE milestone_name = 'AMD power construction complete';
+DELETE FROM moped_milestones WHERE milestone_name = 'Arms hung / cabinet ready to be set';

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/down.sql
@@ -1,0 +1,15 @@
+ALTER TABLE moped_milestones
+    DROP COLUMN is_deleted;
+
+
+
+alter table moped_milestones add column "required_milestone" boolean;
+alter table moped_milestones add column "milestone_average_length" integer;
+
+
+UPDATE moped_milestones SET milestone_name = 'FDU and Task Orders created including Signs and Markings' WHERE milestone_id = 36;
+UPDATE moped_milestones SET milestone_name = 'Contractor DO created' WHERE milestone_id = 40;
+UPDATE moped_milestones SET milestone_name = 'Power has been installed' WHERE milestone_id = 43;
+UPDATE moped_milestones SET milestone_name = 'Verification deficiencies have been addressed ' WHERE milestone_id = 50;
+UPDATE moped_milestones SET milestone_name = 'Signal turn on ' WHERE milestone_id = 51;
+UPDATE moped_milestones SET milestone_name = 'Cabinet ready to be set ' WHERE milestone_id = 44;

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
@@ -5,7 +5,7 @@ ALTER TABLE moped_milestones
     DROP COLUMN milestone_average_length,
     DROP COLUMN required_milestone;
 
-
+-- rename milestones (see list in issue 11863)
 UPDATE moped_milestones SET milestone_name = 'Financial approval (FDU/TK)' WHERE milestone_id = 36;
 UPDATE moped_milestones SET milestone_name = 'Work authorization (DO)' WHERE milestone_id = 40;
 UPDATE moped_milestones SET milestone_name = 'AE power complete' WHERE milestone_id = 43;
@@ -13,6 +13,7 @@ UPDATE moped_milestones SET milestone_name = 'Deficiencies addressed' WHERE mile
 UPDATE moped_milestones SET milestone_name = 'Signal turned on / asset updated' WHERE milestone_id = 51;
 UPDATE moped_milestones SET milestone_name = 'Cabinet / Battery Backup System terminated' WHERE milestone_id = 44;
 
+-- soft delete milestones (see list in issue 11863)
 UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 46;
 UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 45;
 UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 48;

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
@@ -22,4 +22,4 @@ UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 52;
 
 
 INSERT INTO moped_milestones ("is_deleted","milestone_order", "related_phase_id", "milestone_description", "milestone_name") VALUES (false, null, 9, null, E'AMD power construction complete');
--- INSERT INTO moped_milestones ("is_deleted","milestone_order", "related_phase_id", "milestone_description", "milestone_name") VALUES (false, null, 9, null, E'Cabinet / Battery Backup System terminated');
+INSERT INTO moped_milestones ("is_deleted","milestone_order", "related_phase_id", "milestone_description", "milestone_name") VALUES (false, null, 9, null, E'Arms hung / cabinet ready to be set');

--- a/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
+++ b/moped-database/migrations/1680618056213_alter_table_public_moped_milestones_add_column_is_deleted/up.sql
@@ -1,0 +1,24 @@
+alter table "public"."moped_milestones" add column "is_deleted" boolean
+ not null default 'False';
+
+ALTER TABLE moped_milestones
+    DROP COLUMN milestone_average_length,
+    DROP COLUMN required_milestone;
+
+
+UPDATE moped_milestones SET milestone_name = 'Financial approval (FDU/TK)' WHERE milestone_id = 36;
+UPDATE moped_milestones SET milestone_name = 'Work authorization (DO)' WHERE milestone_id = 40;
+UPDATE moped_milestones SET milestone_name = 'AE power complete' WHERE milestone_id = 43;
+UPDATE moped_milestones SET milestone_name = 'Deficiencies addressed' WHERE milestone_id = 50;
+UPDATE moped_milestones SET milestone_name = 'Signal turned on / asset updated' WHERE milestone_id = 51;
+UPDATE moped_milestones SET milestone_name = 'Cabinet / Battery Backup System terminated' WHERE milestone_id = 44;
+
+UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 46;
+UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 45;
+UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 48;
+UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 49;
+UPDATE moped_milestones SET is_deleted = true WHERE milestone_id = 52;
+
+
+INSERT INTO moped_milestones ("is_deleted","milestone_order", "related_phase_id", "milestone_description", "milestone_name") VALUES (false, null, 9, null, E'AMD power construction complete');
+-- INSERT INTO moped_milestones ("is_deleted","milestone_order", "related_phase_id", "milestone_description", "milestone_name") VALUES (false, null, 9, null, E'Cabinet / Battery Backup System terminated');

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -279,7 +279,9 @@ export const TIMELINE_QUERY = gql`
         phase_name
       }
     }
-    moped_milestones(where: { milestone_id: { _gt: 0 }, is_deleted: { _eq: false } }) {
+    moped_milestones(
+      where: { milestone_id: { _gt: 0 }, is_deleted: { _eq: false } }
+    ) {
       milestone_id
       milestone_name
     }

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -279,7 +279,7 @@ export const TIMELINE_QUERY = gql`
         phase_name
       }
     }
-    moped_milestones(where: { milestone_id: { _gt: 0 } }) {
+    moped_milestones(where: { milestone_id: { _gt: 0 }, is_deleted: { _eq: false } }) {
       milestone_id
       milestone_name
     }

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -14,7 +14,10 @@ export const TABLE_LOOKUPS_QUERY = gql`
         subphase_order
       }
     }
-    moped_milestones(order_by: { milestone_id: asc }) {
+    moped_milestones(
+      where: { is_deleted: { _eq: false } }
+      order_by: { milestone_id: asc }
+    ) {
       milestone_id
       milestone_name
       milestone_description


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11919

## Testing
**URL to test:** 

test locally

**Steps to test:**

https://localhost:3000/moped/projects/227?tab=timeline
from the timeline table, select add milestone/new milestone 
check to see that you see the renamed milestones (ex "AE power complete" and "Signal turned on / asset updated") in the list of options
Also check that you do not see "Burn in period" or "Deficiency list created" or any of the other soft deleted milestones. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
