### PR TITLE
Adds length column to line features

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4648,6 +4648,7 @@
           - project_name
           - geography
           - council_districts
+          - length_feet
         filter: {}
         allow_aggregations: true
     - role: moped-editor
@@ -4665,6 +4666,7 @@
           - attributes
           - geography
           - council_districts
+          - length_feet
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
@@ -4682,6 +4684,7 @@
           - project_name
           - geography
           - council_districts
+          - length_feet
         filter: {}
         allow_aggregations: true
 - table:

--- a/moped-database/migrations/1696622988854_add_feature_length_column/down.sql
+++ b/moped-database/migrations/1696622988854_add_feature_length_column/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE feature_street_segments
+    DROP COLUMN length_feet;
+
+ALTER TABLE feature_drawn_lines
+    DROP COLUMN length_feet;

--- a/moped-database/migrations/1696622988854_add_feature_length_column/up.sql
+++ b/moped-database/migrations/1696622988854_add_feature_length_column/up.sql
@@ -1,7 +1,7 @@
 ALTER TABLE feature_street_segments
     ADD COLUMN length_feet INTEGER GENERATED always AS (
-Round(ST_Length(geography) * 3.28084)) stored;
+ST_Length(geography) * 3.28084) stored;
 
 ALTER TABLE feature_drawn_lines
     ADD COLUMN length_feet INTEGER GENERATED always AS (
-Round(ST_Length(geography) * 3.28084)) stored;
+ST_Length(geography) * 3.28084) stored;

--- a/moped-database/migrations/1696622988854_add_feature_length_column/up.sql
+++ b/moped-database/migrations/1696622988854_add_feature_length_column/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE feature_street_segments
+    ADD COLUMN length_feet INTEGER GENERATED always AS (
+Round(ST_Length(geography) * 3.28084)) stored;
+
+ALTER TABLE feature_drawn_lines
+    ADD COLUMN length_feet INTEGER GENERATED always AS (
+Round(ST_Length(geography) * 3.28084)) stored;

--- a/moped-database/migrations/1696624355279_add-length-to-views/down.sql
+++ b/moped-database/migrations/1696624355279_add-length-to-views/down.sql
@@ -1,3 +1,6 @@
+DROP VIEW "public"."project_geography";
+DROP VIEW "public"."uniform_features";
+
 -- reverts to 1691698449987_add-district-columns-to-views
 CREATE OR REPLACE VIEW "public"."uniform_features" AS
 SELECT
@@ -94,3 +97,51 @@ FROM
         GROUP BY
             d.feature_id) districts ON districts.feature_id = feature_drawn_lines.id
 WHERE (feature_drawn_lines.is_deleted = FALSE);
+
+
+-- reverts to 1691698449987_add-district-columns-to-views
+CREATE
+OR REPLACE VIEW "public"."project_geography" AS
+SELECT
+  moped_project.project_id,
+  uniform_features.id AS feature_id,
+  moped_components.component_id AS component_archtype_id,
+  moped_proj_components.project_component_id AS component_id,
+  moped_proj_components.is_deleted,
+  moped_project.project_name,
+  feature_layers.internal_table AS "table",
+  feature_layers.reference_layer_primary_key_column AS original_fk,
+  moped_components.component_name,
+  uniform_features.attributes,
+  uniform_features.geography,
+  uniform_features.council_districts
+FROM
+  (
+    (
+      (
+        (
+          moped_project
+          JOIN moped_proj_components ON (
+            (
+              moped_proj_components.project_id = moped_project.project_id
+            )
+          )
+        )
+        JOIN moped_components ON (
+          (
+            moped_proj_components.component_id = moped_components.component_id
+          )
+        )
+      )
+      JOIN feature_layers ON (
+        (
+          moped_components.feature_layer_id = feature_layers.id
+        )
+      )
+    )
+    JOIN uniform_features ON (
+      (
+        moped_proj_components.project_component_id = uniform_features.component_id
+      )
+    )
+  );

--- a/moped-database/migrations/1696624355279_add-length-to-views/down.sql
+++ b/moped-database/migrations/1696624355279_add-length-to-views/down.sql
@@ -1,5 +1,5 @@
--- latest version 1696624355279_add-length-to-views
-REPLACE VIEW "public"."uniform_features" AS
+-- reverts to 1691698449987_add-district-columns-to-views
+CREATE OR REPLACE VIEW "public"."uniform_features" AS
 SELECT
     feature_signals.id,
     feature_signals.component_id,
@@ -23,7 +23,7 @@ SELECT
     feature_street_segments.id,
     feature_street_segments.component_id,
     'feature_street_segments'::text AS "table",
-    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer, 'length_feet', feature_street_segments.length_feet) AS attributes,
+    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer) AS attributes,
     feature_street_segments.geography,
     districts.council_districts
 FROM
@@ -80,7 +80,7 @@ SELECT
     feature_drawn_lines.id,
     feature_drawn_lines.component_id,
     'feature_drawn_lines'::text AS "table",
