### PR TITLE
Add "SRTS Infrastructure ID" field to component form

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1701,6 +1701,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
     - role: moped-editor
       permission:
         check: {}
@@ -1715,6 +1716,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
   select_permissions:
     - role: moped-admin
       permission:
@@ -1729,6 +1731,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
         filter: {}
     - role: moped-editor
       permission:
@@ -1743,6 +1746,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
         filter: {}
     - role: moped-viewer
       permission:
@@ -1757,6 +1761,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
         filter: {}
   update_permissions:
     - role: moped-admin
@@ -1772,6 +1777,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
         filter: {}
         check: {}
     - role: moped-editor
@@ -1787,6 +1793,7 @@
           - project_component_id
           - project_id
           - subphase_id
+          - srts_id
         filter: {}
         check: {}
   event_triggers:

--- a/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/down.sql
+++ b/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/down.sql
@@ -1,4 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."moped_proj_components" add column "srts_id" text
---  null;
+alter table "public"."moped_proj_components" drop column "srts_id";

--- a/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/down.sql
+++ b/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."moped_proj_components" add column "srts_id" text
+--  null;

--- a/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/up.sql
+++ b/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/up.sql
@@ -1,2 +1,4 @@
 alter table "public"."moped_proj_components" add column "srts_id" text
  null;
+
+COMMENT ON COLUMN moped_proj_components.srts_id IS 'The Safe Routes to School infrastructure plan record identifier';

--- a/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/up.sql
+++ b/moped-database/migrations/1685733117665_alter_table_public_moped_proj_components_add_column_srts_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."moped_proj_components" add column "srts_id" text
+ null;

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -240,9 +240,16 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
     $phaseId: Int
     $subphaseId: Int
     $completionDate: timestamptz
+    $componentTags: [moped_proj_component_tags_insert_input!]!
     $srtsId: String
   ) {
     update_moped_proj_components_subcomponents(
+      where: { project_component_id: { _eq: $projectComponentId } }
+      _set: { is_deleted: true }
+    ) {
+      affected_rows
+    }
+    update_moped_proj_component_tags(
       where: { project_component_id: { _eq: $projectComponentId } }
       _set: { is_deleted: true }
     ) {
@@ -276,6 +283,15 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
       affected_rows
     }
     insert_feature_signals(objects: $signals) {
+      affected_rows
+    }
+    insert_moped_proj_component_tags(
+      objects: $componentTags
+      on_conflict: {
+        constraint: unique_component_and_tag
+        update_columns: [is_deleted]
+      }
+    ) {
       affected_rows
     }
   }

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -182,6 +182,7 @@ export const UPDATE_COMPONENT_ATTRIBUTES = gql`
     $subphaseId: Int
     $completionDate: timestamptz
     $componentTags: [moped_proj_component_tags_insert_input!]!
+    $srtsId: String
   ) {
     update_moped_proj_components_subcomponents(
       where: { project_component_id: { _eq: $projectComponentId } }
@@ -202,6 +203,7 @@ export const UPDATE_COMPONENT_ATTRIBUTES = gql`
         phase_id: $phaseId
         subphase_id: $subphaseId
         completion_date: $completionDate
