### PR TITLE
Add project personnel roles to data dictionary

### DIFF
--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -64,5 +64,13 @@ export const TABLE_LOOKUPS_QUERY = gql`
       name
       slug
     }
+    moped_project_roles(
+      where: { active_role: { _eq: true } }
+      order_by: { role_order: asc }
+    ) {
+      project_role_id
+      project_role_name
+      project_role_description
+    }
   }
 `;

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -184,6 +184,24 @@ export const SETTINGS = [
     ],
   },
   {
+    key: "moped_project_roles",
+    label: "Roles",
+    columns: [
+      {
+        key: "project_role_id",
+        label: "Role ID",
+      },
+      {
+        key: "project_role_name",
+        label: "Name",
+      },
+      {
+        key: "project_role_description",
+        label: "Description",
+      },
+    ],
+  },
+  {
     key: "moped_tags",
     label: "Tags",
     columns: [
@@ -202,24 +220,6 @@ export const SETTINGS = [
       {
         key: "slug",
         label: "Slug",
-      },
-    ],
-  },
-  {
-    key: "moped_project_roles",
-    label: "Roles",
-    columns: [
-      {
-        key: "project_role_id",
-        label: "Role ID",
-      },
-      {
-        key: "project_role_name",
-        label: "Name",
-      },
-      {
-        key: "project_role_description",
-        label: "Description",
       },
     ],
   },

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -210,7 +210,7 @@ export const SETTINGS = [
     label: "Roles",
     columns: [
       {
-        key: "id",
+        key: "project_role_id",
         label: "Role ID",
       },
       {

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -205,4 +205,22 @@ export const SETTINGS = [
       },
     ],
   },
+  {
+    key: "moped_project_roles",
+    label: "Roles",
+    columns: [
+      {
+        key: "id",
+        label: "Role ID",
+      },
+      {
+        key: "project_role_name",
+        label: "Name",
+      },
+      {
+        key: "project_role_description",
+        label: "Description",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/13099

Adds roles to the data dictionary and sorts them by the set `role_order`

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1112--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to the Data Dictionary link
2. Click the **Roles** button at the top and you should arrive at the list of roles
3. You can check them against the local DB or one of the read replicas

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
