### PR TITLE
Add DB support for component tags

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -930,6 +930,45 @@
         filter: {}
         allow_aggregations: true
 - table:
+    name: moped_component_tags
+    schema: public
+  array_relationships:
+    - name: moped_proj_component_tags
+      using:
+        foreign_key_constraint_on:
+          column: component_tag_id
+          table:
+            name: moped_proj_component_tags
+            schema: public
+  select_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - is_deleted
+          - id
+          - name
+          - slug
+          - type
+        filter: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - is_deleted
+          - id
+          - name
+          - slug
+          - type
+        filter: {}
+    - role: moped-viewer
+      permission:
+        columns:
+          - is_deleted
+          - id
+          - name
+          - slug
+          - type
+        filter: {}
+- table:
     name: moped_components
     schema: public
   object_relationships:
@@ -1294,6 +1333,73 @@
           - phase_key
         filter: {}
 - table:
+    name: moped_proj_component_tags
+    schema: public
+  object_relationships:
+    - name: moped_component_tag
+      using:
+        foreign_key_constraint_on: component_tag_id
+    - name: moped_proj_component
+      using:
+        foreign_key_constraint_on: project_component_id
+  insert_permissions:
+    - role: moped-admin
+      permission:
+        check: {}
+        columns:
+          - component_tag_id
+          - is_deleted
+          - project_component_id
+    - role: moped-editor
+      permission:
+        check: {}
+        columns:
+          - component_tag_id
+          - is_deleted
+          - project_component_id
+  select_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - is_deleted
+          - component_tag_id
+          - id
+          - project_component_id
+        filter: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - is_deleted
+          - component_tag_id
+          - id
+          - project_component_id
+        filter: {}
+    - role: moped-viewer
+      permission:
+        columns:
+          - is_deleted
+          - component_tag_id
+          - id
+          - project_component_id
+        filter: {}
+  update_permissions:
+    - role: moped-admin
+      permission:
+        columns:
+          - component_tag_id
+          - is_deleted
+          - project_component_id
+        filter: {}
+        check: {}
+    - role: moped-editor
+      permission:
+        columns:
+          - component_tag_id
+          - is_deleted
+          - project_component_id
+        filter: {}
+        check: {}
+- table:
     name: moped_proj_components
     schema: public
   object_relationships:
@@ -1351,6 +1457,13 @@
           insertion_order: null
           remote_table:
             name: feature_street_segments
+            schema: public
+    - name: moped_proj_component_tags
+      using:
+        foreign_key_constraint_on:
+          column: project_component_id
+          table:
+            name: moped_proj_component_tags
             schema: public
     - name: moped_proj_components_subcomponents
       using:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1399,6 +1399,53 @@
           - project_component_id
         filter: {}
         check: {}
+  event_triggers:
+    - name: activity_log_proj_component_tags
+      definition:
+        delete:
+          columns: '*'
+        enable_manual: false
+        insert:
+          columns: '*'
+        update:
+          columns: '*'
+      retry_conf:
+        interval_sec: 10
+        num_retries: 0
+        timeout_sec: 60
+      webhook_from_env: HASURA_ENDPOINT
+      headers:
+        - name: x-hasura-admin-secret
+          value_from_env: ACTIVITY_LOG_API_SECRET
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",
+              "variables": {
+                "object": {
+                  "record_id": {{ $body.event.data.new.id }},
+                  "record_type":  {{ $body.table.name }},
+                  "activity_id": {{ $body.id }},
+                  "record_data": {"event": {{ $body.event }}},
+                  "description": [{"newSchema": "true"}],
+                  "operation_type": {{ $body.event.op }},
+                  "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
+                }
+              }
+            }
+        method: POST
+        query_params: {}
+        template_engine: Kriti
+        version: 2
+      cleanup_config:
+        batch_size: 10000
+        clean_invocation_logs: false
+        clear_older_than: 168
+        paused: true
+        schedule: 0 0 * * *
+        timeout: 60
 - table:
     name: moped_proj_components
     schema: public

