### PR TITLE
Include filename in API error response

### DIFF
--- a/moped-api/files/files.py
+++ b/moped-api/files/files.py
@@ -93,7 +93,7 @@ def files_request_signature(claims: list) -> dict:
 
     # Check our parameters
     if not is_valid_filename(filename):
-        return jsonify({"status": "error", "message": "Invalid file name"}), 403
+        return jsonify({"status": "error", "message": "Invalid file name", "filename": filename}), 403
 
     # Determine upload type
     if upload_type not in ["private", "public"]:


### PR DESCRIPTION
## Associated issues
This small patch is in service of debugging a file upload issue related to the `&` symbol in filenames. I cannot reproduce the issue locally so I'd like to add this logging to see exactly what data the lambda function is parsing.
- https://github.com/cityofaustin/atd-data-tech/issues/11900#issuecomment-1505588952

## Testing
**URL to test:** Local
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
