### PR TITLE
Ensures correct construction and completion dates are shown in project list view

### DIFF
--- a/moped-database/migrations/1683826893015_list-view-contruct-complete-date/down.sql
+++ b/moped-database/migrations/1683826893015_list-view-contruct-complete-date/down.sql
@@ -1,4 +1,3 @@
--- latest version 1683826893015_list-view-contruct-complete-date
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view
@@ -63,22 +62,24 @@ AS WITH project_person_list_lookup AS (
         WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
         ORDER BY mpn.date_created DESC
         LIMIT 1) AS project_note,
-    ( -- get the date of the construction phase with the earliest start date
-      SELECT min(phases.phase_start)
+    ( -- get me the phase start of the most recently added construction phase entry
+      SELECT phases.phase_start
       FROM moped_proj_phases phases
       WHERE true
         AND phases.project_id = mp.project_id 
         AND phases.phase_id = 9 -- phase_id 9 is construction
         AND phases.is_deleted = false
-    ) AS construction_start_date,
-    ( -- get the date of the completion phase with the latest end date
-      SELECT max(phases.phase_end)
+      ORDER BY phases.date_added DESC
+      LIMIT 1) AS construction_start_date,
+    ( -- get me the phase end of the most recently added completion phase entry
+      SELECT phases.phase_end
       FROM moped_proj_phases phases
       WHERE true 
         AND phases.project_id = mp.project_id 
         AND phases.phase_id = 11 -- phase_id 11 is complete
         AND phases.is_deleted = false
-      ) AS completion_end_date,
+      ORDER BY phases.date_added DESC
+      LIMIT 1) AS completion_end_date,
     ( -- get me a list of the inspectors for this project
       SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
       FROM moped_proj_personnel mpp

--- a/moped-database/migrations/1683826893015_list-view-contruct-complete-date/up.sql
+++ b/moped-database/migrations/1683826893015_list-view-contruct-complete-date/up.sql
@@ -1,4 +1,3 @@
--- latest version 1683826893015_list-view-contruct-complete-date
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12264

## Testing
**URL to test:** Local

**Steps to test:**
1. Create a new project.
2. Add a "Construction" phase to the project with a start date populated.
3. Add another "Construction phase to the project with a start populated that is **later** than the previous phase you added.
4. Add a "Completed" phase to the project with the end date populated.
5. Add another Completed phase to the project with no end date populated.
6. From the project list view, confirm that your project's "Construction start" and "Completion date" columns are populated with the dates you entered in step 2 and step 4, respectively. 
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
