### PR TITLE
Edit component attributes form briefly shows previous values on save

### DIFF
--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -67,6 +67,9 @@ export const PROJECT_COMPONENT_FIELDS = gql`
     }
     moped_proj_components_subcomponents(where: { is_deleted: { _eq: false } }) {
       subcomponent_id
+      moped_subcomponent {
+        subcomponent_name
+      }
     }
     moped_proj_component_tags(where: { is_deleted: { _eq: false } }) {
       component_tag_id

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -73,6 +73,10 @@ export const PROJECT_COMPONENT_FIELDS = gql`
     }
     moped_proj_component_tags(where: { is_deleted: { _eq: false } }) {
       component_tag_id
+      moped_component_tag {
+        name
+        type
+      }
     }
     moped_phase {
       phase_id

--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -9,22 +9,25 @@ import { parseISO, format } from "date-fns";
  * @constructor
  */
 
-const DateFieldEditComponent = ({ onChange, value, ...props }) => {
-  const handleDateChange = (date) => {
-    const newDate = date ? format(date, "yyyy-MM-dd") : null;
-    onChange(newDate);
-  };
+const DateFieldEditComponent = React.forwardRef(
+  ({ onChange, value, ...props }, ref) => {
+    const handleDateChange = (date) => {
+      const newDate = date ? format(date, "yyyy-MM-dd") : null;
+      onChange(newDate);
+    };
 
-  return (
-    <MobileDatePicker
-      format="MM/dd/yyyy"
-      value={value ? parseISO(value) : null}
-      onChange={handleDateChange}
-      InputProps={{ style: { minWidth: "100px" } }}
-      slotProps={{ actionBar: { actions: ["accept", "cancel", "clear"] } }}
-      {...props}
-    />
-  );
-};
+    return (
+      <MobileDatePicker
+        ref={ref}
+        format="MM/dd/yyyy"
+        value={value ? parseISO(value) : null}
+        onChange={handleDateChange}
+        InputProps={{ style: { minWidth: "100px" } }}
+        slotProps={{ actionBar: { actions: ["accept", "cancel", "clear"] } }}
+        {...props}
+      />
+    );
+  }
+);
 
 export default DateFieldEditComponent;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -92,7 +92,7 @@ const ComponentForm = ({
 
   const componentOptions = useComponentOptions(optionsData);
   const phaseOptions = usePhaseOptions(optionsData);
-  const { component, phase } = watch();
+  const { component, phase } = watch(["component", "phase"]);
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const internalTable = component?.data?.feature_layer?.internal_table;
   const isSignalComponent = internalTable === "feature_signals";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -72,7 +72,7 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
-    formState: { isValid },
+    formState: { isDirty, isValid },
   } = useForm({
     defaultValues: initialFormValues ? initialFormValues : defaultFormValues,
     mode: "onChange",
@@ -109,7 +109,6 @@ const ComponentForm = ({
     dependentFieldName: "subphase",
     valueToSet: defaultFormValues.subphase,
     setValue,
-    valuePath: "value",
   });
 
   useResetDependentFieldOnParentChange({
@@ -117,7 +116,6 @@ const ComponentForm = ({
     dependentFieldName: "signal",
     valueToSet: defaultFormValues.signal,
     setValue,
-    valuePath: "value",
   });
 
   // reset subcomponent selections when component to ensure only allowed subcomponents
@@ -128,13 +126,7 @@ const ComponentForm = ({
     dependentFieldName: "subcomponents",
     valueToSet: defaultFormValues.subcomponents,
     setValue,
-    valuePath: "value",
   });
-
-  // We need the signal field to reset when the component field changes ✅
-  // We need the subphase field to reset when the phase field changes ✅
-  // We need the subcomponents to clear when the component changes
-  // We need to take into account that the component and
 
   const isEditingExistingComponent = initialFormValues !== null;
 
@@ -304,7 +296,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={!isValid}
+            disabled={!isDirty || !isValid}
           >
             {isSignalComponent ? "Save" : formButtonText}
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -35,7 +35,7 @@ const defaultFormValues = {
   completionDate: null,
   description: "",
   signal: null,
-  srtsId: null,
+  srtsId: "",
 };
 
 const validationSchema = yup.object().shape({
@@ -118,8 +118,6 @@ const ComponentForm = ({
     setValue,
   });
 
-  // reset subcomponent selections when component to ensure only allowed subcomponents
-  // assumes component type cannot be changed when editing
   // todo: preserve allowed subcomponents when switching b/t component types
   useResetDependentFieldOnParentChange({
     parentValue: watch("component"),
@@ -140,6 +138,7 @@ const ComponentForm = ({
             options={areOptionsLoading ? [] : componentOptions}
             renderOption={(props, option, state) => (
               <ComponentOptionWithIcon
+                key={option.value}
                 option={option}
                 state={state}
                 props={props}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -26,6 +26,7 @@ import {
   makeComponentFormFieldValue,
   makeSubcomponentsFormFieldValues,
   makeSignalFormFieldValue,
+  makePhaseFormFieldValue,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -93,6 +94,7 @@ const ComponentForm = ({
           initialFormValues.subcomponents
         ),
         signal: makeSignalFormFieldValue(initialFormValues.component),
+        phase: makePhaseFormFieldValue(initialFormValues.component),
       }
     : null;
 
@@ -104,7 +106,6 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
-    reset,
     formState: { isValid },
   } = useForm({
     defaultValues: initialFormValues
@@ -156,7 +157,6 @@ const ComponentForm = ({
   useInitialValuesOnAttributesEdit(
     initialFormValues,
     setValue,
-    phaseOptions,
     subphaseOptions,
     componentTagsOptions
   );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -87,14 +87,16 @@ const ComponentForm = ({
   const editDefaultFormValues = initialFormValues
     ? {
         ...defaultFormValues,
-        component: makeComponentFormFieldValue(initialFormValues?.component),
+        component: makeComponentFormFieldValue(initialFormValues.component),
         description: initialFormValues.description,
         subcomponents: makeSubcomponentsFormFieldValues(
-          initialFormValues?.subcomponents
+          initialFormValues.subcomponents
         ),
-        signal: makeSignalFormFieldValue(initialFormValues?.component),
+        signal: makeSignalFormFieldValue(initialFormValues.component),
       }
     : null;
+
+  console.log(initialFormValues);
 
   const {
     register,
@@ -102,6 +104,7 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
+    reset,
     formState: { isValid },
   } = useForm({
     defaultValues: initialFormValues
@@ -125,7 +128,22 @@ const ComponentForm = ({
   const { component, phase } = watch();
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const internalTable = component?.data?.feature_layer?.internal_table;
+  const isSignalComponent = internalTable === "feature_signals";
+  const [areSignalOptionsLoaded, setAreSignalOptionsLoaded] = useState(false);
+  const onOptionsLoaded = () => setAreSignalOptionsLoaded(true);
   const componentTagsOptions = useComponentTagsOptions(optionsData);
+
+  useEffect(() => {
+    if (areOptionsLoading) return;
+
+    setValue("component", editDefaultFormValues.component);
+  }, [areOptionsLoading]);
+
+  useEffect(() => {
+    if (!areSignalOptionsLoaded && isSignalComponent) return;
+
+    setValue("signal", editDefaultFormValues.signal);
+  }, [areSignalOptionsLoaded]);
 
   const subcomponentOptions = useSubcomponentOptions(
     component?.value,
@@ -167,192 +185,190 @@ const ComponentForm = ({
   }, [phase, setValue, initialFormValues]);
 
   const isEditingExistingComponent = initialFormValues !== null;
-  const isSignalComponent = internalTable === "feature_signals";
 
   return (
-    !areOptionsLoading && (
-      <form onSubmit={handleSubmit(onSave)}>
-        <Grid container spacing={2}>
+    <form onSubmit={handleSubmit(onSave)}>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <ControlledAutocomplete
+            id="component"
+            label="Component Type"
+            options={areOptionsLoading ? [] : componentOptions}
+            renderOption={(props, option, state) => (
+              <ComponentOptionWithIcon
+                option={option}
+                state={state}
+                props={props}
+              />
+            )}
+            name="component"
+            control={control}
+            autoFocus
+            disabled={isEditingExistingComponent}
+          />
+        </Grid>
+
+        {isSignalComponent && (
           <Grid item xs={12}>
-            <ControlledAutocomplete
-              id="component"
-              label="Component Type"
-              options={areOptionsLoading ? [] : componentOptions}
-              renderOption={(props, option, state) => (
-                <ComponentOptionWithIcon
-                  option={option}
-                  state={state}
-                  props={props}
+            <Controller
+              id="signal"
+              name="signal"
+              control={control}
+              render={({ field }) => (
+                <SignalComponentAutocomplete
+                  {...field}
+                  onOptionsLoaded={onOptionsLoaded}
+                  signalType={component?.data?.component_subtype}
                 />
               )}
-              name="component"
-              control={control}
-              autoFocus
-              disabled={isEditingExistingComponent}
             />
           </Grid>
+        )}
 
-          {isSignalComponent && (
-            <Grid item xs={12}>
-              <Controller
-                id="signal"
-                name="signal"
-                control={control}
-                render={({ field }) => (
-                  <SignalComponentAutocomplete
-                    {...field}
-                    signalType={component?.data?.component_subtype}
-                  />
-                )}
+        {/* Hide unless there are subcomponents for the chosen component */}
+        {(subcomponentOptions.length !== 0 ||
+          doesInitialValueHaveSubcomponents) && (
+          <Grid item xs={12}>
+            <ControlledAutocomplete
+              id="subcomponents"
+              label="Subcomponents"
+              multiple
+              options={subcomponentOptions}
+              name="subcomponents"
+              control={control}
+            />
+          </Grid>
+        )}
+        <Grid item xs={12}>
+          <ControlledAutocomplete
+            id="tags"
+            label="Tags"
+            multiple
+            options={componentTagsOptions}
+            name="tags"
+            control={control}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            {...register("description")}
+            fullWidth
+            size="small"
+            id="description"
+            label={"Description"}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            variant="outlined"
+            multiline
+            minRows={4}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            {...register("srtsId")}
+            fullWidth
+            size="small"
+            id="srtsId"
+            label={"SRTS Infrastructure ID"}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            variant="outlined"
+            helperText={
+              "The Safe Routes to School infrastructure plan record identifier"
+            }
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={useComponentPhase}
+                onChange={() => setUseComponentPhase(!useComponentPhase)}
+                name="useComponentPhase"
+                color="primary"
               />
-            </Grid>
+            }
+            labelPlacement="start"
+            label="Use component phase"
+            style={{ color: "gray", marginLeft: 0 }}
+          />
+          {useComponentPhase && (
+            <FormHelperText>
+              Assign a phase to the component to differentiate it from the
+              overall phase of this project
+            </FormHelperText>
           )}
-
-          {/* Hide unless there are subcomponents for the chosen component */}
-          {(subcomponentOptions.length !== 0 ||
-            doesInitialValueHaveSubcomponents) && (
+        </Grid>
+        {useComponentPhase && (
+          <>
             <Grid item xs={12}>
               <ControlledAutocomplete
-                id="subcomponents"
-                label="Subcomponents"
-                multiple
-                options={subcomponentOptions}
-                name="subcomponents"
+                id="phase"
+                label="Phase"
+                options={phaseOptions}
+                name="phase"
                 control={control}
+                required
+                autoFocus
               />
             </Grid>
-          )}
-          <Grid item xs={12}>
-            <ControlledAutocomplete
-              id="tags"
-              label="Tags"
-              multiple
-              options={componentTagsOptions}
-              name="tags"
-              control={control}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              {...register("description")}
-              fullWidth
-              size="small"
-              id="description"
-              label={"Description"}
-              InputLabelProps={{
-                shrink: true,
-              }}
-              variant="outlined"
-              multiline
-              minRows={4}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              {...register("srtsId")}
-              fullWidth
-              size="small"
-              id="srtsId"
-              label={"SRTS Infrastructure ID"}
-              InputLabelProps={{
-                shrink: true,
-              }}
-              variant="outlined"
-              helperText={
-                "The Safe Routes to School infrastructure plan record identifier"
-              }
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={useComponentPhase}
-                  onChange={() => setUseComponentPhase(!useComponentPhase)}
-                  name="useComponentPhase"
-                  color="primary"
-                />
-              }
-              labelPlacement="start"
-              label="Use component phase"
-              style={{ color: "gray", marginLeft: 0 }}
-            />
-            {useComponentPhase && (
-              <FormHelperText>
-                Assign a phase to the component to differentiate it from the
-                overall phase of this project
-              </FormHelperText>
-            )}
-          </Grid>
-          {useComponentPhase && (
-            <>
+            {subphaseOptions.length !== 0 && (
               <Grid item xs={12}>
                 <ControlledAutocomplete
-                  id="phase"
-                  label="Phase"
-                  options={phaseOptions}
-                  name="phase"
+                  id="subphase"
+                  label="Subphase"
+                  options={subphaseOptions}
+                  name="subphase"
                   control={control}
-                  required
-                  autoFocus
                 />
               </Grid>
-              {subphaseOptions.length !== 0 && (
-                <Grid item xs={12}>
-                  <ControlledAutocomplete
-                    id="subphase"
-                    label="Subphase"
-                    options={subphaseOptions}
-                    name="subphase"
-                    control={control}
-                  />
-                </Grid>
-              )}
-              <Grid item xs={12}>
-                <Controller
-                  id="completion-date"
-                  name="completionDate"
-                  control={control}
-                  render={({ field }) => {
-                    return (
-                      <MobileDatePicker
-                        {...field}
-                        value={parseDate(field.value)}
-                        onChange={(date) => {
-                          const newDate = date
-                            ? format(date, "yyyy-MM-dd OOOO")
-                            : null;
-                          field.onChange(newDate);
-                        }}
-                        format="MM/dd/yyyy"
-                        variant="outlined"
-                        label={"Completion date"}
-                        slotProps={{
-                          actionBar: { actions: ["accept", "cancel", "clear"] },
-                        }}
-                      />
-                    );
-                  }}
-                />
-              </Grid>
-            </>
-          )}
+            )}
+            <Grid item xs={12}>
+              <Controller
+                id="completion-date"
+                name="completionDate"
+                control={control}
+                render={({ field }) => {
+                  return (
+                    <MobileDatePicker
+                      {...field}
+                      value={parseDate(field.value)}
+                      onChange={(date) => {
+                        const newDate = date
+                          ? format(date, "yyyy-MM-dd OOOO")
+                          : null;
+                        field.onChange(newDate);
+                      }}
+                      format="MM/dd/yyyy"
+                      variant="outlined"
+                      label={"Completion date"}
+                      slotProps={{
+                        actionBar: { actions: ["accept", "cancel", "clear"] },
+                      }}
+                    />
+                  );
+                }}
+              />
+            </Grid>
+          </>
+        )}
+      </Grid>
+      <Grid container spacing={4} display="flex" justifyContent="flex-end">
+        <Grid item style={{ margin: 5 }}>
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<CheckCircle />}
+            type="submit"
+            disabled={!isValid}
+          >
+            {isSignalComponent ? "Save" : formButtonText}
+          </Button>
         </Grid>
-        <Grid container spacing={4} display="flex" justifyContent="flex-end">
-          <Grid item style={{ margin: 5 }}>
-            <Button
-              variant="contained"
-              color="primary"
-              startIcon={<CheckCircle />}
-              type="submit"
-              disabled={!isValid}
-            >
-              {isSignalComponent ? "Save" : formButtonText}
-            </Button>
-          </Grid>
-        </Grid>
-      </form>
-    )
+      </Grid>
+    </form>
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -83,7 +83,6 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
-  console.log(initialFormValues);
   // TODO: Building the initialFormValues should happen in EditAttributesModal
   const editDefaultFormValues = initialFormValues
     ? {
@@ -126,8 +125,6 @@ const ComponentForm = ({
   const { component, phase } = watch();
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const internalTable = component?.data?.feature_layer?.internal_table;
-  const [areSignalOptionsLoaded, setAreSignalOptionsLoaded] = useState(false);
-  const onOptionsLoaded = () => setAreSignalOptionsLoaded(true);
   const componentTagsOptions = useComponentTagsOptions(optionsData);
 
   const subcomponentOptions = useSubcomponentOptions(
@@ -173,8 +170,7 @@ const ComponentForm = ({
   const isSignalComponent = internalTable === "feature_signals";
 
   return (
-    !areOptionsLoading &&
-    areSignalOptionsLoaded && (
+    !areOptionsLoading && (
       <form onSubmit={handleSubmit(onSave)}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
@@ -205,7 +201,6 @@ const ComponentForm = ({
                 render={({ field }) => (
                   <SignalComponentAutocomplete
                     {...field}
-                    onOptionsLoaded={onOptionsLoaded}
                     signalType={component?.data?.component_subtype}
                   />
                 )}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -65,23 +65,6 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
-  // TODO: Building the initialFormValues should happen in EditAttributesModal
-  // const editDefaultFormValues = initialFormValues
-  //   ? {
-  //       component: makeComponentFormFieldValue(initialFormValues.component),
-  //       description: initialFormValues.description,
-  //       subcomponents: makeSubcomponentsFormFieldValues(
-  //         initialFormValues.subcomponents
-  //       ),
-  //       signal: makeSignalFormFieldValue(initialFormValues.component),
-  //       phase: makePhaseFormFieldValue(initialFormValues.component),
-  //       subphase: makeSubphaseFormFieldValue(initialFormValues.component),
-  //       completionDate: initialFormValues.component.completion_date,
-  //       srtsId: initialFormValues.srtsId,
-  //       tags: makeTagFormFieldValues(initialFormValues.tags),
-  //     }
-  //   : null;
-
   const {
     register,
     handleSubmit,
@@ -143,8 +126,11 @@ const ComponentForm = ({
   );
 
   // Reset signal field when component changes so signal matches component signal type
+  // TODO: we have to check if the component still matches otherwise the component useEffect will clear the signal
   useEffect(() => {
-    setValue("signal", null);
+    if (component.value !== initialFormValues?.component?.value) {
+      setValue("signal", null);
+    }
   }, [component, setValue]);
 
   // reset subcomponent selections when component to ensure only allowed subcomponents

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -96,6 +96,8 @@ const ComponentForm = ({
         signal: makeSignalFormFieldValue(initialFormValues.component),
         phase: makePhaseFormFieldValue(initialFormValues.component),
         subphase: makeSubphaseFormFieldValue(initialFormValues.component),
+        completionDate: initialFormValues.component.completion_date,
+        srtsId: initialFormValues.srtsId,
       }
     : null;
 
@@ -166,7 +168,6 @@ const ComponentForm = ({
   useInitialValuesOnAttributesEdit(
     initialFormValues,
     setValue,
-    // subphaseOptions,
     componentTagsOptions
   );
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -21,13 +21,13 @@ import {
   useSubcomponentOptions,
   usePhaseOptions,
   useSubphaseOptions,
-  useInitialValuesOnAttributesEdit,
   useComponentTagsOptions,
   makeComponentFormFieldValue,
   makeSubcomponentsFormFieldValues,
   makeSignalFormFieldValue,
   makePhaseFormFieldValue,
   makeSubphaseFormFieldValue,
+  makeTagFormFieldValues,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -98,6 +98,7 @@ const ComponentForm = ({
         subphase: makeSubphaseFormFieldValue(initialFormValues.component),
         completionDate: initialFormValues.component.completion_date,
         srtsId: initialFormValues.srtsId,
+        tags: makeTagFormFieldValues(initialFormValues.tags),
       }
     : null;
 
@@ -163,12 +164,6 @@ const ComponentForm = ({
   );
   const [useComponentPhase, setUseComponentPhase] = useState(
     !!initialFormValues?.component.moped_phase
-  );
-
-  useInitialValuesOnAttributesEdit(
-    initialFormValues,
-    setValue,
-    componentTagsOptions
   );
 
   // Reset signal field when component changes so signal matches component signal type

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -87,7 +87,6 @@ const ComponentForm = ({
   // TODO: Building the initialFormValues should happen in EditAttributesModal
   const editDefaultFormValues = initialFormValues
     ? {
-        ...defaultFormValues,
         component: makeComponentFormFieldValue(initialFormValues.component),
         description: initialFormValues.description,
         subcomponents: makeSubcomponentsFormFieldValues(
@@ -109,7 +108,7 @@ const ComponentForm = ({
     formState: { isValid },
   } = useForm({
     defaultValues: initialFormValues
-      ? { ...defaultFormValues, ...editDefaultFormValues }
+      ? editDefaultFormValues
       : defaultFormValues,
     mode: "onChange",
     resolver: yupResolver(validationSchema),
@@ -134,14 +133,21 @@ const ComponentForm = ({
   const onOptionsLoaded = () => setAreSignalOptionsLoaded(true);
   const componentTagsOptions = useComponentTagsOptions(optionsData);
 
+  // Set the selected component after the component options are loaded
+  // TODO: This should NOT happen when creating a new component
   useEffect(() => {
-    if (areOptionsLoading) return;
+    if (areOptionsLoading || initialFormValues === null) return;
 
     setValue("component", editDefaultFormValues.component);
   }, [areOptionsLoading]);
 
   useEffect(() => {
-    if (!areSignalOptionsLoaded && isSignalComponent) return;
+    if (
+      !areSignalOptionsLoaded ||
+      !isSignalComponent ||
+      initialFormValues === null
+    )
+      return;
 
     setValue("signal", editDefaultFormValues.signal);
   }, [areSignalOptionsLoaded]);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -22,12 +22,6 @@ import {
   usePhaseOptions,
   useSubphaseOptions,
   useComponentTagsOptions,
-  makeComponentFormFieldValue,
-  makeSubcomponentsFormFieldValues,
-  makeSignalFormFieldValue,
-  makePhaseFormFieldValue,
-  makeSubphaseFormFieldValue,
-  makeTagFormFieldValues,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -86,23 +80,21 @@ const ComponentForm = ({
     initialFormValues?.subcomponents.length > 0;
 
   // TODO: Building the initialFormValues should happen in EditAttributesModal
-  const editDefaultFormValues = initialFormValues
-    ? {
-        component: makeComponentFormFieldValue(initialFormValues.component),
-        description: initialFormValues.description,
-        subcomponents: makeSubcomponentsFormFieldValues(
-          initialFormValues.subcomponents
-        ),
-        signal: makeSignalFormFieldValue(initialFormValues.component),
-        phase: makePhaseFormFieldValue(initialFormValues.component),
-        subphase: makeSubphaseFormFieldValue(initialFormValues.component),
-        completionDate: initialFormValues.component.completion_date,
-        srtsId: initialFormValues.srtsId,
-        tags: makeTagFormFieldValues(initialFormValues.tags),
-      }
-    : null;
-
-  console.log(initialFormValues);
+  // const editDefaultFormValues = initialFormValues
+  //   ? {
+  //       component: makeComponentFormFieldValue(initialFormValues.component),
+  //       description: initialFormValues.description,
+  //       subcomponents: makeSubcomponentsFormFieldValues(
+  //         initialFormValues.subcomponents
+  //       ),
+  //       signal: makeSignalFormFieldValue(initialFormValues.component),
+  //       phase: makePhaseFormFieldValue(initialFormValues.component),
+  //       subphase: makeSubphaseFormFieldValue(initialFormValues.component),
+  //       completionDate: initialFormValues.component.completion_date,
+  //       srtsId: initialFormValues.srtsId,
+  //       tags: makeTagFormFieldValues(initialFormValues.tags),
+  //     }
+  //   : null;
 
   const {
     register,
@@ -112,9 +104,7 @@ const ComponentForm = ({
     setValue,
     formState: { isValid },
   } = useForm({
-    defaultValues: initialFormValues
-      ? editDefaultFormValues
-      : defaultFormValues,
+    defaultValues: initialFormValues ? initialFormValues : defaultFormValues,
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
@@ -143,7 +133,7 @@ const ComponentForm = ({
   useEffect(() => {
     if (areOptionsLoading || initialFormValues === null) return;
 
-    setValue("component", editDefaultFormValues.component);
+    setValue("component", initialFormValues.component);
   }, [areOptionsLoading]);
 
   // TODO: The value of the signal is getting cleared on first load
@@ -155,7 +145,7 @@ const ComponentForm = ({
     )
       return;
 
-    setValue("signal", editDefaultFormValues.signal);
+    setValue("signal", initialFormValues.signal);
   }, [areSignalOptionsLoaded]);
 
   const subcomponentOptions = useSubcomponentOptions(
@@ -163,7 +153,7 @@ const ComponentForm = ({
     optionsData?.moped_components
   );
   const [useComponentPhase, setUseComponentPhase] = useState(
-    !!initialFormValues?.component.moped_phase
+    !!initialFormValues?.phase
   );
 
   // Reset signal field when component changes so signal matches component signal type
@@ -184,7 +174,7 @@ const ComponentForm = ({
   useEffect(() => {
     if (!phase?.value) return;
     if (!initialFormValues) return;
-    if (initialFormValues.phase?.phase_id !== phase?.value) {
+    if (initialFormValues.phase?.value !== phase?.value) {
       setValue("subphase", null);
     }
   }, [phase, setValue, initialFormValues]);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -104,48 +104,6 @@ const ComponentForm = ({
     !!initialFormValues?.phase
   );
 
-  // Reset signal field when component changes so signal matches component signal type
-  // TODO: we have to check if the component still matches otherwise the component useEffect will clear the signal
-  // useEffect(() => {
-  //   if (component?.value !== initialFormValues?.component?.value) {
-  //     setValue("signal", null);
-  //   }
-  // }, [component, setValue, initialFormValues]);
-
-  // reset subcomponent selections when component to ensure only allowed subcomponents
-  // assumes component type cannot be changed when editing
-  // todo: preserve allowed subcomponents when switching b/t component types
-  useEffect(() => {
-    if (!initialFormValues?.subcomponents) {
-      setValue("subcomponents", []);
-    }
-  }, [subcomponentOptions, initialFormValues, setValue]);
-
-  // useResetDependentFieldOnParentChange({
-  //   watch,
-  //   fieldName: "component",
-  //   dependentFieldName: "signal",
-  //   initialFormValues,
-  //   defaultFormValues,
-  //   setValue,
-  // });
-
-  // useResetDependentFieldOnParentChange({
-  //   watch,
-  //   fieldName: "phase",
-  //   dependentFieldName: "subphase",
-  //   initialFormValues,
-  //   defaultFormValues,
-  //   setValue,
-  // });
-
-  // useResetDependentFieldOnParentChange({
-  //   parentValue: watch("phase"),
-  //   dependentFieldName: "subphase",
-  //   valueToSet: defaultFormValues.subphase,
-  //   setValue,
-  // });
-
   useResetDependentFieldOnParentChange({
     parentValue: watch("phase"),
     dependentFieldName: "subphase",
@@ -162,7 +120,18 @@ const ComponentForm = ({
     valuePath: "value",
   });
 
-  // We need the signal field to reset when the component field changes
+  // reset subcomponent selections when component to ensure only allowed subcomponents
+  // assumes component type cannot be changed when editing
+  // todo: preserve allowed subcomponents when switching b/t component types
+  useResetDependentFieldOnParentChange({
+    parentValue: watch("component"),
+    dependentFieldName: "subcomponents",
+    valueToSet: defaultFormValues.subcomponents,
+    setValue,
+    valuePath: "value",
+  });
+
+  // We need the signal field to reset when the component field changes ✅
   // We need the subphase field to reset when the phase field changes ✅
   // We need the subcomponents to clear when the component changes
   // We need to take into account that the component and

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -12,7 +12,10 @@ import {
 } from "@mui/material";
 import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
 import { CheckCircle } from "@mui/icons-material";
-import { ControlledAutocomplete } from "./utils/form";
+import {
+  ControlledAutocomplete,
+  makeSubcomponentsFormFieldValues,
+} from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import SignalComponentAutocomplete from "./SignalComponentAutocomplete";
 import {
@@ -23,6 +26,7 @@ import {
   useSubphaseOptions,
   useInitialValuesOnAttributesEdit,
   useComponentTagsOptions,
+  makeComponentFormFieldValue,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -83,15 +87,11 @@ const ComponentForm = ({
   console.log(initialFormValues);
   const editDefaultFormValues = {
     ...defaultFormValues,
-    component: {
-      value: initialFormValues.component.component_id,
-      label: initialFormValues.component.moped_components.component_name,
-      data: {
-        // Include component subcomponents and metadata about the internal_table needed for the form
-        ...initialFormValues.component.moped_components,
-      },
-    },
+    component: makeComponentFormFieldValue(initialFormValues?.component),
     description: initialFormValues.description,
+    subcomponents: makeSubcomponentsFormFieldValues(
+      initialFormValues?.subcomponents
+    ),
   };
 
   const {
@@ -137,7 +137,6 @@ const ComponentForm = ({
   useInitialValuesOnAttributesEdit(
     initialFormValues,
     setValue,
-    subcomponentOptions,
     phaseOptions,
     subphaseOptions,
     areSignalOptionsLoaded,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -12,10 +12,7 @@ import {
 } from "@mui/material";
 import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
 import { CheckCircle } from "@mui/icons-material";
-import {
-  ControlledAutocomplete,
-  makeSubcomponentsFormFieldValues,
-} from "./utils/form";
+import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import SignalComponentAutocomplete from "./SignalComponentAutocomplete";
 import {
@@ -27,6 +24,8 @@ import {
   useInitialValuesOnAttributesEdit,
   useComponentTagsOptions,
   makeComponentFormFieldValue,
+  makeSubcomponentsFormFieldValues,
+  makeSignalFormFieldValue,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -85,14 +84,18 @@ const ComponentForm = ({
     initialFormValues?.subcomponents.length > 0;
 
   console.log(initialFormValues);
-  const editDefaultFormValues = {
-    ...defaultFormValues,
-    component: makeComponentFormFieldValue(initialFormValues?.component),
-    description: initialFormValues.description,
-    subcomponents: makeSubcomponentsFormFieldValues(
-      initialFormValues?.subcomponents
-    ),
-  };
+  // TODO: Building the initialFormValues should happen in EditAttributesModal
+  const editDefaultFormValues = initialFormValues
+    ? {
+        ...defaultFormValues,
+        component: makeComponentFormFieldValue(initialFormValues?.component),
+        description: initialFormValues.description,
+        subcomponents: makeSubcomponentsFormFieldValues(
+          initialFormValues?.subcomponents
+        ),
+        signal: makeSignalFormFieldValue(initialFormValues?.component),
+      }
+    : null;
 
   const {
     register,
@@ -102,8 +105,9 @@ const ComponentForm = ({
     setValue,
     formState: { isValid },
   } = useForm({
-    // defaultValues: defaultFormValues,
-    defaultValues: { ...defaultFormValues, ...editDefaultFormValues },
+    defaultValues: initialFormValues
+      ? { ...defaultFormValues, ...editDefaultFormValues }
+      : defaultFormValues,
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
@@ -139,7 +143,6 @@ const ComponentForm = ({
     setValue,
     phaseOptions,
     subphaseOptions,
-    areSignalOptionsLoaded,
     componentTagsOptions
   );
 
@@ -170,7 +173,8 @@ const ComponentForm = ({
   const isSignalComponent = internalTable === "feature_signals";
 
   return (
-    !areOptionsLoading && (
+    !areOptionsLoading &&
+    areSignalOptionsLoaded && (
       <form onSubmit={handleSubmit(onSave)}>
         <Grid container spacing={2}>
           <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -80,6 +80,7 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
+  console.log(initialFormValues);
   const editDefaultFormValues = {
     ...defaultFormValues,
     component: {
@@ -90,6 +91,7 @@ const ComponentForm = ({
         ...initialFormValues.component.moped_components,
       },
     },
+    description: initialFormValues.description,
   };
 
   const {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -22,7 +22,7 @@ import {
   usePhaseOptions,
   useSubphaseOptions,
   useComponentTagsOptions,
-  useResetDependentFieldOnParentChange,
+  useResetDependentFieldOnAutocompleteChange,
 } from "./utils/form";
 import * as yup from "yup";
 
@@ -104,14 +104,14 @@ const ComponentForm = ({
     !!initialFormValues?.phase
   );
 
-  useResetDependentFieldOnParentChange({
+  useResetDependentFieldOnAutocompleteChange({
     parentValue: watch("phase"),
     dependentFieldName: "subphase",
     valueToSet: defaultFormValues.subphase,
     setValue,
   });
 
-  useResetDependentFieldOnParentChange({
+  useResetDependentFieldOnAutocompleteChange({
     parentValue: watch("component"),
     dependentFieldName: "signal",
     valueToSet: defaultFormValues.signal,
@@ -119,7 +119,7 @@ const ComponentForm = ({
   });
 
   // todo: preserve allowed subcomponents when switching b/t component types
-  useResetDependentFieldOnParentChange({
+  useResetDependentFieldOnAutocompleteChange({
     parentValue: watch("component"),
     dependentFieldName: "subcomponents",
     valueToSet: defaultFormValues.subcomponents,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -134,7 +134,7 @@ const ComponentForm = ({
     if (areOptionsLoading || initialFormValues === null) return;
 
     setValue("component", initialFormValues.component);
-  }, [areOptionsLoading]);
+  }, [areOptionsLoading, initialFormValues, setValue]);
 
   // TODO: The value of the signal is getting cleared on first load
   useEffect(() => {
@@ -146,7 +146,7 @@ const ComponentForm = ({
       return;
 
     setValue("signal", initialFormValues.signal);
-  }, [areSignalOptionsLoaded]);
+  }, [areSignalOptionsLoaded, initialFormValues, setValue, isSignalComponent]);
 
   const subcomponentOptions = useSubcomponentOptions(
     component?.value,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -22,6 +22,7 @@ import {
   usePhaseOptions,
   useSubphaseOptions,
   useComponentTagsOptions,
+  useResetDependentFieldOnParentChange,
 } from "./utils/form";
 import * as yup from "yup";
 
@@ -131,7 +132,7 @@ const ComponentForm = ({
     if (component.value !== initialFormValues?.component?.value) {
       setValue("signal", null);
     }
-  }, [component, setValue]);
+  }, [component, setValue, initialFormValues]);
 
   // reset subcomponent selections when component to ensure only allowed subcomponents
   // assumes component type cannot be changed when editing
@@ -150,6 +151,15 @@ const ComponentForm = ({
       setValue("subphase", null);
     }
   }, [phase, setValue, initialFormValues]);
+
+  useResetDependentFieldOnParentChange({ fieldName: "phase" });
+
+  React.useEffect(() => {
+    const subscription = watch((value, { name, type }) =>
+      console.log(value, name, type)
+    );
+    return () => subscription.unsubscribe();
+  }, [watch]);
 
   const isEditingExistingComponent = initialFormValues !== null;
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -94,29 +94,7 @@ const ComponentForm = ({
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const internalTable = component?.data?.feature_layer?.internal_table;
   const isSignalComponent = internalTable === "feature_signals";
-  const [areSignalOptionsLoaded, setAreSignalOptionsLoaded] = useState(false);
-  const onOptionsLoaded = () => setAreSignalOptionsLoaded(true);
   const componentTagsOptions = useComponentTagsOptions(optionsData);
-
-  // Set the selected component after the component options are loaded
-  // TODO: This should NOT happen when creating a new component
-  useEffect(() => {
-    if (areOptionsLoading || initialFormValues === null) return;
-
-    setValue("component", initialFormValues.component);
-  }, [areOptionsLoading, initialFormValues, setValue]);
-
-  // TODO: The value of the signal is getting cleared on first load
-  useEffect(() => {
-    if (
-      !areSignalOptionsLoaded ||
-      !isSignalComponent ||
-      initialFormValues === null
-    )
-      return;
-
-    setValue("signal", initialFormValues.signal);
-  }, [areSignalOptionsLoaded, initialFormValues, setValue, isSignalComponent]);
 
   const subcomponentOptions = useSubcomponentOptions(
     component?.value,
@@ -128,11 +106,11 @@ const ComponentForm = ({
 
   // Reset signal field when component changes so signal matches component signal type
   // TODO: we have to check if the component still matches otherwise the component useEffect will clear the signal
-  useEffect(() => {
-    if (component.value !== initialFormValues?.component?.value) {
-      setValue("signal", null);
-    }
-  }, [component, setValue, initialFormValues]);
+  // useEffect(() => {
+  //   if (component?.value !== initialFormValues?.component?.value) {
+  //     setValue("signal", null);
+  //   }
+  // }, [component, setValue, initialFormValues]);
 
   // reset subcomponent selections when component to ensure only allowed subcomponents
   // assumes component type cannot be changed when editing
@@ -143,23 +121,51 @@ const ComponentForm = ({
     }
   }, [subcomponentOptions, initialFormValues, setValue]);
 
-  // Reset subphases field when phase changes so subphase options match phase
-  useEffect(() => {
-    if (!phase?.value) return;
-    if (!initialFormValues) return;
-    if (initialFormValues.phase?.value !== phase?.value) {
-      setValue("subphase", null);
-    }
-  }, [phase, setValue, initialFormValues]);
+  // useResetDependentFieldOnParentChange({
+  //   watch,
+  //   fieldName: "component",
+  //   dependentFieldName: "signal",
+  //   initialFormValues,
+  //   defaultFormValues,
+  //   setValue,
+  // });
 
-  useResetDependentFieldOnParentChange({ fieldName: "phase" });
+  // useResetDependentFieldOnParentChange({
+  //   watch,
+  //   fieldName: "phase",
+  //   dependentFieldName: "subphase",
+  //   initialFormValues,
+  //   defaultFormValues,
+  //   setValue,
+  // });
 
-  React.useEffect(() => {
-    const subscription = watch((value, { name, type }) =>
-      console.log(value, name, type)
-    );
-    return () => subscription.unsubscribe();
-  }, [watch]);
+  // useResetDependentFieldOnParentChange({
+  //   parentValue: watch("phase"),
+  //   dependentFieldName: "subphase",
+  //   valueToSet: defaultFormValues.subphase,
+  //   setValue,
+  // });
+
+  useResetDependentFieldOnParentChange({
+    parentValue: watch("phase"),
+    dependentFieldName: "subphase",
+    valueToSet: defaultFormValues.subphase,
+    setValue,
+    valuePath: "value",
+  });
+
+  useResetDependentFieldOnParentChange({
+    parentValue: watch("component"),
+    dependentFieldName: "signal",
+    valueToSet: defaultFormValues.signal,
+    setValue,
+    valuePath: "value",
+  });
+
+  // We need the signal field to reset when the component field changes
+  // We need the subphase field to reset when the phase field changes ✅
+  // We need the subcomponents to clear when the component changes
+  // We need to take into account that the component and
 
   const isEditingExistingComponent = initialFormValues !== null;
 
@@ -194,7 +200,6 @@ const ComponentForm = ({
               render={({ field }) => (
                 <SignalComponentAutocomplete
                   {...field}
-                  onOptionsLoaded={onOptionsLoaded}
                   signalType={component?.data?.component_subtype}
                 />
               )}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -72,12 +72,14 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
-    formState: { isDirty, isValid },
+    formState: { isDirty, errors },
   } = useForm({
     defaultValues: initialFormValues ? initialFormValues : defaultFormValues,
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
+
+  const areFormErrors = Object.keys(errors).length > 0;
 
   // Get and format component and subcomponent options
   const {
@@ -295,7 +297,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={!isDirty || !isValid}
+            disabled={!isDirty || areFormErrors}
           >
             {isSignalComponent ? "Save" : formButtonText}
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -80,6 +80,18 @@ const ComponentForm = ({
   const doesInitialValueHaveSubcomponents =
     initialFormValues?.subcomponents.length > 0;
 
+  const editDefaultFormValues = {
+    ...defaultFormValues,
+    component: {
+      value: initialFormValues.component.component_id,
+      label: initialFormValues.component.moped_components.component_name,
+      data: {
+        // Include component subcomponents and metadata about the internal_table needed for the form
+        ...initialFormValues.component.moped_components,
+      },
+    },
+  };
+
   const {
     register,
     handleSubmit,
@@ -88,7 +100,8 @@ const ComponentForm = ({
     setValue,
     formState: { isValid },
   } = useForm({
-    defaultValues: defaultFormValues,
+    // defaultValues: defaultFormValues,
+    defaultValues: { ...defaultFormValues, ...editDefaultFormValues },
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
@@ -119,16 +132,15 @@ const ComponentForm = ({
     !!initialFormValues?.component.moped_phase
   );
 
-  // useInitialValuesOnAttributesEdit(
-  //   initialFormValues,
-  //   setValue,
-  //   componentOptions,
-  //   subcomponentOptions,
-  //   phaseOptions,
-  //   subphaseOptions,
-  //   areSignalOptionsLoaded,
-  //   componentTagsOptions
-  // );
+  useInitialValuesOnAttributesEdit(
+    initialFormValues,
+    setValue,
+    subcomponentOptions,
+    phaseOptions,
+    subphaseOptions,
+    areSignalOptionsLoaded,
+    componentTagsOptions
+  );
 
   // Reset signal field when component changes so signal matches component signal type
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -119,16 +119,16 @@ const ComponentForm = ({
     !!initialFormValues?.component.moped_phase
   );
 
-  useInitialValuesOnAttributesEdit(
-    initialFormValues,
-    setValue,
-    componentOptions,
-    subcomponentOptions,
-    phaseOptions,
-    subphaseOptions,
-    areSignalOptionsLoaded,
-    componentTagsOptions
-  );
+  // useInitialValuesOnAttributesEdit(
+  //   initialFormValues,
+  //   setValue,
+  //   componentOptions,
+  //   subcomponentOptions,
+  //   phaseOptions,
+  //   subphaseOptions,
+  //   areSignalOptionsLoaded,
+  //   componentTagsOptions
+  // );
 
   // Reset signal field when component changes so signal matches component signal type
   useEffect(() => {
@@ -157,188 +157,190 @@ const ComponentForm = ({
   const isSignalComponent = internalTable === "feature_signals";
 
   return (
-    <form onSubmit={handleSubmit(onSave)}>
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
-          <ControlledAutocomplete
-            id="component"
-            label="Component Type"
-            options={areOptionsLoading ? [] : componentOptions}
-            renderOption={(props, option, state) => (
-              <ComponentOptionWithIcon
-                option={option}
-                state={state}
-                props={props}
-              />
-            )}
-            name="component"
-            control={control}
-            autoFocus
-            disabled={isEditingExistingComponent}
-          />
-        </Grid>
-
-        {isSignalComponent && (
-          <Grid item xs={12}>
-            <Controller
-              id="signal"
-              name="signal"
-              control={control}
-              render={({ field }) => (
-                <SignalComponentAutocomplete
-                  {...field}
-                  onOptionsLoaded={onOptionsLoaded}
-                  signalType={component?.data?.component_subtype}
-                />
-              )}
-            />
-          </Grid>
-        )}
-
-        {/* Hide unless there are subcomponents for the chosen component */}
-        {(subcomponentOptions.length !== 0 ||
-          doesInitialValueHaveSubcomponents) && (
+    !areOptionsLoading && (
+      <form onSubmit={handleSubmit(onSave)}>
+        <Grid container spacing={2}>
           <Grid item xs={12}>
             <ControlledAutocomplete
-              id="subcomponents"
-              label="Subcomponents"
+              id="component"
+              label="Component Type"
+              options={areOptionsLoading ? [] : componentOptions}
+              renderOption={(props, option, state) => (
+                <ComponentOptionWithIcon
+                  option={option}
+                  state={state}
+                  props={props}
+                />
+              )}
+              name="component"
+              control={control}
+              autoFocus
+              disabled={isEditingExistingComponent}
+            />
+          </Grid>
+
+          {isSignalComponent && (
+            <Grid item xs={12}>
+              <Controller
+                id="signal"
+                name="signal"
+                control={control}
+                render={({ field }) => (
+                  <SignalComponentAutocomplete
+                    {...field}
+                    onOptionsLoaded={onOptionsLoaded}
+                    signalType={component?.data?.component_subtype}
+                  />
+                )}
+              />
+            </Grid>
+          )}
+
+          {/* Hide unless there are subcomponents for the chosen component */}
+          {(subcomponentOptions.length !== 0 ||
+            doesInitialValueHaveSubcomponents) && (
+            <Grid item xs={12}>
+              <ControlledAutocomplete
+                id="subcomponents"
+                label="Subcomponents"
+                multiple
+                options={subcomponentOptions}
+                name="subcomponents"
+                control={control}
+              />
+            </Grid>
+          )}
+          <Grid item xs={12}>
+            <ControlledAutocomplete
+              id="tags"
+              label="Tags"
               multiple
-              options={subcomponentOptions}
-              name="subcomponents"
+              options={componentTagsOptions}
+              name="tags"
               control={control}
             />
           </Grid>
-        )}
-        <Grid item xs={12}>
-          <ControlledAutocomplete
-            id="tags"
-            label="Tags"
-            multiple
-            options={componentTagsOptions}
-            name="tags"
-            control={control}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            {...register("description")}
-            fullWidth
-            size="small"
-            id="description"
-            label={"Description"}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            variant="outlined"
-            multiline
-            minRows={4}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            {...register("srtsId")}
-            fullWidth
-            size="small"
-            id="srtsId"
-            label={"SRTS Infrastructure ID"}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            variant="outlined"
-            helperText={
-              "The Safe Routes to School infrastructure plan record identifier"
-            }
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={useComponentPhase}
-                onChange={() => setUseComponentPhase(!useComponentPhase)}
-                name="useComponentPhase"
-                color="primary"
-              />
-            }
-            labelPlacement="start"
-            label="Use component phase"
-            style={{ color: "gray", marginLeft: 0 }}
-          />
+          <Grid item xs={12}>
+            <TextField
+              {...register("description")}
+              fullWidth
+              size="small"
+              id="description"
+              label={"Description"}
+              InputLabelProps={{
+                shrink: true,
+              }}
+              variant="outlined"
+              multiline
+              minRows={4}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              {...register("srtsId")}
+              fullWidth
+              size="small"
+              id="srtsId"
+              label={"SRTS Infrastructure ID"}
+              InputLabelProps={{
+                shrink: true,
+              }}
+              variant="outlined"
+              helperText={
+                "The Safe Routes to School infrastructure plan record identifier"
+              }
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={useComponentPhase}
+                  onChange={() => setUseComponentPhase(!useComponentPhase)}
+                  name="useComponentPhase"
+                  color="primary"
+                />
+              }
+              labelPlacement="start"
+              label="Use component phase"
+              style={{ color: "gray", marginLeft: 0 }}
+            />
+            {useComponentPhase && (
+              <FormHelperText>
+                Assign a phase to the component to differentiate it from the
+                overall phase of this project
+              </FormHelperText>
+            )}
+          </Grid>
           {useComponentPhase && (
-            <FormHelperText>
-              Assign a phase to the component to differentiate it from the
-              overall phase of this project
-            </FormHelperText>
-          )}
-        </Grid>
-        {useComponentPhase && (
-          <>
-            <Grid item xs={12}>
-              <ControlledAutocomplete
-                id="phase"
-                label="Phase"
-                options={phaseOptions}
-                name="phase"
-                control={control}
-                required
-                autoFocus
-              />
-            </Grid>
-            {subphaseOptions.length !== 0 && (
+            <>
               <Grid item xs={12}>
                 <ControlledAutocomplete
-                  id="subphase"
-                  label="Subphase"
-                  options={subphaseOptions}
-                  name="subphase"
+                  id="phase"
+                  label="Phase"
+                  options={phaseOptions}
+                  name="phase"
                   control={control}
+                  required
+                  autoFocus
                 />
               </Grid>
-            )}
-            <Grid item xs={12}>
-              <Controller
-                id="completion-date"
-                name="completionDate"
-                control={control}
-                render={({ field }) => {
-                  return (
-                    <MobileDatePicker
-                      {...field}
-                      value={parseDate(field.value)}
-                      onChange={(date) => {
-                        const newDate = date
-                          ? format(date, "yyyy-MM-dd OOOO")
-                          : null;
-                        field.onChange(newDate);
-                      }}
-                      format="MM/dd/yyyy"
-                      variant="outlined"
-                      label={"Completion date"}
-                      slotProps={{
-                        actionBar: { actions: ["accept", "cancel", "clear"] },
-                      }}
-                    />
-                  );
-                }}
-              />
-            </Grid>
-          </>
-        )}
-      </Grid>
-      <Grid container spacing={4} display="flex" justifyContent="flex-end">
-        <Grid item style={{ margin: 5 }}>
-          <Button
-            variant="contained"
-            color="primary"
-            startIcon={<CheckCircle />}
-            type="submit"
-            disabled={!isValid}
-          >
-            {isSignalComponent ? "Save" : formButtonText}
-          </Button>
+              {subphaseOptions.length !== 0 && (
+                <Grid item xs={12}>
+                  <ControlledAutocomplete
+                    id="subphase"
+                    label="Subphase"
+                    options={subphaseOptions}
+                    name="subphase"
+                    control={control}
+                  />
+                </Grid>
+              )}
+              <Grid item xs={12}>
+                <Controller
+                  id="completion-date"
+                  name="completionDate"
+                  control={control}
+                  render={({ field }) => {
+                    return (
+                      <MobileDatePicker
+                        {...field}
+                        value={parseDate(field.value)}
+                        onChange={(date) => {
+                          const newDate = date
+                            ? format(date, "yyyy-MM-dd OOOO")
+                            : null;
+                          field.onChange(newDate);
+                        }}
+                        format="MM/dd/yyyy"
+                        variant="outlined"
+                        label={"Completion date"}
+                        slotProps={{
+                          actionBar: { actions: ["accept", "cancel", "clear"] },
+                        }}
+                      />
+                    );
+                  }}
+                />
+              </Grid>
+            </>
+          )}
         </Grid>
-      </Grid>
-    </form>
+        <Grid container spacing={4} display="flex" justifyContent="flex-end">
+          <Grid item style={{ margin: 5 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<CheckCircle />}
+              type="submit"
+              disabled={!isValid}
+            >
+              {isSignalComponent ? "Save" : formButtonText}
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    )
   );
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -27,6 +27,7 @@ import {
   makeSubcomponentsFormFieldValues,
   makeSignalFormFieldValue,
   makePhaseFormFieldValue,
+  makeSubphaseFormFieldValue,
 } from "./utils/form";
 import * as yup from "yup";
 import { format } from "date-fns";
@@ -94,6 +95,7 @@ const ComponentForm = ({
         ),
         signal: makeSignalFormFieldValue(initialFormValues.component),
         phase: makePhaseFormFieldValue(initialFormValues.component),
+        subphase: makeSubphaseFormFieldValue(initialFormValues.component),
       }
     : null;
 
@@ -141,6 +143,7 @@ const ComponentForm = ({
     setValue("component", editDefaultFormValues.component);
   }, [areOptionsLoading]);
 
+  // TODO: The value of the signal is getting cleared on first load
   useEffect(() => {
     if (
       !areSignalOptionsLoaded ||
@@ -163,7 +166,7 @@ const ComponentForm = ({
   useInitialValuesOnAttributesEdit(
     initialFormValues,
     setValue,
-    subphaseOptions,
+    // subphaseOptions,
     componentTagsOptions
   );
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -1,4 +1,4 @@
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import List from "@mui/material/List";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -51,16 +51,14 @@ const CreateComponentModal = ({
       line_representation,
       internal_table,
       moped_subcomponents: subcomponents,
-      // TODO: Can we remove this because RHF returns null now?
-      description: description.length > 0 ? description : null,
+      description,
       phase_id: phase?.data.phase_id,
       subphase_id: subphase?.data.subphase_id,
       completion_date: completionDate,
       label: component_name,
       features: [],
       moped_proj_component_tags: tags,
-      // TODO: Can we remove this because RHF returns null now?
-      srts_id: srtsId.length > 0 ? srtsId : null,
+      srts_id: srtsId,
     };
 
     const linkMode = newComponent.line_representation ? "lines" : "points";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -51,14 +51,14 @@ const CreateComponentModal = ({
       line_representation,
       internal_table,
       moped_subcomponents: subcomponents,
-      description,
+      description: description?.length > 0 ? description : null,
       phase_id: phase?.data.phase_id,
       subphase_id: subphase?.data.subphase_id,
       completion_date: completionDate,
       label: component_name,
       features: [],
       moped_proj_component_tags: tags,
-      srts_id: srtsId,
+      srts_id: srtsId?.length > 0 ? srtsId : null,
     };
 
     const linkMode = newComponent.line_representation ? "lines" : "points";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -51,6 +51,7 @@ const CreateComponentModal = ({
       line_representation,
       internal_table,
       moped_subcomponents: subcomponents,
+      // TODO: Can we remove this because RHF returns null now?
       description: description.length > 0 ? description : null,
       phase_id: phase?.data.phase_id,
       subphase_id: subphase?.data.subphase_id,
@@ -58,6 +59,7 @@ const CreateComponentModal = ({
       label: component_name,
       features: [],
       moped_proj_component_tags: tags,
+      // TODO: Can we remove this because RHF returns null now?
       srts_id: srtsId.length > 0 ? srtsId : null,
     };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -11,6 +11,14 @@ import {
 import { knackSignalRecordToFeatureSignalsRecord } from "src/utils/signalComponentHelpers";
 import { zoomMapToFeatureCollection } from "./utils/map";
 import { fitBoundsOptions } from "./mapSettings";
+import {
+  makeComponentFormFieldValue,
+  makeSubcomponentsFormFieldValues,
+  makeSignalFormFieldValue,
+  makePhaseFormFieldValue,
+  makeSubphaseFormFieldValue,
+  makeTagFormFieldValues,
+} from "./utils/form";
 
 const useStyles = makeStyles((theme) => ({
   dialogTitle: {
@@ -138,16 +146,33 @@ const EditAttributesModal = ({
     editDispatch({ type: "cancel_attributes_edit" });
   };
 
-  const initialFormValues = {
-    component: componentToEdit,
-    subcomponents: componentToEdit?.moped_proj_components_subcomponents,
-    description: componentToEdit?.description,
-    phase: componentToEdit?.moped_phase,
-    subphase: componentToEdit?.moped_subphase,
-    completionDate: componentToEdit?.completion_date,
-    tags: componentToEdit?.moped_proj_component_tags,
-    srtsId: componentToEdit?.srts_id,
-  };
+  // const initialFormValues = {
+  //   component: componentToEdit,
+  //   subcomponents: componentToEdit?.moped_proj_components_subcomponents,
+  //   description: componentToEdit?.description,
+  //   phase: componentToEdit?.moped_phase,
+  //   subphase: componentToEdit?.moped_subphase,
+  //   completionDate: componentToEdit?.completion_date,
+  //   tags: componentToEdit?.moped_proj_component_tags,
+  //   srtsId: componentToEdit?.srts_id,
+  // };
+  const initialFormValues = componentToEdit
+    ? {
+        component: makeComponentFormFieldValue(componentToEdit),
+        description: componentToEdit?.description,
+        subcomponents: makeSubcomponentsFormFieldValues(
+          componentToEdit.moped_proj_components_subcomponents
+        ),
+        signal: makeSignalFormFieldValue(componentToEdit),
+        phase: makePhaseFormFieldValue(componentToEdit.moped_phase),
+        subphase: makeSubphaseFormFieldValue(componentToEdit),
+        completionDate: componentToEdit.completion_date,
+        srtsId: componentToEdit.srts_id,
+        tags: makeTagFormFieldValues(
+          componentToEdit?.moped_proj_component_tags
+        ),
+      }
+    : null;
 
   return (
     <Dialog open={showDialog} onClose={onClose} fullWidth scroll="body">

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -147,7 +147,10 @@ const EditAttributesModal = ({
   const initialFormValues = componentToEdit
     ? {
         component: makeComponentFormFieldValue(componentToEdit),
-        description: componentToEdit.description,
+        description:
+          componentToEdit.description.length > 0
+            ? componentToEdit.description
+            : "",
         subcomponents: makeSubcomponentsFormFieldValues(
           componentToEdit.moped_proj_components_subcomponents
         ),
@@ -155,7 +158,7 @@ const EditAttributesModal = ({
         phase: makePhaseFormFieldValue(componentToEdit.moped_phase),
         subphase: makeSubphaseFormFieldValue(componentToEdit.moped_subphase),
         completionDate: componentToEdit.completion_date,
-        srtsId: componentToEdit.srts_id,
+        srtsId: componentToEdit.srts_id > 0 ? componentToEdit.srts_id : "",
         tags: makeTagFormFieldValues(componentToEdit.moped_proj_component_tags),
       }
     : null;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -53,10 +53,8 @@ const EditAttributesModal = ({
 
     const { subcomponents, phase, subphase, tags } = formData;
     const completionDate = !!phase ? formData.completionDate : null;
-    // TODO: Can we remove this because RHF returns null now?
     const description =
       formData.description?.length > 0 ? formData.description : null;
-    // TODO: Can we remove this because RHF returns null now?
     const srtsId = formData.srtsId?.length > 0 ? formData.srtsId : null;
     const { project_component_id: projectComponentId } = componentToEdit;
 
@@ -93,8 +91,8 @@ const EditAttributesModal = ({
           description,
           subcomponents: subcomponentsArray,
           signals: [signalToInsert],
-          phaseId: phase?.data.phase_id,
-          subphaseId: subphase?.data.subphase_id,
+          phaseId: phase?.value,
+          subphaseId: subphase?.value,
           componentTags: tagsArray,
           completionDate,
           srtsId,
@@ -128,8 +126,8 @@ const EditAttributesModal = ({
           projectComponentId: projectComponentId,
           description,
           subcomponents: subcomponentsArray,
-          phaseId: phase?.data.phase_id,
-          subphaseId: subphase?.data.subphase_id,
+          phaseId: phase?.value,
+          subphaseId: subphase?.value,
           componentTags: tagsArray,
           completionDate,
           srtsId,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -1,7 +1,13 @@
 import React from "react";
 import { useMutation } from "@apollo/client";
 import ComponentForm from "./ComponentForm";
-import { Dialog, DialogTitle, DialogContent, IconButton } from "@mui/material";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
 import {
@@ -146,26 +152,16 @@ const EditAttributesModal = ({
     editDispatch({ type: "cancel_attributes_edit" });
   };
 
-  // const initialFormValues = {
-  //   component: componentToEdit,
-  //   subcomponents: componentToEdit?.moped_proj_components_subcomponents,
-  //   description: componentToEdit?.description,
-  //   phase: componentToEdit?.moped_phase,
-  //   subphase: componentToEdit?.moped_subphase,
-  //   completionDate: componentToEdit?.completion_date,
-  //   tags: componentToEdit?.moped_proj_component_tags,
-  //   srtsId: componentToEdit?.srts_id,
-  // };
   const initialFormValues = componentToEdit
     ? {
         component: makeComponentFormFieldValue(componentToEdit),
-        description: componentToEdit?.description,
+        description: componentToEdit.description,
         subcomponents: makeSubcomponentsFormFieldValues(
           componentToEdit.moped_proj_components_subcomponents
         ),
         signal: makeSignalFormFieldValue(componentToEdit),
         phase: makePhaseFormFieldValue(componentToEdit.moped_phase),
-        subphase: makeSubphaseFormFieldValue(componentToEdit),
+        subphase: makeSubphaseFormFieldValue(componentToEdit.moped_subphase),
         completionDate: componentToEdit.completion_date,
         srtsId: componentToEdit.srts_id,
         tags: makeTagFormFieldValues(

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -156,9 +156,7 @@ const EditAttributesModal = ({
         subphase: makeSubphaseFormFieldValue(componentToEdit.moped_subphase),
         completionDate: componentToEdit.completion_date,
         srtsId: componentToEdit.srts_id,
-        tags: makeTagFormFieldValues(
-          componentToEdit?.moped_proj_component_tags
-        ),
+        tags: makeTagFormFieldValues(componentToEdit.moped_proj_component_tags),
       }
     : null;
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -27,7 +27,6 @@ const EditAttributesModal = ({
   editDispatch,
   componentToEdit,
   refetchProjectComponents,
-  setClickedComponent,
   mapRef,
 }) => {
   const classes = useStyles();
@@ -35,15 +34,9 @@ const EditAttributesModal = ({
   const [updateComponentAttributes] = useMutation(UPDATE_COMPONENT_ATTRIBUTES);
   const [updateSignalComponent] = useMutation(UPDATE_SIGNAL_COMPONENT);
 
-  const onComponentSaveSuccess = (updatedClickedComponentState) => {
-    // Update component list item and clicked component state to keep UI up to date
+  const onSaveSuccess = () => {
     refetchProjectComponents().then(() => {
       onClose();
-      // Update clickedComponent with the attributes that were just edited
-      setClickedComponent((prevComponent) => ({
-        ...prevComponent,
-        ...updatedClickedComponentState,
-      }));
     });
   };
 
@@ -52,8 +45,10 @@ const EditAttributesModal = ({
 
     const { subcomponents, phase, subphase, tags } = formData;
     const completionDate = !!phase ? formData.completionDate : null;
+    // TODO: Can we remove this because RHF returns null now?
     const description =
       formData.description?.length > 0 ? formData.description : null;
+    // TODO: Can we remove this because RHF returns null now?
     const srtsId = formData.srtsId?.length > 0 ? formData.srtsId : null;
     const { project_component_id: projectComponentId } = componentToEdit;
 
@@ -84,19 +79,6 @@ const EditAttributesModal = ({
         component_id: projectComponentId,
       };
 
-      const updatedClickedComponentState = {
-        description,
-        moped_proj_components_subcomponents: subcomponentsArray,
-        feature_signals: [
-          { ...featureSignalRecord, geometry: featureSignalRecord.geography },
-        ],
-        moped_proj_component_tags: tagsArray,
-        moped_phase: phase?.data,
-        moped_subphase: subphase?.data,
-        completion_date: completionDate,
-        srts_id: srtsId,
-      };
-
       updateSignalComponent({
         variables: {
           projectComponentId: projectComponentId,
@@ -111,7 +93,8 @@ const EditAttributesModal = ({
         },
       })
         .then(() => {
-          onComponentSaveSuccess(updatedClickedComponentState);
+          onSaveSuccess();
+
           const [existingLongitude, existingLatitude] =
             featureSignalRecord.geography.coordinates[0];
           const [newLongitude, newLatitude] =
@@ -132,16 +115,6 @@ const EditAttributesModal = ({
           console.log(error);
         });
     } else {
-      const updatedClickedComponentState = {
-        description,
-        moped_proj_components_subcomponents: subcomponentsArray,
-        moped_proj_component_tags: tagsArray,
-        moped_phase: phase?.data,
-        moped_subphase: subphase?.data,
-        completion_date: completionDate,
-        srts_id: srtsId,
-      };
-
       updateComponentAttributes({
         variables: {
           projectComponentId: projectComponentId,
@@ -154,7 +127,7 @@ const EditAttributesModal = ({
           srtsId,
         },
       })
-        .then(() => onComponentSaveSuccess(updatedClickedComponentState))
+        .then(() => onSaveSuccess())
         .catch((error) => {
           console.log(error);
         });

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -148,7 +148,7 @@ const EditAttributesModal = ({
     ? {
         component: makeComponentFormFieldValue(clickedComponent),
         description:
-          clickedComponent.description.length > 0
+          clickedComponent.description?.length > 0
             ? clickedComponent.description
             : "",
         subcomponents: makeSubcomponentsFormFieldValues(
@@ -159,7 +159,7 @@ const EditAttributesModal = ({
         subphase: makeSubphaseFormFieldValue(clickedComponent.moped_subphase),
         completionDate: clickedComponent.completion_date,
         srtsId:
-          clickedComponent.srts_id.length > 0 ? clickedComponent.srts_id : "",
+          clickedComponent.srts_id?.length > 0 ? clickedComponent.srts_id : "",
         tags: makeTagFormFieldValues(
           clickedComponent.moped_proj_component_tags
         ),

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -1,13 +1,7 @@
 import React from "react";
 import { useMutation } from "@apollo/client";
 import ComponentForm from "./ComponentForm";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  IconButton,
-  Typography,
-} from "@mui/material";
+import { Dialog, DialogTitle, DialogContent, IconButton } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
 import {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
 const EditAttributesModal = ({
   showDialog,
   editDispatch,
-  componentToEdit,
+  clickedComponent,
   refetchProjectComponents,
   mapRef,
 }) => {
@@ -56,7 +56,7 @@ const EditAttributesModal = ({
     const description =
       formData.description?.length > 0 ? formData.description : null;
     const srtsId = formData.srtsId?.length > 0 ? formData.srtsId : null;
-    const { project_component_id: projectComponentId } = componentToEdit;
+    const { project_component_id: projectComponentId } = clickedComponent;
 
     // Prepare the subcomponent data for the mutation
     const subcomponentsArray = subcomponents
@@ -144,22 +144,25 @@ const EditAttributesModal = ({
     editDispatch({ type: "cancel_attributes_edit" });
   };
 
-  const initialFormValues = componentToEdit
+  const initialFormValues = clickedComponent
     ? {
-        component: makeComponentFormFieldValue(componentToEdit),
+        component: makeComponentFormFieldValue(clickedComponent),
         description:
-          componentToEdit.description.length > 0
-            ? componentToEdit.description
+          clickedComponent.description.length > 0
+            ? clickedComponent.description
             : "",
         subcomponents: makeSubcomponentsFormFieldValues(
-          componentToEdit.moped_proj_components_subcomponents
+          clickedComponent.moped_proj_components_subcomponents
         ),
-        signal: makeSignalFormFieldValue(componentToEdit),
-        phase: makePhaseFormFieldValue(componentToEdit.moped_phase),
-        subphase: makeSubphaseFormFieldValue(componentToEdit.moped_subphase),
-        completionDate: componentToEdit.completion_date,
-        srtsId: componentToEdit.srts_id > 0 ? componentToEdit.srts_id : "",
-        tags: makeTagFormFieldValues(componentToEdit.moped_proj_component_tags),
+        signal: makeSignalFormFieldValue(clickedComponent),
+        phase: makePhaseFormFieldValue(clickedComponent.moped_phase),
+        subphase: makeSubphaseFormFieldValue(clickedComponent.moped_subphase),
+        completionDate: clickedComponent.completion_date,
+        srtsId:
+          clickedComponent.srts_id.length > 0 ? clickedComponent.srts_id : "",
+        tags: makeTagFormFieldValues(
+          clickedComponent.moped_proj_component_tags
+        ),
       }
     : null;
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectComponentsList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectComponentsList.js
@@ -74,7 +74,7 @@ const ProjectComponentsList = ({
                   <Button
                     fullWidth
                     size="small"
-                    style={{color: theme.palette.text.primary}}
+                    style={{ color: theme.palette.text.primary }}
                     startIcon={<DeleteIcon />}
                     onClick={() => setIsDeletingComponent(true)}
                   >

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/SignalComponentAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/SignalComponentAutocomplete.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from "react";
 import { CircularProgress, TextField } from "@mui/material";
-import { Autocomplete, Alert } from '@mui/material';
+import { Autocomplete, Alert } from "@mui/material";
 import { useSocrataGeojson } from "src/utils/socrataHelpers";
 import {
   getSignalOptionLabel,
@@ -38,7 +38,7 @@ const SignalComponentAutocomplete = React.forwardRef(
     useEffect(() => {
       if (features === null) return;
 
-      onOptionsLoaded();
+      onOptionsLoaded && onOptionsLoaded();
     }, [features, onOptionsLoaded]);
 
     if (loading) {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import { useParams } from "react-router";
 import makeStyles from "@mui/styles/makeStyles";
@@ -119,6 +119,18 @@ export default function MapView({
 
   const { projectComponents, allRelatedComponents } =
     useProjectComponents(data);
+
+  // Keep clickedComponent state up to date with edits made to project components
+  useEffect(() => {
+    if (clickedComponent === null) return;
+
+    const clickedComponentId = clickedComponent?.project_component_id;
+    const updatedClickedComponent = projectComponents.find(
+      (component) => component.project_component_id === clickedComponentId
+    );
+
+    setClickedComponent(updatedClickedComponent);
+  }, [clickedComponent, projectComponents]);
 
   const {
     onStartCreatingComponent,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -308,7 +308,7 @@ export default function MapView({
           <EditAttributesModal
             showDialog={editState.showEditAttributesDialog}
             editDispatch={editDispatch}
-            componentToEdit={clickedComponent}
+            clickedComponent={clickedComponent}
             refetchProjectComponents={refetchProjectComponents}
             mapRef={mapRef}
           />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -298,7 +298,6 @@ export default function MapView({
             editDispatch={editDispatch}
             componentToEdit={clickedComponent}
             refetchProjectComponents={refetchProjectComponents}
-            setClickedComponent={setClickedComponent}
             mapRef={mapRef}
           />
         </main>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -131,7 +131,7 @@ export const useComponentTagsOptions = (data) =>
   }, [data]);
 
 /**
- * Create the value for the component autocomplete including component metadata for dependent fields
+ * Create the value for the required component autocomplete including component metadata for dependent fields
  * @param {Object} component - The component record
  * @returns {Object} the field value
  */

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -157,7 +157,7 @@ export const makePhaseFormFieldValue = (phase) => {
     value: phase?.phase_id,
     label: phase?.phase_name,
     data: {
-      // Include component subphases and metadata about the internal_table needed for the form
+      // Include component metadata needed for subphase options that correspond with selected phase
       ...phase,
     },
   };
@@ -167,10 +167,6 @@ export const makeSubphaseFormFieldValue = (subphase) => {
   return {
     value: subphase?.subphase_id,
     label: subphase?.subphase_name,
-    // data: {
-    //   // Include component subcomponents and metadata about the internal_table needed for the form
-    //   ...subphase,
-    // },
   };
 };
 
@@ -280,6 +276,7 @@ export const ControlledAutocomplete = ({
 
 // TODO: Rename? This is only going to work on autocomplete or selects
 // because they have options with value and label
+// reset dependent field selections when parent field changes to ensure only valid options are available
 export const useResetDependentFieldOnParentChange = ({
   parentValue,
   dependentFieldName,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -152,31 +152,23 @@ export const makeSignalFormFieldValue = (component) => {
   return knackFormatSignalOption;
 };
 
+export const makePhaseFormFieldValue = (component) => {
+  return {
+    value: component?.moped_phase.phase_id,
+    label: component?.moped_phase.phase_name,
+    data: {
+      // Include component subphases and metadata about the internal_table needed for the form
+      ...component?.moped_phase,
+    },
+  };
+};
+
 export const useInitialValuesOnAttributesEdit = (
   initialFormValues,
   setValue,
-  phaseOptions,
   subphaseOptions,
   componentTagsOptions
 ) => {
-  // Set the selected phase after the phase options are loaded
-  useEffect(() => {
-    if (!initialFormValues?.component?.moped_phase) return;
-    if (phaseOptions.length === 0) return;
-
-    setValue("phase", {
-      value: initialFormValues.component?.moped_phase.phase_id,
-      label: phaseOptions.find(
-        (option) =>
-          option.value === initialFormValues.component?.moped_phase.phase_id
-      ).label,
-      data: {
-        // Include component subcomponents and metadata about the internal_table needed for the form
-        ...initialFormValues.component?.moped_phase,
-      },
-    });
-  }, [phaseOptions, initialFormValues, setValue]);
-
   // Set the selected subphase after the subphase options are loaded
   useEffect(() => {
     if (!initialFormValues?.component?.moped_subphase) return;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -156,13 +156,13 @@ export const makeSignalFormFieldValue = (component) => {
   return knackFormatSignalOption;
 };
 
-export const makePhaseFormFieldValue = (component) => {
+export const makePhaseFormFieldValue = (phase) => {
   return {
-    value: component?.moped_phase.phase_id,
-    label: component?.moped_phase.phase_name,
+    value: phase.phase_id,
+    label: phase.phase_name,
     data: {
       // Include component subphases and metadata about the internal_table needed for the form
-      ...component?.moped_phase,
+      ...phase,
     },
   };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -119,10 +119,27 @@ export const useComponentTagsOptions = (data) =>
     return options;
   }, [data]);
 
+export const makeComponentFormFieldValue = (component) => {
+  return {
+    value: component.component_id,
+    label: component.moped_components.component_name,
+    data: {
+      // Include component subcomponents and metadata about the internal_table needed for the form
+      ...component.moped_components,
+    },
+  };
+};
+
+export const makeSubcomponentsFormFieldValues = (subcomponents) => {
+  return subcomponents.map((subcomponent) => ({
+    value: subcomponent.subcomponent_id,
+    label: subcomponent.moped_subcomponent.subcomponent_name,
+  }));
+};
+
 export const useInitialValuesOnAttributesEdit = (
   initialFormValues,
   setValue,
-  subcomponentOptions,
   phaseOptions,
   subphaseOptions,
   areSignalOptionsLoaded,
@@ -144,24 +161,6 @@ export const useInitialValuesOnAttributesEdit = (
 
     setValue("signal", knackFormatSignalOption);
   }, [initialFormValues, areSignalOptionsLoaded, setValue]);
-
-  // Set the selected subcomponent after the subcomponent options are loaded
-  useEffect(() => {
-    if (!initialFormValues) return;
-    if (subcomponentOptions.length === 0) return;
-    if (initialFormValues.subcomponents.length === 0) return;
-
-    const selectedSubcomponents = initialFormValues.subcomponents.map(
-      (subcomponent) => ({
-        value: subcomponent.subcomponent_id,
-        label: subcomponentOptions.find(
-          (option) => option.value === subcomponent.subcomponent_id
-        ).label,
-      })
-    );
-
-    setValue("subcomponents", selectedSubcomponents);
-  }, [subcomponentOptions, initialFormValues, setValue]);
 
   // Set the selected phase after the phase options are loaded
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -122,30 +122,12 @@ export const useComponentTagsOptions = (data) =>
 export const useInitialValuesOnAttributesEdit = (
   initialFormValues,
   setValue,
-  componentOptions,
   subcomponentOptions,
   phaseOptions,
   subphaseOptions,
   areSignalOptionsLoaded,
   componentTagsOptions
 ) => {
-  // Set the selected component after the component options are loaded
-  useEffect(() => {
-    if (!initialFormValues) return;
-    if (componentOptions.length === 0) return;
-
-    setValue("component", {
-      value: initialFormValues.component.component_id,
-      label: componentOptions.find(
-        (option) => option.value === initialFormValues.component.component_id
-      ).label,
-      data: {
-        // Include component subcomponents and metadata about the internal_table needed for the form
-        ...initialFormValues.component.moped_components,
-      },
-    });
-  }, [componentOptions, initialFormValues, setValue]);
-
   // Set the selected signal if this is a signal component
   useEffect(() => {
     if (!initialFormValues) return;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -23,6 +23,12 @@ export const makeComponentLabel = ({ component_name, component_subtype }) => {
     : `${component_name}`;
 };
 
+/**
+ * Create component tag label out of the type and name
+ * @param {string} type The type of the component tag
+ * @param {string} name The name of the component tag
+ * @returns {string}
+ */
 export const makeComponentTagLabel = ({ type, name }) => {
   return `${type} - ${name}`;
 };
@@ -124,6 +130,11 @@ export const useComponentTagsOptions = (data) =>
     return options;
   }, [data]);
 
+/**
+ * Create the value for the component autocomplete including component metadata for dependent fields
+ * @param {Object} component - The component record
+ * @returns {Object} the field value
+ */
 export const makeComponentFormFieldValue = (component) => {
   return {
     value: component.component_id,
@@ -135,6 +146,11 @@ export const makeComponentFormFieldValue = (component) => {
   };
 };
 
+/**
+ * Create the values for the subcomponents autocomplete
+ * @param {Array} subcomponents - The subcomponent records
+ * @returns {Object} the field value
+ */
 export const makeSubcomponentsFormFieldValues = (subcomponents) => {
   return subcomponents.map((subcomponent) => ({
     value: subcomponent.subcomponent_id,
@@ -142,6 +158,11 @@ export const makeSubcomponentsFormFieldValues = (subcomponents) => {
   }));
 };
 
+/**
+ * Create the value for the signal autocomplete if the component is a signal component
+ * @param {Object} component - The component record
+ * @returns {Object} the field value
+ */
 export const makeSignalFormFieldValue = (component) => {
   if (!isSignalComponent(component)) return null;
 
@@ -152,17 +173,27 @@ export const makeSignalFormFieldValue = (component) => {
   return knackFormatSignalOption;
 };
 
+/**
+ * Create the value for the phase autocomplete including phase metadata for dependent fields
+ * @param {Object} phase - The component phase record
+ * @returns {Object} the field value
+ */
 export const makePhaseFormFieldValue = (phase) => {
   return {
     value: phase?.phase_id,
     label: phase?.phase_name,
     data: {
-      // Include component metadata needed for subphase options that correspond with selected phase
+      // Include component phase metadata needed for subphase options that correspond with selected phase
       ...phase,
     },
   };
 };
 
+/**
+ * Create the value for the subphase autocomplete
+ * @param {Object} subphase - The component subphase record
+ * @returns {Object} the field value
+ */
 export const makeSubphaseFormFieldValue = (subphase) => {
   return {
     value: subphase?.subphase_id,
@@ -170,6 +201,11 @@ export const makeSubphaseFormFieldValue = (subphase) => {
   };
 };
 
+/**
+ * Create the value for the component tags field
+ * @param {Array} tags - The component tag records
+ * @returns {Object} the field value
+ */
 export const makeTagFormFieldValues = (tags) => {
   return tags.map((tag) => ({
     value: tag.component_tag_id,
@@ -274,10 +310,15 @@ export const ControlledAutocomplete = ({
   />
 );
 
-// TODO: Rename? This is only going to work on autocomplete or selects
-// because they have options with value and label
-// reset dependent field selections when parent field changes to ensure only valid options are available
-export const useResetDependentFieldOnParentChange = ({
+/**
+ * Watch parent field and reset dependent field to default value when parent field changes
+ * @param {Object} parentValue - Option object with value and label
+ * @param {string} dependentFieldName - Name of the dependent field
+ * @param {*} valueToSet - Any value to set the dependent field to
+ * @param {Function} setValue - React Hook Form setValue function
+ * @returns {Object} the field value
+ */
+export const useResetDependentFieldOnAutocompleteChange = ({
   parentValue,
   dependentFieldName,
   valueToSet,
@@ -290,6 +331,7 @@ export const useResetDependentFieldOnParentChange = ({
   // when the parent value changes, compare to previous value
   // if it is different, reset the dependent field to its default
   useEffect(() => {
+    // keep update from firing if the parent value hasn't changed
     if (parentValue?.value === previousParentFormValue?.value) return;
 
     setValue(dependentFieldName, valueToSet);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -179,8 +179,6 @@ export const makeSubphaseFormFieldValue = (component) => {
   };
 };
 
-// TODO: this breaks when using the state that is set in EditAttributesModal
-// TODO: this will be fixed when that state setting is removed and we refetch
 export const makeTagFormFieldValues = (tags) => {
   return tags.map((tag) => ({
     value: tag.component_tag_id,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -163,32 +163,24 @@ export const makePhaseFormFieldValue = (component) => {
   };
 };
 
+export const makeSubphaseFormFieldValue = (component) => {
+  return {
+    value: component?.moped_subphase?.subphase_id,
+    // if there is no matching subphase (e.g., you changed the phase), return null
+    label: component?.moped_subphase?.subphase_name,
+    data: {
+      // Include component subcomponents and metadata about the internal_table needed for the form
+      ...component?.moped_subphase,
+    },
+  };
+};
+
 export const useInitialValuesOnAttributesEdit = (
   initialFormValues,
   setValue,
-  subphaseOptions,
+  // subphaseOptions,
   componentTagsOptions
 ) => {
-  // Set the selected subphase after the subphase options are loaded
-  useEffect(() => {
-    if (!initialFormValues?.component?.moped_subphase) return;
-    if (subphaseOptions.length === 0) return;
-
-    setValue("subphase", {
-      value: initialFormValues.component?.moped_subphase?.subphase_id,
-      // if there is no matching subphase (e.g., you changed the phase), return null
-      label: subphaseOptions.find(
-        (option) =>
-          option.value ===
-          initialFormValues.component?.moped_subphase.subphase_id
-      )?.label,
-      data: {
-        // Include component subcomponents and metadata about the internal_table needed for the form
-        ...initialFormValues.component?.moped_subphase,
-      },
-    });
-  }, [subphaseOptions, initialFormValues, setValue]);
-
   // Set the datepicker value
   useEffect(() => {
     if (!initialFormValues) return;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { Autocomplete } from "@mui/material";
-import { Controller, useWatch } from "react-hook-form";
+import { Controller } from "react-hook-form";
 import { Icon, TextField } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { featureSignalsRecordToKnackSignalRecord } from "src/utils/signalComponentHelpers";
@@ -154,8 +154,8 @@ export const makeSignalFormFieldValue = (component) => {
 
 export const makePhaseFormFieldValue = (phase) => {
   return {
-    value: phase.phase_id,
-    label: phase.phase_name,
+    value: phase?.phase_id,
+    label: phase?.phase_name,
     data: {
       // Include component subphases and metadata about the internal_table needed for the form
       ...phase,
@@ -278,8 +278,31 @@ export const ControlledAutocomplete = ({
   />
 );
 
-export const useResetDependentFieldOnValueChange = ({ fieldName }) => {
-  const fieldValue = useWatch({ name: fieldName });
+export const useResetDependentFieldOnParentChange = ({
+  parentValue,
+  dependentFieldName,
+  valueToSet,
+  setValue,
+  valuePath,
+}) => {
+  // Track previous value to compare new value
+  const [previousParentFormValue, setPreviousParentValue] =
+    useState(parentValue);
 
-  console.log({ [fieldName]: fieldValue });
+  // when the parent value changes, compare to previous value
+  // if it is different, reset the dependent field to its default
+  useEffect(() => {
+    if (parentValue?.[valuePath] === previousParentFormValue?.[valuePath])
+      return;
+    console.log("parent changed", parentValue, previousParentFormValue);
+
+    setValue(dependentFieldName, valueToSet);
+    setPreviousParentValue(parentValue);
+  }, [
+    parentValue,
+    previousParentFormValue,
+    setValue,
+    dependentFieldName,
+    valueToSet,
+  ]);
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -133,8 +133,23 @@ export const makeComponentFormFieldValue = (component) => {
 export const makeSubcomponentsFormFieldValues = (subcomponents) => {
   return subcomponents.map((subcomponent) => ({
     value: subcomponent.subcomponent_id,
-    label: subcomponent.moped_subcomponent.subcomponent_name,
+    label: subcomponent.moped_subcomponent?.subcomponent_name,
   }));
+};
+
+// TODO: isn't there a isSignalComponent helper elsewhere?
+export const makeSignalFormFieldValue = (component) => {
+  const internalTable =
+    component?.moped_components?.feature_layer?.internal_table;
+  const isSignalComponent = internalTable === "feature_signals";
+
+  if (!isSignalComponent) return null;
+
+  const componentSignal = component?.feature_signals?.[0];
+  const knackFormatSignalOption =
+    featureSignalsRecordToKnackSignalRecord(componentSignal);
+
+  return knackFormatSignalOption;
 };
 
 export const useInitialValuesOnAttributesEdit = (
@@ -142,26 +157,8 @@ export const useInitialValuesOnAttributesEdit = (
   setValue,
   phaseOptions,
   subphaseOptions,
-  areSignalOptionsLoaded,
   componentTagsOptions
 ) => {
-  // Set the selected signal if this is a signal component
-  useEffect(() => {
-    if (!initialFormValues) return;
-    const internalTable =
-      initialFormValues.component?.moped_components?.feature_layer
-        ?.internal_table;
-    const isSignalComponent = internalTable === "feature_signals";
-    if (!isSignalComponent) return;
-    if (!areSignalOptionsLoaded) return;
-
-    const componentSignal = initialFormValues.component?.feature_signals?.[0];
-    const knackFormatSignalOption =
-      featureSignalsRecordToKnackSignalRecord(componentSignal);
-
-    setValue("signal", knackFormatSignalOption);
-  }, [initialFormValues, areSignalOptionsLoaded, setValue]);
-
   // Set the selected phase after the phase options are loaded
   useEffect(() => {
     if (!initialFormValues?.component?.moped_phase) return;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -278,12 +278,13 @@ export const ControlledAutocomplete = ({
   />
 );
 
+// TODO: Rename? This is only going to work on autocomplete or selects
+// because they have options with value and label
 export const useResetDependentFieldOnParentChange = ({
   parentValue,
   dependentFieldName,
   valueToSet,
   setValue,
-  valuePath,
 }) => {
   // Track previous value to compare new value
   const [previousParentFormValue, setPreviousParentValue] =
@@ -292,9 +293,7 @@ export const useResetDependentFieldOnParentChange = ({
   // when the parent value changes, compare to previous value
   // if it is different, reset the dependent field to its default
   useEffect(() => {
-    if (parentValue?.[valuePath] === previousParentFormValue?.[valuePath])
-      return;
-    console.log("parent changed", parentValue, previousParentFormValue);
+    if (parentValue?.value === previousParentFormValue?.value) return;
 
     setValue(dependentFieldName, valueToSet);
     setPreviousParentValue(parentValue);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -122,7 +122,7 @@ export const useComponentTagsOptions = (data) =>
 export const makeComponentFormFieldValue = (component) => {
   return {
     value: component.component_id,
-    label: component.moped_components.component_name,
+    label: makeComponentLabel(component.moped_components),
     data: {
       // Include component subcomponents and metadata about the internal_table needed for the form
       ...component.moped_components,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -178,16 +178,8 @@ export const makeSubphaseFormFieldValue = (component) => {
 export const useInitialValuesOnAttributesEdit = (
   initialFormValues,
   setValue,
-  // subphaseOptions,
   componentTagsOptions
 ) => {
-  // Set the datepicker value
-  useEffect(() => {
-    if (!initialFormValues) return;
-
-    setValue("completionDate", initialFormValues?.component?.completion_date);
-  }, [initialFormValues, setValue]);
-
   // Set the tags value
   useEffect(() => {
     if (!initialFormValues) return;
@@ -203,13 +195,6 @@ export const useInitialValuesOnAttributesEdit = (
 
     setValue("tags", selectedTags);
   }, [componentTagsOptions, initialFormValues, setValue]);
-
-  // Set the srts id value
-  useEffect(() => {
-    if (!initialFormValues) return;
-
-    setValue("srtsId", initialFormValues.srtsId);
-  }, [initialFormValues, setValue]);
 };
 
 const useComponentIconByLineRepresentationStyles = makeStyles(() => ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from "react";
+import { useMemo } from "react";
 import { Autocomplete } from "@mui/material";
 import { Controller } from "react-hook-form";
 import { Icon, TextField } from "@mui/material";
@@ -20,6 +20,10 @@ export const makeComponentLabel = ({ component_name, component_subtype }) => {
   return component_subtype
     ? `${component_name} - ${component_subtype}`
     : `${component_name}`;
+};
+
+export const makeComponentTagLabel = ({ type, name }) => {
+  return `${type} - ${name}`;
 };
 
 /**
@@ -112,7 +116,7 @@ export const useComponentTagsOptions = (data) =>
 
     const options = data.moped_component_tags.map((tag) => ({
       value: tag.id,
-      label: `${tag.type} - ${tag.name}`,
+      label: makeComponentTagLabel(tag),
       data: tag,
     }));
 
@@ -175,26 +179,13 @@ export const makeSubphaseFormFieldValue = (component) => {
   };
 };
 
-export const useInitialValuesOnAttributesEdit = (
-  initialFormValues,
-  setValue,
-  componentTagsOptions
-) => {
-  // Set the tags value
-  useEffect(() => {
-    if (!initialFormValues) return;
-    if (componentTagsOptions.length === 0) return;
-    if (initialFormValues.tags.length === 0) return;
-
-    const selectedTags = initialFormValues.tags.map((tag) => ({
-      value: tag.component_tag_id,
-      label: componentTagsOptions.find(
-        (option) => option.value === tag.component_tag_id
-      ).label,
-    }));
-
-    setValue("tags", selectedTags);
-  }, [componentTagsOptions, initialFormValues, setValue]);
+// TODO: this breaks when using the state that is set in EditAttributesModal
+// TODO: this will be fixed when that state setting is removed and we refetch
+export const makeTagFormFieldValues = (tags) => {
+  return tags.map((tag) => ({
+    value: tag.component_tag_id,
+    label: makeComponentTagLabel(tag.moped_component_tag),
+  }));
 };
 
 const useComponentIconByLineRepresentationStyles = makeStyles(() => ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -4,6 +4,7 @@ import { Controller } from "react-hook-form";
 import { Icon, TextField } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { featureSignalsRecordToKnackSignalRecord } from "src/utils/signalComponentHelpers";
+import { isSignalComponent } from "./componentList";
 import {
   RoomOutlined as RoomOutlinedIcon,
   Timeline as TimelineIcon,
@@ -141,13 +142,8 @@ export const makeSubcomponentsFormFieldValues = (subcomponents) => {
   }));
 };
 
-// TODO: isn't there a isSignalComponent helper elsewhere?
 export const makeSignalFormFieldValue = (component) => {
-  const internalTable =
-    component?.moped_components?.feature_layer?.internal_table;
-  const isSignalComponent = internalTable === "feature_signals";
-
-  if (!isSignalComponent) return null;
+  if (!isSignalComponent(component)) return null;
 
   const componentSignal = component?.feature_signals?.[0];
   const knackFormatSignalOption =
@@ -167,14 +163,13 @@ export const makePhaseFormFieldValue = (phase) => {
   };
 };
 
-export const makeSubphaseFormFieldValue = (component) => {
+export const makeSubphaseFormFieldValue = (subphase) => {
   return {
-    value: component?.moped_subphase?.subphase_id,
-    // if there is no matching subphase (e.g., you changed the phase), return null
-    label: component?.moped_subphase?.subphase_name,
+    value: subphase?.subphase_id,
+    label: subphase?.subphase_name,
     data: {
       // Include component subcomponents and metadata about the internal_table needed for the form
-      ...component?.moped_subphase,
+      ...subphase,
     },
   };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -167,10 +167,10 @@ export const makeSubphaseFormFieldValue = (subphase) => {
   return {
     value: subphase?.subphase_id,
     label: subphase?.subphase_name,
-    data: {
-      // Include component subcomponents and metadata about the internal_table needed for the form
-      ...subphase,
-    },
+    // data: {
+    //   // Include component subcomponents and metadata about the internal_table needed for the form
+    //   ...subphase,
+    // },
   };
 };
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Autocomplete } from "@mui/material";
-import { Controller } from "react-hook-form";
+import { Controller, useWatch } from "react-hook-form";
 import { Icon, TextField } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { featureSignalsRecordToKnackSignalRecord } from "src/utils/signalComponentHelpers";
@@ -277,3 +277,9 @@ export const ControlledAutocomplete = ({
     )}
   />
 );
+
+export const useResetDependentFieldOnValueChange = ({ fieldName }) => {
+  const fieldValue = useWatch({ name: fieldName });
+
+  console.log({ [fieldName]: fieldValue });
+};

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -201,13 +201,6 @@ export const useInitialValuesOnAttributesEdit = (
     });
   }, [subphaseOptions, initialFormValues, setValue]);
 
-  // Set the description value
-  useEffect(() => {
-    if (!initialFormValues) return;
-
-    setValue("description", initialFormValues.description);
-  }, [initialFormValues, setValue]);
-
   // Set the datepicker value
   useEffect(() => {
     if (!initialFormValues) return;

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -179,6 +179,8 @@ export const makeSignalFormFieldValue = (component) => {
  * @returns {Object} the field value
  */
 export const makePhaseFormFieldValue = (phase) => {
+  if (!phase) return null;
+
   return {
     value: phase?.phase_id,
     label: phase?.phase_name,
@@ -195,6 +197,8 @@ export const makePhaseFormFieldValue = (phase) => {
  * @returns {Object} the field value
  */
 export const makeSubphaseFormFieldValue = (subphase) => {
+  if (!subphase) return null;
+
   return {
     value: subphase?.subphase_id,
     label: subphase?.subphase_name,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeFeatureCollections.js
@@ -47,7 +47,7 @@ export const getAllComponentFeatures = (component) => {
  */
 export const useComponentFeatureCollection = (component) =>
   useMemo(() => {
-    if (component === null)
+    if (!component)
       return {
         type: "FeatureCollection",
         features: [],


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11612

This PR updates the component attributes edit form to fix an issue where the previous values briefly flashed in the UI when saving. I included a diagram of the refactor but it comes down to updating the UI through the new edits through the same channel that the initial data comes through. This PR also pulls out all of the data prep for the form fields out of a custom hook and into individual helpers.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Through a project's Map tab, create a signal component (Signal - PHB or Signal - Traffic) and another non-signal component with all parts of the component form filled in
2. Edit these attributes and make sure the previous values don't show as the modal is closing
3. Try creating other components with different combinations of attributes filled in the form
4. Edit the components to make sure:
   - the form will not let you submit without selecting a component type
   - the form will not let you submit without selecting a signal type if you choose a signal component
   - all of the fields that you added when creating a component are shown in the form when you edit a component
   - the submit button is disabled until you make a change from the initial value of a field

![change](https://github.com/cityofaustin/atd-moped/assets/37249039/b143f7ae-dc6c-42cc-8237-c7b0488e1351)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable


