### PR TITLE
Adds ability to copy user email addresses from staff list

### DIFF
--- a/moped-editor/src/views/staff/EditStaffView.js
+++ b/moped-editor/src/views/staff/EditStaffView.js
@@ -67,6 +67,8 @@ const EditStaffView = () => {
       password,
       roles,
       workgroup_id,
+      is_user_group_member,
+      note,
     } = data;
 
     const payload = {
@@ -77,6 +79,8 @@ const EditStaffView = () => {
       password,
       roles,
       workgroup_id,
+      is_user_group_member,
+      note,
     };
 
     // Navigate to user table on successful add/edit

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -7,7 +7,11 @@ import { DataGrid, GridToolbar } from "@mui/x-data-grid";
 
 import Page from "src/components/Page";
 import { GET_ALL_USERS } from "src/queries/staff";
-import { AddUserButton, EditUserButton } from "./StaffListViewCustomComponents";
+import {
+  AddUserButton,
+  EditUserButton,
+  CopyMugUsersButton,
+} from "./StaffListViewCustomComponents";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -18,9 +22,9 @@ const useStyles = makeStyles((theme) => ({
   container: {
     maxWidth: "100%",
   },
-  addStaffButton: {
+  buttonContainer: {
     display: "flex",
-    justifyContent: "flex-end",
+    justifyContent: "space-between",
     marginBottom: "24px",
   },
 }));
@@ -70,7 +74,7 @@ const staffColumns = [
       const role = props.value[0].replace("moped-", "");
       return role.charAt(0).toUpperCase() + role.slice(1);
     },
-    width: 125
+    width: 125,
   },
   {
     headerName: "MUG Member",
@@ -100,13 +104,14 @@ const StaffListView = () => {
         <CircularProgress />
       ) : (
         <Container className={classes.container}>
-          <Box className={classes.addStaffButton}>
+          <Box className={classes.buttonContainer}>
+            <CopyMugUsersButton users={data?.moped_users} />
             <AddUserButton />
           </Box>
           <Card>
             <DataGrid
               disableRowSelectionOnClick
-              rows={data["moped_users"]}
+              rows={data?.moped_users}
               columns={staffColumns}
               getRowId={(row) => row.user_id}
               slots={{ toolbar: GridToolbar }}

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -1,7 +1,16 @@
 import React from "react";
 import Can from "../../auth/Can";
+import Alert from "@mui/material/Alert";
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import Button from "@mui/material/Button";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
-import { Button, Icon } from "@mui/material";
+import Email from "@mui/icons-material/Email";
+import Icon from "@mui/material/Icon";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import Snackbar from "@mui/material/Snackbar";
 import { NavLink as RouterLink } from "react-router-dom";
 
 export const AddUserButton = () => (
@@ -11,6 +20,7 @@ export const AddUserButton = () => (
       <Button
         color="primary"
         variant="contained"
+        size="small"
         component={RouterLink}
         to={"/moped/staff/new"}
         startIcon={<Icon>add_circle</Icon>}
@@ -18,9 +28,10 @@ export const AddUserButton = () => (
         Add Staff
       </Button>
     }
-  /> )
+  />
+);
 
-export const EditUserButton = ({id}) => (
+export const EditUserButton = ({ id }) => (
   <Can
     perform="user:edit"
     yes={
@@ -30,3 +41,97 @@ export const EditUserButton = ({id}) => (
     }
   />
 );
+
+const writeTextToClipboard = (text, onSuccessCallback) => {
+  const type = "text/plain";
+  const blob = new Blob([text], { type });
+  const data = [new ClipboardItem({ [type]: blob })];
+  navigator.clipboard.write(data).then(
+    () => onSuccessCallback(),
+    () => console.error("Something went wrong :/")
+  );
+};
+
+const onCopyAllEmails = (users) => {
+  debugger;
+  const emailString = users
+    ?.filter((u) => !u.is_deleted)
+    .map((u) => u.email)
+    .join(";");
+  writeTextToClipboard(emailString, () => console.log("success"));
+};
+
+const onCopyMugEmails = (users) => {
+  const emailString = users
+    ?.filter((u) => u.is_user_group_member && !u.is_deleted)
+    .map((u) => u.email)
+    .join(";");
+  writeTextToClipboard(emailString, () => console.log("success"));
+};
+
+export const CopyMugUsersButton = ({ users }) => {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+  const [snackbarOpen, setSnackbarOpen] = React.useState(false);
+
+  const handleMenuClick = (e) => {
+    setAnchorEl(e.currentTarget);
+  };
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+  const handleSnackbarOpen = () => setSnackbarOpen(true);
+  const handleSnackbarClose = () => setSnackbarOpen(false);
+
+  console.log("USERS", users);
+  return (
+    <div>
+      <Button
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleMenuClick}
+        startIcon={<Email />}
+      >
+        Copy email addresses
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleCloseMenu}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <MenuItem onClick={handleCloseMenu}>
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Moped User Group</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={handleCloseMenu}>
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>All active users</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleSnackbarClose}
+      >
+        <Alert
+          onClose={handleSnackbarClose}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
+          This is a success message!
+        </Alert>
+      </Snackbar>
+    </div>
+  );
+};

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -140,7 +140,7 @@ export const CopyMugUsersButton = ({ users }) => {
             )}
           </ListItemIcon>
           <ListItemText>
-            {copiedListName === "allUsers"
+            {copiedListName === "mug"
               ? "Copied!"
               : "Copy Moped User Group (MUG) email addresses"}
           </ListItemText>

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -70,10 +70,7 @@ const copyEmailsToClipboard = (users, userFilter) => {
     .filter(userFilter)
     .map((u) => u.email)
     .join(";");
-  const type = "text/plain";
-  const blob = new Blob([emails], { type });
-  const data = [new ClipboardItem({ [type]: blob })];
-  return navigator.clipboard.write(data);
+  return navigator.clipboard.writeText(emails);
 };
 
 /**

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -4,7 +4,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import Button from "@mui/material/Button";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import Email from "@mui/icons-material/Email";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Icon from "@mui/material/Icon";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
@@ -49,12 +49,15 @@ export const EditUserButton = ({ id }) => (
 const mugUserFilter = (user) => user.is_user_group_member && !user.is_deleted;
 
 /**
- * Filter function to identify all active users who are not non-login users
+ * Filter function to identify all active users who are not non-login users and
+ * do not have a `+` in their email address
  * @param {object} user - a `moped_user` object
  * @returns user
  */
 const allUserFilter = (user) =>
-  !user.is_deleted && !user.roles.includes("non-login-user");
+  !user.is_deleted &&
+  !user.roles.includes("non-login-user") &&
+  user.email.indexOf("+") < 0;
 
 /**
  * Copies user email addresses to clipboard as a semi-colon-separated string
@@ -104,7 +107,7 @@ export const CopyMugUsersButton = ({ users }) => {
     const timeout = setTimeout(() => {
       setCopiedListName(null);
       handleCloseMenu();
-    }, 300);
+    }, 500);
     return () => clearTimeout(timeout);
   }, [copiedListName, handleCloseMenu]);
 
@@ -118,7 +121,7 @@ export const CopyMugUsersButton = ({ users }) => {
         aria-haspopup="true"
         aria-expanded={menuOpen ? "true" : undefined}
         onClick={handleMenuClick}
-        startIcon={<Email />}
+        endIcon={<ArrowDropDownIcon />}
       >
         Contact users
       </Button>
@@ -139,7 +142,11 @@ export const CopyMugUsersButton = ({ users }) => {
               <ContentCopyIcon fontSize="small" />
             )}
           </ListItemIcon>
-          <ListItemText>Moped User Group</ListItemText>
+          <ListItemText>
+            {copiedListName === "allUsers"
+              ? "Copied!"
+              : "Copy Moped User Group (MUG) email addresses"}
+          </ListItemText>
         </MenuItem>
         <MenuItem onClick={() => onMenuItemClick("allUsers")}>
           <ListItemIcon>
@@ -149,7 +156,11 @@ export const CopyMugUsersButton = ({ users }) => {
               <ContentCopyIcon fontSize="small" />
             )}
           </ListItemIcon>
-          <ListItemText>All active users</ListItemText>
+          <ListItemText>
+            {copiedListName === "allUsers"
+              ? "Copied!"
+              : "Copy all active user email addresses"}
+          </ListItemText>
         </MenuItem>
       </Menu>
     </div>

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -97,6 +97,9 @@ export const CopyMugUsersButton = ({ users }) => {
   };
 
   useEffect(() => {
+    /**
+     * Effect which closes the menu after a brief pause
+     */
     if (!copiedListName) return;
     const timeout = setTimeout(() => {
       setCopiedListName(null);
@@ -105,27 +108,27 @@ export const CopyMugUsersButton = ({ users }) => {
     return () => clearTimeout(timeout);
   }, [copiedListName, handleCloseMenu]);
 
-  const open = Boolean(anchorEl);
+  const menuOpen = Boolean(anchorEl);
 
   return (
     <div>
       <Button
-        id="basic-button"
-        aria-controls={open ? "basic-menu" : undefined}
+        id="copy-users-menu-button"
+        aria-controls={menuOpen ? "copy-users-menu" : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
+        aria-expanded={menuOpen ? "true" : undefined}
         onClick={handleMenuClick}
         startIcon={<Email />}
       >
         Contact users
       </Button>
       <Menu
-        id="basic-menu"
+        id="copy-users-menu"
         anchorEl={anchorEl}
-        open={open}
+        open={menuOpen}
         onClose={handleCloseMenu}
         MenuListProps={{
-          "aria-labelledby": "basic-button",
+          "aria-labelledby": "copy-users-menu-button",
         }}
       >
         <MenuItem onClick={() => onMenuItemClick("mug")}>

--- a/moped-editor/src/views/staff/StaffListViewCustomComponents.js
+++ b/moped-editor/src/views/staff/StaffListViewCustomComponents.js
@@ -64,7 +64,7 @@ const allUserFilter = (user) =>
  */
 const copyEmailsToClipboard = (users, userFilter) => {
   const emails = users
-    ?.filter(userFilter)
+    .filter(userFilter)
     .map((u) => u.email)
     .join(";");
   const type = "text/plain";
@@ -74,7 +74,7 @@ const copyEmailsToClipboard = (users, userFilter) => {
 };
 
 /**
- * Menu component which copies Moped user emails to clopboard
+ * Menu component which copies Moped user emails to clipboard
  * @param {object[]} users - array of `moped_user` objects
  */
 export const CopyMugUsersButton = ({ users }) => {
@@ -91,7 +91,7 @@ export const CopyMugUsersButton = ({ users }) => {
 
   const onMenuItemClick = (name) => {
     const userFilter = name === "mug" ? mugUserFilter : allUserFilter;
-    copyEmailsToClipboard(users, userFilter).then(() => {
+    copyEmailsToClipboard(users || [], userFilter).then(() => {
       setCopiedListName(name);
     });
   };


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13507

## Testing
**URL to test:**  [Netlify](https://deploy-preview-1110--atd-moped-main.netlify.app/)

1. Navigate to the Staff page
2. Find your user account and edit it so that you are a MUG member and also add a note. Save.
3. Find you user account and click the edit icon to verify your changes were saved. Now return to the staff list.
4. Add a filter to staff list: **MUG Member** **equals**  **Yes**
6. Now use the menu above the top-left of the staff list to copy all Moped User Group email addresses.
7. Paste your clipboard somewhere and observe that the email addresses you pasted match the filtered staff list.
8. Now use the same menu to copy **All active users**. Paste your clipboard and observer it is a long list that only includes active users who do not have the **non-login user** role.



---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
