### PR TITLE
revokes hasura permissions for lookup tables

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1062,29 +1062,6 @@
           table:
             name: moped_project
             schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - entity_uuid
-          - entity_name
-          - entity_id
-          - workgroup_id
-          - date_added
-          - organization_id
-          - department_id
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - department_id
-          - entity_id
-          - organization_id
-          - workgroup_id
-          - entity_name
-          - date_added
-          - entity_uuid
   select_permissions:
     - role: moped-admin
       permission:
@@ -1122,47 +1099,9 @@
           - entity_uuid
         filter: {}
         allow_aggregations: true
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - department_id
-          - entity_id
-          - organization_id
-          - workgroup_id
-          - entity_name
-          - date_added
-          - entity_uuid
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - department_id
-          - entity_id
-          - organization_id
-          - workgroup_id
-          - entity_name
-          - date_added
-          - entity_uuid
-        filter: {}
-        check: null
 - table:
     name: moped_fund_programs
     schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - funding_program_id
-          - funding_program_name
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - funding_program_id
-          - funding_program_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -1185,39 +1124,9 @@
           - funding_program_name
         filter: {}
         allow_aggregations: true
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - funding_program_id
-          - funding_program_name
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - funding_program_id
-          - funding_program_name
-        filter: {}
-        check: null
 - table:
     name: moped_fund_sources
     schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - funding_source_id
-          - funding_source_name
-          - funding_source_category
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - funding_source_id
-          - funding_source_name
-          - funding_source_category
   select_permissions:
     - role: moped-admin
       permission:
@@ -1243,39 +1152,9 @@
           - funding_source_category
         filter: {}
         allow_aggregations: true
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - funding_source_id
-          - funding_source_category
-          - funding_source_name
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - funding_source_id
-          - funding_source_category
-          - funding_source_name
-        filter: {}
-        check: null
 - table:
     name: moped_fund_status
     schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - funding_status_id
-          - funding_status_name
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - funding_status_id
-          - funding_status_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -1294,47 +1173,10 @@
         columns:
           - funding_status_id
           - funding_status_name
-        filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - funding_status_id
-          - funding_status_name
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - funding_status_id
-          - funding_status_name
-        filter: {}
-        check: {}
-  delete_permissions:
-    - role: moped-admin
-      permission:
-        filter: {}
-    - role: moped-editor
-      permission:
         filter: {}
 - table:
     name: moped_funds
     schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - id
-          - fund_id
-          - fund_name
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - id
-          - fund_id
-          - fund_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -1357,23 +1199,6 @@
           - fund_id
           - fund_name
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - id
-          - fund_id
-          - fund_name
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - id
-          - fund_id
-          - fund_name
-        filter: {}
-        check: {}
 - table:
     name: moped_milestones
     schema: public
@@ -1389,29 +1214,6 @@
           table:
             name: moped_proj_milestones
             schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -1446,31 +1248,6 @@
           - milestone_description
           - milestone_name
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - required_milestone
-          - milestone_average_length
-          - milestone_id
-          - milestone_order
-          - related_phase_id
-          - milestone_description
-          - milestone_name
-        filter: {}
-        check: {}
 - table:
     name: moped_organization
     schema: public
@@ -1519,31 +1296,6 @@
           - phase_name
           - phase_key
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - required_phase
-          - phase_average_length
-          - phase_id
-          - phase_order
-          - phase_description
-          - phase_name
-          - phase_key
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - required_phase
-          - phase_average_length
-          - phase_id
-          - phase_order
-          - phase_description
-          - phase_name
-          - phase_key
-        filter: {}
-        check: {}
 - table:
     name: moped_proj_components
     schema: public
@@ -3921,27 +3673,6 @@
           table:
             name: moped_proj_personnel_roles
             schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - active_role
-          - date_added
-          - project_role_description
-          - project_role_id
-          - project_role_name
-          - role_order
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - active_role
-          - date_added
-          - project_role_description
-          - project_role_id
-          - project_role_name
-          - role_order
   select_permissions:
     - role: moped-admin
       permission:
