### PR TITLE
Upgrades production cognito lambda packages

### DIFF
--- a/.github/workflows/atd_moped_cognito_hooks_build.yml
+++ b/.github/workflows/atd_moped_cognito_hooks_build.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
+          # this python version must be compatible with aws lambda!
           python-version: "3.8"
           architecture: "x64"
       # Get the code first

--- a/moped-auth/cognito-pre-token-hook/requirements/production.txt
+++ b/moped-auth/cognito-pre-token-hook/requirements/production.txt
@@ -1,14 +1,2 @@
-boto3==1.17.100
-botocore==1.20.100
-certifi==2022.12.7
-cffi==1.14.3
-chardet==4.0.0
-cryptography==3.3.2
-idna==2.10
-jmespath==0.10.0
-pycparser==2.20
-python-dateutil==2.8.1
-requests==2.25.1
-s3transfer==0.4.2
-six==1.15.0
-urllib3==1.26.6
+boto3==1.26.*
+cryptography==39.0.*


### PR DESCRIPTION
This bumps our production cognito hook requirements. Not in the diff, but we are working around a known Lambda env limitation (discussed [here](https://github.com/pyca/cryptography/issues/6391)) by installing the `manylinux2014_x86_64` packages with  `--only-binary=:all:`.

See here: https://github.com/cityofaustin/atd-moped/blob/60a015765b6cdccdefb74354a102181540134c51/.github/workflows/aws-moped-cognito-helper.sh#L26

I did make some other changes to the github action and helper while debugging this, starting with [this commit.](https://github.com/cityofaustin/atd-moped/commit/991d73f8005024a2833ee5bcd96ca45d4bf10f20)

This is deployed on staging so you can test staging. 


