### PR TITLE
Adds work type select input to component form 

### DIFF
--- a/moped-database/migrations/1691181649099_alter_table_public_moped_proj_component_work_types_add_unique_project_component_id_work_type_id/down.sql
+++ b/moped-database/migrations/1691181649099_alter_table_public_moped_proj_component_work_types_add_unique_project_component_id_work_type_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_proj_component_work_types" drop constraint "moped_proj_component_work_types_project_component_id_work_type_id_key";

--- a/moped-database/migrations/1691181649099_alter_table_public_moped_proj_component_work_types_add_unique_project_component_id_work_type_id/up.sql
+++ b/moped-database/migrations/1691181649099_alter_table_public_moped_proj_component_work_types_add_unique_project_component_id_work_type_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_proj_component_work_types" add constraint "moped_proj_component_work_types_project_component_id_work_type_id_key" unique ("project_component_id", "work_type_id");

--- a/moped-database/migrations/1691442787520_refresh-component-work-types/down.sql
+++ b/moped-database/migrations/1691442787520_refresh-component-work-types/down.sql
@@ -1,0 +1,2 @@
+-- can't undo
+SELECT 0;

--- a/moped-database/migrations/1691442787520_refresh-component-work-types/up.sql
+++ b/moped-database/migrations/1691442787520_refresh-component-work-types/up.sql
@@ -1,0 +1,21 @@
+-- delete existing component work types
+DELETE FROM moped_component_work_types WHERE 1 = 1;
+
+-- for now, set new, mod, and maintenance as the allowed types for all components
+WITH inserts_todo AS (
+    SELECT
+        id AS work_type_id,
+        component_id
+    FROM (
+        values('new'),
+            ('modification'),
+            ('maintenance_repair')) AS data (work_type_key)
+        LEFT JOIN moped_components ON TRUE
+        LEFT JOIN moped_work_types mwt ON data.work_type_key = mwt.key
+    WHERE
+        moped_components.is_deleted = FALSE
+) INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    *
+FROM
+    inserts_todo;

--- a/moped-database/migrations/1691442787520_refresh-component-work-types/up.sql
+++ b/moped-database/migrations/1691442787520_refresh-component-work-types/up.sql
@@ -19,3 +19,48 @@ SELECT
     *
 FROM
     inserts_todo;
