### PR TITLE
Deletes "Construction Inspection" work type

### DIFF
--- a/moped-database/migrations/1692285495049_delete_work_type_construction_inspection/down.sql
+++ b/moped-database/migrations/1692285495049_delete_work_type_construction_inspection/down.sql
@@ -1,0 +1,23 @@
+INSERT INTO moped_work_types (name, key) VALUES 
+    ('Construction Inspection', 'construction_inspection');
+
+-- add as allowed work type for signal components
+-- see 1691442787520_refresh-component-work-types
+WITH inserts_todo AS (
+    SELECT
+        id AS work_type_id,
+        component_id
+    FROM (
+        values('construction_inspection')) AS data (work_type_key)
+        LEFT JOIN moped_components ON TRUE
+        LEFT JOIN moped_work_types mwt ON data.work_type_key = mwt.key
+    WHERE
+        moped_components.is_deleted = FALSE
+        AND lower(moped_components.component_name) = 'signal'
+        AND(lower(moped_components.component_subtype) = 'traffic'
+            OR lower(moped_components.component_subtype) = 'phb')
+) INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    *
+FROM
+    inserts_todo;

--- a/moped-database/migrations/1692285495049_delete_work_type_construction_inspection/up.sql
+++ b/moped-database/migrations/1692285495049_delete_work_type_construction_inspection/up.sql
@@ -1,0 +1,1 @@
+DELETE FROM moped_work_types WHERE KEY = 'construction_inspection';


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13426

## Testing
**URL to test:** Local

1. Start your Moped
2. Create a new signal component. On the component attributes form, confirm that "construction inspection" is not available as a work type.
3. You can also peep the data dictionary and there should be no trace of this component work type.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
