### PR TITLE
Adds MUG tracking to user profiles

### DIFF
--- a/moped-api/users/helpers.py
+++ b/moped-api/users/helpers.py
@@ -37,6 +37,8 @@ def generate_user_profile(cognito_id: str, json_data: dict) -> dict:
         "title": json_data.get("title", None),
         "workgroup_id": json_data.get("workgroup_id", None),
         "roles": json_data.get("roles", None),
+        "is_user_group_member": json_data.get("is_user_group_member", False),
+        "note": json_data.get("note", None),
     }
 
 

--- a/moped-api/users/validation.py
+++ b/moped-api/users/validation.py
@@ -79,6 +79,16 @@ USER_VALIDATION_SCHEMA = {
         "minlength": 1,
         "maxlength": 3,
     },
+    "is_user_group_member": {
+        "type": "boolean",
+        "nullable": True,
+        "required": False,
+    },
+    "note": {
+        "type": "string",
+        "nullable": True,
+        "required": False,
+    },
 }
 
 PASSWORD_VALIDATION_SCHEMA = {

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4443,88 +4443,98 @@
       permission:
         check: {}
         columns:
-          - is_coa_staff
+          - cognito_user_id
+          - date_added
           - email
+          - first_name
+          - is_coa_staff
+          - is_deleted
+          - is_user_group_member
+          - last_name
+          - note
+          - picture
+          - roles
+          - title
           - user_id
           - workgroup_id
-          - roles
-          - first_name
-          - last_name
-          - picture
-          - title
-          - date_added
-          - cognito_user_id
-          - is_deleted
   select_permissions:
     - role: moped-admin
       permission:
         columns:
-          - is_coa_staff
+          - cognito_user_id
+          - date_added
           - email
+          - first_name
+          - is_coa_staff
+          - is_deleted
+          - is_user_group_member
+          - last_name
+          - note
+          - picture
+          - roles
+          - title
           - user_id
           - workgroup_id
-          - roles
-          - first_name
-          - last_name
-          - picture
-          - title
-          - date_added
-          - cognito_user_id
-          - is_deleted
         filter: {}
         allow_aggregations: true
     - role: moped-editor
       permission:
         columns:
-          - is_coa_staff
+          - cognito_user_id
+          - date_added
           - email
+          - first_name
+          - is_coa_staff
+          - is_deleted
+          - is_user_group_member
+          - last_name
+          - note
+          - picture
+          - roles
+          - title
           - user_id
           - workgroup_id
-          - roles
-          - first_name
-          - last_name
-          - picture
-          - title
-          - date_added
-          - cognito_user_id
-          - is_deleted
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
       permission:
         columns:
-          - is_coa_staff
+          - cognito_user_id
+          - date_added
           - email
+          - first_name
+          - is_coa_staff
+          - is_deleted
+          - is_user_group_member
+          - last_name
+          - note
+          - picture
+          - roles
+          - title
           - user_id
           - workgroup_id
-          - roles
-          - first_name
-          - last_name
-          - picture
-          - title
-          - date_added
-          - cognito_user_id
-          - is_deleted
         filter: {}
         allow_aggregations: true
   update_permissions:
     - role: moped-admin
       permission:
         columns:
+          - cognito_user_id
+          - date_added
+          - email
           - first_name
+          - is_coa_staff
+          - is_deleted
+          - is_user_group_member
           - last_name
+          - note
+          - picture
+          - roles
           - title
           - user_id
           - workgroup_id
-          - cognito_user_id
-          - date_added
-          - is_coa_staff
-          - email
-          - roles
-          - picture
-          - is_deleted
         filter: {}
-        check: null
+        check: {}
     - role: moped-editor
       permission:
         columns:

--- a/moped-database/migrations/1691507775643_add-staff-mug-tracking/down.sql
+++ b/moped-database/migrations/1691507775643_add-staff-mug-tracking/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE moped_users
+DROP COLUMN is_user_group_member,
+    DROP COLUMN note;

--- a/moped-database/migrations/1691507775643_add-staff-mug-tracking/up.sql
+++ b/moped-database/migrations/1691507775643_add-staff-mug-tracking/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE moped_users
+    ADD COLUMN is_user_group_member boolean NOT NULL DEFAULT FALSE,
+        ADD COLUMN note text;
+
+COMMENT ON COLUMN moped_users.is_user_group_member IS 'Tracks if the user is a member of the Moped User Group, aka the MUG.';
+
+COMMENT ON COLUMN moped_users.note IS 'A place to add any notes about this user, e.g. why they were deactivated.';

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -69,9 +69,9 @@ INSERT INTO public.feature_street_segments (id, component_id, ctn_segment_id, fr
 -- Data for Name: moped_users; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('JD', 'Maccombs', 'Software Developer', 1, 18, NULL, '2021-03-09 17:08:14+00', true, 'jd@emailhost.xyz', '["moped-admin"]', NULL, false, true, 'JD was contracted to assist with the initial Moped research and build out.');
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false);
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["moped-editor"]', NULL, false);
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('JD', 'Maccombs', 'Software Developer', 1, 18, NULL, '2021-03-09 17:08:14+00', true, 'jd@emailhost.xyz', '["moped-admin"]', NULL, false, false, 'JD was contracted to assist with the initial Moped research and build out.');
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false, false, NULL);
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["non-login-user"]', NULL, false, true, NULL);
 
 
 

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -69,7 +69,7 @@ INSERT INTO public.feature_street_segments (id, component_id, ctn_segment_id, fr
 -- Data for Name: moped_users; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted) VALUES ('JD', 'Maccombs', 'Software Developer', 1, 18, NULL, '2021-03-09 17:08:14+00', true, 'jd@emailhost.xyz', '["moped-admin"]', NULL, false);
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('JD', 'Maccombs', 'Software Developer', 1, 18, NULL, '2021-03-09 17:08:14+00', true, 'jd@emailhost.xyz', '["moped-admin"]', NULL, false, true, 'JD was contracted to assist with the initial Moped research and build out.');
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false);
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["moped-editor"]', NULL, false);
 

