### PR TITLE
creates new AMD milestone templates

### DIFF
--- a/moped-editor/src/utils/timelineTemplates.js
+++ b/moped-editor/src/utils/timelineTemplates.js
@@ -1,161 +1,161 @@
-export const returnSignalPHBMilestoneTemplate = projectId => {
+export const returnAMDSignalInfrastructureMilestoneTemplate = (projectId) => {
   return [
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 34,
+      milestone_id: 36,
       milestone_order: 1,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 35,
+      milestone_id: 38,
       milestone_order: 2,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 36,
+      milestone_id: 39,
       milestone_order: 3,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 37,
+      milestone_id: 40,
       milestone_order: 4,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 31,
+      milestone_id: 41,
       milestone_order: 5,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 38,
+      milestone_id: 63,
       milestone_order: 6,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 39,
+      milestone_id: 43,
       milestone_order: 7,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 40,
+      milestone_id: 64,
       milestone_order: 8,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 41,
+      milestone_id: 44,
       milestone_order: 9,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 42,
+      milestone_id: 47,
       milestone_order: 10,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 43,
+      milestone_id: 50,
       milestone_order: 11,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 44,
+      milestone_id: 51,
       milestone_order: 12,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 45,
-      milestone_description: "traffic and pedestrian",
+      milestone_id: 53,
       milestone_order: 13,
+    },
+  ];
+};
+
+export const returnAMDInspectionOnlyMilestoneTemplate = (projectId) => {
+  return [
+    {
+      project_id: projectId,
+      is_deleted: false,
+      completed: false,
+      milestone_id: 63,
+      milestone_order: 1,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
-      milestone_id: 46,
-      milestone_order: 14,
+      milestone_id: 43,
+      milestone_order: 2,
+    },
+    {
+      project_id: projectId,
+      is_deleted: false,
+      completed: false,
+      milestone_id: 64,
+      milestone_order: 3,
+    },
+    {
+      project_id: projectId,
+      is_deleted: false,
+      completed: false,
+      milestone_id: 44,
+      milestone_order: 4,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
       milestone_id: 47,
-      milestone_order: 15,
-    },
-    {
-      project_id: projectId,
-      is_deleted: false,
-      completed: false,
-      milestone_id: 48,
-      milestone_order: 16,
-    },
-    {
-      project_id: projectId,
-      is_deleted: false,
-      completed: false,
-      milestone_id: 49,
-      milestone_order: 17,
+      milestone_order: 5,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
       milestone_id: 50,
-      milestone_order: 18,
+      milestone_order: 6,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
       milestone_id: 51,
-      milestone_order: 19,
-    },
-    {
-      project_id: projectId,
-      is_deleted: false,
-      completed: false,
-      milestone_id: 52,
-      milestone_description: "typically 30 days",
-      milestone_order: 20,
+      milestone_order: 7,
     },
     {
       project_id: projectId,
       is_deleted: false,
       completed: false,
       milestone_id: 53,
-      milestone_description:
-        "for signals constructed by others/documentation that burn in period is complete",
-      milestone_order: 21,
+      milestone_order: 8,
     },
   ];
 };
 
-
-export const returnPDDMilestoneTemplate = projectId => {
+export const returnPDDMilestoneTemplate = (projectId) => {
   return [
     {
       project_id: projectId,

--- a/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
+++ b/moped-editor/src/views/projects/projectView/MilestoneTemplateModal.js
@@ -18,7 +18,8 @@ import { makeStyles } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import AddCircle from "@material-ui/icons/AddCircle";
 import {
-  returnSignalPHBMilestoneTemplate,
+  returnAMDSignalInfrastructureMilestoneTemplate,
+  returnAMDInspectionOnlyMilestoneTemplate,
   returnPDDMilestoneTemplate,
 } from "../../../utils/timelineTemplates";
 
@@ -35,7 +36,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const templateChoices = ["Arterial Management", "Project Delivery"];
+const templateChoices = [
+  "AMD Signal Infrastructure",
+  "AMD Inspection-only",
+  "Project Delivery",
+];
 
 /**
  * useMemo hook to choose milestone options
@@ -43,8 +48,10 @@ const templateChoices = ["Arterial Management", "Project Delivery"];
  */
 const useMilestoneOptions = (template, projectId) =>
   useMemo(() => {
-    if (template === "Arterial Management") {
-      return returnSignalPHBMilestoneTemplate(projectId);
+    if (template === "AMD Signal Infrastructure") {
+      return returnAMDSignalInfrastructureMilestoneTemplate(projectId);
+    } else if (template === "AMD Inspection-only") {
+      return returnAMDInspectionOnlyMilestoneTemplate(projectId);
     } else if (template === "Project Delivery") {
       return returnPDDMilestoneTemplate(projectId);
     } else {


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/11863

this pr is based on https://github.com/cityofaustin/atd-moped/pull/1009, please review that one first!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
- this is best tested on a project that doesn't have any milestones
- from the timeline table, select add milestone/from template
- select 'AMD Inspection-only' and add click 'add milestones'
- you should see 8 milestones populated that match the milestones in the issue description
- delete the milestones
- add the milestones from the `AMD Signal Infrastructure` template
- you should see 13 milestones, those from the previous template plus five additional

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