-    json_build_object('length_feet', feature_drawn_lines.length_feet),
+    NULL::json AS attributes,
     feature_drawn_lines.geography,
     districts.council_districts
 FROM

--- a/moped-database/migrations/1696624355279_add-length-to-views/up.sql
+++ b/moped-database/migrations/1696624355279_add-length-to-views/up.sql
@@ -79,7 +79,7 @@ SELECT
     feature_drawn_lines.id,
     feature_drawn_lines.component_id,
     'feature_drawn_lines'::text AS "table",
-    json_build_object('length_feet', feature_drawn_lines.length_feet),
+    json_build_object('length_feet', feature_drawn_lines.length_feet) AS attributes,
     feature_drawn_lines.geography,
     districts.council_districts
 FROM

--- a/moped-database/migrations/1696624355279_add-length-to-views/up.sql
+++ b/moped-database/migrations/1696624355279_add-length-to-views/up.sql
@@ -1,11 +1,14 @@
-CREATE OR REPLACE VIEW "public"."uniform_features" AS
+DROP VIEW "public"."project_geography";
+DROP VIEW "public"."uniform_features";
+CREATE VIEW "public"."uniform_features" AS
 SELECT
     feature_signals.id,
     feature_signals.component_id,
     'feature_signals'::text AS "table",
     json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type) AS attributes,
     feature_signals.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_signals
     LEFT JOIN (
@@ -22,9 +25,10 @@ SELECT
     feature_street_segments.id,
     feature_street_segments.component_id,
     'feature_street_segments'::text AS "table",
-    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer, 'length_feet', feature_street_segments.length_feet) AS attributes,
+    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer) AS attributes,
     feature_street_segments.geography,