+
+-- add special work types for bike lanes
+WITH inserts_todo AS (
+    SELECT
+        id AS work_type_id,
+        component_id
+    FROM (
+        values('design_review'),
+            ('lane_conversion'),
+            ('parking_mod'),
+            ('reinstall'),
+            ('remove_bike_lane'),
+            ('remove_double_yellow')) AS data (work_type_key)
+        LEFT JOIN moped_components ON TRUE
+        LEFT JOIN moped_work_types mwt ON data.work_type_key = mwt.key
+    WHERE
+        moped_components.is_deleted = FALSE
+        AND lower(moped_components.component_name) = 'bike lane'
+) INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    *
+FROM
+    inserts_todo;
+
+-- add special work types for traffic signals and PHBs
+WITH inserts_todo AS (
+    SELECT
+        id AS work_type_id,
+        component_id
+    FROM (
+        values('construction_inspection'),
+            ('replacement'),
+            ('signal_take_over')) AS data (work_type_key)
+        LEFT JOIN moped_components ON TRUE
+        LEFT JOIN moped_work_types mwt ON data.work_type_key = mwt.key
+    WHERE
+        moped_components.is_deleted = FALSE
+        AND lower(moped_components.component_name) = 'signal'
+        AND(lower(moped_components.component_subtype) = 'traffic'
+            OR lower(moped_components.component_subtype) = 'phb')
+) INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    *
+FROM
+    inserts_todo;

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -21,6 +21,12 @@ export const GET_COMPONENTS_FORM_OPTIONS = gql`
           subcomponent_name
         }
       }
+      moped_component_work_types {
+        moped_work_type {
+          id
+          name
+        }
+      }
     }
     moped_phases(order_by: { phase_order: asc }) {
       phase_name
@@ -69,6 +75,12 @@ export const PROJECT_COMPONENT_FIELDS = gql`
       subcomponent_id
       moped_subcomponent {
         subcomponent_name
+      }
+    }
+    moped_proj_component_work_types(where: { is_deleted: { _eq: false } }) {
+      moped_work_type {
+        id
+        name
       }
     }
     moped_proj_component_tags(where: { is_deleted: { _eq: false } }) {
@@ -185,6 +197,7 @@ export const UPDATE_COMPONENT_ATTRIBUTES = gql`
     $projectComponentId: Int!
     $description: String!
     $subcomponents: [moped_proj_components_subcomponents_insert_input!]!
+    $workTypes: [moped_proj_component_work_types_insert_input!]!
     $phaseId: Int
     $subphaseId: Int
     $completionDate: timestamptz
@@ -192,6 +205,12 @@ export const UPDATE_COMPONENT_ATTRIBUTES = gql`
     $srtsId: String
   ) {
     update_moped_proj_components_subcomponents(
+      where: { project_component_id: { _eq: $projectComponentId } }
+      _set: { is_deleted: true }
+    ) {
+      affected_rows
+    }
+    update_moped_proj_component_work_types(
       where: { project_component_id: { _eq: $projectComponentId } }
       _set: { is_deleted: true }
     ) {
@@ -224,6 +243,15 @@ export const UPDATE_COMPONENT_ATTRIBUTES = gql`
     ) {
       affected_rows
     }
+    insert_moped_proj_component_work_types(
+      objects: $workTypes
+      on_conflict: {
+        constraint: moped_proj_component_work_types_project_component_id_work_type_
+        update_columns: [is_deleted]
+      }
+    ) {
+      affected_rows
+    }
     insert_moped_proj_component_tags(
       objects: $componentTags
       on_conflict: {
@@ -243,6 +271,7 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
     $projectComponentId: Int!
     $description: String!
     $subcomponents: [moped_proj_components_subcomponents_insert_input!]!
+    $workTypes: [moped_proj_component_work_types_insert_input!]!
     $signals: [feature_signals_insert_input!]!
     $phaseId: Int
     $subphaseId: Int
@@ -251,6 +280,12 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
     $srtsId: String
   ) {
     update_moped_proj_components_subcomponents(
+      where: { project_component_id: { _eq: $projectComponentId } }
+      _set: { is_deleted: true }
+    ) {
+      affected_rows
+    }
+    update_moped_proj_component_work_types(
       where: { project_component_id: { _eq: $projectComponentId } }
       _set: { is_deleted: true }
     ) {
@@ -284,6 +319,15 @@ export const UPDATE_SIGNAL_COMPONENT = gql`
       objects: $subcomponents
       on_conflict: {
         constraint: unique_component_and_subcomponent
+        update_columns: [is_deleted]
+      }
+    ) {
+      affected_rows
+    }
+    insert_moped_proj_component_work_types(
+      objects: $workTypes
+      on_conflict: {
+        constraint: moped_proj_component_work_types_project_component_id_work_type_
         update_columns: [is_deleted]
       }
     ) {

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -41,6 +41,13 @@ export const TABLE_LOOKUPS_QUERY = gql`
           subcomponent_name
         }
       }
+
+      moped_component_work_types(order_by: { moped_work_type: { name: asc } }) {
+        moped_work_type {
+          id
+          name
+        }
+      }
     }
     moped_tags(where: { is_deleted: { _eq: false } }, order_by: { name: asc }) {
       id

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -41,7 +41,6 @@ export const TABLE_LOOKUPS_QUERY = gql`
           subcomponent_name
         }
       }
