### PR TITLE
Refine map default zoom/fit behavior

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -19,7 +19,7 @@ import {
   SOURCES,
   MIN_SELECT_FEATURE_ZOOM,
 } from "./mapSettings";
-import { interactiveLayerIds } from "./utils/map";
+import { interactiveLayerIds, useZoomToExistingComponents } from "./utils/map";
 import {
   useAgolFeatures,
   findFeatureInAgolGeojsonFeatures,
@@ -76,6 +76,11 @@ export default function TheMap({
     useAllComponentsFeatureCollection(projectComponents);
   const allRelatedComponentsFeatureCollection =
     useAllComponentsFeatureCollection(allRelatedComponents);
+  const projectAndRelatedComponentsFeatureCollection =
+    useAllComponentsFeatureCollection([
+      ...projectComponents,
+      ...allRelatedComponents,
+    ]);
 
   const draftComponentFeatures = useDraftComponentFeatures(draftComponent);
   const draftEditComponentFeatureCollection =
@@ -90,6 +95,11 @@ export default function TheMap({
     setIsFetchingFeatures,
     currentZoom,
     bounds
+  );
+
+  useZoomToExistingComponents(
+    mapRef,
+    projectAndRelatedComponentsFeatureCollection
   );
 
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -99,7 +99,8 @@ export default function TheMap({
 
   useZoomToExistingComponents(
     mapRef,
-    projectAndRelatedComponentsFeatureCollection
+    projectAndRelatedComponentsFeatureCollection,
+    false
   );
 
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -13,7 +13,7 @@ import EditAttributesModal from "./EditAttributesModal";
 import DeleteComponentModal from "./DeleteComponentModal";
 import EditModeDialog from "./EditModeDialog";
 import ComponentMapToolbar from "./ComponentMapToolbar";
-import { useAppBarHeight, useZoomToExistingComponents } from "./utils/map";
+import { useAppBarHeight } from "./utils/map";
 import { GET_PROJECT_COMPONENTS } from "src/queries/components";
 import { getAllComponentFeatures } from "./utils/makeFeatureCollections";
 import { fitBoundsOptions } from "./mapSettings";
@@ -163,11 +163,6 @@ export default function MapView({
   const { errorMessageDispatch, errorMessageState } = useToolbarErrorMessage();
 
   if (error) console.log(error);
-
-  useZoomToExistingComponents(mapRef, {
-    type: "FeatureCollection",
-    features: data?.project_geography,
-  });
 
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import { useQuery } from "@apollo/client";
 import { useParams } from "react-router";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import { Dialog } from "@mui/material";
 import Drawer from "@mui/material/Drawer";
 import CssBaseline from "@mui/material/CssBaseline";
@@ -164,7 +164,10 @@ export default function MapView({
 
   if (error) console.log(error);
 
-  useZoomToExistingComponents(mapRef, data);
+  useZoomToExistingComponents(mapRef, {
+    type: "FeatureCollection",
+    features: data?.project_geography,
+  });
 
   /* fits clickedComponent to map bounds - called from component list item secondary action */
   const onClickZoomToComponent = (component) => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -41,13 +41,13 @@ export const fitBoundsOptions = {
   zoomToExtent: {
     maxZoom: 15,
     // accounting for fixed top bar
-    padding: 200,
+    padding: 50,
   },
   zoomToClickedComponent: {
     maxZoom: 19,
     padding: 200,
     duration: 1500,
-    linear: true
+    linear: true,
   },
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -40,13 +40,12 @@ export const initialViewState = {
 export const fitBoundsOptions = {
   zoomToExtent: {
     maxZoom: 15,
-    // accounting for fixed top bar
     padding: 50,
   },
   zoomToClickedComponent: {
     maxZoom: 19,
-    padding: 200,
-    duration: 1500,
+    padding: 50,
+    duration: 500,
     linear: true,
   },
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -126,25 +126,24 @@ export const zoomMapToFeatureCollection = (
 /**
  * Use Mapbox fitBounds to zoom to existing project components feature collection
  * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
- * @param {Object} data - Data returned from the moped_components query
- * @param {Array} data.project_geography - Array of existing component features
+ * @param {Object} featureCollection - feature collection of project components
  */
-export const useZoomToExistingComponents = (mapRef, data) => {
+export const useZoomToExistingComponents = (mapRef, featureCollection) => {
   const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
 
   useEffect(() => {
-    if (!data || hasMapZoomedInitially) return;
+    if (!featureCollection || hasMapZoomedInitially) return;
     if (!mapRef?.current) return;
 
-    if (data.project_geography.length === 0) {
-      setHasMapZoomedInitially(true);
-      return;
-    }
+    // if (data.project_geography.length === 0) {
+    //   setHasMapZoomedInitially(true);
+    //   return;
+    // }
 
-    const featureCollection = {
-      type: "FeatureCollection",
-      features: data.project_geography,
-    };
+    // const featureCollection = {
+    //   type: "FeatureCollection",
+    //   features: data.project_geography,
+    // };
 
     zoomMapToFeatureCollection(
       mapRef,
@@ -153,5 +152,5 @@ export const useZoomToExistingComponents = (mapRef, data) => {
     );
 
     setHasMapZoomedInitially(true);
-  }, [data, hasMapZoomedInitially, mapRef]);
+  }, [featureCollection, hasMapZoomedInitially, mapRef]);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -147,5 +147,10 @@ export const useZoomToExistingComponents = (
     );
 
     !refreshOnComponentsUpdate && setHasMapZoomedInitially(true);
-  }, [featureCollection, hasMapZoomedInitially, mapRef]);
+  }, [
+    featureCollection,
+    hasMapZoomedInitially,
+    mapRef,
+    refreshOnComponentsUpdate,
+  ]);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -127,23 +127,18 @@ export const zoomMapToFeatureCollection = (
  * Use Mapbox fitBounds to zoom to existing project components feature collection
  * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
  * @param {Object} featureCollection - feature collection of project components
+ * @param {boolean}
  */
-export const useZoomToExistingComponents = (mapRef, featureCollection) => {
+export const useZoomToExistingComponents = (
+  mapRef,
+  featureCollection,
+  refreshOnComponentsUpdate = false
+) => {
   const [hasMapZoomedInitially, setHasMapZoomedInitially] = useState(false);
 
   useEffect(() => {
     if (!featureCollection || hasMapZoomedInitially) return;
     if (!mapRef?.current) return;
-
-    // if (data.project_geography.length === 0) {
-    //   setHasMapZoomedInitially(true);
-    //   return;
-    // }
-
-    // const featureCollection = {
-    //   type: "FeatureCollection",
-    //   features: data.project_geography,
-    // };
 
     zoomMapToFeatureCollection(
       mapRef,
@@ -151,6 +146,6 @@ export const useZoomToExistingComponents = (mapRef, featureCollection) => {
       fitBoundsOptions.zoomToExtent
     );
 
-    setHasMapZoomedInitially(true);
+    !refreshOnComponentsUpdate && setHasMapZoomedInitially(true);
   }, [featureCollection, hasMapZoomedInitially, mapRef]);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -127,7 +127,7 @@ export const zoomMapToFeatureCollection = (
  * Use Mapbox fitBounds to zoom to existing project components feature collection
  * @param {Object} mapRef - React ref that stores the Mapbox map instance (mapRef.current)
  * @param {Object} featureCollection - feature collection of project components
- * @param {boolean}
+ * @param {boolean} refreshOnComponentsUpdate - if true, zoom to components on every update
  */
 export const useZoomToExistingComponents = (
   mapRef,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel.js
@@ -24,6 +24,7 @@ const ProjectSummaryLabel = ({
       <Typography
         className={className ?? classes.fieldLabelText}
         onClick={onClickEdit}
+        component="span"
       >
         {/* If there is no input, render a "-" */}
         {text.length === 0 && <span>-</span>}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -43,7 +43,10 @@ const ProjectSummaryMap = ({ data }) => {
   const childComponentsFeatureCollection =
     useAllComponentsFeatureCollection(childComponents);
 
-  useZoomToExistingComponents(mapRefState, data);
+  useZoomToExistingComponents(mapRefState, {
+    type: "FeatureCollection",
+    features: data.project_geography,
+  });
 
   const areThereComponentFeatures =
     projectComponentsFeatureCollection.features.length > 0 ||

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -42,11 +42,17 @@ const ProjectSummaryMap = ({ data }) => {
     useAllComponentsFeatureCollection(projectComponents);
   const childComponentsFeatureCollection =
     useAllComponentsFeatureCollection(childComponents);
+  const projectAndChildComponentsFeatureCollection =
+    useAllComponentsFeatureCollection([
+      ...projectComponents,
+      ...childComponents,
+    ]);
 
-  useZoomToExistingComponents(mapRefState, {
-    type: "FeatureCollection",
-    features: data.project_geography,
-  });
+  useZoomToExistingComponents(
+    mapRefState,
+    projectAndChildComponentsFeatureCollection,
+    true
+  );
 
   const areThereComponentFeatures =
     projectComponentsFeatureCollection.features.length > 0 ||


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12353

This PR updates the project summary map to zoom to a project's components and subproject components on load. The padding around components on the map has also been reduced.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1059--atd-moped-main.netlify.app/moped/projects/1941

**Steps to test:**
1. Go to [this project in staging](https://moped.austinmobility.io/moped/projects/1941?tab=summary), and you should see that the project summary map shows the components of subprojects in green but you must zoom out to see them.
2. Now, go to [the same project in the deploy preview](https://deploy-preview-1059--atd-moped-main.netlify.app/moped/projects/1941?tab=summary).
3. You should see the summary map load with all project components and subproject components in view.
4. Try adding and removing the other subprojects, and you should see the map zoom update to show all components for the current project and its updated subprojects.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
