### PR TITLE
[BUG] Long project names overflow component list + map

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     zIndex: theme.zIndex.drawer + 1,
   },
   toolbarContainer: {
-    backgroundColor: "#fff",
+    backgroundColor: theme.palette.background.paper,
   },
 }));
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
@@ -1,4 +1,4 @@
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
@@ -13,6 +13,10 @@ import { useNavigate, useParams } from "react-router";
 const useStyles = makeStyles((theme) => ({
   appBar: {
     zIndex: theme.zIndex.drawer + 1,
+    backgroundColor: "#1493dd",
+  },
+  toolbarContainer: {
+    backgroundColor: "#fff",
   },
 }));
 
@@ -30,7 +34,7 @@ export default function ComponentMapToolbar({
 
   return (
     <AppBar position="fixed" className={classes.appBar}>
-      <Toolbar style={{ backgroundColor: "#fff" }}>
+      <Toolbar className={classes.toolbarContainer}>
         <Box mr={2}>
           <ProjectName name={projectName} id={projectId} />
         </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentMapToolbar.js
@@ -13,7 +13,6 @@ import { useNavigate, useParams } from "react-router";
 const useStyles = makeStyles((theme) => ({
   appBar: {
     zIndex: theme.zIndex.drawer + 1,
-    backgroundColor: "#1493dd",
   },
   toolbarContainer: {
     backgroundColor: "#fff",

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles(() => ({
   titleText: {
     // textOverflow: "ellipsis",
     textWrap: "nowrap",
-    maxWidth: "800px", // this needs to match the width of teh screen dynamically
+    maxWidth: "calc(100vw - 450px)", // visible width minus space for project id, status and close map
     overflow: "scroll",
   },
   titleId: {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
@@ -1,9 +1,12 @@
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import { Typography } from "@mui/material";
 
 const useStyles = makeStyles(() => ({
   titleDisplayField: {
     display: "flex",
+  },
+  titleId: {
+    alignSelf: "center",
   },
 }));
 
@@ -15,7 +18,11 @@ const ProjectName = ({ name, id }) => {
       <Typography color="textPrimary" variant="h1">
         {name}
       </Typography>
-      <Typography color="textSecondary" variant="h1">
+      <Typography
+        color="textSecondary"
+        variant="h1"
+        className={classes.titleId}
+      >
         &nbsp;#{id}
       </Typography>
     </span>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
@@ -5,6 +5,12 @@ const useStyles = makeStyles(() => ({
   titleDisplayField: {
     display: "flex",
   },
+  titleText: {
+    // textOverflow: "ellipsis",
+    textWrap: "nowrap",
+    maxWidth: "800px", // this needs to match the width of teh screen dynamically
+    overflow: "scroll",
+  },
   titleId: {
     alignSelf: "center",
   },
@@ -15,7 +21,11 @@ const ProjectName = ({ name, id }) => {
 
   return (
     <span className={classes.titleDisplayField}>
-      <Typography color="textPrimary" variant="h1">
+      <Typography
+        color="textPrimary"
+        variant="h1"
+        className={classes.titleText}
+      >
         {name}
       </Typography>
       <Typography

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectName.js
@@ -6,10 +6,10 @@ const useStyles = makeStyles(() => ({
     display: "flex",
   },
   titleText: {
-    // textOverflow: "ellipsis",
+    textOverflow: "ellipsis",
     textWrap: "nowrap",
     maxWidth: "calc(100vw - 450px)", // visible width minus space for project id, status and close map
-    overflow: "scroll",
+    overflow: "hidden",
   },
   titleId: {
     alignSelf: "center",
@@ -23,14 +23,15 @@ const ProjectName = ({ name, id }) => {
     <span className={classes.titleDisplayField}>
       <Typography
         color="textPrimary"
-        variant="h1"
+        variant="h2"
         className={classes.titleText}
+        title={name}
       >
         {name}
       </Typography>
       <Typography
         color="textSecondary"
-        variant="h1"
+        variant="h2"
         className={classes.titleId}
       >
         &nbsp;#{id}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -69,7 +69,6 @@ export function useAppBarHeight() {
     mixins: { toolbar },
     breakpoints,
   } = useTheme();
-
   const toolbarDesktopQuery = breakpoints.up("sm");
   const toolbarLandscapeQuery = `${breakpoints.up(
     "xs"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -84,7 +84,6 @@ export function useAppBarHeight() {
   } else {
     currentToolbarMinHeight = toolbar;
   }
-  console.log(currentToolbarMinHeight)
 
   return currentToolbarMinHeight.minHeight;
 }

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/map.js
@@ -69,6 +69,7 @@ export function useAppBarHeight() {
     mixins: { toolbar },
     breakpoints,
   } = useTheme();
+
   const toolbarDesktopQuery = breakpoints.up("sm");
   const toolbarLandscapeQuery = `${breakpoints.up(
     "xs"
@@ -83,6 +84,7 @@ export function useAppBarHeight() {
   } else {
     currentToolbarMinHeight = toolbar;
   }
+  console.log(currentToolbarMinHeight)
 
   return currentToolbarMinHeight.minHeight;
 }

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -189,14 +189,14 @@ const ProjectNameEditable = (props) => {
           <span className={classes.titleDisplayField}>
             <Typography
               color="textPrimary"
-              variant="h1"
+              variant="h2"
               onClick={() => setIsEditing(true)}
             >
               {projectName}
             </Typography>
             <Typography
               color="textSecondary"
-              variant="h1"
+              variant="h2"
               className={classes.titleId}
             >
               &nbsp;#{props.projectId}

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import {
   Box,
   Grid,
@@ -9,7 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useMutation } from "@apollo/client";
-import { Alert } from '@mui/material';
+import { Alert } from "@mui/material";
 import { UPDATE_PROJECT_NAME_QUERY } from "../../../queries/project";
 
 /**
@@ -42,6 +42,9 @@ const useStyles = makeStyles((theme) => ({
   },
   boxField: {
     width: "100%",
+  },
+  titleId: {
+    alignSelf: "center",
   },
 }));
 
@@ -160,7 +163,8 @@ const ProjectNameEditable = (props) => {
                   classes: {
                     input: classes.titleEditField,
                   },
-                }} />
+                }}
+              />
             </Grid>
             <Grid item xs={12} sm={1} className={classes.fieldGridItemButtons}>
               <Icon
@@ -190,7 +194,11 @@ const ProjectNameEditable = (props) => {
             >
               {projectName}
             </Typography>
-            <Typography color="textSecondary" variant="h1">
+            <Typography
+              color="textSecondary"
+              variant="h1"
+              className={classes.titleId}
+            >
               &nbsp;#{props.projectId}
             </Typography>
           </span>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13129

## Testing
**URL to test:** 

https://deploy-preview-1089--atd-moped-main.netlify.app/moped/projects/1950?tab=map

**Steps to test:**

Look at the super long titled projects -- the map tab's titlebar should be the same size as titlebar on short project names and should not be overflowing on the component list or map. 

Try resizing the screen to confirm the title maxWidth shrinks so the project id and the phase chip and close map buttons are still visible at smaller sizes. 

Right now the title is scrollable horizontally, but it could also be ellipsis truncated. I put instructions in a comment on the files if you want to try that. If we like the scroll, ill clean up that part and remove the ellipsis part. 



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