-    districts.council_districts
+    districts.council_districts,
+    feature_street_segments.length_feet
 FROM
     feature_street_segments
     LEFT JOIN (
@@ -43,7 +47,8 @@ SELECT
     'feature_intersections'::text AS "table",
     json_build_object('intersection_id', feature_intersections.intersection_id, 'source_layer', feature_intersections.source_layer) AS attributes,
     feature_intersections.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_intersections
     LEFT JOIN (
@@ -62,7 +67,8 @@ SELECT
     'feature_drawn_points'::text AS "table",
     NULL::json AS attributes,
     feature_drawn_points.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_drawn_points
     LEFT JOIN (
@@ -79,9 +85,10 @@ SELECT
     feature_drawn_lines.id,
     feature_drawn_lines.component_id,
     'feature_drawn_lines'::text AS "table",
-    json_build_object('length_feet', feature_drawn_lines.length_feet) AS attributes,
+    NULL::json as attributes,
     feature_drawn_lines.geography,
-    districts.council_districts
+    districts.council_districts,
+    feature_drawn_lines.length_feet
 FROM
     feature_drawn_lines
     LEFT JOIN (
@@ -93,3 +100,49 @@ FROM
         GROUP BY
             d.feature_id) districts ON districts.feature_id = feature_drawn_lines.id
 WHERE (feature_drawn_lines.is_deleted = FALSE);
+
+CREATE VIEW "public"."project_geography" AS
+SELECT
+  moped_project.project_id,
+  uniform_features.id AS feature_id,
+  moped_components.component_id AS component_archtype_id,
+  moped_proj_components.project_component_id AS component_id,
+  moped_proj_components.is_deleted,
+  moped_project.project_name,
+  feature_layers.internal_table AS "table",
+  feature_layers.reference_layer_primary_key_column AS original_fk,
+  moped_components.component_name,
+  uniform_features.attributes,
+  uniform_features.geography,
+  uniform_features.council_districts,
+  uniform_features.length_feet
+FROM
+  (
+    (
+      (
+        (
+          moped_project
+          JOIN moped_proj_components ON (
+            (
+              moped_proj_components.project_id = moped_project.project_id
+            )
+          )
+        )
+        JOIN moped_components ON (
+          (
+            moped_proj_components.component_id = moped_components.component_id
+          )
+        )
+      )
+      JOIN feature_layers ON (
+        (
+          moped_components.feature_layer_id = feature_layers.id
+        )
+      )
+    )
+    JOIN uniform_features ON (
+      (
+        moped_proj_components.project_component_id = uniform_features.component_id
+      )
+    )
+  );

--- a/moped-database/migrations/1696624355279_add-length-to-views/up.sql
+++ b/moped-database/migrations/1696624355279_add-length-to-views/up.sql
@@ -1,5 +1,4 @@
--- latest version 1696624355279_add-length-to-views
-REPLACE VIEW "public"."uniform_features" AS
+CREATE OR REPLACE VIEW "public"."uniform_features" AS
 SELECT
     feature_signals.id,
     feature_signals.component_id,

--- a/moped-database/views/project_geography.sql
+++ b/moped-database/views/project_geography.sql
@@ -1,6 +1,5 @@
--- latest version from 1691698449987_add-district-columns-to-views
-CREATE
-OR REPLACE VIEW "public"."project_geography" AS
+-- latest version 1696622988854_add_feature_length_column
+CREATE VIEW "public"."project_geography" AS
 SELECT
   moped_project.project_id,
   uniform_features.id AS feature_id,
@@ -13,7 +12,8 @@ SELECT
   moped_components.component_name,
   uniform_features.attributes,
   uniform_features.geography,
-  uniform_features.council_districts
+  uniform_features.council_districts,
+  uniform_features.length_feet
 FROM
   (
     (

--- a/moped-database/views/uniform_features.sql
+++ b/moped-database/views/uniform_features.sql
@@ -1,12 +1,13 @@
 -- latest version 1696624355279_add-length-to-views
-CREATE OR REPLACE VIEW "public"."uniform_features" AS
+CREATE VIEW "public"."uniform_features" AS
 SELECT
     feature_signals.id,
     feature_signals.component_id,
     'feature_signals'::text AS "table",
     json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type) AS attributes,
     feature_signals.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_signals
     LEFT JOIN (
@@ -23,9 +24,10 @@ SELECT
     feature_street_segments.id,
     feature_street_segments.component_id,
     'feature_street_segments'::text AS "table",
-    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer, 'length_feet', feature_street_segments.length_feet) AS attributes,
+    json_build_object('ctn_segment_id', feature_street_segments.ctn_segment_id, 'from_address_min', feature_street_segments.from_address_min, 'to_address_max', feature_street_segments.to_address_max, 'full_street_name', feature_street_segments.full_street_name, 'line_type', feature_street_segments.line_type, 'symbol', feature_street_segments.symbol, 'source_layer', feature_street_segments.source_layer) AS attributes,
     feature_street_segments.geography,
-    districts.council_districts
+    districts.council_districts,
+    feature_street_segments.length_feet
 FROM
     feature_street_segments
     LEFT JOIN (
@@ -44,7 +46,8 @@ SELECT
     'feature_intersections'::text AS "table",
     json_build_object('intersection_id', feature_intersections.intersection_id, 'source_layer', feature_intersections.source_layer) AS attributes,
     feature_intersections.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_intersections
     LEFT JOIN (
@@ -63,7 +66,8 @@ SELECT
     'feature_drawn_points'::text AS "table",
     NULL::json AS attributes,
     feature_drawn_points.geography,
-    districts.council_districts
+    districts.council_districts,
+    NULL as length_feet
 FROM
     feature_drawn_points
     LEFT JOIN (
@@ -80,9 +84,10 @@ SELECT
     feature_drawn_lines.id,
     feature_drawn_lines.component_id,
     'feature_drawn_lines'::text AS "table",
-    json_build_object('length_feet', feature_drawn_lines.length_feet) AS attributes,
+    NULL::json as attributes,
     feature_drawn_lines.geography,
-    districts.council_districts
+    districts.council_districts,
+    feature_drawn_lines.length_feet
 FROM
     feature_drawn_lines
     LEFT JOIN (

--- a/moped-database/views/uniform_features.sql
+++ b/moped-database/views/uniform_features.sql
@@ -1,5 +1,5 @@
 -- latest version 1696624355279_add-length-to-views
-REPLACE VIEW "public"."uniform_features" AS
+CREATE OR REPLACE VIEW "public"."uniform_features" AS
 SELECT
     feature_signals.id,
     feature_signals.component_id,

--- a/moped-database/views/uniform_features.sql
+++ b/moped-database/views/uniform_features.sql
@@ -80,7 +80,7 @@ SELECT
     feature_drawn_lines.id,
     feature_drawn_lines.component_id,
     'feature_drawn_lines'::text AS "table",
-    json_build_object('length_feet', feature_drawn_lines.length_feet),
+    json_build_object('length_feet', feature_drawn_lines.length_feet) AS attributes,
     feature_drawn_lines.geography,
     districts.council_districts
 FROM


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14155

## Testing
**URL to test:**  Local

1. Create a project component using a mix of selected street segments and drawn lines. 
2. Use google maps (or your favorite mapping platform) to measure the approximate distance of your components.
<img width="657" alt="Screenshot 2023-10-06 at 5 01 07 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/5efd9382-85c4-4648-9104-09bfe9d74a12">

3. Compare those measurements to the length stored in the DB. This query will sum up `length_feet` from all line features in a component:

```sql
SELECT
    project_id,
    project_component_id,
    description,
    sum(length_feet) AS total_component_length
FROM (
    SELECT
        project_id,
        mpc.project_component_id,
        mpc.description,
        length_feet
    FROM
        feature_street_segments
    LEFT JOIN moped_proj_components mpc ON mpc.project_component_id = feature_street_segments.component_id
WHERE
    feature_street_segments.is_deleted = FALSE
UNION ALL
SELECT
    project_id,
    mpc.project_component_id,
    mpc.description,
    length_feet
FROM
    feature_drawn_lines
    LEFT JOIN moped_proj_components mpc ON mpc.project_component_id = feature_drawn_lines.component_id
WHERE
    feature_drawn_lines.is_deleted = FALSE) uniform_length
GROUP BY
    project_id,
    project_component_id,
    description;
```


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
