### PR TITLE
Patch 1.22.1 - define DeleteIcon

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -8,11 +8,14 @@ import {
   FormControl,
   FormHelperText,
 } from "@mui/material";
-import { EditOutlined as EditOutlinedIcon } from "@mui/icons-material";
+import {
+  EditOutlined as EditOutlinedIcon,
+  DeleteOutline as DeleteOutlineIcon,
+} from "@mui/icons-material";
 import MaterialTable, {
   MTableEditRow,
   MTableAction,
-  MTableToolbar
+  MTableToolbar,
 } from "@material-table/core";
 import typography from "../../../theme/typography";
 
@@ -25,7 +28,7 @@ import {
 import { useMutation } from "@apollo/client";
 import { format } from "date-fns";
 import parseISO from "date-fns/parseISO";
-import Autocomplete from '@mui/material/Autocomplete';
+import Autocomplete from "@mui/material/Autocomplete";
 
 // Helpers
 import { phaseNameLookup } from "src/utils/timelineTableHelpers";
@@ -89,7 +92,9 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
             isOptionEqualToValue={(option, value) => option === value}
             value={props.value}
             onChange={(event, value) => props.onChange(value)}
-            renderInput={(params) => <TextField variant="standard" {...params} />}
+            renderInput={(params) => (
+              <TextField variant="standard" {...params} />
+            )}
           />
           <FormHelperText>Required</FormHelperText>
         </FormControl>
@@ -175,9 +180,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
       <MaterialTable
         columns={milestoneColumns}
         data={data.moped_proj_milestones}
-        icons={{
-          Edit: EditOutlinedIcon,
-        }}
+        icons={{ Delete: DeleteOutlineIcon, Edit: EditOutlinedIcon }}
         components={{
           EditRow: (props) => (
             <MTableEditRow
@@ -215,7 +218,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
             <div style={{ marginLeft: "-10px" }}>
               <MTableToolbar {...props} />
             </div>
-          )
+          ),
         }}
         editable={{
           onRowAdd: (newData) => {
@@ -300,6 +303,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
           rowStyle: { fontFamily: typography.fontFamily },
           actionsColumnIndex: -1,
           addRowPosition: "first",
+          idSynonym: "project_milestone_id",
         }}
         localization={{
           header: {

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -14,12 +14,13 @@ import { green } from "@mui/material/colors";
 
 import {
   EditOutlined as EditOutlinedIcon,
+  DeleteOutline as DeleteOutlineIcon,
   CheckCircleOutline,
 } from "@mui/icons-material";
 import MaterialTable, {
   MTableEditRow,
   MTableAction,
-  MTableToolbar
+  MTableToolbar,
 } from "@material-table/core";
 import typography from "../../../theme/typography";
 
@@ -232,9 +233,7 @@ const ProjectPhases = ({
         isLoading={isMutating}
         columns={phasesColumns}
         data={data.moped_proj_phases}
-        icons={{
-          Edit: EditOutlinedIcon,
-        }}
+        icons={{ Delete: DeleteOutlineIcon, Edit: EditOutlinedIcon }}
         // Action component customized as described in this gh-issue:
         // https://github.com/mbrn/material-table/issues/2133
         components={{
@@ -274,7 +273,7 @@ const ProjectPhases = ({
             <div style={{ marginLeft: "-10px" }}>
               <MTableToolbar {...props} />
             </div>
-          )
+          ),
         }}
         editable={{
           onRowAdd: async (newData) => {
@@ -326,7 +325,6 @@ const ProjectPhases = ({
             } = newData;
             // extract phase_id from moped_phase object
             updatedPhasePayload.phase_id = moped_phase.phase_id;
-
 
             // Remove extraneous fields given by MaterialTable that
             // Hasura doesn't need

--- a/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeamTable.js
@@ -333,6 +333,7 @@ const ProjectTeamTable = ({ projectId }) => {
           search: false,
           rowStyle: { fontFamily: typography.fontFamily },
           actionsColumnIndex: -1,
+          idSynonym: "project_personnel_id"
         }}
         localization={{
           header: {


### PR DESCRIPTION
## Associated issues

I noticed that the delete icon is missing on the phases table and the timeline table

![Screenshot 2023-05-04 at 2 00 12 PM](https://user-images.githubusercontent.com/12474808/236309622-1a40c99d-a184-41f9-9ed2-fb0a6cb25efc.png)

This PR defines the icon so it shows up. 

## Testing
**URL to test:** 
https://deploy-preview-1037--atd-moped-main.netlify.app/moped/projects/1933?tab=timeline

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