-
       moped_component_work_types(order_by: { moped_work_type: { name: asc } }) {
         moped_work_type {
           id

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -30,6 +30,17 @@ const subComponentHandler = (subcomponents) =>
   ));
 
 /**
+ * Parses an array of component work types into an array of work type names
+ * @param {Object[]} workTypes - array of moped_work_types objects
+ * @returns { JSX } An array of <div>s with the work type name
+ */
+const workTypeHandler = (workTypes) =>
+  workTypes &&
+  workTypes.map((workType) => (
+    <div key={workType.moped_work_type.id}>{workType.moped_work_type.name}</div>
+  ));
+
+/**
  * Definitions for data tables.
  * @type { Object[]}  - An array of settings for data tables. Each object references a typename
  * returned from a Hasura query
@@ -78,6 +89,11 @@ export const SETTINGS = [
         key: "moped_components_subcomponents",
         label: "Subcomponents",
         handler: subComponentHandler,
+      },
+      {
+        key: "moped_component_work_types",
+        label: "Work types",
+        handler: workTypeHandler,
       },
     ],
   },

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -12,16 +12,17 @@ import {
 } from "@mui/material";
 import DateFieldEditComponent from "../DateFieldEditComponent";
 import { CheckCircle } from "@mui/icons-material";
-import { ControlledAutocomplete } from "./utils/form";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import SignalComponentAutocomplete from "./SignalComponentAutocomplete";
 import {
+  ControlledAutocomplete,
   ComponentOptionWithIcon,
   useComponentOptions,
   useSubcomponentOptions,
   usePhaseOptions,
   useSubphaseOptions,
   useComponentTagsOptions,
+  useWorkTypeOptions,
   useResetDependentFieldOnAutocompleteChange,
 } from "./utils/form";
 import * as yup from "yup";
@@ -98,6 +99,11 @@ const ComponentForm = ({
   const isSignalComponent = internalTable === "feature_signals";
   const componentTagsOptions = useComponentTagsOptions(optionsData);
 
+  const workTypeOptions = useWorkTypeOptions(
+    component?.value,
+    optionsData?.moped_components
+  );
+
   const subcomponentOptions = useSubcomponentOptions(
     component?.value,
     optionsData?.moped_components
@@ -150,6 +156,7 @@ const ComponentForm = ({
             control={control}
             autoFocus
             disabled={isEditingExistingComponent}
+            helperText="Required"
           />
         </Grid>
 
@@ -168,7 +175,16 @@ const ComponentForm = ({
             />
           </Grid>
         )}
-
+        <Grid item xs={12}>
+          <ControlledAutocomplete
+            id="work_type"
+            label="Work Type(s)"
+            multiple
+            options={workTypeOptions}
+            name="work_types"
+            control={control}
+          />
+        </Grid>
         {/* Hide unless there are subcomponents for the chosen component */}
         {(subcomponentOptions.length !== 0 ||
           doesInitialValueHaveSubcomponents) && (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -15,8 +15,8 @@ import { CheckCircle } from "@mui/icons-material";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
 import SignalComponentAutocomplete from "./SignalComponentAutocomplete";
 import {
-  ControlledAutocomplete,
   ComponentOptionWithIcon,
+  DEFAULT_COMPONENT_WORK_TYPE_OPTION,
   useComponentOptions,
   useSubcomponentOptions,
   usePhaseOptions,
@@ -25,6 +25,8 @@ import {
   useWorkTypeOptions,
   useResetDependentFieldOnAutocompleteChange,
 } from "./utils/form";
+import ControlledAutocomplete from "./ControlledAutocomplete";
+
 import * as yup from "yup";
 
 const defaultFormValues = {
@@ -35,6 +37,7 @@ const defaultFormValues = {
   tags: [],
   completionDate: null,
   description: "",
+  work_types: [DEFAULT_COMPONENT_WORK_TYPE_OPTION],
   signal: null,
   srtsId: "",
 };
@@ -47,6 +50,7 @@ const validationSchema = yup.object().shape({
   tags: yup.array().optional(),
   completionDate: yup.date().nullable().optional(),
   description: yup.string(),
+  work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
   signal: yup
     .object()
@@ -126,11 +130,19 @@ const ComponentForm = ({
     setValue,
   });
 
-  // todo: preserve allowed subcomponents when switching b/t component types
+  // todo: preserve subcomponent choices if allowed when switching b/t component types
   useResetDependentFieldOnAutocompleteChange({
     parentValue: watch("component"),
     dependentFieldName: "subcomponents",
     valueToSet: defaultFormValues.subcomponents,
+    setValue,
+  });
+
+  // todo: preserve work type if allowed when switching b/t component types
+  useResetDependentFieldOnAutocompleteChange({
+    parentValue: watch("component"),
+    dependentFieldName: "work_types",
+    valueToSet: defaultFormValues.work_types,
     setValue,
   });
 
@@ -183,6 +195,8 @@ const ComponentForm = ({
             options={workTypeOptions}
             name="work_types"
             control={control}
+            error={errors?.work_types}
+            helperText="Required"
           />
         </Grid>
         {/* Hide unless there are subcomponents for the chosen component */}
@@ -270,7 +284,6 @@ const ComponentForm = ({
                 options={phaseOptions}
                 name="phase"
                 control={control}
-                required
                 autoFocus
               />
             </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ControlledAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ControlledAutocomplete.js
@@ -43,7 +43,6 @@ export default function ControlledAutocomplete({
               label={label}
               variant="outlined"
               autoFocus={autoFocus}
-              //   helperText={error ? error.message : helperText}
               helperText={helperText}
               error={error}
             />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ControlledAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ControlledAutocomplete.js
@@ -1,0 +1,56 @@
+import { Autocomplete } from "@mui/material";
+import { Controller } from "react-hook-form";
+import { TextField } from "@mui/material";
+
+/**
+ * A react-hook-form wrapper of the MUI autocomplete component
+ * @return {JSX.Element}
+ */
+export default function ControlledAutocomplete({
+  id,
+  options,
+  renderOption,
+  name,
+  control,
+  label,
+  autoFocus = false,
+  multiple = false,
+  disabled,
+  helperText,
+  error,
+}) {
+  return (
+    <Controller
+      id={id}
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <Autocomplete
+          {...field}
+          options={options}
+          multiple={multiple}
+          getOptionLabel={(option) => option?.label || ""}
+          isOptionEqualToValue={(option, value) =>
+            option?.value === value?.value
+          }
+          renderOption={renderOption}
+          disabled={disabled}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              inputRef={field.ref}
+              size="small"
+              label={label}
+              variant="outlined"
+              autoFocus={autoFocus}
+              //   helperText={error ? error.message : helperText}
+              helperText={helperText}
+              error={error}
+            />
+          )}
+          onChange={(_event, option) => field.onChange(option)}
+        />
+      )}
+    />
+  );
+}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -41,6 +41,7 @@ const CreateComponentModal = ({
       subphase,
       completionDate,
       tags,
+      work_types,
       srtsId,
     } = formData;
 
@@ -51,6 +52,7 @@ const CreateComponentModal = ({
       line_representation,
       internal_table,
       moped_subcomponents: subcomponents,
+      work_types,
       description: description?.length > 0 ? description : null,
       phase_id: phase?.data.phase_id,
       subphase_id: subphase?.data.subphase_id,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -18,6 +18,7 @@ import {
   makePhaseFormFieldValue,
   makeSubphaseFormFieldValue,
   makeTagFormFieldValues,
+  makeWorkTypesFormFieldValues,
 } from "./utils/form";
 
 const useStyles = makeStyles((theme) => ({
@@ -51,7 +52,8 @@ const EditAttributesModal = ({
   const onSave = (formData) => {
     const isSavingSignalFeature = Boolean(formData.signal);
 
-    const { subcomponents, phase, subphase, tags } = formData;
+    const { subcomponents, phase, subphase, tags, work_types } = formData;
+
     const completionDate = !!phase ? formData.completionDate : null;
     const description =
       formData.description?.length > 0 ? formData.description : null;
@@ -63,6 +65,15 @@ const EditAttributesModal = ({
       ? subcomponents.map((subcomponent) => ({
           subcomponent_id: subcomponent.value,
           is_deleted: false, // Used for update on constraint in mutation
+          project_component_id: projectComponentId,
+        }))
+      : [];
+
+    // Prepare the work type data for the mutation
+    const workTypesArray = work_types
+      ? work_types.map((workType) => ({
+          work_type_id: workType.value,
+          is_deleted: false,
           project_component_id: projectComponentId,
         }))
       : [];
@@ -90,6 +101,7 @@ const EditAttributesModal = ({
           projectComponentId: projectComponentId,
           description,
           subcomponents: subcomponentsArray,
+          workTypes: workTypesArray,
           signals: [signalToInsert],
           phaseId: phase?.value,
           subphaseId: subphase?.value,
@@ -126,6 +138,7 @@ const EditAttributesModal = ({
           projectComponentId: projectComponentId,
           description,
           subcomponents: subcomponentsArray,
+          workTypes: workTypesArray,
           phaseId: phase?.value,
           subphaseId: subphase?.value,
           componentTags: tagsArray,
@@ -153,6 +166,9 @@ const EditAttributesModal = ({
             : "",
         subcomponents: makeSubcomponentsFormFieldValues(
           clickedComponent.moped_proj_components_subcomponents
+        ),
+        work_types: makeWorkTypesFormFieldValues(
+          clickedComponent.moped_proj_component_work_types
         ),
         signal: makeSignalFormFieldValue(clickedComponent),
         phase: makePhaseFormFieldValue(clickedComponent.moped_phase),

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -12,6 +12,12 @@ import {
 import theme from "src/theme/index";
 
 /**
+ * Allows the component work type to be default to `New` -
+ * this value matches the `moped_work_types.id` value in the DB.
+ */
+export const DEFAULT_COMPONENT_WORK_TYPE_OPTION = { value: 7, label: "New" };
+
+/**
  * Not all component type records have a value in the subtype column but let's concatenate them if they do
  * @param {string} component_name The name of the component
  * @param {string} component_subtype The name value in the component_subtype column of the component record
@@ -310,48 +316,6 @@ export const ComponentOptionWithIcon = ({ option, state, props }) => {
     </span>
   );
 };
-
-export const ControlledAutocomplete = ({
-  id,
-  options,
-  renderOption,
-  name,
-  control,
-  label,
-  autoFocus = false,
-  multiple = false,
-  disabled,
-  helperText,
-}) => (
-  <Controller
-    id={id}
-    name={name}
-    control={control}
-    render={({ field }) => (
-      <Autocomplete
-        {...field}
-        options={options}
-        multiple={multiple}
-        getOptionLabel={(option) => option?.label || ""}
-        isOptionEqualToValue={(option, value) => option?.value === value?.value}
-        renderOption={renderOption}
-        disabled={disabled}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            inputRef={field.ref}
-            size="small"
-            label={label}
-            variant="outlined"
-            autoFocus={autoFocus}
-            helperText={helperText}
-          />
-        )}
-        onChange={(_event, option) => field.onChange(option)}
-      />
-    )}
-  />
-);
 
 /**
  * Watch parent field and reset dependent field to default value when parent field changes

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,7 +1,5 @@
 import { useMemo, useEffect, useState } from "react";
-import { Autocomplete } from "@mui/material";
-import { Controller } from "react-hook-form";
-import { Icon, TextField } from "@mui/material";
+import { Icon } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { featureSignalsRecordToKnackSignalRecord } from "src/utils/signalComponentHelpers";
 import { isSignalComponent } from "./componentList";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -77,6 +77,31 @@ export const useSubcomponentOptions = (componentId, optionsData) =>
   }, [componentId, optionsData]);
 
 /**
+ * Take the data nested in the chosen moped_components option and produce a list of work type options (if there are some)
+ * for a MUI autocomplete
+ * @param {Integer} componentId The unique ID of the moped_component
+ * @param {Object[]} optionsData And array of moped_components records
+ * @returns {Array} The work type options with value and label
+ */
+export const useWorkTypeOptions = (componentId, optionsData) =>
+  useMemo(() => {
+    if (!componentId || !optionsData) return [];
+
+    const workTypes = optionsData.find(
+      (option) => option.component_id === componentId
+    )?.moped_component_work_types;
+
+    if (!workTypes) return [];
+
+    const options = workTypes.map((workType) => ({
+      value: workType.moped_work_type.id,
+      label: workType.moped_work_type.name,
+    }));
+
+    return options;
+  }, [componentId, optionsData]);
+
+/**
  * Take the moped_phases records data response and create options for a MUI autocomplete
  * @param {Object} data Data returned with moped_phases records
  * @returns {Array} The options with value, label, and full data object to produce the phases options
@@ -155,6 +180,18 @@ export const makeSubcomponentsFormFieldValues = (subcomponents) => {
   return subcomponents.map((subcomponent) => ({
     value: subcomponent.subcomponent_id,
     label: subcomponent.moped_subcomponent?.subcomponent_name,
+  }));
+};
+
+/**
+ * Create the values for the work types autocomplete
+ * @param {Array} workTypes - The work type records
+ * @returns {Object} the field value
+ */
+export const makeWorkTypesFormFieldValues = (workTypes) => {
+  return workTypes.map((workType) => ({
+    value: workType.moped_work_type.id,
+    label: workType.moped_work_type.name,
   }));
 };
 
@@ -284,6 +321,7 @@ export const ControlledAutocomplete = ({
   autoFocus = false,
   multiple = false,
   disabled,
+  helperText,
 }) => (
   <Controller
     id={id}
@@ -306,6 +344,7 @@ export const ControlledAutocomplete = ({
             label={label}
             variant="outlined"
             autoFocus={autoFocus}
+            helperText={helperText}
           />
         )}
         onChange={(_event, option) => field.onChange(option)}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -10,7 +10,7 @@ import {
 import theme from "src/theme/index";
 
 /**
- * Allows the component work type to be default to `New` -
+ * Allows the component work type to be defaulted to `New` -
  * this value matches the `moped_work_types.id` value in the DB.
  */
 export const DEFAULT_COMPONENT_WORK_TYPE_OPTION = { value: 7, label: "New" };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeComponentData.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/makeComponentData.js
@@ -18,6 +18,7 @@ export const makeComponentInsertData = (projectId, component) => {
     component_id,
     description,
     moped_subcomponents,
+    work_types,
     phase_id,
     subphase_id,
     completion_date,
@@ -30,6 +31,12 @@ export const makeComponentInsertData = (projectId, component) => {
   const subcomponentsArray = moped_subcomponents
     ? moped_subcomponents.map((subcomponent) => ({
         subcomponent_id: subcomponent.value,
+      }))
+    : [];
+
+  const workTypesArray = work_types
+    ? work_types.map((workType) => ({
+        work_type_id: workType.value,
       }))
     : [];
 
@@ -80,6 +87,9 @@ export const makeComponentInsertData = (projectId, component) => {
     project_id: projectId,
     moped_proj_components_subcomponents: {
       data: subcomponentsArray,
+    },
+    moped_proj_component_work_types: {
+      data: workTypesArray,
     },
     [featureTable]: {
       data: featuresToInsert,


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12230

## Testing
**URL to test:** Local :/

**Steps to test:**
1. Navigate to the [data dictionary](https://localhost:3000/moped/dev/lookups#moped-components)  and verify that every component has three work types listed in the "Work types" column. The bike lane and signal type components have some extra/special work types as well. This list is going to change a bit over time. There are more work types coming soon via the access migration and user feedback.
2. Go to a project's Map tab and click "New component" to bring up the new component form.
3. Observe that there is a **Work type** field immediately below the component type field with a pre-populated selection of `New`. Nice!
4. Click into the **Work type** field and observe two additional options: `Maintenance / repair` and `Modification`. Select one of those so that two work types are now selected.
5. Click the **Continue** button, map your component it, and save.
6. Edit your component's attributes to bring up the component form again. Confirm that the work types you selected are populated correctly. 
7. Remove the work type options from the input and observe that the input becomes highlighted in red and the "Save" button is disabled, indicating that the field is required
8. Pick a work type and save your changes. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
