### PR TITLE
Removes deleted projects from projects list view

### DIFF
--- a/moped-database/migrations/1681854063780_filter_deleted_projects_from_projects_list_view/down.sql
+++ b/moped-database/migrations/1681854063780_filter_deleted_projects_from_projects_list_view/down.sql
@@ -1,4 +1,4 @@
--- latest version 1681854063780_filter_deleted_projects_from_projects_list_view
+-- remove is_deleted filter from project view
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view
@@ -145,8 +145,6 @@ AS WITH project_person_list_lookup AS (
      LEFT JOIN moped_users added_by_user ON mp.added_by = added_by_user.user_id
      LEFT JOIN current_phase_view current_phase on mp.project_id = current_phase.project_id
      LEFT JOIN moped_public_process_statuses mpps ON mpps.id = mp.public_process_status_id 
-  WHERE
-    mp.is_deleted = false
   GROUP BY
     mp.project_id, 
     mp.project_name, 

--- a/moped-database/migrations/1681854063780_filter_deleted_projects_from_projects_list_view/up.sql
+++ b/moped-database/migrations/1681854063780_filter_deleted_projects_from_projects_list_view/up.sql
@@ -1,4 +1,4 @@
--- latest version 1681854063780_filter_deleted_projects_from_projects_list_view
+-- add is_deleted query filter to remove deleted projects from list view
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -240,6 +240,7 @@ export const ProjectsListViewQueryConf = {
   },
   // This object gets consumed into the GQLAbstract system, and here is the single, un-nested order_by directive. ✅
   order_by: { updated_at: "desc" },
+  where: null,
   or: null,
   and: null,
   limit: 100,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -240,9 +240,6 @@ export const ProjectsListViewQueryConf = {
   },
   // This object gets consumed into the GQLAbstract system, and here is the single, un-nested order_by directive. ✅
   order_by: { updated_at: "desc" },
-  where: {
-    is_deleted: "_eq: false",
-  },
   or: null,
   and: null,
   limit: 100,


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/10582

there won't be a perceptible change since this just moves the filter that excludes deleted projects from `ProjectsListViewQueryConf` to `project_list_view`

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local (since there are database changes)

**Steps to test:**
1. go the projects list view, select a project and delete it
2. go back to the projects list view, the project should no longer display

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
