### PR TITLE
Advanced filter for projects with Subprojects

### DIFF
--- a/moped-editor/src/components/GridTable/GridTableFiltersCommonOperators.js
+++ b/moped-editor/src/components/GridTable/GridTableFiltersCommonOperators.js
@@ -163,4 +163,18 @@ export const GridTableFiltersCommonOperators = {
     envelope: null,
     type: "string",
   },
+  subprojects_array_is_null: {
+    operator: "_is_null",
+    label: "No",
+    description: "Project does not have subprojects",
+    type: "array",
+    envelope: "true",
+  },
+  subprojects_array_is_not_null: {
+    operator: "_is_null",
+    label: "Yes",
+    description: "Project has subprojects",
+    type: "array",
+    envelope: "false",
+  },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -3,6 +3,7 @@ import {
   filterProjectTeamMembers,
   filterProjectSignals,
   filterTaskOrderName,
+  resolveHasSubprojects,
 } from "./helpers.js";
 
 /**
@@ -108,5 +109,13 @@ export const ProjectsListViewExportConf = {
   public_process_status: {
     label: "Public process status",
     filter: filterNullValues,
+  },
+  parent_project_name: {
+    label: "Parent project name",
+    filter: filterNullValues,
+  },
+  children_project_ids: {
+    label: "Has subprojects",
+    filter: resolveHasSubprojects,
   },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -360,6 +360,16 @@ export const ProjectsListViewFiltersConf = {
         "*", // All of them (shortcut)
       ],
     },
+    {
+      name: "children_project_ids",
+      label: "Has Subprojects",
+      placeholder: "thing",
+      type: "array",
+      operators: [
+        "subprojects_array_is_null",
+        "subprojects_array_is_not_null"
+      ],
+    },
   ],
 
   operators: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -363,7 +363,7 @@ export const ProjectsListViewFiltersConf = {
     {
       name: "children_project_ids",
       label: "Has Subprojects",
-      placeholder: "thing",
+      placeholder: "Subproject",
       type: "array",
       operators: [
         "subprojects_array_is_null",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -56,3 +56,12 @@ export const filterTaskOrderName = (value) => {
   });
   return taskOrderArray.join(", ");
 };
+
+export const resolveHasSubprojects = (array) => {
+  if (array) {
+    if (array.length > 0) {
+      return "Yes";
+    }
+  }
+  return "No";
+};


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13904

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1138--atd-moped-main.netlify.app/moped/

**Steps to test:**

Toggle the "has subprojects" column to be visible
Advanced filter, choose Has Subprojects as the field. 
Choose either yes or no. 
See the results. 


I also added the has subprojects column and the parent project name column to the csv export. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
