### PR TITLE
BUG -- hidden columns not persisting

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -90,7 +90,9 @@ const DEFAULT_HIDDEN_COLS = {
  * @param {Bool} hidden - the hidden state of the column
  */
 const handleColumnChange = ({ field }, hidden) => {
-  let storedConfig = JSON.parse(localStorage.getItem("mopedColumnConfig"));
+  let storedConfig =
+    JSON.parse(localStorage.getItem("mopedColumnConfig")) ??
+    DEFAULT_HIDDEN_COLS;
   storedConfig = { ...storedConfig, [field]: hidden };
   localStorage.setItem("mopedColumnConfig", JSON.stringify(storedConfig));
 };


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13898

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

https://deploy-preview-1135--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

To reproduce:
1. Load the project list view. 
2. Use your browser's dev tools to delete `mopedColumnConfig` from local storage.
    `localStorage.removeItem("mopedColumnConfig")`
4. Refresh the page. The list view has the default columns visible. Good.
5. Update the list view column settings to show one of the hidden columns.
6. Refresh the page. Your column choice should be the only change you see. 

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