--- a/moped-database/migrations/1683643688424_create-component-tags/down.sql
+++ b/moped-database/migrations/1683643688424_create-component-tags/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE "public"."moped_proj_component_tags";
+DROP TABLE "public"."moped_component_tags";

--- a/moped-database/migrations/1683643688424_create-component-tags/up.sql
+++ b/moped-database/migrations/1683643688424_create-component-tags/up.sql
@@ -27,5 +27,5 @@ INSERT INTO public.moped_component_tags (name, "type", slug) values
     ('Council Adopted 2019','bikeways','CouncilAdopted2019'),
     ('Proposed Post-ATX Walk-bike-run','bikeways','ProposedPostATXWBR'),
     ('Proposed','bikeways','Proposed'),
-    ('OtherJuristiction','bikeways','OtherJuristiction'),
+    ('Other Jurisdiction','bikeways','OtherJurisdiction'),
     ('Proposed ATX Walk-bike-run (tentative)','bikeways','ProposedATXWBR(tentative)');

--- a/moped-database/migrations/1683643688424_create-component-tags/up.sql
+++ b/moped-database/migrations/1683643688424_create-component-tags/up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "public"."moped_component_tags" (
+    "id" serial,
+    "name" text NOT NULL,
+    "type" text NOT NULL,
+    "slug" text NOT NULL,
+    "is_deleted" boolean NOT NULL DEFAULT FALSE,
+    PRIMARY KEY ("id"),
+    UNIQUE ("name"),
+    UNIQUE ("slug")
+);
+
+COMMENT ON TABLE "public"."moped_component_tags" IS 'Lookup table for component tags';
+
+CREATE TABLE "public"."moped_proj_component_tags" (
+    id SERIAL PRIMARY KEY,
+    project_component_id INTEGER NOT NULL REFERENCES moped_proj_components(project_component_id) ON UPDATE CASCADE ON DELETE CASCADE,
+    component_tag_id INTEGER NOT NULL REFERENCES moped_component_tags(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+COMMENT ON TABLE "public"."moped_proj_component_tags" IS 'Tracks many tags per project component';
+
+INSERT INTO public.moped_component_tags (name, "type", slug) values
+    ('Proposed Pre-ATX Walk-bike-run','bikeways','ProposedPreATXWBR'),
+    ('Proposed ATX Walk-bike-run','bikeways','ProposedATXWBR'),
+    ('Council Adopted 2014','bikeways','CouncilAdopted2014'),
+    ('Council Adopted 2019','bikeways','CouncilAdopted2019'),
+    ('Proposed Post-ATX Walk-bike-run','bikeways','ProposedPostATXWBR'),
+    ('Proposed','bikeways','Proposed'),
+    ('OtherJuristiction','bikeways','OtherJuristiction'),
+    ('Proposed ATX Walk-bike-run (tentative)','bikeways','ProposedATXWBR(tentative)');


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12222

Same deal as https://github.com/cityofaustin/atd-moped/pull/1014, the rows in `moped_component_tags` are going to change after MUG feedback, but the schema should be sound.

## Testing
**URL to test:** Local
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
Using the Hasura console / graphiql:

- insert some proj component tags

```graphql
  mutation InsertProjComponentTags {
    insert_moped_proj_component_tags(
      objects: [
        { component_tag_id: 1, project_component_id: 2 }
        { component_tag_id: 2, project_component_id: 2 }
        { component_tag_id: 3, project_component_id: 2 }
      ]
    ) {
      affected_rows
    }
  }
```

- query project components with the nested component tag relationships

```graphql
query ProjComponent {
  moped_proj_components_by_pk(project_component_id: 2) {
    project_component_id
    moped_proj_component_tags {
      moped_component_tag {
        name
        slug
      }
    }
  }
}
```

- confirm the activity log events are captured

```graphql
query ActivityLog {
  moped_activity_log(where: {record_type: {_eq: "moped_proj_component_tags"}}) {
    activity_id
    record_type
    data: record_data(path: "$.event.data.new")
  }
}
```
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
