### PR TITLE
[Enhancement] Refinements to project summary status update

### DIFF
--- a/moped-editor/src/utils/dateAndTime.js
+++ b/moped-editor/src/utils/dateAndTime.js
@@ -76,7 +76,7 @@ const MILLS_CONVERSION = {
  * Format millseconds into a relative description
  * @param {integer} millsElapsed - the elapsed time in milliseconds to format
  * @param {string} unitName - the name of the units to convert to - the string must
- * be defined in the MILLS_CONVERSION objeect
+ * be defined in the MILLS_CONVERSION object
  * @returns {string} in format  `<value> <unit-name> ago`
  */
 const formatRelativeTime = (millsElapsed, unitName) => {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -60,6 +60,12 @@ const useStyles = makeStyles((theme) => ({
     fontSize: ".8rem",
     paddingLeft: theme.spacing(0.5),
   },
+  fieldLabelSmall: {
+    width: "100%",
+    color: theme.palette.text.secondary,
+    fontSize: ".7rem",
+    paddingLeft: theme.spacing(0.5),
+  },
   fieldLabelText: {
     width: "calc(100% - 2rem)",
     paddingLeft: theme.spacing(0.5),

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -76,10 +76,6 @@ const useStyles = makeStyles((theme) => ({
     },
     overflowWrap: "break-word",
   },
-  fieldAuthor: {
-    marginRight: ".25rem",
-    fontSize: ".8rem",
-  },
   knackFieldLabelText: {
     width: "calc(100% - 2rem)",
     cursor: "pointer",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -73,7 +73,6 @@ const useStyles = makeStyles((theme) => ({
   fieldAuthor: {
     marginRight: ".25rem",
     fontSize: ".8rem",
-    fontWeight: "bold",
   },
   knackFieldLabelText: {
     width: "calc(100% - 2rem)",

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -51,7 +51,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
             <div>
               <div>{parse(String(statusUpdate))}</div>
               <span className={classes.fieldAuthor}>{addedBy}</span>
-              <span className={classes.fieldLabel}>{dateCreated}</span>
+              <span className={classes.fieldLabelSmall}>{dateCreated}</span>
             </div>
           )}
         </DashboardStatusModal>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -3,9 +3,9 @@ import React from "react";
 import { Box, Grid, Typography } from "@mui/material";
 import parse from "html-react-parser";
 
-import { makeUSExpandedFormDateFromTimeStampTZ } from "../../../../utils/dateAndTime";
 import DashboardStatusModal from "src/views/dashboard/DashboardStatusModal";
 import { getUserFullName } from "src/utils/userNames";
+import { formatRelativeDate } from "src/utils/dateAndTime";
 
 /**
  * ProjectSummaryStatusUpdate Component
@@ -24,9 +24,9 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
   const currentPhaseId =
     data.moped_project[0].moped_proj_phases[0]?.moped_phase.phase_id;
 
-  const dateCreated = makeUSExpandedFormDateFromTimeStampTZ(
+  const dateCreated = formatRelativeDate(
     data.moped_project[0].moped_proj_notes[0]?.date_created
-  ).toUpperCase();
+  );
 
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
@@ -51,11 +51,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
             <div>
               <div>{parse(String(statusUpdate))}</div>
               <span className={classes.fieldAuthor}>{addedBy}</span>
-              <span className={classes.fieldLabel}>
-                {makeUSExpandedFormDateFromTimeStampTZ(
-                  dateCreated
-                ).toUpperCase()}
-              </span>
+              <span className={classes.fieldLabel}>{dateCreated}</span>
             </div>
           )}
         </DashboardStatusModal>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -50,8 +50,9 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
           {!!statusUpdate && (
             <div>
               <div>{parse(String(statusUpdate))}</div>
-              <span className={classes.fieldAuthor}>{addedBy}</span>
-              <span className={classes.fieldLabelSmall}>{dateCreated}</span>
+              <span className={classes.fieldLabelSmall}>
+                {addedBy} - {dateCreated}
+              </span>
             </div>
           )}
         </DashboardStatusModal>

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(2),
   },
   title: {
-    height: "3rem",
+    minHeight: "3rem",
   },
   moreHorizontal: {
     fontSize: "2rem",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/12832 -- format long titles
https://github.com/cityofaustin/atd-data-tech/issues/10596 -- style changes to project summary status updates

## Testing
**URL to test:** 

https://deploy-preview-1079--atd-moped-main.netlify.app/moped/projects/1950

**Steps to test:**

Project 1950 has a super long title, check to see that the title doesnt overlap with the project tabs
The status update author's name shouldn't be bolded, and the timestamp should be relative to now. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
