### PR TITLE
Adds Office of Performance Management workgroup

### DIFF
--- a/moped-database/migrations/1688663620552_add_opm_workgroup/down.sql
+++ b/moped-database/migrations/1688663620552_add_opm_workgroup/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM moped_workgroup WHERE workgroup_name = 'Office of Performance Management';

--- a/moped-database/migrations/1688663620552_add_opm_workgroup/up.sql
+++ b/moped-database/migrations/1688663620552_add_opm_workgroup/up.sql
@@ -1,0 +1,2 @@
+INSERT INTO moped_workgroup (workgroup_name, department_id, workgroup_abbreviation)
+        values('Office of Performance Management', 1, 'OPM');


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12726

This is a quick fix to get OPM into Moped so I can issue a few new accounts. The workgroups/entities/departments data model is quite a mess, which is why I am not touching ATD/PWD/TPW in this PR.

## Testing
**URL to test:** Local

**Steps to test:**
1. Navigate to the staff form
2. In the workgroup field, observe **Office of Performance Management** as an option.

<img width="1143" alt="Screenshot 2023-07-06 at 1 38 42 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/e04b799e-6449-41b8-a7a6-7de22f88aa76">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
