### PR TITLE
[BUG] Signal IDs are duplicated in the project view

### DIFF
--- a/moped-database/migrations/1695755972720_project_list_view_signals/down.sql
+++ b/moped-database/migrations/1695755972720_project_list_view_signals/down.sql
@@ -1,4 +1,3 @@
--- latest version 1695052574993_parent_child_list_view
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view
@@ -66,8 +65,7 @@ AS WITH project_person_list_lookup AS (
         WHERE TRUE
           AND components.is_deleted = false
           AND components.project_id = mp.project_id
-          AND feature_signals.signal_id is not null
-          AND feature_signals.is_deleted = false
+          and feature_signals.signal_id is not null
         ) as project_feature,
     fsl.funding_source_name,
     ptl.type_name,

--- a/moped-database/migrations/1695755972720_project_list_view_signals/up.sql
+++ b/moped-database/migrations/1695755972720_project_list_view_signals/up.sql
@@ -1,4 +1,3 @@
--- latest version 1695052574993_parent_child_list_view
 DROP VIEW project_list_view;
 
 CREATE OR REPLACE VIEW public.project_list_view


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13988

## Testing
**URL to test:** 

Gotta test local, project list view changes!

**Steps to test:**
I tested with prod data, and the project mentioned in the issue no longer has duplicate signals


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
