### PR TITLE
adds component phases to activity log

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -1,7 +1,12 @@
 import RoomOutlinedIcon from "@material-ui/icons/RoomOutlined";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 
-export const formatComponentsActivity = (change, componentList) => {
+export const formatComponentsActivity = (
+  change,
+  componentList,
+  phaseList,
+  subphaseList
+) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_components"];
 
   const changeIcon = <RoomOutlinedIcon />;
@@ -11,6 +16,17 @@ export const formatComponentsActivity = (change, componentList) => {
     text: component,
     style: "boldText",
   };
+  const phase = phaseList[change.record_data.event.data.new.phase_id];
+  const subphase = subphaseList[change.record_data.event.data.new.subphase_id];
+  const phaseText = {
+    text: phase,
+    style: "boldText",
+  };
+  const subphaseText = {
+    text: ` - ${subphase}`,
+    style: "boldText",
+  };
+  const previousPhase = change.record_data.event.data.old?.phase_id;
 
   // add a new component
   if (change.description.length === 0) {
@@ -26,6 +42,32 @@ export const formatComponentsActivity = (change, componentList) => {
       changeIcon,
       changeText: [
         { text: "Removed a component: ", style: null },
+        componentText,
+      ],
+    };
+  }
+
+  // add a new component phase
+  if (phase && !previousPhase) {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Added the phase ", style: null },
+        phaseText,
+        // include subphase name if one exists
+        ...(subphase ? [subphaseText] : []),
+        { text: " to component ", style: null },
+        componentText,
+      ],
+    };
+  }
+
+  // delete an existing component phase
+  if (!phase && previousPhase) {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Deleted the phase from component ", style: null },
         componentText,
       ],
     };

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -54,7 +54,12 @@ export const formatActivityLogEntry = (change, lookupData) => {
     case "moped_proj_notes":
       return formatNotesActivity(change);
     case "moped_proj_components":
-      return formatComponentsActivity(change, lookupData.componentList);
+      return formatComponentsActivity(
+        change,
+        lookupData.componentList,
+        lookupData.phaseList,
+        lookupData.subphaseList
+      );
     case "moped_project_types":
       return formatProjectTypesActivity(change, lookupData.projectTypeList);
     case "moped_project_files":

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -366,6 +366,15 @@ export const ProjectActivityLogTableMaps = {
       is_deleted: {
         label: "is deleted",
       },
+      phase_id: {
+        label: "component phase"
+      },
+      subphase_id: {
+        label: "component subphase",
+      },
+      completion_date: {
+        label: "completion date",
+      },
     },
   },
   moped_project_files: {


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11884

this pr adds phase changes to the component activity log events. I tried to mirror the phases activity log events as closely as possible.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1010--atd-moped-main.netlify.app/

**Steps to test:**
1. add a project component and save it without a component phase
2. edit the project component and add a component phase with a subphase and completion date
3. go to the activity log to see the new entry, listing the phase, subphase and component name
4. edit the component phase to edit or remove the subphase and/or completion date
5. go to the activity log to see the updated fields listed
6. remove the component phase by clearing the toggle
7. go to the activity log to see the update

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
