### PR TITLE
[Bug] CSV export is broken because commas are not escaped properly

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -3,6 +3,7 @@ import {
   filterProjectTeamMembers,
   filterProjectSignals,
   filterTaskOrderName,
+  filterStatusUpdate,
 } from "./helpers.js";
 
 /**
@@ -72,7 +73,7 @@ export const ProjectsListViewExportConf = {
   },
   project_note: {
     label: "Status Update",
-    filter: filterNullValues,
+    filter: filterStatusUpdate,
   },
   construction_start_date: {
     label: "Construction start",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -56,3 +56,19 @@ export const filterTaskOrderName = (value) => {
   });
   return taskOrderArray.join(", ");
 };
+
+export const filterStatusUpdate = (value) => {
+  if (!value || value === "-") {
+    return "";
+  } else {
+    // escape " by preceding it with another "
+    if (value.includes('"')) {
+      value = value.replace(/"/g, '""');
+    }
+    // escape , by wrapping it in ""
+    if (value.includes(",")) {
+      value = value.replace(/,/g, '"",""');
+    }
+    return value;
+  }
+};


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/13978

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1140--atd-moped-main.netlify.app/moped/projects

or locally with prod data

**Steps to test:**
Click download button next to search input. Check that the csv export makes sense, a good way to quickly eyeball this is by scrolling horizontally to the end and seeing that there aren't extra columns with empty headers. In prod right now, commas that are in the status update column are being interpreted as delimiters and inserting extra columns. 

It turns out that different applications can parse csvs differently, and I found that just using one set of quotes to parse commas wasn't working when I opened it in Numbers. So I uploaded it to excel online (https://www.office.com/launch/excel) and that did a better job of handling the singular set of quotes. 

**Question**

the file that is downloaded is named `project_list_view2023-09-27blahblahtodaystime.csv` Do you think we should prepend the word moped to the file name?

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
