### PR TITLE
Add council districts to project summary tab

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -126,6 +126,7 @@ export const SUMMARY_QUERY = gql`
     ) {
       geometry: geography
       attributes
+      council_districts
     }
     moped_proj_components(
       where: { project_id: { _eq: $projectId }, is_deleted: { _eq: false } }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
 
-import { Grid, CardContent, CircularProgress } from "@mui/material";
+import { Grid, CardContent, CircularProgress, Typography } from "@mui/material";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -143,6 +143,16 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
 
   if (loading) return <CircularProgress />;
   if (error) return `Error! ${error.message}`;
+
+  const getDistricts = (data) => {
+    const initialValue = [];
+    const districts = data.reduce(
+      (acc, component) => [...acc, component["council_districts"]],
+      initialValue
+    );
+
+    return [...new Set(districts.flat())];
+  };
 
   return (
     <ApolloErrorHandler errors={error}>
@@ -295,6 +305,12 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
             <Grid container spacing={2}>
               <Grid item xs={12}>
                 <ProjectSummaryMap data={data} />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography>
+                  Council districts:{" "}
+                  {getDistricts(data.project_geography).join(", ")}
+                </Typography>
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
 
-import { Grid, CardContent, CircularProgress, Typography } from "@mui/material";
+import { Grid, CardContent, CircularProgress } from "@mui/material";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -19,6 +19,7 @@ import ProjectSummaryWorkOrders from "./ProjectSummaryWorkOrders";
 import ProjectSummaryInterimID from "./ProjectSummaryInterimID";
 import ProjectSummaryAutocomplete from "./ProjectSummaryAutocomplete";
 import ProjectSummaryProjectPartners from "./ProjectSummaryProjectPartners";
+import ProjectSummaryCouncilDistricts from "./ProjectSummaryCouncilDistricts";
 
 import SubprojectsTable from "./SubprojectsTable";
 import TagsSection from "./TagsSection";
@@ -74,6 +75,11 @@ const useStyles = makeStyles((theme) => ({
       borderRadius: theme.spacing(0.5),
       cursor: "pointer",
     },
+    overflowWrap: "break-word",
+  },
+  fieldLabelTextNoHover: {
+    width: "calc(100% - 2rem)",
+    paddingLeft: theme.spacing(0.5),
     overflowWrap: "break-word",
   },
   knackFieldLabelText: {
@@ -143,16 +149,6 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
 
   if (loading) return <CircularProgress />;
   if (error) return `Error! ${error.message}`;
-
-  const getDistricts = (data) => {
-    const initialValue = [];
-    const districts = data.reduce(
-      (acc, component) => [...acc, component["council_districts"]],
-      initialValue
-    );
-
-    return [...new Set(districts.flat())];
-  };
 
   return (
     <ApolloErrorHandler errors={error}>
@@ -307,10 +303,10 @@ const ProjectSummary = ({ loading, error, data, refetch }) => {
                 <ProjectSummaryMap data={data} />
               </Grid>
               <Grid item xs={12}>
-                <Typography>
-                  Council districts:{" "}
-                  {getDistricts(data.project_geography).join(", ")}
-                </Typography>
+                <ProjectSummaryCouncilDistricts
+                  classes={classes}
+                  projectGeography={data.project_geography}
+                />
               </Grid>
               <Grid item xs={12}>
                 <TagsSection projectId={projectId} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -9,7 +9,11 @@ import { Box, Grid, Typography } from "@mui/material";
       initialValue
     );
 
-    return [...new Set(districts.flat().sort((a, b) => a - b))];
+    // flatten the array of arrays and remove empty districts
+    const districtsArray = districts.flat().filter(d=>d)
+
+    // sort in ascending order and use Set to only return unique districts
+    return [...new Set(districtsArray.sort((a, b) => a - b))];
   };
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Box, Grid, Typography } from "@mui/material";
+
+/**
+ * ProjectSummaryCouncilDistricts Component
+ * @param {Object} data - The project geography from the graphql query's data object
+ * @param {Object} classes - The shared style settings
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
+  // reduce the array of geography objects into an array of city council districts
+  const getDistricts = (data) => {
+    const initialValue = [];
+    const districts = data.reduce(
+      (acc, component) => [...acc, component["council_districts"]],
+      initialValue
+    );
+
+    return [...new Set(districts.flat())];
+  };
+
+  return (
+    <Grid item xs={12} className={classes.fieldGridItem}>
+      <Typography className={classes.fieldLabel}>
+        Council district(s):
+      </Typography>
+      <Box className={classes.fieldBox}>
+        <Typography className={classes.fieldLabelTextNoHover}>
+          {getDistricts(projectGeography).join(", ")}
+        </Typography>
+      </Box>
+    </Grid>
+  );
+};
+
+export default ProjectSummaryCouncilDistricts;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -1,14 +1,6 @@
 import React from "react";
 import { Box, Grid, Typography } from "@mui/material";
 
-/**
- * ProjectSummaryCouncilDistricts Component
- * @param {Object} data - The project geography from the graphql query's data object
- * @param {Object} classes - The shared style settings
- * @returns {JSX.Element}
- * @constructor
- */
-const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
   // reduce the array of geography objects into an array of city council districts
   const getDistricts = (data) => {
     const initialValue = [];
@@ -17,8 +9,17 @@ const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
       initialValue
     );
 
-    return [...new Set(districts.flat())];
+    return [...new Set(districts.flat().sort((a, b) => a - b))];
   };
+
+/**
+ * ProjectSummaryCouncilDistricts Component
+ * @param {Object} data - The project geography from the graphql query's data object
+ * @param {Object} classes - The shared style settings
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
 
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/10894

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

https://deploy-preview-1122--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

Check different projects and see that their council districts appear under the summary map. 
If there is no council district, you will see a blank space. 

Question -- should it be sorted in numerical ascending order? 


---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