@@ -3973,29 +3704,6 @@
           - project_role_name
           - role_order
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - active_role
-          - date_added
-          - project_role_description
-          - project_role_id
-          - project_role_name
-          - role_order
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - active_role
-          - date_added
-          - project_role_description
-          - project_role_id
-          - project_role_name
-          - role_order
-        filter: {}
-        check: {}
 - table:
     name: moped_project_types
     schema: public
@@ -4182,29 +3890,6 @@
     - name: moped_phase
       using:
         foreign_key_constraint_on: related_phase_id
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - subphase_id
-          - subphase_name
-          - subphase_description
-          - subphase_order
-          - subphase_average_length
-          - required_subphase
-          - related_phase_id
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - required_subphase
-          - related_phase_id
-          - subphase_average_length
-          - subphase_id
-          - subphase_order
-          - subphase_description
-          - subphase_name
   select_permissions:
     - role: moped-admin
       permission:
@@ -4239,31 +3924,6 @@
           - subphase_description
           - subphase_name
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - required_subphase
-          - related_phase_id
-          - subphase_average_length
-          - subphase_id
-          - subphase_order
-          - subphase_description
-          - subphase_name
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - required_subphase
-          - related_phase_id
-          - subphase_average_length
-          - subphase_id
-          - subphase_order
-          - subphase_description
-          - subphase_name
-        filter: {}
-        check: null
 - table:
     name: moped_tags
     schema: public
@@ -4275,25 +3935,6 @@
           table:
             name: moped_proj_tags
             schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - id
-          - name
-          - type
-          - slug
-          - is_deleted
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - id
-          - name
-          - type
-          - slug
-          - is_deleted
   select_permissions:
     - role: moped-admin
       permission:
@@ -4322,53 +3963,9 @@
           - slug
           - is_deleted
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - id
-          - name
-          - type
-          - slug
-          - is_deleted
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - id
-          - name
-          - type
-          - slug
-          - is_deleted
-        filter: {}
-        check: {}
 - table:
     name: moped_types
     schema: public
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - type_name
-          - type_id
-          - active_type
-          - on_street
-          - sensitivity
-          - type_order
-          - date_added
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - type_name
-          - type_id
-          - active_type
-          - on_street
-          - sensitivity
-          - type_order
-          - date_added
   select_permissions:
     - role: moped-admin
       permission:
@@ -4403,31 +4000,6 @@
           - type_order
           - date_added
         filter: {}
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - type_name
-          - type_id
-          - active_type
-          - on_street
-          - sensitivity
-          - type_order
-          - date_added
-        filter: {}
-        check: {}
-    - role: moped-editor
-      permission:
-        columns:
-          - type_name
-          - type_id
-          - active_type
-          - on_street
-          - sensitivity
-          - type_order
-          - date_added
-        filter: {}
-        check: {}
 - table:
     name: moped_user_followed_projects
     schema: public
@@ -4656,21 +4228,6 @@
     - name: moped_department
       using:
         foreign_key_constraint_on: department_id
-  insert_permissions:
-    - role: moped-admin
-      permission:
-        check: {}
-        columns:
-          - workgroup_name
-          - workgroup_id
-          - date_added
-    - role: moped-editor
-      permission:
-        check: {}
-        columns:
-          - workgroup_name
-          - workgroup_id
-          - date_added
   select_permissions:
     - role: moped-admin
       permission:
@@ -4696,23 +4253,6 @@
           - date_added
         filter: {}
         allow_aggregations: true
-  update_permissions:
-    - role: moped-admin
-      permission:
-        columns:
-          - workgroup_id
-          - workgroup_name
-          - date_added
-        filter: {}
-        check: null
-    - role: moped-editor
-      permission:
-        columns:
-          - workgroup_id
-          - workgroup_name
-          - date_added
-        filter: {}
-        check: null
 - table:
     name: project_geography
     schema: public


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10525

this pr revokes hasura permissions for lookup tables. i believe i covered all of them! please let me know if i missed any or if i cut any that we should keep.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local

**Steps to test:**
- i don't know that there is a good way to test this aside from looking at the tables.yaml file and confirming that the permissions that were cut all relate to lookup tables. or you can spin up the local hasura cluster and then look at the permissions we now have set for each table in the console. open to suggestions!

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
