### PR TITLE
Sets component work type when creating a signal project

### DIFF
--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -8,6 +8,12 @@ export const SOCRATA_ENDPOINT =
   "https://data.austintexas.gov/resource/p53x-x73x.geojson?$select=signal_id,location_name,location,signal_type,id&$order=signal_id asc&$limit=9999";
 
 /**
+ * An array to use as the default value for
+ * moped_proj_component_work_type: 7 = "New"
+ */
+const DEFAULT_SIGNAL_WORK_TYPE = [{ work_type_id: 7 }];
+
+/**
  * MUI autocomplete getOptionSelected function to which matches input signal value to
  * select options.
  */
@@ -175,6 +181,11 @@ export const generateProjectComponent = (
     component_id: componentDef.component_id,
     feature_signals: {
       data: [signalRecord],
+    },
+    // create default value for component work type, which
+    // is a required field enforced through the UI
+    moped_proj_component_work_types: {
+      data: DEFAULT_SIGNAL_WORK_TYPE,
     },
   };
 };


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13413

## Testing
**URL to test:**  [Netlify](https://deploy-preview-1103--atd-moped-main.netlify.app/) ✨ 

1. Create a new project using the "From signal" toggle, which enables you to select a signal from a list.
2. Navigate to your new project's map and confirm that the component's work type is populated as `New` in the attribute edit modal.
3. Create a non-signal project and make sure it is created without any errors.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