+        srts_id: $srtsId
       }
     ) {
       project_component_id
@@ -238,6 +240,7 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
     $phaseId: Int
     $subphaseId: Int
     $completionDate: timestamptz
+    $srtsId: String
   ) {
     update_moped_proj_components_subcomponents(
       where: { project_component_id: { _eq: $projectComponentId } }
@@ -258,6 +261,7 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
         phase_id: $phaseId
         subphase_id: $subphaseId
         completion_date: $completionDate
+        srts_id: $srtsId
       }
     ) {
       project_component_id

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -56,6 +56,7 @@ export const PROJECT_COMPONENT_FIELDS = gql`
     subphase_id
     completion_date
     project_id
+    srts_id
     moped_components {
       component_name
       component_subtype
@@ -170,7 +171,7 @@ export const GET_PROJECT_COMPONENTS = gql`
 
 // This mutation updates component subcomponents and component tags by first updating *all* existing
 // subcomponents and tags to is_deleted = true and then inserting the new subcomponents and tags
-// with is_deleted = false on conflict (Attributes that are not deleted in the UI by the user 
+// with is_deleted = false on conflict (Attributes that are not deleted in the UI by the user
 // are switched to is_deleted = false by the mutation)
 export const UPDATE_COMPONENT_ATTRIBUTES = gql`
   mutation UpdateComponentAttributes(

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -36,6 +36,7 @@ const defaultFormValues = {
   completionDate: null,
   description: "",
   signal: null,
+  srtsId: null,
 };
 
 const validationSchema = yup.object().shape({
@@ -51,6 +52,7 @@ const validationSchema = yup.object().shape({
     is: (val) => val?.data?.feature_layer?.internal_table === "feature_signals",
     then: yup.object().required(),
   }),
+  srtsId: yup.string().nullable().optional(),
 });
 
 /**
@@ -121,7 +123,8 @@ const ComponentForm = ({
     phaseOptions,
     subphaseOptions,
     areSignalOptionsLoaded,
-    componentTagsOptions
+    componentTagsOptions,
+    srtsId
   );
 
   // Reset signal field when component changes so signal matches component signal type
@@ -223,6 +226,22 @@ const ComponentForm = ({
             name="description"
             id="description"
             label={"Description"}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            variant="outlined"
+            multiline
+            minRows={4}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            inputRef={register}
+            fullWidth
+            size="small"
+            name="srtsId"
+            id="srtsId"
+            label={"SRTS Infrastructure ID"}
             InputLabelProps={{
               shrink: true,
             }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -245,7 +245,6 @@ const ComponentForm = ({
               shrink: true,
             }}
             variant="outlined"
-            minRows={4}
             helperText={
               "The Safe Routes to School infrastructure plan record identifier"
             }

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -123,8 +123,7 @@ const ComponentForm = ({
     phaseOptions,
     subphaseOptions,
     areSignalOptionsLoaded,
-    componentTagsOptions,
-    srtsId
+    componentTagsOptions
   );
 
   // Reset signal field when component changes so signal matches component signal type
@@ -246,8 +245,10 @@ const ComponentForm = ({
               shrink: true,
             }}
             variant="outlined"
-            multiline
             minRows={4}
+            helperText={
+              "The Safe Routes to School infrastructure plan record identifier"
+            }
           />
         </Grid>
         <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -41,6 +41,7 @@ const CreateComponentModal = ({
       subphase,
       completionDate,
       tags,
+      srtsId,
     } = formData;
 
     const newComponent = {
@@ -57,6 +58,7 @@ const CreateComponentModal = ({
       label: component_name,
       features: [],
       moped_proj_component_tags: tags,
+      srtsId: srtsId.length > 0 ? srtsId : null,
     };
 
     const linkMode = newComponent.line_representation ? "lines" : "points";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -1,12 +1,7 @@
 import React from "react";
 import ComponentForm from "./ComponentForm";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  IconButton,
-} from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import { Dialog, DialogTitle, DialogContent, IconButton } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
 
 const useStyles = makeStyles((theme) => ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -58,7 +58,7 @@ const CreateComponentModal = ({
       label: component_name,
       features: [],
       moped_proj_component_tags: tags,
-      srtsId: srtsId.length > 0 ? srtsId : null,
+      srts_id: srtsId.length > 0 ? srtsId : null,
     };
 
     const linkMode = newComponent.line_representation ? "lines" : "points";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -50,9 +50,11 @@ const EditAttributesModal = ({
   const onSave = (formData) => {
     const isSavingSignalFeature = Boolean(formData.signal);
 
-    const { description, subcomponents, phase, subphase, tags, srtsId } =
-      formData;
+    const { subcomponents, phase, subphase, tags } = formData;
     const completionDate = !!phase ? formData.completionDate : null;
+    const description =
+      formData.description.length > 0 ? formData.description : null;
+    const srtsId = formData.srtsId.length > 0 ? formData.srtsId : null;
     const { project_component_id: projectComponentId } = componentToEdit;
 
     // Prepare the subcomponent data for the mutation

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -162,7 +162,7 @@ const EditAttributesModal = ({
   const onClose = () => {
     editDispatch({ type: "cancel_attributes_edit" });
   };
-  console.log(componentToEdit);
+
   const initialFormValues = {
     component: componentToEdit,
     subcomponents: componentToEdit?.moped_proj_components_subcomponents,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -50,7 +50,8 @@ const EditAttributesModal = ({
   const onSave = (formData) => {
     const isSavingSignalFeature = Boolean(formData.signal);
 
-    const { description, subcomponents, phase, subphase, tags } = formData;
+    const { description, subcomponents, phase, subphase, tags, srtsId } =
+      formData;
     const completionDate = !!phase ? formData.completionDate : null;
     const { project_component_id: projectComponentId } = componentToEdit;
 
@@ -62,7 +63,6 @@ const EditAttributesModal = ({
           project_component_id: projectComponentId,
         }))
       : [];
-
 
     const tagsArray = tags
       ? tags.map((tag) => ({
@@ -92,6 +92,7 @@ const EditAttributesModal = ({
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
         completion_date: completionDate,
+        srts_id: srtsId,
       };
 
       updateSignalComponent({
@@ -104,6 +105,7 @@ const EditAttributesModal = ({
           subphaseId: subphase?.data.subphase_id,
           componentTags: tagsArray,
           completionDate,
+          srtsId,
         },
       })
         .then(() => {
@@ -135,6 +137,7 @@ const EditAttributesModal = ({
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
         completion_date: completionDate,
+        srts_id: srtsId,
       };
 
       updateComponentAttributes({
@@ -146,6 +149,7 @@ const EditAttributesModal = ({
           subphaseId: subphase?.data.subphase_id,
           componentTags: tagsArray,
           completionDate,
+          srtsId,
         },
       })
         .then(() => onComponentSaveSuccess(updatedClickedComponentState))
@@ -158,7 +162,7 @@ const EditAttributesModal = ({
   const onClose = () => {
     editDispatch({ type: "cancel_attributes_edit" });
   };
-
+  console.log(componentToEdit);
   const initialFormValues = {
     component: componentToEdit,
     subcomponents: componentToEdit?.moped_proj_components_subcomponents,
@@ -167,6 +171,7 @@ const EditAttributesModal = ({
     subphase: componentToEdit?.moped_subphase,
     completionDate: componentToEdit?.completion_date,
     tags: componentToEdit?.moped_proj_component_tags,
+    srtsId: componentToEdit?.srts_id,
   };
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -252,8 +252,8 @@ export const useInitialValuesOnAttributesEdit = (
   // Set the srts id once
   useEffect(() => {
     if (!initialFormValues) return;
-
-    setValue("srtsId", initialFormValues.srtsId);
+    debugger;
+    setValue("srtsId", initialFormValues.srts_id);
   }, [initialFormValues, setValue]);
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -252,8 +252,8 @@ export const useInitialValuesOnAttributesEdit = (
   // Set the srts id once
   useEffect(() => {
     if (!initialFormValues) return;
-    debugger;
-    setValue("srtsId", initialFormValues.srts_id);
+
+    setValue("srtsId", initialFormValues.srtsId);
   }, [initialFormValues, setValue]);
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -248,6 +248,13 @@ export const useInitialValuesOnAttributesEdit = (
 
     setValue("tags", selectedTags);
   }, [componentTagsOptions, initialFormValues, setValue]);
+
+  // Set the srts id once
+  useEffect(() => {
+    if (!initialFormValues) return;
+
+    setValue("srtsId", initialFormValues.srtsId);
+  }, [initialFormValues, setValue]);
 };
 
 const useComponentIconByLineRepresentationStyles = makeStyles(() => ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -219,7 +219,7 @@ export const useInitialValuesOnAttributesEdit = (
     });
   }, [subphaseOptions, initialFormValues, setValue]);
 
-  // Set the description once
+  // Set the description value
   useEffect(() => {
     if (!initialFormValues) return;
 
@@ -249,7 +249,7 @@ export const useInitialValuesOnAttributesEdit = (
     setValue("tags", selectedTags);
   }, [componentTagsOptions, initialFormValues, setValue]);
 
-  // Set the srts id once
+  // Set the srts id value
   useEffect(() => {
     if (!initialFormValues) return;
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeComponentData.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeComponentData.js
@@ -24,6 +24,7 @@ export const makeComponentInsertData = (projectId, component) => {
     internal_table,
     features,
     moped_proj_component_tags,
+    srts_id,
   } = component;
 
   const subcomponentsArray = moped_subcomponents
@@ -89,6 +90,7 @@ export const makeComponentInsertData = (projectId, component) => {
     phase_id,
     subphase_id,
     completion_date,
+    srts_id,
     feature_drawn_lines: { data: drawnLinesToInsert },
     feature_drawn_points: { data: drawnPointsToInsert },
     feature_signals: { data: signalFeaturesToInsert },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12338

This PR adds a **SRTS Infrastructure ID** field to the project component attributes create and edit forms. There are a couple of bug fixes in here too:
- updated the edit form to send `null` instead of an empty string for `description` just like how it does on create
- added the edit component attributes mutation to send tag edits along with the other values

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Create a project component and add a value for the **SRTS Infrastructure ID** field
2. Check the new component to make sure that you can edit its attributes and see the current value of the SRTS id field
3. Close the map modal and then go back to the **Map** tab
4. Check the component to make sure that your value came through in the project components request and shows in the edit component form when editing the attributes
5. Edit the SRTS Infrastructure ID field and close and reopen the map to verify that the value is coming through in the request

---
#### Ship list
- [ ] Make sure helper text is final
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
