### PR TITLE
Fix project components showing in green when clicking from a related component

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -293,7 +293,12 @@ export default function TheMap({
       /* Assign to clickedComponent and trigger side-panel scroll  */
       if (clickedComponentFromMap) {
         clickedComponentFromMap && setClickedComponent(clickedComponentFromMap);
+
+        // Make sure that state reflects whether the clicked component is related or not
+        // so that we see the map display features with the corresponding color
         isNewClickedComponentRelated && setIsClickedComponentRelated(true);
+        !isNewClickedComponentRelated && setIsClickedComponentRelated(false);
+
         const ref = clickedComponentFromMap?._ref;
         ref?.current && ref.current.scrollIntoView({ behavior: "smooth" });
       }


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/13336

Caught this while working on the layers earlier this week. It was a quick fix. You can see the bug in the recording in the bug issue, or you can test in staging using the steps below.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1099--atd-moped-main.netlify.app/moped/ or local

**Steps to test:**
1. Go staging and find or make a project with components that has a subproject with components ([here is one](https://moped.austinmobility.io/moped/projects/1703?tab=map))
2. Go to the Map tab and click on a green feature on the map of a related component
3. After that first click, click a blue feature (current project component)
4. You should see the blue feature turn green even though it isn't a related component
5. Go to this deploy preview or run this locally and repeat the steps ([here is the same example in the deploy preview](https://deploy-preview-1099--atd-moped-main.netlify.app/moped/projects/1703?tab=map))
6. You should see that the blue feature remains blue 🔵 and does not turn green 🟢

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
