### PR TITLE
Validate project website and store null when a user removes a project website

### DIFF
--- a/moped-editor/src/utils/test/urls.js
+++ b/moped-editor/src/utils/test/urls.js
@@ -1,7 +1,7 @@
 import { isValidUrl } from "../urls";
 
 describe("isValidUrl()", () => {
-  it("returns a full name string from a user object", () => {
+  it("validates a url using Yup", () => {
     const httpAddress = "http://www.austintexas.gov";
     const httpsAddress = "https://www.austintexas.gov";
     const wwwOnlyAddress = "www.austintexas.gov";

--- a/moped-editor/src/utils/test/urls.js
+++ b/moped-editor/src/utils/test/urls.js
@@ -1,0 +1,15 @@
+import { isValidUrl } from "../urls";
+
+describe("isValidUrl()", () => {
+  it("returns a full name string from a user object", () => {
+    const httpAddress = "http://www.austintexas.gov";
+    const httpsAddress = "https://www.austintexas.gov";
+    const wwwOnlyAddress = "www.austintexas.gov";
+    const justLetters = "fjdksaljfdlksa";
+
+    expect(isValidUrl(httpAddress)).toBe(true);
+    expect(isValidUrl(httpsAddress)).toBe(true);
+    expect(isValidUrl(wwwOnlyAddress)).toBe(false);
+    expect(isValidUrl(justLetters)).toBe(false);
+  });
+});

--- a/moped-editor/src/utils/urls.js
+++ b/moped-editor/src/utils/urls.js
@@ -2,6 +2,7 @@ import * as yup from "yup";
 
 /**
  * Validate a url using yup
+ * @see https://github.com/jquense/yup/blob/1086aa93fdd08a554936a409c30788058dbc7c32/src/string.ts#L24-L26
  * @param {string} url - url to validate
  * @returns {Boolean} is the url valid?
  */

--- a/moped-editor/src/utils/urls.js
+++ b/moped-editor/src/utils/urls.js
@@ -1,5 +1,12 @@
 import * as yup from "yup";
 
+/**
+ * Validate a non-empty string url using yup
+ * @param {string} url - url to validate
+ * @returns {Boolean} is the url valid?
+ */
 export const isValidUrl = (url) => {
+  if (url === "") return false;
+
   return yup.string().url().isValidSync(url);
 };

--- a/moped-editor/src/utils/urls.js
+++ b/moped-editor/src/utils/urls.js
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export const isValidUrl = (url) => {
+  return yup.string().url().isValidSync(url);
+};

--- a/moped-editor/src/utils/urls.js
+++ b/moped-editor/src/utils/urls.js
@@ -1,12 +1,10 @@
 import * as yup from "yup";
 
 /**
- * Validate a non-empty string url using yup
+ * Validate a url using yup
  * @param {string} url - url to validate
  * @returns {Boolean} is the url valid?
  */
 export const isValidUrl = (url) => {
-  if (url === "") return false;
-
   return yup.string().url().isValidSync(url);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -7,7 +7,7 @@ import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
 import { Grid, CardContent, CircularProgress } from "@mui/material";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import ProjectSummarySnackbar from "./ProjectSummarySnackbar";
 import ProjectSummaryProjectWebsite from "./ProjectSummaryProjectWebsite";
 import ProjectSummaryProjectDescription from "./ProjectSummaryProjectDescription";
@@ -48,6 +48,12 @@ const useStyles = makeStyles((theme) => ({
     cursor: "pointer",
     margin: ".25rem 0",
     fontSize: "24px",
+  },
+  editIconConfirmDisabled: {
+    cursor: "pointer",
+    margin: ".25rem 0",
+    fontSize: "24px",
+    color: theme.palette.text.secondary,
   },
   fieldLabel: {
     width: "100%",
@@ -176,9 +182,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                   field="Lead"
                   idColumn={"entity_id"}
                   nameColumn={"entity_name"}
-                  initialValue={
-                    data?.moped_project[0]?.moped_project_lead
-                  }
+                  initialValue={data?.moped_project[0]?.moped_project_lead}
                   optionList={data?.moped_entity ?? []}
                   updateMutation={PROJECT_UPDATE_LEAD}
                   tooltipText="Division, department, or organization responsible for successful project implementation"

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -50,7 +50,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "24px",
   },
   editIconConfirmDisabled: {
-    cursor: "pointer",
     margin: ".25rem 0",
     fontSize: "24px",
     color: theme.palette.text.secondary,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,5 +1,13 @@
 import React, { useState } from "react";
-import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Grid,
+  IconButton,
+  Icon,
+  Link,
+  TextField,
+  Typography,
+} from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
@@ -29,6 +37,7 @@ const ProjectSummaryProjectWebsite = ({
 
   const [editMode, setEditMode] = useState(false);
   const [website, setWebsite] = useState(originalWebsite);
+  const isWebsiteValid = isValidUrl(website);
 
   const [updateProjectWebsite] = useMutation(PROJECT_UPDATE_WEBSITE);
 
@@ -47,7 +56,7 @@ const ProjectSummaryProjectWebsite = ({
     updateProjectWebsite({
       variables: {
         projectId: projectId,
-        website: website,
+        website: isWebsiteValid ? website : null,
       },
     })
       .then(() => {
@@ -92,20 +101,24 @@ const ProjectSummaryProjectWebsite = ({
               label={null}
               onChange={handleProjectWebsiteChange}
               value={website}
-              error={!isValidUrl(website)}
+              error={!isWebsiteValid}
             />
-            <Icon
-              className={classes.editIconConfirm}
-              onClick={handleProjectWebsiteSave}
-            >
-              check
-            </Icon>
-            <Icon
-              className={classes.editIconConfirm}
-              onClick={handleProjectWebsiteClose}
-            >
-              close
-            </Icon>
+            <IconButton disabled={!isWebsiteValid}>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={handleProjectWebsiteSave}
+              >
+                check
+              </Icon>
+            </IconButton>
+            <IconButton>
+              <Icon
+                className={classes.editIconConfirm}
+                onClick={handleProjectWebsiteClose}
+              >
+                close
+              </Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -6,6 +6,7 @@ import ProjectSummaryLabel from "./ProjectSummaryLabel";
 import { PROJECT_UPDATE_WEBSITE } from "../../../../queries/project";
 import { useMutation } from "@apollo/client";
 import { OpenInNew } from "@mui/icons-material";
+import { isValidUrl } from "src/utils/urls";
 
 /**
  * ProjectSummaryProjectWebsite Component
@@ -46,7 +47,7 @@ const ProjectSummaryProjectWebsite = ({
     updateProjectWebsite({
       variables: {
         projectId: projectId,
-        website: website ? website : null,
+        website: website,
       },
     })
       .then(() => {
@@ -91,6 +92,7 @@ const ProjectSummaryProjectWebsite = ({
               label={null}
               onChange={handleProjectWebsiteChange}
               value={website}
+              error={!isValidUrl(website)}
             />
             <Icon
               className={classes.editIconConfirm}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,13 +1,5 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Grid,
-  IconButton,
-  Icon,
-  Link,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
@@ -53,10 +45,14 @@ const ProjectSummaryProjectWebsite = ({
    * Saves the new project website...
    */
   const handleProjectWebsiteSave = () => {
+    // Prevent saving if the website is not valid
+    if (!isWebsiteValid) return;
+    const isWebsiteEmpty = website === "";
+
     updateProjectWebsite({
       variables: {
         projectId: projectId,
-        website: isWebsiteValid ? website : null,
+        website: isWebsiteEmpty ? null : website,
       },
     })
       .then(() => {
@@ -103,22 +99,22 @@ const ProjectSummaryProjectWebsite = ({
               value={website}
               error={!isWebsiteValid}
             />
-            <IconButton disabled={!isWebsiteValid}>
-              <Icon
-                className={classes.editIconConfirm}
-                onClick={handleProjectWebsiteSave}
-              >
-                check
-              </Icon>
-            </IconButton>
-            <IconButton>
-              <Icon
-                className={classes.editIconConfirm}
-                onClick={handleProjectWebsiteClose}
-              >
-                close
-              </Icon>
-            </IconButton>
+            <Icon
+              className={
+                isWebsiteValid
+                  ? classes.editIconConfirm
+                  : classes.editIconConfirmDisabled
+              }
+              onClick={handleProjectWebsiteSave}
+            >
+              check
+            </Icon>
+            <Icon
+              className={classes.editIconConfirm}
+              onClick={handleProjectWebsiteClose}
+            >
+              close
+            </Icon>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -29,7 +29,8 @@ const ProjectSummaryProjectWebsite = ({
 
   const [editMode, setEditMode] = useState(false);
   const [website, setWebsite] = useState(originalWebsite);
-  const isWebsiteValid = isValidUrl(website);
+  // Hasura returns null if the website is empty which is a valid entry
+  const isWebsiteValid = isValidUrl(website) || website === null;
 
   const [updateProjectWebsite] = useMutation(PROJECT_UPDATE_WEBSITE);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,12 +1,5 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Grid,
-  Icon,
-  Link,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
@@ -53,7 +46,7 @@ const ProjectSummaryProjectWebsite = ({
     updateProjectWebsite({
       variables: {
         projectId: projectId,
-        website: website,
+        website: website ? website : null,
       },
     })
       .then(() => {
@@ -97,7 +90,8 @@ const ProjectSummaryProjectWebsite = ({
               id="moped-project-website"
               label={null}
               onChange={handleProjectWebsiteChange}
-              value={website} />
+              value={website}
+            />
             <Icon
               className={classes.editIconConfirm}
               onClick={handleProjectWebsiteSave}


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12158
https://github.com/cityofaustin/atd-data-tech/issues/12159

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
