### PR TITLE
Fix bug where Mapbox fitBounds fails with small screen widths

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -101,7 +101,20 @@ export const zoomMapToFeatureCollection = (
   if (!mapRef?.current) return;
 
   const bboxOfFeatureCollection = bbox(featureCollection);
-  mapRef.current.fitBounds(bboxOfFeatureCollection, fitBoundsOptions);
+
+  /**
+   * There is a known issue with fitBounds throwing an error with padding on smaller screens
+   * So, we try to fitBounds with padding, and if that fails, we try again without padding
+   * @see https://stackoverflow.com/a/76011418
+   * */
+  try {
+    return mapRef.current.fitBounds(bboxOfFeatureCollection, fitBoundsOptions);
+  } catch {
+    console.log(
+      "fitBounds failed, trying again without padding",
+      fitBoundsOptions
+    );
+  }
 };
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -115,6 +115,12 @@ export const zoomMapToFeatureCollection = (
       fitBoundsOptions
     );
   }
+
+  try {
+    mapRef.current.fitBounds(bboxOfFeatureCollection);
+  } catch {
+    console.log("Unable to fitBounds to feature collection");
+  }
 };
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -119,7 +119,7 @@ export const zoomMapToFeatureCollection = (
   try {
     mapRef.current.fitBounds(bboxOfFeatureCollection);
   } catch {
-    console.log("Unable to fitBounds to feature collection");
+    console.log("Unable to fitBounds to feature collection", featureCollection);
   }
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -110,10 +110,10 @@ export const zoomMapToFeatureCollection = (
   try {
     return mapRef.current.fitBounds(bboxOfFeatureCollection, fitBoundsOptions);
   } catch {
-    console.log(
-      "fitBounds failed, trying again without padding",
-      fitBoundsOptions
-    );
+    console.log("fitBounds failed, trying again without padding", {
+      fitBoundsOptions,
+      screenWidth: window.innerWidth,
+    });
   }
 
   try {


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12213

Mapbox's fitBounds method can fail with certain combinations of its padding parameter and browser screen widths. You can check out https://stackoverflow.com/a/76011418 for more background. This adds some handling of that failure and some logging in case we need a better fix down the line.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1042--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to https://deploy-preview-1042--atd-moped-main.netlify.app/moped/projects/1933
2. Go the summary page, open dev tools, and decrease your screen width until you see a console message that looks like `fitBounds failed, trying again without padding`. I'm getting 512px or smaller on my screen
3. Go to the Map tab and do the same and you should see the message at 750px or smaller
---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
