### PR TITLE
Add data dictionary link to mobile nav and make parent project name full-width

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -30,22 +30,22 @@ import emailToInitials from "../../../utils/emailToInitials";
 export const helpItems = [
   {
     linkType: "external",
-    href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D",
+    link: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D",
     title: "Report a bug ",
   },
   {
     linkType: "external",
-    href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Moped%22%7D",
+    link: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Moped%22%7D",
     title: "Request an enhancement ",
   },
   {
     linkType: "external",
-    href: "https://teams.microsoft.com/l/channel/19%3ab1179ddfc92d44ea9abb23db713eb60c%40thread.tacv2/General?groupId=54a90854-d3fa-4053-9173-5352715bab37&tenantId=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f",
+    link: "https://teams.microsoft.com/l/channel/19%3ab1179ddfc92d44ea9abb23db713eb60c%40thread.tacv2/General?groupId=54a90854-d3fa-4053-9173-5352715bab37&tenantId=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f",
     title: "Ask a question ",
   },
   {
     linkType: "external",
-    href: "https://atd-dts.gitbook.io/moped/",
+    link: "https://atd-dts.gitbook.io/moped/",
     title: "Moped user guide ",
   },
   {
@@ -141,12 +141,12 @@ const DropdownMenu = ({
         {helpItems.map((item) => {
           if (item.linkType === "external") {
             return (
-              <MenuItem key={item.href} onClick={handleDropdownClose}>
+              <MenuItem key={item.link} onClick={handleDropdownClose}>
                 <ListItemIcon>
                   {item.Icon || <OpenInNewIcon fontSize="small" />}
                 </ListItemIcon>
                 <Link
-                  href={item.href}
+                  href={item.link}
                   target="_blank"
                   rel="noopener noreferrer"
                   color="inherit"
@@ -160,6 +160,7 @@ const DropdownMenu = ({
           if (item.linkType === "internal") {
             return (
               <MenuItem
+                key={item.link}
                 className={classes.helpItems}
                 onClick={() => {
                   handleDropdownClose();

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -19,6 +19,14 @@ import { getSessionDatabaseData, useUser } from "../../../auth/user";
 import { getInitials } from "src/utils/userNames";
 import emailToInitials from "../../../utils/emailToInitials";
 
+/**
+ * Configuration for help menu items we iterate to render menu items in DropdownMenu and MobileDropdownMenu
+ * @property {string} linkType - "internal" or "external" to determine how to render link
+ * @property {string} href - URL to link to if linkType is "external"
+ * @property {string} link - URL to link to if linkType is "internal"
+ * @property {string} title - Text to display for menu item
+ * @property {JSX.Element} Icon - Icon to display for menu item in place of the default OpenInNewIcon
+ */
 export const helpItems = [
   {
     linkType: "external",
@@ -165,6 +173,7 @@ const DropdownMenu = ({
               </MenuItem>
             );
           }
+          return null;
         })}
         <Divider />
         <MenuItem

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -22,8 +22,7 @@ import emailToInitials from "../../../utils/emailToInitials";
 /**
  * Configuration for help menu items we iterate to render menu items in DropdownMenu and MobileDropdownMenu
  * @property {string} linkType - "internal" or "external" to determine how to render link
- * @property {string} href - URL to link to if linkType is "external"
- * @property {string} link - URL to link to if linkType is "internal"
+ * @property {string} link - external href or internal route
  * @property {string} title - Text to display for menu item
  * @property {JSX.Element} Icon - Icon to display for menu item in place of the default OpenInNewIcon
  */

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -1,32 +1,50 @@
 import React from "react";
-import { Button, Divider, Link, Menu, MenuItem, Typography, ListItemIcon } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import {
+  Button,
+  Divider,
+  Link,
+  Menu,
+  MenuItem,
+  Typography,
+  ListItemIcon,
+} from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
 import { useNavigate } from "react-router-dom";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import MenuIcon from "@mui/icons-material/Menu";
+import MenuBookOutlined from "@mui/icons-material/MenuBookOutlined";
 import CDNAvatar from "../../../components/CDN/Avatar";
 import { getSessionDatabaseData, useUser } from "../../../auth/user";
 import { getInitials } from "src/utils/userNames";
 import emailToInitials from "../../../utils/emailToInitials";
-import clsx from "clsx";
 
 export const helpItems = [
   {
+    linkType: "external",
     href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Moped%22%7D",
     title: "Report a bug ",
   },
   {
+    linkType: "external",
     href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Moped%22%7D",
     title: "Request an enhancement ",
   },
   {
+    linkType: "external",
     href: "https://teams.microsoft.com/l/channel/19%3ab1179ddfc92d44ea9abb23db713eb60c%40thread.tacv2/General?groupId=54a90854-d3fa-4053-9173-5352715bab37&tenantId=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f",
     title: "Ask a question ",
   },
   {
+    linkType: "external",
     href: "https://atd-dts.gitbook.io/moped/",
     title: "Moped user guide ",
+  },
+  {
+    linkType: "internal",
+    link: "/moped/dev/lookups",
+    title: "Data Dictionary",
+    Icon: <MenuBookOutlined fontSize="small" />,
   },
 ];
 
@@ -52,9 +70,6 @@ const useStyles = makeStyles((theme) => ({
   },
   helpItems: {
     paddingBottom: "12px",
-  },
-  materialSymbol: {
-    fontSize: "1.25rem",
   },
 }));
 
@@ -115,44 +130,42 @@ const DropdownMenu = ({
             Support
           </Typography>
         </span>
-        {helpItems.map((item) => (
-          <MenuItem key={item.href} onClick={handleDropdownClose}>
-            <ListItemIcon>
-              <OpenInNewIcon fontSize="small" />
-            </ListItemIcon>
-            <Link
-              href={item.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              color="inherit"
-              underline="none"
-            >
-              {item.title}
-            </Link>
-          </MenuItem>
-        ))}
-        <MenuItem
-          className={classes.helpItems}
-          onClick={() => {
-            handleDropdownClose();
-            navigate("/moped/dev/lookups");
-          }}
-        >
-          <ListItemIcon>
-            {
-              // todo clsx to make this more
-            }
-            <span
-              className={clsx(
-                classes.materialSymbol,
-                "material-symbols-outlined"
-              )}
-            >
-              menu_book
-            </span>
-          </ListItemIcon>
-          Data Dictionary
-        </MenuItem>
+        {helpItems.map((item) => {
+          if (item.linkType === "external") {
+            return (
+              <MenuItem key={item.href} onClick={handleDropdownClose}>
+                <ListItemIcon>
+                  {item.Icon || <OpenInNewIcon fontSize="small" />}
+                </ListItemIcon>
+                <Link
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="inherit"
+                  underline="none"
+                >
+                  {item.title}
+                </Link>
+              </MenuItem>
+            );
+          }
+          if (item.linkType === "internal") {
+            return (
+              <MenuItem
+                className={classes.helpItems}
+                onClick={() => {
+                  handleDropdownClose();
+                  navigate(item.link);
+                }}
+              >
+                <ListItemIcon>
+                  {item.Icon || <OpenInNewIcon fontSize="small" />}
+                </ListItemIcon>
+                {item.title}
+              </MenuItem>
+            );
+          }
+        })}
         <Divider />
         <MenuItem
           className={classes.logoutItem}

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -62,10 +62,10 @@ const MobileDropdownMenu = () => {
       >
         {navigationItems.map((item) => (
           <MenuItem
-            key={item.href}
+            key={item.link}
             onClick={() => {
               handleMobileClose();
-              navigate(item.href);
+              navigate(item.link);
             }}
           >
             {item.title}
@@ -78,11 +78,12 @@ const MobileDropdownMenu = () => {
         {subMenu && (
           <div className={classes.subMenu}>
             {helpItems.map((item) => {
+              console.log(item.linkType, item.link);
               if (item.linkType === "external") {
                 return (
-                  <MenuItem key={item.href} onClick={handleMobileClose}>
+                  <MenuItem key={item.link} onClick={handleMobileClose}>
                     <Link
-                      href={item.href}
+                      href={item.link}
                       target="_blank"
                       rel="noopener noreferrer"
                       color="inherit"
@@ -96,6 +97,7 @@ const MobileDropdownMenu = () => {
               if (item.linkType === "internal") {
                 return (
                   <MenuItem
+                    key={item.link}
                     onClick={() => {
                       handleMobileClose();
                       navigate(item.link);

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -105,6 +105,7 @@ const MobileDropdownMenu = () => {
                   </MenuItem>
                 );
               }
+              return null;
             })}
           </div>
         )}

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -77,19 +77,35 @@ const MobileDropdownMenu = () => {
         </MenuItem>
         {subMenu && (
           <div className={classes.subMenu}>
-            {helpItems.map((item) => (
-              <MenuItem key={item.href} onClick={handleMobileClose}>
-                <Link
-                  href={item.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  color="inherit"
-                  underline="none"
-                >
-                  {item.title}
-                </Link>
-              </MenuItem>
-            ))}
+            {helpItems.map((item) => {
+              if (item.linkType === "external") {
+                return (
+                  <MenuItem key={item.href} onClick={handleMobileClose}>
+                    <Link
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      color="inherit"
+                      underline="none"
+                    >
+                      {item.title}
+                    </Link>
+                  </MenuItem>
+                );
+              }
+              if (item.linkType === "internal") {
+                return (
+                  <MenuItem
+                    onClick={() => {
+                      handleMobileClose();
+                      navigate(item.link);
+                    }}
+                  >
+                    {item.title}
+                  </MenuItem>
+                );
+              }
+            })}
           </div>
         )}
         <MenuItem

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -62,7 +62,7 @@ const MobileDropdownMenu = () => {
       >
         {navigationItems.map((item) => (
           <MenuItem
-            key={item.link}
+            key={item.href}
             onClick={() => {
               handleMobileClose();
               navigate(item.link);
@@ -78,7 +78,6 @@ const MobileDropdownMenu = () => {
         {subMenu && (
           <div className={classes.subMenu}>
             {helpItems.map((item) => {
-              console.log(item.linkType, item.link);
               if (item.linkType === "external") {
                 return (
                   <MenuItem key={item.link} onClick={handleMobileClose}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -16,12 +16,7 @@ const ProjectSummaryParentProjectLink = ({ data, classes }) => {
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Typography className={classes.fieldLabel}>Parent project</Typography>
-      <Box
-        display="flex"
-        justifyContent="flex-start"
-        className={classes.fieldBox}
-        alignItems="center"
-      >
+      <Box className={classes.fieldBox}>
         <RouterLink
           id="projectKnackSyncLink"
           to={`/moped/projects/${parentProjectId}`}


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12485
https://github.com/cityofaustin/atd-data-tech/issues/12377

This updates the mobile navigation with the data dictionary link. I might have gone a bit overboard on reusing the config for both and handling internal vs. external links, but I wanted to give it a shot. I also fixed the issue with the parent project name link not using the full width available to it.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1077--atd-moped-main.netlify.app/

**Steps to test:**
1. Test the navigation bar help links in mobile and desktop widths to make sure they still go to the right places
2. Add a parent project to a project and then update the parent project's name to something really long like `Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1 Demo Project #1`. It should take up the full width available to it and wrap below.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
