### PR TITLE
Unable to edit component completion date in Firefox and Safari

### DIFF
--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -16,8 +16,6 @@ const DateFieldEditComponent = ({ onChange, value }) => {
     onChange(newDate);
   };
 
-  // the issue is that we want to use the value here but the onChange from the props
-  // choose which to override and which to not
   return (
     <MobileDatePicker
       format="MM/dd/yyyy"

--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -9,10 +9,9 @@ import { parseISO, format } from "date-fns";
  * @constructor
  */
 
-const DateFieldEditComponent = ({ onChange, value }) => {
+const DateFieldEditComponent = ({ onChange, value, ...props }) => {
   const handleDateChange = (date) => {
     const newDate = date ? format(date, "yyyy-MM-dd") : null;
-    debugger;
     onChange(newDate);
   };
 
@@ -23,6 +22,7 @@ const DateFieldEditComponent = ({ onChange, value }) => {
       onChange={handleDateChange}
       InputProps={{ style: { minWidth: "100px" } }}
       slotProps={{ actionBar: { actions: ["accept", "cancel", "clear"] } }}
+      {...props}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -9,16 +9,19 @@ import { parseISO, format } from "date-fns";
  * @constructor
  */
 
-const DateFieldEditComponent = (props) => {
+const DateFieldEditComponent = ({ onChange, value }) => {
   const handleDateChange = (date) => {
     const newDate = date ? format(date, "yyyy-MM-dd") : null;
-    props.onChange(newDate);
+    debugger;
+    onChange(newDate);
   };
 
+  // the issue is that we want to use the value here but the onChange from the props
+  // choose which to override and which to not
   return (
     <MobileDatePicker
       format="MM/dd/yyyy"
-      value={props.value ? parseISO(props.value) : null}
+      value={value ? parseISO(value) : null}
       onChange={handleDateChange}
       InputProps={{ style: { minWidth: "100px" } }}
       slotProps={{ actionBar: { actions: ["accept", "cancel", "clear"] } }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -307,7 +307,7 @@ const ComponentForm = ({
                       value={parseDate(value)}
                       onChange={(date) => {
                         const newDate = date
-                          ? format(date, "yyyy-MM-dd OOOO")
+                          ? format(date, "yyyy-MM-dd")
                           : null;
                         onChange(newDate);
                       }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -10,7 +10,6 @@ import {
   FormControlLabel,
   FormHelperText,
 } from "@mui/material";
-import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
 import { CheckCircle } from "@mui/icons-material";
 import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
@@ -25,7 +24,6 @@ import {
   useComponentTagsOptions,
 } from "./utils/form";
 import * as yup from "yup";
-import { format } from "date-fns";
 import DateFieldEditComponent from "../DateFieldEditComponent";
 
 const defaultFormValues = {
@@ -55,19 +53,6 @@ const validationSchema = yup.object().shape({
   }),
   srtsId: yup.string().nullable().optional(),
 });
-
-/**
- * Return a Date object from a string date
- * @param {string} value - the string formatted date
- * @returns
- */
-const parseDate = (value) => {
-  if (value) {
-    let newdate = new Date(value);
-    return newdate;
-  }
-  return null;
-};
 
 const ComponentForm = ({
   formButtonText,
@@ -307,35 +292,9 @@ const ComponentForm = ({
                       inputRef={ref}
                       value={value}
                       onChange={onChange}
-                      // onChange={(date) => {
-                      //   const newDate = date
-                      //     ? format(date, "yyyy-MM-dd")
-                      //     : null;
-                      //   onChange(newDate);
-                      // }}
-                      // format="MM/dd/yyyy"
                       variant="outlined"
                       label={"Completion date"}
-                      // slotProps={{
-                      //   actionBar: { actions: ["accept", "cancel", "clear"] },
-                      // }}
                     />
-                    // <MobileDatePicker
-                    //   inputRef={ref}
-                    //   value={parseDate(value)}
-                    //   onChange={(date) => {
-                    //     const newDate = date
-                    //       ? format(date, "yyyy-MM-dd")
-                    //       : null;
-                    //     onChange(newDate);
-                    //   }}
-                    //   format="MM/dd/yyyy"
-                    //   variant="outlined"
-                    //   label={"Completion date"}
-                    //   slotProps={{
-                    //     actionBar: { actions: ["accept", "cancel", "clear"] },
-                    //   }}
-                    // />
                   );
                 }}
               />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -26,6 +26,7 @@ import {
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
+import DateFieldEditComponent from "../DateFieldEditComponent";
 
 const defaultFormValues = {
   component: null,
@@ -302,22 +303,39 @@ const ComponentForm = ({
                 control={control}
                 render={({ onChange, value, ref }) => {
                   return (
-                    <MobileDatePicker
+                    <DateFieldEditComponent
                       inputRef={ref}
-                      value={parseDate(value)}
-                      onChange={(date) => {
-                        const newDate = date
-                          ? format(date, "yyyy-MM-dd")
-                          : null;
-                        onChange(newDate);
-                      }}
-                      format="MM/dd/yyyy"
+                      value={value}
+                      onChange={onChange}
+                      // onChange={(date) => {
+                      //   const newDate = date
+                      //     ? format(date, "yyyy-MM-dd")
+                      //     : null;
+                      //   onChange(newDate);
+                      // }}
+                      // format="MM/dd/yyyy"
                       variant="outlined"
                       label={"Completion date"}
-                      slotProps={{
-                        actionBar: { actions: ["accept", "cancel", "clear"] },
-                      }}
+                      // slotProps={{
+                      //   actionBar: { actions: ["accept", "cancel", "clear"] },
+                      // }}
                     />
+                    // <MobileDatePicker
+                    //   inputRef={ref}
+                    //   value={parseDate(value)}
+                    //   onChange={(date) => {
+                    //     const newDate = date
+                    //       ? format(date, "yyyy-MM-dd")
+                    //       : null;
+                    //     onChange(newDate);
+                    //   }}
+                    //   format="MM/dd/yyyy"
+                    //   variant="outlined"
+                    //   label={"Completion date"}
+                    //   slotProps={{
+                    //     actionBar: { actions: ["accept", "cancel", "clear"] },
+                    //   }}
+                    // />
                   );
                 }}
               />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -10,6 +10,7 @@ import {
   FormControlLabel,
   FormHelperText,
 } from "@mui/material";
+import DateFieldEditComponent from "../DateFieldEditComponent";
 import { CheckCircle } from "@mui/icons-material";
 import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
@@ -24,7 +25,6 @@ import {
   useComponentTagsOptions,
 } from "./utils/form";
 import * as yup from "yup";
-import DateFieldEditComponent from "../DateFieldEditComponent";
 
 const defaultFormValues = {
   component: null,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -58,6 +58,11 @@ const EditAttributesModal = ({
     const srtsId = formData.srtsId.length > 0 ? formData.srtsId : null;
     const { project_component_id: projectComponentId } = componentToEdit;
 
+    // This date returns as timestamp with time zone so use that format for the form to consume
+    const completionDateForState = completionDate
+      ? formatISO(completionDate)
+      : null;
+
     // Prepare the subcomponent data for the mutation
     const subcomponentsArray = subcomponents
       ? subcomponents.map((subcomponent) => ({
@@ -94,8 +99,7 @@ const EditAttributesModal = ({
         moped_proj_component_tags: tagsArray,
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
-        // This date returns as timestamp with time zone so emulate that for the form to consume
-        completion_date: formatISO(completionDate),
+        completion_date: completionDateForState,
         srts_id: srtsId,
       };
 
@@ -141,7 +145,7 @@ const EditAttributesModal = ({
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
         // This date returns as timestamp with time zone so emulate that for the form to consume
-        completion_date: formatISO(completionDate),
+        completion_date: completionDateForState,
         srts_id: srtsId,
       };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -11,6 +11,7 @@ import {
 import { knackSignalRecordToFeatureSignalsRecord } from "src/utils/signalComponentHelpers";
 import { zoomMapToFeatureCollection } from "./utils/map";
 import { fitBoundsOptions } from "./mapSettings";
+import { formatISO } from "date-fns";
 
 const useStyles = makeStyles((theme) => ({
   dialogTitle: {
@@ -93,7 +94,8 @@ const EditAttributesModal = ({
         moped_proj_component_tags: tagsArray,
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
-        completion_date: completionDate,
+        // This date returns as timestamp with time zone so emulate that for the form to consume
+        completion_date: formatISO(completionDate),
         srts_id: srtsId,
       };
 
@@ -138,7 +140,8 @@ const EditAttributesModal = ({
         moped_proj_component_tags: tagsArray,
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
-        completion_date: completionDate,
+        // This date returns as timestamp with time zone so emulate that for the form to consume
+        completion_date: formatISO(completionDate),
         srts_id: srtsId,
       };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -144,7 +144,6 @@ const EditAttributesModal = ({
         moped_proj_component_tags: tagsArray,
         moped_phase: phase?.data,
         moped_subphase: subphase?.data,
-        // This date returns as timestamp with time zone so emulate that for the form to consume
         completion_date: completionDateForState,
         srts_id: srtsId,
       };


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12356

This PR updates the component phase completion date part of the component attribute edit form to use `DateFieldEditComponent`. This fixes an issue where the format of the date set in the picker wasn't quite what the MUI component was expecting. This should keep it working in the same way the project milestone and phase date pickers work going forward in Chrome, Firefox, and Safari.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1064--atd-moped-main.netlify.app/moped/

**Steps to test:**

**Using Firefox**
1. Go to https://deploy-preview-1064--atd-moped-main.netlify.app/moped/projects/1945?tab=map or your own new project
2. Edit a component phase completion date and make sure the the form accepts your new date selected in the picker on the first try
3. Save the new date and then check the edit form to make sure that the value updated in state
4. Refresh the page to make sure the form populates the new value after fetching the saved data
5. Test clearing the values of component phase and completion date to make sure we can still null them out.
6. Go the the **Timeline** tab and add and update phase and milestone dates to make sure that everything is still working there.

**Using Safari**
1. Repeat the steps above

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
