### PR TITLE
Rework signal feature in project list view query

### DIFF
--- a/moped-database/migrations/1694809058492_list_view_optimize/up.sql
+++ b/moped-database/migrations/1694809058492_list_view_optimize/up.sql
@@ -1,4 +1,3 @@
--- latest version 1694809058492_list_view_optimize
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view

--- a/moped-database/migrations/1694809881268_moped_project_updated_at_index/down.sql
+++ b/moped-database/migrations/1694809881268_moped_project_updated_at_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX moped_project_updated_at_idx;

--- a/moped-database/migrations/1694809881268_moped_project_updated_at_index/down.sql
+++ b/moped-database/migrations/1694809881268_moped_project_updated_at_index/down.sql
@@ -1,1 +1,2 @@
+DROP INDEX moped_project_name_idx;
 DROP INDEX moped_project_updated_at_idx;

--- a/moped-database/migrations/1694809881268_moped_project_updated_at_index/up.sql
+++ b/moped-database/migrations/1694809881268_moped_project_updated_at_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX moped_project_updated_at_idx ON moped_project (updated_at);

--- a/moped-database/migrations/1694809881268_moped_project_updated_at_index/up.sql
+++ b/moped-database/migrations/1694809881268_moped_project_updated_at_index/up.sql
@@ -1,1 +1,2 @@
 CREATE INDEX moped_project_updated_at_idx ON moped_project (updated_at);
+CREATE INDEX moped_project_name_idx on moped_project (project_name);


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13857

## Testing
**URL to test:** Local

It's going to be hard to notice the performance improvements without a large number of projects. But definitely you want to test that the list view loads normally.

1. Start yer Moped
2. Make sure the project list view loads normally.
3. Make all columns visible.
4. Try some advanced search filters

To test the query performance itself you can connect to the read replica!

1. Connect to the prod read replica
2. Run the `up` version of the view sql. (exclude the "CREATE OR REPLACE VIEW..." bit).
3. Run the `down` version of the view sql (exclude the "CREATE OR REPLACE VIEW..." bit).

I am seeing a roughly 50% speed up versus the old list view query. ~500ms vs 1000ms once the query is warm.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
