### PR TITLE
Fixes subcomponent editing

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -53,7 +53,7 @@ const validationSchema = yup.object().shape({
 /**
  * Return a Date object from a string date
  * @param {string} value - the string formatted date
- * @returns 
+ * @returns
  */
 const parseDate = (value) => {
   if (value) {
@@ -127,8 +127,10 @@ const ComponentForm = ({
   // reset subcomponent selections when component to ensure only allowed subcomponents
   // todo: preserve allowed subcomponents when switching b/t component types
   useEffect(() => {
-    setValue("subcomponents", []);
-  }, [subcomponentOptions, setValue]);
+    if (!initialFormValues?.subcomponents) {
+      setValue("subcomponents", []);
+    }
+  }, [subcomponentOptions, initialFormValues, setValue]);
 
   // Reset subphases field when phase changes so subphase options match phase
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -125,6 +125,7 @@ const ComponentForm = ({
   }, [component, setValue]);
 
   // reset subcomponent selections when component to ensure only allowed subcomponents
+  // assumes component type cannot be changed when editing
   // todo: preserve allowed subcomponents when switching b/t component types
   useEffect(() => {
     if (!initialFormValues?.subcomponents) {


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11968

This change unbreaks [a previous patch](https://github.com/cityofaustin/atd-moped/pull/978/files#diff-be66300e240d2abb87784e0db4a1a85c1c9040251d43a82a17500c9091b4f63c) which is preventing users from selecting/editing subcomponents.

This feels a wee bit hacky, since it only works because we do not allow users to edit their component's type/subtype. If that were not the case this would be a lot harder!

## Testing
**URL to test:** [Netlify](https://deploy-preview-1032--atd-moped-main.netlify.app/)
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Start creating a new bike lane component and select the "Raised pavement markers" subcomponent
2. Before you save, switch the component type to Traffic signal.
3. Observe that the subcomponent input is cleared ("Raised pavement markers" is removed)
4. Now select the "Bicycle signal" subcomponent and save.
5. Edit the component again to remove the bicycle signal subcomponent and add an Audible push button subcomponent.
6. Refresh your page and open the component editor one more time to confirm your subcomponent selection is persisted/correct

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
