### PR TITLE
Global search is affected by previous advanced search

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -159,6 +159,12 @@ const NavigationSearchInput = ({ input404Class }) => {
     projectSearchQuery.current.config.options.useQuery
   );
 
+  /* Clear input and reset the gqlabstract 'or' config */
+  const clearSearchInput = () => {
+    setSearchTerm("");
+    projectSearchQuery.current.resetFull();
+  };
+
   // when magnifying glass icon is clicked, show search bar and initiate animation
   const handleMagClick = () => {
     showSearchInput(true);
@@ -169,9 +175,7 @@ const NavigationSearchInput = ({ input404Class }) => {
   const handleDropdownClose = () => {
     setSearchResultsAnchor(null);
     showSearchInput(false);
-    setSearchTerm("");
     setPopperEntered(false);
-    projectSearchQuery.current.resetFull();
   };
 
   // show popper results when search input gets focus
@@ -182,7 +186,7 @@ const NavigationSearchInput = ({ input404Class }) => {
 
   // initiate exiting animation when clicking outside of search bar / popper results
   const startSlideAway = () => {
-    setSearchTerm("");
+    clearSearchInput();
     setPopperEntered(false);
     toggleSlideIn(false);
   };
@@ -202,8 +206,10 @@ const NavigationSearchInput = ({ input404Class }) => {
     switch (key) {
       // On Escape key, clear the search
       case "Escape":
-        setSearchTerm("");
         setSearchResultsAnchor(null);
+        // Slide away the search bar and reset the input
+        toggleSlideIn(false);
+        clearSearchInput();
         break;
       // On Enter key, initialize the search
       case "Enter":

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -140,6 +140,15 @@ const NavigationSearchInput = ({ input404Class }) => {
   const classes = useStyles();
   const divRef = React.useRef();
   let projectSearchQuery = new GQLAbstract(ProjectsListViewQueryConf);
+  console.log(projectSearchQuery);
+
+  // TODO: Refactor this so that the we don't reuse the saved GQLAbstract parameters (filters to ID 228)
+  // when viewing a project summary.
+  // TODO: Create a separate GQLAbstract for the project summary page?
+  // TODO: Two separate components based on view? Maybe...
+  // need to figure out how the filters are persisted between views
+  // because we still want to be filtered down when going back to the
+  // project list view
 
   // Toggle Text Input or magnifying glass
   const [searchInput, showSearchInput] = useState(false);
@@ -301,7 +310,7 @@ const NavigationSearchInput = ({ input404Class }) => {
             onClose={handleDropdownClose}
             placement="bottom-start"
             // inherit the position from the modifiers and dont reset to 0
-            style={{position: "fixed", top: "unset", left:"unset"}}
+            style={{ position: "fixed", top: "unset", left: "unset" }}
             // disablePortal=true ensures the popper wont slip behind the material tables
             disablePortal
             modifiers={[]}

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -139,7 +139,9 @@ const useStyles = makeStyles((theme) => ({
 const NavigationSearchInput = ({ input404Class }) => {
   const classes = useStyles();
   const divRef = React.useRef();
-  let projectSearchQuery = new GQLAbstract(NavigationSearchQueryConf);
+  const projectSearchQuery = React.useRef(
+    new GQLAbstract(NavigationSearchQueryConf)
+  );
 
   // Toggle Text Input or magnifying glass
   const [searchInput, showSearchInput] = useState(false);
@@ -152,8 +154,8 @@ const NavigationSearchInput = ({ input404Class }) => {
   const [showSlideIn, toggleSlideIn] = useState(false);
 
   const [loadSearchResults, { called, loading, data }] = useLazyQuery(
-    projectSearchQuery.gql,
-    projectSearchQuery.config.options.useQuery
+    projectSearchQuery.current.gql,
+    projectSearchQuery.current.config.options.useQuery
   );
 
   // when magnifying glass icon is clicked, show search bar and initiate animation
@@ -168,7 +170,7 @@ const NavigationSearchInput = ({ input404Class }) => {
     showSearchInput(false);
     setSearchTerm("");
     setPopperEntered(false);
-    projectSearchQuery.reset();
+    projectSearchQuery.current.resetFull();
   };
 
   // show popper results when search input gets focus
@@ -226,13 +228,16 @@ const NavigationSearchInput = ({ input404Class }) => {
     if (event) event.preventDefault();
 
     // Formats search query based on project search columns and config
-    Object.keys(projectSearchQuery.config.columns)
-      .filter((column) => projectSearchQuery.config.columns[column]?.searchable)
+    Object.keys(projectSearchQuery.current.config.columns)
+      .filter(
+        (column) =>
+          projectSearchQuery.current.config.columns[column]?.searchable
+      )
       .forEach((column) => {
         const { operator, quoted, envelope } =
-          projectSearchQuery.config.columns[column].search;
+          projectSearchQuery.current.config.columns[column].search;
         const searchValue = getSearchValue(
-          projectSearchQuery,
+          projectSearchQuery.current,
           column,
           searchTerm
         );
@@ -240,7 +245,10 @@ const NavigationSearchInput = ({ input404Class }) => {
           ? `"${envelope.replace("{VALUE}", searchValue)}"`
           : searchValue;
 
-        projectSearchQuery.setOr(column, `${operator}: ${graphqlSearchValue}`);
+        projectSearchQuery.current.setOr(
+          column,
+          `${operator}: ${graphqlSearchValue}`
+        );
       });
 
     // Initiate Lazy Query to get search results

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -148,6 +148,7 @@ const NavigationSearchInput = ({ input404Class }) => {
   // anchor element for results popper to "attach" to
   const [searchResultsAnchor, setSearchResultsAnchor] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
+  console.log(searchTerm);
   // keep track if popper animation has completed so border can be applied
   const [popperEnterComplete, setPopperEntered] = useState(false);
   // boolean used to initiate slide animation

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -148,7 +148,6 @@ const NavigationSearchInput = ({ input404Class }) => {
   // anchor element for results popper to "attach" to
   const [searchResultsAnchor, setSearchResultsAnchor] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
-  console.log(searchTerm);
   // keep track if popper animation has completed so border can be applied
   const [popperEnterComplete, setPopperEntered] = useState(false);
   // boolean used to initiate slide animation
@@ -176,6 +175,7 @@ const NavigationSearchInput = ({ input404Class }) => {
     setSearchResultsAnchor(null);
     showSearchInput(false);
     setPopperEntered(false);
+    clearSearchInput();
   };
 
   // show popper results when search input gets focus

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -141,14 +141,6 @@ const NavigationSearchInput = ({ input404Class }) => {
   const divRef = React.useRef();
   let projectSearchQuery = new GQLAbstract(NavigationSearchQueryConf);
 
-  // TODO: Refactor this so that the we don't reuse the saved GQLAbstract parameters (filters to ID 228)
-  // when viewing a project summary.
-  // TODO: Create a separate GQLAbstract for the project summary page?
-  // TODO: Two separate components based on view? Maybe...
-  // need to figure out how the filters are persisted between views
-  // because we still want to be filtered down when going back to the
-  // project list view
-
   // Toggle Text Input or magnifying glass
   const [searchInput, showSearchInput] = useState(false);
   // anchor element for results popper to "attach" to
@@ -176,6 +168,7 @@ const NavigationSearchInput = ({ input404Class }) => {
     showSearchInput(false);
     setSearchTerm("");
     setPopperEntered(false);
+    projectSearchQuery.reset();
   };
 
   // show popper results when search input gets focus

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -12,7 +12,7 @@ import clsx from "clsx";
 import SearchIcon from "@mui/icons-material/Search";
 import GQLAbstract from "../../../libs/GQLAbstract";
 import { useLazyQuery } from "@apollo/client";
-import { NavigationSearchQueryConf } from "../../../queries/NavigationSearchQueryConf";
+import { NavigationSearchQueryConf } from "./NavigationSearchQueryConf";
 import NavigationSearchResults from "./NavigationSearchResults.js";
 import { getSearchValue } from "../../../utils/gridTableHelpers";
 

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -12,7 +12,7 @@ import clsx from "clsx";
 import SearchIcon from "@mui/icons-material/Search";
 import GQLAbstract from "../../../libs/GQLAbstract";
 import { useLazyQuery } from "@apollo/client";
-import { ProjectsListViewQueryConf } from "../../../views/projects/projectsListView/ProjectsListViewQueryConf";
+import { NavigationSearchQueryConf } from "../../../queries/NavigationSearchQueryConf";
 import NavigationSearchResults from "./NavigationSearchResults.js";
 import { getSearchValue } from "../../../utils/gridTableHelpers";
 
@@ -139,8 +139,7 @@ const useStyles = makeStyles((theme) => ({
 const NavigationSearchInput = ({ input404Class }) => {
   const classes = useStyles();
   const divRef = React.useRef();
-  let projectSearchQuery = new GQLAbstract(ProjectsListViewQueryConf);
-  console.log(projectSearchQuery);
+  let projectSearchQuery = new GQLAbstract(NavigationSearchQueryConf);
 
   // TODO: Refactor this so that the we don't reuse the saved GQLAbstract parameters (filters to ID 228)
   // when viewing a project summary.

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
@@ -1,6 +1,4 @@
 import React from "react";
-import { ProjectsListViewFiltersConf } from "./ProjectsListViewFiltersConf";
-import { ProjectsListViewExportConf } from "./ProjectsListViewExportConf";
 import ExternalLink from "../../../components/ExternalLink";
 import { NavLink as RouterLink } from "react-router-dom";
 import theme from "src/theme/index";
@@ -32,8 +30,6 @@ export const NavigationSearchQueryConf = {
   pagination: {
     rowsPerPageOptions: [250, 1000],
   },
-  filters: ProjectsListViewFiltersConf,
-  export: ProjectsListViewExportConf,
   search: {
     placeholder:
       "Search by ID, name, description, phase, lead, sponsor, partners, eCAPRIS ID...",

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
@@ -1,8 +1,3 @@
-import React from "react";
-import ExternalLink from "../../../components/ExternalLink";
-import { NavLink as RouterLink } from "react-router-dom";
-import theme from "src/theme/index";
-
 /**
  * The Query configuration (now also including filters)
  * @constant
@@ -17,19 +12,6 @@ export const NavigationSearchQueryConf = {
     },
   },
   table: "project_list_view",
-  single_item: "/moped/projects",
-  new_item: "/moped/projects/new",
-  new_item_label: "New Project",
-  showDateRange: false,
-  showSearchBar: true,
-  showFilters: false,
-  showExport: true,
-  showNewItemButton: false,
-  noResultsMessage: "No projects found.",
-  showPagination: true,
-  pagination: {
-    rowsPerPageOptions: [250, 1000],
-  },
   search: {
     placeholder:
       "Search by ID, name, description, phase, lead, sponsor, partners, eCAPRIS ID...",
@@ -37,83 +19,41 @@ export const NavigationSearchQueryConf = {
   },
   columns: {
     project_id: {
-      hidden: true,
-      primary_key: true,
       searchable: true,
-      sortable: false,
-      label: "Project ID",
       search: {
-        label: "Search by project ID",
         operator: "_eq",
         quoted: false,
         envelope: "%{VALUE}%",
         invalidValueDefault: 0,
       },
-      icon: {
-        name: "edit_road",
-        color: "primary",
-      },
-      width: "*",
       type: "Int",
     },
     project_name: {
       searchable: true,
-      sortable: false,
-      link: "project_id",
-      label: "Project name",
       search: {
-        label: "Search by project name",
         operator: "_ilike",
         quoted: true,
         envelope: "%{VALUE}%",
       },
-      width: "*",
       type: "String",
-      filter: (values) => {
-        const jsonValues = JSON.parse(values);
-        return (
-          <RouterLink
-            to={`/${jsonValues.singleItem}/${jsonValues.link}/`}
-            state={jsonValues.state}
-            style={{ color: theme.palette.primary.main }}
-          >
-            {jsonValues.data}
-          </RouterLink>
-        );
-      },
     },
     project_description: {
-      hidden: true,
       searchable: true,
-      sortable: false,
-      label: "Project description",
       search: {
-        label: "Search by project description",
         operator: "_ilike",
         quoted: true,
         envelope: "%{VALUE}%",
       },
-      width: "50%",
       type: "String",
     },
     ecapris_subproject_id: {
-      hidden: false,
       searchable: true,
-      sortable: true,
-      label: "eCAPRIS ID",
-      filter: (value) => (
-        <ExternalLink
-          text={value}
-          url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${value}`}
-        />
-      ),
-      type: "string",
       search: {
-        label: "Search by eCapris subproject ID",
         operator: "_ilike",
         quoted: true,
         envelope: "%{VALUE}%",
       },
+      type: "string",
     },
   },
   // This object gets consumed into the GQLAbstract system, and here is the single, un-nested order_by directive. ✅

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchQueryConf.js
@@ -1,0 +1,130 @@
+import React from "react";
+import { ProjectsListViewFiltersConf } from "./ProjectsListViewFiltersConf";
+import { ProjectsListViewExportConf } from "./ProjectsListViewExportConf";
+import ExternalLink from "../../../components/ExternalLink";
+import { NavLink as RouterLink } from "react-router-dom";
+import theme from "src/theme/index";
+
+/**
+ * The Query configuration (now also including filters)
+ * @constant
+ * @type {object}
+ * @augments NavigationSearchFiltersConf
+ * @default
+ */
+export const NavigationSearchQueryConf = {
+  options: {
+    useQuery: {
+      fetchPolicy: "cache-first", // Default is "cache-first", or use "no-cache"
+    },
+  },
+  table: "project_list_view",
+  single_item: "/moped/projects",
+  new_item: "/moped/projects/new",
+  new_item_label: "New Project",
+  showDateRange: false,
+  showSearchBar: true,
+  showFilters: false,
+  showExport: true,
+  showNewItemButton: false,
+  noResultsMessage: "No projects found.",
+  showPagination: true,
+  pagination: {
+    rowsPerPageOptions: [250, 1000],
+  },
+  filters: ProjectsListViewFiltersConf,
+  export: ProjectsListViewExportConf,
+  search: {
+    placeholder:
+      "Search by ID, name, description, phase, lead, sponsor, partners, eCAPRIS ID...",
+    defaultFieldsOperator: "_or",
+  },
+  columns: {
+    project_id: {
+      hidden: true,
+      primary_key: true,
+      searchable: true,
+      sortable: false,
+      label: "Project ID",
+      search: {
+        label: "Search by project ID",
+        operator: "_eq",
+        quoted: false,
+        envelope: "%{VALUE}%",
+        invalidValueDefault: 0,
+      },
+      icon: {
+        name: "edit_road",
+        color: "primary",
+      },
+      width: "*",
+      type: "Int",
+    },
+    project_name: {
+      searchable: true,
+      sortable: false,
+      link: "project_id",
+      label: "Project name",
+      search: {
+        label: "Search by project name",
+        operator: "_ilike",
+        quoted: true,
+        envelope: "%{VALUE}%",
+      },
+      width: "*",
+      type: "String",
+      filter: (values) => {
+        const jsonValues = JSON.parse(values);
+        return (
+          <RouterLink
+            to={`/${jsonValues.singleItem}/${jsonValues.link}/`}
+            state={jsonValues.state}
+            style={{ color: theme.palette.primary.main }}
+          >
+            {jsonValues.data}
+          </RouterLink>
+        );
+      },
+    },
+    project_description: {
+      hidden: true,
+      searchable: true,
+      sortable: false,
+      label: "Project description",
+      search: {
+        label: "Search by project description",
+        operator: "_ilike",
+        quoted: true,
+        envelope: "%{VALUE}%",
+      },
+      width: "50%",
+      type: "String",
+    },
+    ecapris_subproject_id: {
+      hidden: false,
+      searchable: true,
+      sortable: true,
+      label: "eCAPRIS ID",
+      filter: (value) => (
+        <ExternalLink
+          text={value}
+          url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${value}`}
+        />
+      ),
+      type: "string",
+      search: {
+        label: "Search by eCapris subproject ID",
+        operator: "_ilike",
+        quoted: true,
+        envelope: "%{VALUE}%",
+      },
+    },
+  },
+  // This object gets consumed into the GQLAbstract system, and here is the single, un-nested order_by directive. ✅
+  order_by: { updated_at: "desc" },
+  where: null,
+  or: null,
+  and: null,
+  limit: 250,
+  offset: 0,
+};

--- a/moped-editor/src/libs/GQLAbstract.js
+++ b/moped-editor/src/libs/GQLAbstract.js
@@ -135,14 +135,6 @@ class GQLAbstract {
   }
 
   /**
-   * Reset all config to initial values
-   * @returns {Array}
-   */
-  get reset() {
-    this.resetFull();
-  }
-
-  /**
    * Resets the value of where and or to empty
    */
   cleanWhere() {

--- a/moped-editor/src/libs/GQLAbstract.js
+++ b/moped-editor/src/libs/GQLAbstract.js
@@ -51,14 +51,14 @@ class GQLAbstract {
    * @param {string} exp - The GraphQL expression
    * @returns {string}
    */
-  getExpKey = exp => exp.split(/[{} ]+/, 1)[0].trim();
+  getExpKey = (exp) => exp.split(/[{} ]+/, 1)[0].trim();
 
   /**
    * Returns the value of a nested expression, usually another expression.
    * @param {string} exp - The GraphQL expression
    * @returns {string}
    */
-  getExpValue = exp =>
+  getExpValue = (exp) =>
     exp.substring(exp.indexOf("{") + 1, exp.lastIndexOf("}")).trim();
 
   /**
@@ -132,6 +132,14 @@ class GQLAbstract {
       if (value.searchable) columns.push(key);
     }
     return columns;
+  }
+
+  /**
+   * Reset all config to initial values
+   * @returns {Array}
+   */
+  get reset() {
+    this.resetFull();
   }
 
   /**
@@ -375,7 +383,7 @@ class GQLAbstract {
    * @returns {Array}
    */
   get columns() {
-    return this.getEntries("columns").map(k => k[0]);
+    return this.getEntries("columns").map((k) => k[0]);
   }
 
   /**
@@ -419,7 +427,7 @@ class GQLAbstract {
     if (this.config.and !== null) {
       for (const [key, value] of this.getEntries("and")) {
         const andValues = value.split(",");
-        andValues.forEach(andValue => and.push(`{${key}: {${andValue}}}`));
+        andValues.forEach((andValue) => and.push(`{${key}: {${andValue}}}`));
         // remove key from where clause after including the values in "and"
         this.deleteWhere(key);
       }
@@ -551,7 +559,7 @@ class GQLAbstract {
     const aggregatesQueryArray = [];
 
     // For each config, create query, replace filters/columns, and push to aggregatesQueryArray
-    queryConfigArray.forEach(config => {
+    queryConfigArray.forEach((config) => {
       let query = `
       gqlAbstractTableAggregateName (
           gqlAbstractAggregateFilters


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/7659

This PR fixes a bug where the config for the advanced search and the global search were intertwined. My leading theory is that GQLAbstract was using the same object reference for both the global search and the advanced search since the global search recycled the project list view config. So, both components were mutating the same object. Pretty gnarly! 

[Here are the lines](https://github.com/cityofaustin/atd-moped/blob/caffff6ffac648ba034f13b0163dd68f81533599/moped-editor/src/libs/GQLAbstract.js#L11-L12) where the GQLAbstract class assigns the object reference to its instance property called `initConfig` instead of creating a new reference. This remains a bug with GQLAbstract, but I didn't want to make such a large change in this PR. And, I could definitely use some backup on this theory. 🙏

**Before**:
`ProjectsListViewQueryConf` 🔗 gqlabstract config for advanced search 🔗  gqlabstract config for global search

**After**:
`ProjectsListViewQueryConf` 🔗 gqlabstract config for advanced search
`NavigationSearchQueryConf` 🔗  gqlabstract config for global search

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1115--atd-moped-main.netlify.app/moped

**Steps to test:**
1. Do an advanced search from the projects page like Project ID is 228 if testing locally or Project ID is 1930 if testing in the deploy preview
2. Navigate to a project summary page from a project in the search results
3. Use the global search to find other projects using a search string like demo or another project ID
4. You should see that other projects populate in the results dropdown

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
