### PR TITLE
backfills location description with signal location

### DIFF
--- a/moped-database/migrations/1694711478835_backfill-com-loc-desc/down.sql
+++ b/moped-database/migrations/1694711478835_backfill-com-loc-desc/down.sql
@@ -1,0 +1,14 @@
+UPDATE
+    moped_proj_components
+SET
+    location_description =  null
+FROM (
+    SELECT
+        component_id AS project_component_id,
+        attributes -> 'location_name'::text AS location_description
+    FROM
+        project_geography
+    WHERE
+        "table" = 'feature_signals') AS locations
+WHERE
+    moped_proj_components.project_component_id = locations.project_component_id;

--- a/moped-database/migrations/1694711478835_backfill-com-loc-desc/down.sql
+++ b/moped-database/migrations/1694711478835_backfill-com-loc-desc/down.sql
@@ -4,8 +4,7 @@ SET
     location_description =  null
 FROM (
     SELECT
-        component_id AS project_component_id,
-        attributes -> 'location_name'::text AS location_description
+        component_id AS project_component_id
     FROM
         project_geography
     WHERE

--- a/moped-database/migrations/1694711478835_backfill-com-loc-desc/up.sql
+++ b/moped-database/migrations/1694711478835_backfill-com-loc-desc/up.sql
@@ -5,7 +5,7 @@ SET
 FROM (
     SELECT
         component_id AS project_component_id,
-        attributes -> 'location_name'::text AS location_description
+        attributes ->> 'signal_id' || ': ' || trim(attributes ->> 'location_name') AS location_description
     FROM
         project_geography
     WHERE

--- a/moped-database/migrations/1694711478835_backfill-com-loc-desc/up.sql
+++ b/moped-database/migrations/1694711478835_backfill-com-loc-desc/up.sql
@@ -1,0 +1,14 @@
+UPDATE
+    moped_proj_components
+SET
+    location_description = locations.location_description
+FROM (
+    SELECT
+        component_id AS project_component_id,
+        attributes -> 'location_name'::text AS location_description
+    FROM
+        project_geography
+    WHERE
+        "table" = 'feature_signals') AS locations
+WHERE
+    moped_proj_components.project_component_id = locations.project_component_id;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13800

## Testing
**URL to test:**  Local

**Steps to test:**
1. Start Moped!
2. Open the map for project 228—observe that the signal component has the location description "365:  CESAR CHAVEZ ST / ROBERT T MARTINEZ JR ST"
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
