### PR TITLE
Replace status_id column with is_deleted on moped_components table

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -950,7 +950,7 @@
         columns:
           - component_id
           - component_name
-          - status_id
+          - is_deleted
           - component_subtype
           - line_representation
           - feature_layer_id
@@ -960,7 +960,7 @@
         columns:
           - component_id
           - component_name
-          - status_id
+          - is_deleted
           - component_subtype
           - line_representation
           - feature_layer_id
@@ -970,7 +970,7 @@
         columns:
           - component_id
           - component_name
-          - status_id
+          - is_deleted
           - component_subtype
           - line_representation
           - feature_layer_id

--- a/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/down.sql
+++ b/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "public"."moped_components" ADD column "status_id" int4 NOT NULL DEFAULT 0;
+
+-- Go back to status_id for soft deletes
+UPDATE moped_components
+SET status_id = 0
+WHERE is_deleted = TRUE;
+
+ALTER TABLE "public"."moped_components" DROP COLUMN "is_deleted";

--- a/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/down.sql
+++ b/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "public"."moped_components" ADD column "status_id" int4 NOT NULL DEFAULT 0;
+ALTER TABLE "public"."moped_components" ADD COLUMN "status_id" int4 NOT NULL DEFAULT 0;
 
 -- Go back to status_id for soft deletes
 UPDATE moped_components

--- a/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/up.sql
+++ b/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "public"."moped_components" ADD column "is_deleted" boolean NOT NULL DEFAULT false;
+ALTER TABLE "public"."moped_components" ADD COLUMN "is_deleted" boolean NOT NULL DEFAULT false;
 
 COMMENT ON COLUMN moped_components.is_deleted IS 'Indicates soft deletion';
 
@@ -8,4 +8,4 @@ SET is_deleted = TRUE
 WHERE status_id = 0;
 
 -- Remove the old status_id column
-ALTER TABLE "public"."moped_components" DROP column "status_id" cascade;
+ALTER TABLE "public"."moped_components" DROP COLUMN "status_id" cascade;

--- a/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/up.sql
+++ b/moped-database/migrations/1683740879611_alter_table_public_moped_components_add_column_is_deleted/up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "public"."moped_components" ADD column "is_deleted" boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN moped_components.is_deleted IS 'Indicates soft deletion';
+
+-- Update new is_deleted columns to preserve existing soft deletes that used status_id = 0
+UPDATE moped_components
+SET is_deleted = TRUE
+WHERE status_id = 0;
+
+-- Remove the old status_id column
+ALTER TABLE "public"."moped_components" DROP column "status_id" cascade;

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -4,7 +4,7 @@ export const GET_COMPONENTS_FORM_OPTIONS = gql`
   query GetComponentsFormOptions {
     moped_components(
       order_by: [{ component_name: asc }, { component_subtype: asc }]
-      where: { status_id: { _neq: 0 } }
+      where: { is_deleted: { _eq: false } }
     ) {
       component_id
       component_name

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -26,6 +26,7 @@ export const TABLE_LOOKUPS_QUERY = gql`
       }
     }
     moped_components(
+      where: { is_deleted: { _eq: false } }
       order_by: [{ component_name: asc }, { component_subtype: asc }]
     ) {
       component_name

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -86,7 +86,7 @@ export const SETTINGS = [
       },
       {
         key: "milestone_name",
-        label: "Milestone name",
+        label: "Milestone",
       },
       {
         key: "moped_phase",

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -78,7 +78,7 @@ const ProjectMilestones = ({ projectId, loading, data, refetch }) => {
    */
   const milestoneColumns = [
     {
-      title: "Milestone name",
+      title: "Milestone",
       field: "milestone_id",
       render: (milestone) => milestone.moped_milestone.milestone_name,
       validate: (milestone) => !!milestone.milestone_id,


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12248
https://github.com/cityofaustin/atd-data-tech/issues/12255

This PR removes the last remaining `status_id` column. 🥲

_**Note: merging of this and https://github.com/cityofaustin/atd-moped/pull/1014 will have to be coordinated since this update affects a query in there.**_

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Make sure the local stack spins up with the new migration
2. To make sure the updated query still works, go to the Map tab of a project and try to add a new component
3. If you see components in the dropdown of the new component form, this is working. 👍
4. Go to the Timeline tab and you should see the first header in the Milestone table is `Milestone` instead of `Milestone name` (this is also updated in the data dictionary https://localhost:3000/moped/dev/lookups#moped-milestones)

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
