### PR TITLE
Show summary map if a project's subprojects are mapped

### DIFF
--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -41,7 +41,7 @@ export const ADD_PROJECT_COMPONENT = gql`
   }
 `;
 
-export const GET_PROJECT_COMPONENTS = gql`
+export const PROJECT_COMPONENT_FIELDS = gql`
   fragment projectComponentFields on moped_proj_components {
     project_component_id
     component_id
@@ -109,6 +109,10 @@ export const GET_PROJECT_COMPONENTS = gql`
       component_id
     }
   }
+`;
+
+export const GET_PROJECT_COMPONENTS = gql`
+  ${PROJECT_COMPONENT_FIELDS}
   query GetProjectComponents($projectId: Int!, $parentProjectId: Int = 0) {
     moped_proj_components(
       where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { PROJECT_COMPONENT_FIELDS } from "./components";
 
 export const ADD_PROJECT = gql`
   mutation AddProject($object: moped_project_insert_input!) {
@@ -20,6 +21,7 @@ export const ADD_PROJECT = gql`
 `;
 
 export const SUMMARY_QUERY = gql`
+  ${PROJECT_COMPONENT_FIELDS}
   query ProjectSummary($projectId: Int, $userId: Int) {
     moped_project(where: { project_id: { _eq: $projectId } }) {
       project_id
@@ -124,6 +126,21 @@ export const SUMMARY_QUERY = gql`
     ) {
       geometry: geography
       attributes
+    }
+    moped_proj_components(
+      where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
+    ) {
+      ...projectComponentFields
+    }
+    childProjects: moped_project(
+      where: {
+        parent_project_id: { _eq: $projectId }
+        is_deleted: { _eq: false }
+      }
+    ) {
+      moped_proj_components(where: { is_deleted: { _eq: false } }) {
+        ...projectComponentFields
+      }
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useProjectComponents.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useProjectComponents.js
@@ -52,5 +52,6 @@ export const useProjectComponents = (data) => {
   return {
     projectComponents,
     allRelatedComponents,
+    childComponents,
   };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -303,7 +303,10 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
               </Grid>
               <Grid item xs={12}>
                 {!data.moped_project[0].parent_project_id && (
-                  <SubprojectsTable projectId={projectId} />
+                  <SubprojectsTable
+                    projectId={projectId}
+                    refetchSummaryData={refetch}
+                  />
                 )}
               </Grid>
             </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -121,7 +121,7 @@ const useStyles = makeStyles((theme) => ({
  * @return {JSX.Element}
  * @constructor
  */
-const ProjectSummary = ({ loading, error, data, refetch }) => {
+const ProjectSummary = ({ loading, error, data, refetch, parentProjectId }) => {
   const { projectId } = useParams();
   const classes = useStyles();
 
@@ -293,7 +293,10 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                <ProjectSummaryMap data={data} />
+                <ProjectSummaryMap
+                  data={data}
+                  parentProjectId={parentProjectId}
+                />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -293,10 +293,7 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
           <Grid item xs={12} md={6}>
             <Grid container spacing={2}>
               <Grid item xs={12}>
-                <ProjectSummaryMap
-                  data={data}
-                  // parentProjectId={parentProjectId}
-                />
+                <ProjectSummaryMap data={data} />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -121,7 +121,7 @@ const useStyles = makeStyles((theme) => ({
  * @return {JSX.Element}
  * @constructor
  */
-const ProjectSummary = ({ loading, error, data, refetch, parentProjectId }) => {
+const ProjectSummary = ({ loading, error, data, refetch }) => {
   const { projectId } = useParams();
   const classes = useStyles();
 
@@ -295,7 +295,7 @@ const ProjectSummary = ({ loading, error, data, refetch, parentProjectId }) => {
               <Grid item xs={12}>
                 <ProjectSummaryMap
                   data={data}
-                  parentProjectId={parentProjectId}
+                  // parentProjectId={parentProjectId}
                 />
               </Grid>
               <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -37,18 +37,20 @@ const useMapRef = () => {
   return [mapRef, mapRefState];
 };
 
-const ProjectSummaryMap = ({ parentProjectId }) => {
-  const { projectId } = useParams();
+// TODO Handle stale data Ex. removing a subproject -> refresh this map
+
+const ProjectSummaryMap = ({ data }) => {
+  // const { projectId } = useParams();
   const [mapRef, mapRefState] = useMapRef();
   const [basemapKey, setBasemapKey] = useState("streets");
 
-  const { data, error } = useQuery(GET_PROJECT_COMPONENTS, {
-    variables: {
-      projectId,
-      ...(parentProjectId && { parentProjectId }),
-    },
-    fetchPolicy: "no-cache",
-  });
+  // const { data, error } = useQuery(GET_PROJECT_COMPONENTS, {
+  //   variables: {
+  //     projectId,
+  //     ...(parentProjectId && { parentProjectId }),
+  //   },
+  //   fetchPolicy: "no-cache",
+  // });
 
   const { projectComponents, childComponents } = useProjectComponents(data);
 
@@ -63,7 +65,7 @@ const ProjectSummaryMap = ({ parentProjectId }) => {
     projectComponentsFeatureCollection.features.length > 0 ||
     childComponentsFeatureCollection.features.length > 0;
 
-  if (error) console.log(error);
+  // if (error) console.log(error);
 
   return (
     <Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -8,6 +8,7 @@ import BaseMapSourceAndLayers from "../ProjectComponents/BaseMapSourceAndLayers"
 import BasemapSpeedDial from "../ProjectComponents/BasemapSpeedDial";
 import ProjectSummaryMapSourcesAndLayers from "./ProjectSummaryMapSourcesAndLayers";
 import ProjectSourcesAndLayers from "../ProjectComponents/ProjectSourcesAndLayers";
+import RelatedProjectSourcesAndLayers from "../ProjectComponents/RelatedProjectSourcesAndLayers";
 import {
   basemaps,
   mapParameters,
@@ -49,29 +50,10 @@ const ProjectSummaryMap = ({ parentProjectId }) => {
     fetchPolicy: "no-cache",
   });
 
-  const { projectComponents, allRelatedComponents } =
-    useProjectComponents(data);
+  const { projectComponents, childComponents } = useProjectComponents(data);
 
   const projectComponentsFeatureCollection =
     useAllComponentsFeatureCollection(projectComponents);
-
-  // const { projectComponents, allRelatedComponents } =
-  //   useProjectComponents(data);
-
-  // const projectFeatureCollection = useMemo(() => {
-  //   const featureCollection = {
-  //     type: "FeatureCollection",
-  //     features: [],
-  //   };
-
-  //   if (!data?.project_geography) return featureCollection;
-
-  //   const projectGeographyGeoJSONFeatures = data.project_geography.map(
-  //     (feature) => makeFeatureFromProjectGeographyRecord(feature)
-  //   );
-
-  //   return { ...featureCollection, features: projectGeographyGeoJSONFeatures };
-  // }, [data]);
 
   useZoomToExistingComponents(mapRefState, data);
 
@@ -106,6 +88,13 @@ const ProjectSummaryMap = ({ parentProjectId }) => {
               projectComponentsFeatureCollection
             }
             draftEditComponent={null}
+          />
+          <RelatedProjectSourcesAndLayers
+            isCreatingComponent={false}
+            isEditingComponent={false}
+            featureCollection={childComponents}
+            shouldShowRelatedProjects={true}
+            clickedComponent={null}
           />
           {/* <ProjectSummaryMapSourcesAndLayers
             projectFeatureCollection={projectFeatureCollection}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,17 +1,20 @@
 import React, { useCallback, useState, useMemo } from "react";
 import { useQuery } from "@apollo/client";
+import { useParams } from "react-router";
 import MapGL from "react-map-gl";
 import { Box } from "@mui/material";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
 import BaseMapSourceAndLayers from "../ProjectComponents/BaseMapSourceAndLayers";
 import BasemapSpeedDial from "../ProjectComponents/BasemapSpeedDial";
 import ProjectSummaryMapSourcesAndLayers from "./ProjectSummaryMapSourcesAndLayers";
+import ProjectSourcesAndLayers from "../ProjectComponents/ProjectSourcesAndLayers";
 import {
   basemaps,
   mapParameters,
   initialViewState,
 } from "../ProjectComponents/mapSettings";
 import { makeFeatureFromProjectGeographyRecord } from "../ProjectComponents/utils/makeFeatureCollections";
+import { GET_PROJECT_COMPONENTS } from "src/queries/components";
 import { useZoomToExistingComponents } from "../ProjectComponents/utils/map";
 import { useAllComponentsFeatureCollection } from "../ProjectComponents/utils/makeFeatureCollections";
 import { useProjectComponents } from "../ProjectComponents/utils/useProjectComponents";
@@ -22,8 +25,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
  * @see https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
  * @returns {Array} - [mapRef, mapRefState] - mapRef is a callback ref, mapRefState is a state variable
  */
-const useMapRef = ({ parentProjectId }) => {
-  const { projectId } = useParams();
+const useMapRef = () => {
   const [mapRefState, setMapRefState] = useState(null);
   const mapRef = useCallback((mapInstance) => {
     if (mapInstance !== null) {
@@ -34,7 +36,8 @@ const useMapRef = ({ parentProjectId }) => {
   return [mapRef, mapRefState];
 };
 
-const ProjectSummaryMap = () => {
+const ProjectSummaryMap = ({ parentProjectId }) => {
+  const { projectId } = useParams();
   const [mapRef, mapRefState] = useMapRef();
   const [basemapKey, setBasemapKey] = useState("streets");
 
@@ -73,7 +76,7 @@ const ProjectSummaryMap = () => {
   useZoomToExistingComponents(mapRefState, data);
 
   const areThereComponentFeatures =
-    projectFeatureCollection.features.length > 0;
+    projectComponentsFeatureCollection.features.length > 0;
 
   if (error) console.log(error);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -54,11 +54,14 @@ const ProjectSummaryMap = ({ parentProjectId }) => {
 
   const projectComponentsFeatureCollection =
     useAllComponentsFeatureCollection(projectComponents);
+  const childComponentsFeatureCollection =
+    useAllComponentsFeatureCollection(childComponents);
 
   useZoomToExistingComponents(mapRefState, data);
 
   const areThereComponentFeatures =
-    projectComponentsFeatureCollection.features.length > 0;
+    projectComponentsFeatureCollection.features.length > 0 ||
+    childComponentsFeatureCollection.features.length > 0;
 
   if (error) console.log(error);
 
@@ -92,7 +95,7 @@ const ProjectSummaryMap = ({ parentProjectId }) => {
           <RelatedProjectSourcesAndLayers
             isCreatingComponent={false}
             isEditingComponent={false}
-            featureCollection={childComponents}
+            featureCollection={childComponentsFeatureCollection}
             shouldShowRelatedProjects={true}
             clickedComponent={null}
           />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -1,12 +1,9 @@
-import React, { useCallback, useState, useMemo } from "react";
-import { useQuery } from "@apollo/client";
-import { useParams } from "react-router";
+import React, { useCallback, useState } from "react";
 import MapGL from "react-map-gl";
 import { Box } from "@mui/material";
 import ProjectSummaryMapFallback from "./ProjectSummaryMapFallback";
 import BaseMapSourceAndLayers from "../ProjectComponents/BaseMapSourceAndLayers";
 import BasemapSpeedDial from "../ProjectComponents/BasemapSpeedDial";
-import ProjectSummaryMapSourcesAndLayers from "./ProjectSummaryMapSourcesAndLayers";
 import ProjectSourcesAndLayers from "../ProjectComponents/ProjectSourcesAndLayers";
 import RelatedProjectSourcesAndLayers from "../ProjectComponents/RelatedProjectSourcesAndLayers";
 import {
@@ -14,8 +11,6 @@ import {
   mapParameters,
   initialViewState,
 } from "../ProjectComponents/mapSettings";
-import { makeFeatureFromProjectGeographyRecord } from "../ProjectComponents/utils/makeFeatureCollections";
-import { GET_PROJECT_COMPONENTS } from "src/queries/components";
 import { useZoomToExistingComponents } from "../ProjectComponents/utils/map";
 import { useAllComponentsFeatureCollection } from "../ProjectComponents/utils/makeFeatureCollections";
 import { useProjectComponents } from "../ProjectComponents/utils/useProjectComponents";
@@ -37,20 +32,9 @@ const useMapRef = () => {
   return [mapRef, mapRefState];
 };
 
-// TODO Handle stale data Ex. removing a subproject -> refresh this map
-
 const ProjectSummaryMap = ({ data }) => {
-  // const { projectId } = useParams();
   const [mapRef, mapRefState] = useMapRef();
   const [basemapKey, setBasemapKey] = useState("streets");
-
-  // const { data, error } = useQuery(GET_PROJECT_COMPONENTS, {
-  //   variables: {
-  //     projectId,
-  //     ...(parentProjectId && { parentProjectId }),
-  //   },
-  //   fetchPolicy: "no-cache",
-  // });
 
   const { projectComponents, childComponents } = useProjectComponents(data);
 
@@ -64,8 +48,6 @@ const ProjectSummaryMap = ({ data }) => {
   const areThereComponentFeatures =
     projectComponentsFeatureCollection.features.length > 0 ||
     childComponentsFeatureCollection.features.length > 0;
-
-  // if (error) console.log(error);
 
   return (
     <Box>
@@ -101,9 +83,6 @@ const ProjectSummaryMap = ({ data }) => {
             shouldShowRelatedProjects={true}
             clickedComponent={null}
           />
-          {/* <ProjectSummaryMapSourcesAndLayers
-            projectFeatureCollection={projectFeatureCollection}
-          /> */}
         </MapGL>
       ) : (
         <ProjectSummaryMapFallback />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -151,6 +151,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
           actionsColumnIndex: -1,
           tableLayout: "fixed",
           addRowPosition: "first",
+          idSynonym: "project_id",
         }}
         localization={{
           header: {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -30,7 +30,7 @@ import {
 } from "../../../../queries/subprojects";
 import typography from "../../../../theme/typography";
 
-const SubprojectsTable = ({ projectId = null }) => {
+const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
   const addActionRef = React.useRef();
 
   const { loading, error, data, refetch } = useQuery(SUBPROJECT_QUERY, {
@@ -177,6 +177,7 @@ const SubprojectsTable = ({ projectId = null }) => {
             })
               .then(() => {
                 refetch();
+                refetchSummaryData();
               })
               .catch((error) => console.error(error));
           },
@@ -189,6 +190,7 @@ const SubprojectsTable = ({ projectId = null }) => {
             })
               .then(() => {
                 refetch();
+                refetchSummaryData();
               })
               .catch((error) => console.error(error));
           },

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -177,7 +177,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
             })
               .then(() => {
                 refetch();
-                refetchSummaryData();
+                refetchSummaryData(); // Refresh subprojects in summary map
               })
               .catch((error) => console.error(error));
           },
@@ -190,7 +190,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
             })
               .then(() => {
                 refetch();
-                refetchSummaryData();
+                refetchSummaryData(); // Refresh subprojects in summary map
               })
               .catch((error) => console.error(error));
           },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12262

This PR updates the summary map to show subproject components even if the current project has no components of its own. I updated the summary map to use the same hooks and layers that the component map uses. I also updated the project summary query to fetch the components for the current project _and_ its subprojects so that we can refetch that top-level data when adding or removing subprojects in the `SubprojectTable` component. That way the summary map updates without a page refresh.

@johnclary and everyone else - I couldn't decide on whether the initial map zoom should include subprojects. The components map in the **Map** tab only zooms to components in the current project - not related projects. So, that is what I did here. Happy to update if needed!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1050--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Create a new project and notice that the summary map does not appear since there are no components or subprojects associated with it
2. In the summary view, add a subproject, and you should see the summary map appear with the subproject's components displayed
3. Remove the subproject and the map should go back to the fallback view with the "Add Components" button
4. Add some components through the **Map** tab and you can see them on the summary map along with any subproject components

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
