### PR TITLE
Prevent white screen crash when editing component phase date

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -24,6 +24,7 @@ import {
   useInitialValuesOnAttributesEdit,
 } from "./utils/form";
 import * as yup from "yup";
+import { parseISO } from "date-fns";
 
 const defaultFormValues = {
   component: null,
@@ -252,7 +253,7 @@ const ComponentForm = ({
                 render={({ onChange, value, ref }) => (
                   <DatePicker
                     inputRef={ref}
-                    value={value}
+                    value={value ? parseISO(value) : null}
                     onChange={onChange}
                     clearable={true}
                     emptyLabel="mm/dd/yyyy"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -10,7 +10,7 @@ import {
   FormControlLabel,
   FormHelperText,
 } from "@mui/material";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
 import { CheckCircle } from "@mui/icons-material";
 import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
@@ -261,7 +261,7 @@ const ComponentForm = ({
                 control={control}
                 render={({ onChange, value, ref }) => {
                   return (
-                    <DatePicker
+                    <MobileDatePicker
                       inputRef={ref}
                       value={parseDate(value)}
                       onChange={(date) => {
@@ -270,11 +270,12 @@ const ComponentForm = ({
                           : null;
                         onChange(newDate);
                       }}
-                      clearable={true}
                       format="MM/dd/yyyy"
                       variant="outlined"
                       label={"Completion date"}
-                      onAccept={(props) => console.log(props)}
+                      slotProps={{
+                        actionBar: { actions: ["accept", "cancel", "clear"] },
+                      }}
                     />
                   );
                 }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -24,7 +24,7 @@ import {
   useInitialValuesOnAttributesEdit,
 } from "./utils/form";
 import * as yup from "yup";
-import { parseISO, format } from "date-fns";
+import { format } from "date-fns";
 
 const defaultFormValues = {
   component: null,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -24,7 +24,7 @@ import {
   useInitialValuesOnAttributesEdit,
 } from "./utils/form";
 import * as yup from "yup";
-import { parseISO } from "date-fns";
+import { parseISO, format } from "date-fns";
 
 const defaultFormValues = {
   component: null,
@@ -254,7 +254,10 @@ const ComponentForm = ({
                   <DatePicker
                     inputRef={ref}
                     value={value ? parseISO(value) : null}
-                    onChange={onChange}
+                    onChange={(date) => {
+                      const newDate = date ? format(date, "yyyy-MM-dd") : null;
+                      onChange(newDate);
+                    }}
                     clearable={true}
                     emptyLabel="mm/dd/yyyy"
                     format="MM/dd/yyyy"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -50,6 +50,19 @@ const validationSchema = yup.object().shape({
   }),
 });
 
+/**
+ * Return a Date object from a string date
+ * @param {string} value - the string formatted date
+ * @returns 
+ */
+const parseDate = (value) => {
+  if (value) {
+    let newdate = new Date(value);
+    return newdate;
+  }
+  return null;
+};
+
 const ComponentForm = ({
   formButtonText,
   onSave,
@@ -128,15 +141,6 @@ const ComponentForm = ({
 
   const isEditingExistingComponent = initialFormValues !== null;
   const isSignalComponent = internalTable === "feature_signals";
-
-  const parseDate = (value) => {
-    if (value) {
-      let newdate = new Date(value);
-      return newdate;
-    }
-
-    return null;
-  };
 
   return (
     <form onSubmit={handleSubmit(onSave)}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -129,6 +129,15 @@ const ComponentForm = ({
   const isEditingExistingComponent = initialFormValues !== null;
   const isSignalComponent = internalTable === "feature_signals";
 
+  const parseDate = (value) => {
+    if (value) {
+      let newdate = new Date(value);
+      return newdate;
+    }
+
+    return null;
+  };
+
   return (
     <form onSubmit={handleSubmit(onSave)}>
       <Grid container spacing={2}>
@@ -250,21 +259,25 @@ const ComponentForm = ({
                 id="completion-date"
                 name="completionDate"
                 control={control}
-                render={({ onChange, value, ref }) => (
-                  <DatePicker
-                    inputRef={ref}
-                    value={value ? parseISO(value) : null}
-                    onChange={(date) => {
-                      const newDate = date ? format(date, "yyyy-MM-dd") : null;
-                      onChange(newDate);
-                    }}
-                    clearable={true}
-                    emptyLabel="mm/dd/yyyy"
-                    format="MM/dd/yyyy"
-                    variant="outlined"
-                    label={"Completion date"}
-                  />
-                )}
+                render={({ onChange, value, ref }) => {
+                  return (
+                    <DatePicker
+                      inputRef={ref}
+                      value={parseDate(value)}
+                      onChange={(date) => {
+                        const newDate = date
+                          ? format(date, "yyyy-MM-dd OOOO")
+                          : null;
+                        onChange(newDate);
+                      }}
+                      clearable={true}
+                      format="MM/dd/yyyy"
+                      variant="outlined"
+                      label={"Completion date"}
+                      onAccept={(props) => console.log(props)}
+                    />
+                  );
+                }}
               />
             </Grid>
           </>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditModeDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditModeDialog.js
@@ -5,10 +5,11 @@ import {
   IconButton,
   Grid,
   Button,
+  Typography,
 } from "@mui/material";
 import TimelineIcon from "@mui/icons-material/Timeline";
 import ListIcon from "@mui/icons-material/List";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
 
 const useStyles = makeStyles((theme) => ({
@@ -22,6 +23,10 @@ const useStyles = makeStyles((theme) => ({
   dialogContent: {
     paddingBottom: theme.spacing(3),
   },
+  titleStyles: {
+    fontWeight: 500,
+    fontSize: "20px",
+  },
 }));
 
 const EditModeDialog = ({ showDialog, editDispatch, onEditFeatures }) => {
@@ -34,7 +39,9 @@ const EditModeDialog = ({ showDialog, editDispatch, onEditFeatures }) => {
   return (
     <Dialog open={showDialog} onClose={onClose}>
       <DialogTitle className={classes.dialogTitle}>
-        <h3>What do you want to edit?</h3>
+        <Typography className={classes.titleStyles}>
+          What do you want to edit?
+        </Typography>
         <IconButton onClick={onClose} size="large">
           <CloseIcon />
         </IconButton>


### PR DESCRIPTION
I believe I have unraveled what is happening here, and I think it has something to do with the react-hook form controller. It is changing the date format into something that `parseISO` can't handle. I did a lot of console logging and used the `onAccept` function to see what the date looks like when the form is accepted. I found that parsing the date with new Date() can handle it. See our slack for more detailed explanation


## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**

https://deploy-preview-1029--atd-moped-main.netlify.app/moped/projects


![Screenshot 2023-04-27 at 12 04 57 PM](https://user-images.githubusercontent.com/12474808/234936986-63c2c68d-6688-44ca-a43f-4e83b4503e68.png)


add a component phase. Edit the date and save. refresh the page, edit again and it should not completely fail on you. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