--- a/moped-editor/src/queries/staff.js
+++ b/moped-editor/src/queries/staff.js
@@ -14,6 +14,8 @@ export const GET_ALL_USERS = gql`
         workgroup_id
         workgroup_name
       }
+      is_user_group_member
+      note
     }
   }
 `;
@@ -32,6 +34,8 @@ export const GET_USER = gql`
       email
       roles
       is_deleted
+      is_user_group_member
+      note
     }
   }
 `;
@@ -54,6 +58,8 @@ export const ADD_NON_MOPED_USER = gql`
       email
       roles
       is_deleted
+      is_user_group_member
+      note
     }
   }
 `;
@@ -73,6 +79,8 @@ export const UPDATE_NON_MOPED_USER = gql`
       email
       roles
       is_deleted
+      is_user_group_member
+      note
     }
   }
 `;

--- a/moped-editor/src/views/staff/NewStaffView.js
+++ b/moped-editor/src/views/staff/NewStaffView.js
@@ -28,6 +28,8 @@ export const initialFormValues = {
   password: "",
   workgroup_id: null,
   roles: ["moped-editor"],
+  is_user_group_member: false,
+  note: "",
 };
 
 const newUserRoleOptions = [
@@ -71,6 +73,7 @@ const NewStaffView = () => {
 
     const isNonLoginUser = isUserNonLoginUser(data.roles);
 
+    console.log("Submitted data is: ", data);
     if (isNonLoginUser) {
       // Remove the password for the non-login user create mutation
       const { password, ...restOfData } = data;

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -297,7 +297,8 @@ const StaffForm = ({
             </FormControl>
           )}
         </Grid>
-        <Grid item xs={12} md={6}>
+
+        <Grid item xs={12} md={3}>
           <FormControl variant="standard" component="fieldset">
             <FormLabel id="roles-label">Role</FormLabel>
             <Controller
@@ -323,6 +324,55 @@ const StaffForm = ({
               )}
             />
           </FormControl>
+        </Grid>
+        <Grid item xs={12} md={3}>
+          <FormControl variant="standard" component="fieldset">
+            <FormLabel id="roles-label">
+              Moped User Group (MUG) Member
+            </FormLabel>
+            <Controller
+              name="is_user_group_member"
+              control={control}
+              render={({ field: { name, value, onChange } }) => (
+                <RadioGroup
+                  aria-label="roles"
+                  name={name}
+                  value={value ? "true" : "false"}
+                  onChange={(e) => {
+                    const newValue = e.target.value === "true";
+                    return onChange(newValue);
+                  }}
+                >
+                  <FormControlLabel
+                    value="true"
+                    control={<Radio />}
+                    label="Yes"
+                    disabled={!isUserActive}
+                  />
+                  <FormControlLabel
+                    value="false"
+                    control={<Radio />}
+                    label="No"
+                    disabled={!isUserActive}
+                  />
+                </RadioGroup>
+              )}
+            />
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            id="note"
+            label="Note"
+            InputLabelProps={{
+              shrink: true,
+            }}
+            variant="outlined"
+            {...register("note")}
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           &nbsp;

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -47,7 +47,7 @@ const staffColumns = [
   {
     headerName: "E-mail",
     field: "email",
-    width: 225,
+    width: 200,
   },
   {
     headerName: "Title",
@@ -67,10 +67,10 @@ const staffColumns = [
       if (!props.value || !props.value[0]) {
         return "N/A";
       }
-
       const role = props.value[0].replace("moped-", "");
       return role.charAt(0).toUpperCase() + role.slice(1);
     },
+    width: 125
   },
   {
     headerName: "MUG Member",

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -47,7 +47,7 @@ const staffColumns = [
   {
     headerName: "E-mail",
     field: "email",
-    width: 325,
+    width: 225,
   },
   {
     headerName: "Title",
@@ -71,6 +71,11 @@ const staffColumns = [
       const role = props.value[0].replace("moped-", "");
       return role.charAt(0).toUpperCase() + role.slice(1);
     },
+  },
+  {
+    headerName: "MUG Member",
+    field: "is_user_group_member",
+    valueGetter: (props) => (props.value ? "Yes" : "No"),
   },
   {
     headerName: "Active",

--- a/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
+++ b/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
@@ -7,6 +7,7 @@ import {
   roleLooksGood,
   passwordLooksGood,
   fieldParsers,
+  transformFormDataIntoDatabaseTypes,
 } from "../helpers";
 import { useButtonStyles } from "./StaffFormButtons";
 
@@ -59,7 +60,8 @@ const NonLoginUserActivationButtons = ({
   };
 
   const handleUpdateNonLoginUser = async () => {
-    const { password, __typename, ...restOfFormValues } = formValues;
+    const { password, __typename, ...restOfFormValues } =
+      transformFormDataIntoDatabaseTypes(formValues);
     updateNonMopedUser({
       variables: {
         userId: userId,


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13274

I decided to add a "note" column as well, because there are a handful of special users in our DB that would benefit from a note. Eg. the "unknown" user ([discussion](https://austininnovation.slack.com/archives/CNUEPKLB1/p1691170753237639)).


## Testing
**URL to test:**  Local

**Steps to test the Moped user API changes:**
I'm not sure how to test the API changes. I've tried in the past to run the test fixtures but have not been able to configure the local setup. I am happy to be on standby to patch this code on staging. Any suggestions?


**Steps to test the Moped editor changes:**
1. Start the Hasura cluster and editor.
2. Navigate to the staff page and observe the new MUG member column on the staff list. Observe that Patricia is listed as "Yes" to being a MUG member.
3. Because Patricia is a non-login user, you can edit her profile without interacting with the user API. So edit Patricia's profile so that she is not a MUG member and add a note. Save.
4. Observe that the staff list reflects Patricia as a non-mug member. Click to edit her profile again to bring up the staff edit form and observe that your changes have persisted. Switch her back to a MUG member and save.



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
