### PR TITLE
Creates flashing beacon components and updates old RRFB components

### DIFF
--- a/moped-database/migrations/1684865704636_flashing-beacon-components/down.sql
+++ b/moped-database/migrations/1684865704636_flashing-beacon-components/down.sql
@@ -1,0 +1,52 @@
+UPDATE
+    moped_components
+SET
+    component_name = 'Signage'
+WHERE
+    component_name = 'Flashing Beacon'
+    AND component_subtype = 'RRFB';
+
+-- revert update proj components using old signal - rrfb component and make it deleted
+DO $$
+DECLARE
+    old_component_id INTEGER;
+    new_component_id INTEGER;
+BEGIN
+    -- get signal - rrfb component id
+    SELECT
+        component_id INTO old_component_id
+    FROM
+        moped_components
+    WHERE
+        component_name = 'Signal'
+        AND component_subtype = 'RRFB';
+    
+    -- get flashing beacon - rrfb component id
+    SELECT
+        component_id INTO new_component_id
+    FROM
+        moped_components
+    WHERE
+        component_name = 'Flashing Beacon'
+        AND component_subtype = 'RRFB';
+    
+    -- update all proj components using the old id
+    UPDATE
+        moped_proj_components
+    SET
+        component_id = old_component_id
+    WHERE
+        component_id = new_component_id;
+
+    -- revert set the old signal component to deleted
+    UPDATE
+        moped_components
+    SET
+        is_deleted = FALSE
+    WHERE
+        component_id = old_component_id;
+END
+$$;
+
+-- delete new beacon types
+delete from  moped_components where component_name = 'Flashing Beacon';

--- a/moped-database/migrations/1684865704636_flashing-beacon-components/down.sql
+++ b/moped-database/migrations/1684865704636_flashing-beacon-components/down.sql
@@ -1,3 +1,5 @@
+-- change component back to "Signage - RRFB"
+-- note: we cannot undo conversion of Signal - RRFB to Signage - RRFB
 UPDATE
     moped_components
 SET
@@ -6,47 +8,13 @@ WHERE
     component_name = 'Flashing Beacon'
     AND component_subtype = 'RRFB';
 
--- revert update proj components using old signal - rrfb component and make it deleted
-DO $$
-DECLARE
-    old_component_id INTEGER;
-    new_component_id INTEGER;
-BEGIN
-    -- get signal - rrfb component id
-    SELECT
-        component_id INTO old_component_id
-    FROM
-        moped_components
-    WHERE
-        component_name = 'Signal'
-        AND component_subtype = 'RRFB';
-    
-    -- get flashing beacon - rrfb component id
-    SELECT
-        component_id INTO new_component_id
-    FROM
-        moped_components
-    WHERE
-        component_name = 'Flashing Beacon'
-        AND component_subtype = 'RRFB';
-    
-    -- update all proj components using the old id
-    UPDATE
-        moped_proj_components
-    SET
-        component_id = old_component_id
-    WHERE
-        component_id = new_component_id;
-
-    -- revert set the old signal component to deleted
-    UPDATE
-        moped_components
-    SET
-        is_deleted = FALSE
-    WHERE
-        component_id = old_component_id;
-END
-$$;
+-- revert set the old signal component to deleted
+UPDATE
+    moped_components
+SET
+    is_deleted = FALSE
+WHERE
+    component_id = old_component_id;
 
 -- delete new beacon types
 delete from  moped_components where component_name = 'Flashing Beacon';

--- a/moped-database/migrations/1684865704636_flashing-beacon-components/up.sql
+++ b/moped-database/migrations/1684865704636_flashing-beacon-components/up.sql
@@ -1,0 +1,60 @@
+-- rename Signage - RRFB to Flashing Beacon - RRFB
+UPDATE
+    moped_components
+SET
+    component_name = 'Flashing Beacon'
+WHERE
+    component_name = 'Signage'
+    AND component_subtype = 'RRFB';
+
+-- create additional beacon types
+INSERT into moped_components (component_name, component_subtype, line_representation, feature_layer_id) values
+    ('Flashing Beacon', 'Curve Warning', FALSE, 5),
+    ('Flashing Beacon', 'Hazard', FALSE, 5),
+    ('Flashing Beacon', 'Intersection', FALSE, 5),
+    ('Flashing Beacon', 'Pedestrian', FALSE, 5),
+    ('Flashing Beacon', 'Signal Ahead', FALSE, 5),
+    ('Flashing Beacon', 'Speed Limit', FALSE, 5),
+    ('Flashing Beacon', 'Stop Sign', FALSE, 5);
+
+-- update proj components using old signal - rrfb component and make it deleted
+DO $$
+DECLARE
+    old_component_id INTEGER;
+    new_component_id INTEGER;
+BEGIN
+    -- get signal - rrfb component id
+    SELECT
+        component_id INTO old_component_id
+    FROM
+        moped_components
+    WHERE
+        component_name = 'Signal'
+        AND component_subtype = 'RRFB';
+    
+    -- get flashing beacon - rrfb component id
+    SELECT
+        component_id INTO new_component_id
+    FROM
+        moped_components
+    WHERE
+        component_name = 'Flashing Beacon'
+        AND component_subtype = 'RRFB';
+    
+    -- update all proj components using the old id
+    UPDATE
+        moped_proj_components
+    SET
+        component_id = new_component_id
+    WHERE
+        component_id = old_component_id;
+
+    -- set the old signal component to deleted
+    UPDATE
+        moped_components
+    SET
+        is_deleted = TRUE
+    WHERE
+        component_id = old_component_id;
+END
+$$;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11860

This PR:
- Creates new "Flashing beacon" components and changes the Signage - RRFB component to be part of the "Flashing beacon" group
- Soft deletes the old "Signal - RRFB" component and migrates that data to the Flashing Beacon component, which was actually hidden from users before we overhauled the components UI.
 
Note that AMD has also requested to have the ability to pick these beacon components from a list, in the same way that Signals + PHBs are selectable, but that is out of scope for now.

## Testing
**URL to test:** Local
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**

### Test new component types
1. Create a new component by typing "RRFB" into the component autocomplete.
2. Verify that the only available option is "Flashing Beacon - RRFB".
3. Now type "flashing beacon" into the component input and verify all beacon options are available as **points**

- RRFB
- Curve Warning
- Hazard
- Intersection
- Pedestrian
- Signal Ahead
- Speed Limit
- Stop Sign

4. Pick one of these ☝️ and map it with selected and drawn points

### Test component migration

The easiest way to test this is probably through the hasura console.
1. Edit a moped_proj_component record to use component ID `17`, which is the Signal - RRFB component.
2. Copy/run [this update procedure](https://github.com/cityofaustin/atd-moped/blob/2cbd55f8a5231f69de3d99a1b3c4d2cebf345646/moped-database/migrations/1684865704636_flashing-beacon-components/up.sql#L21-L60) from the migration.
3. Verify that the project component you edited now has the ID of the "Flashing beacon - RRB" component

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
