### PR TITLE
Fixes non-login user editing

### DIFF
--- a/moped-editor/src/queries/staff.js
+++ b/moped-editor/src/queries/staff.js
@@ -25,7 +25,6 @@ export const GET_USER = gql`
       first_name
       is_coa_staff
       last_name
-      staff_uuid
       title
       user_id
       workgroup_id
@@ -46,7 +45,6 @@ export const ADD_NON_MOPED_USER = gql`
       date_added
       first_name
       last_name
-      staff_uuid
       title
       user_id
       moped_workgroup {
@@ -66,7 +64,6 @@ export const UPDATE_NON_MOPED_USER = gql`
       date_added
       first_name
       last_name
-      staff_uuid
       title
       user_id
       moped_workgroup {

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivitiesTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivitiesTable.js
@@ -154,7 +154,7 @@ const ProjectWorkActivitiesTable = () => {
                   startIcon={<AddCircleIcon />}
                   onClick={props.action.onClick}
                 >
-                  Add Contract
+                  Add Work
                 </Button>
               );
             }

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -257,6 +257,7 @@ const StaffForm = ({
                 render={({ field }) => (
                   <Select
                     {...field}
+                    value={field.value || ""}
                     variant="outlined"
                     id="workgroup_id"
                     labelId="workgroup-label"

--- a/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
+++ b/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
@@ -58,9 +58,8 @@ const NonLoginUserActivationButtons = ({
     });
   };
 
-  const handleUpdateNonLoginUser = () => {
-    const { password, ...restOfFormValues } = formValues;
-
+  const handleUpdateNonLoginUser = async () => {
+    const { password, __typename, ...restOfFormValues } = formValues;
     updateNonMopedUser({
       variables: {
         userId: userId,


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13153'

This also resolves a bug i created [here](https://github.com/cityofaustin/atd-moped/pull/1085/files#diff-0aaf9775780004fb06632bc543b836ac98b0f690c74ec3f8862609e75749094e) which broke the users query. Sorry I missed this 😑 

## Testing
**URL to test:**  [Netlify](https://deploy-preview-1087--atd-moped-main.netlify.app/) or local

**Steps to test:**
1. Go to the staff page and create a non-login user
2. Edit that user by changing the name or workgroup
3. ☝️ please do not edit any users you did not create — the staging user pool needs to stay in sync with the access DB for the migration.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
