### PR TITLE
[Enhancement] Ability to set component completion date without setting a component phase

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -97,7 +97,11 @@ const ComponentForm = ({
 
   const componentOptions = useComponentOptions(optionsData);
   const phaseOptions = usePhaseOptions(optionsData);
-  const [component, phase] = watch(["component", "phase"]);
+  const [component, phase, completionDate] = watch([
+    "component",
+    "phase",
+    "completionDate",
+  ]);
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const internalTable = component?.data?.feature_layer?.internal_table;
   const isSignalComponent = internalTable === "feature_signals";
@@ -195,7 +199,7 @@ const ComponentForm = ({
             options={workTypeOptions}
             name="work_types"
             control={control}
-            error={errors?.work_types}
+            error={!!errors?.work_types}
             helperText="Required"
           />
         </Grid>
@@ -262,6 +266,7 @@ const ComponentForm = ({
                 onChange={() => setUseComponentPhase(!useComponentPhase)}
                 name="useComponentPhase"
                 color="primary"
+                disabled={!!phase || !!completionDate}
               />
             }
             labelPlacement="start"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -113,7 +113,7 @@ const ComponentForm = ({
     optionsData?.moped_components
   );
   const [useComponentPhase, setUseComponentPhase] = useState(
-    !!initialFormValues?.phase
+    !!initialFormValues?.phase || !!initialFormValues?.completionDate
   );
 
   useResetDependentFieldOnAutocompleteChange({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -52,9 +52,8 @@ const EditAttributesModal = ({
   const onSave = (formData) => {
     const isSavingSignalFeature = Boolean(formData.signal);
 
-    const { subcomponents, phase, subphase, tags, work_types } = formData;
+    const { subcomponents, phase, subphase, tags, work_types, completionDate } = formData;
 
-    const completionDate = !!phase ? formData.completionDate : null;
     const description =
       formData.description?.length > 0 ? formData.description : null;
     const srtsId = formData.srtsId?.length > 0 ? formData.srtsId : null;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13120

## Testing
**URL to test:** 

https://deploy-preview-1097--atd-moped-main.netlify.app/moped/projects/

**Steps to test:**

Add a new component. Toggle the "Use component phase" 
Only add a completion date, but leave the phase blank. 
Save.
Open the component attributes again, and check that the completion date is there, and that the toggle is selected. 

Open an existing component and repeat the steps above. Confirm the completion date saves, even if there is no phase. 

![Screenshot 2023-08-10 at 2 04 45 PM](https://github.com/cityofaustin/atd-moped/assets/12474808/09862578-4ce1-4adb-8d4e-cdf8b966311d)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
