### PR TITLE
Show error alert when component is unmapped

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -9,6 +9,7 @@ import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import IconButton from "@mui/material/IconButton";
 import ListItemText from "@mui/material/ListItemText";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { COLORS } from "./mapStyleSettings";
 import {
   useComponentListItemText,
@@ -59,7 +60,7 @@ export default function ComponentListItem({
         className={classes.listItem}
         ref={component._ref}
       >
-        {Icon}
+        {isComponentMapped ? Icon : <ErrorOutlineIcon color="error" />}
         <ListItemText
           className={classes.listItemText}
           primary={primary}
@@ -78,15 +79,17 @@ export default function ComponentListItem({
           </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
-      {!isComponentMapped && (
-        <ListItem dense className={classes.listItem}>
-          <ListItemText
-            primary={<Alert severity="error">Component is not mapped</Alert>}
-          />
-        </ListItem>
-      )}
       <Collapse in={isExpanded}>
         <List component="div" disablePadding dense>
+          {!isComponentMapped && (
+            <ListItem dense className={classes.listItem}>
+              <ListItemText
+                primary={
+                  <Alert severity="error">Component is not mapped</Alert>
+                }
+              />
+            </ListItem>
+          )}
           {component.description && (
             <ListItem className={classes.nested}>
               <ListItemText secondary={component.description} />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import makeStyles from "@mui/styles/makeStyles";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -12,7 +12,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { COLORS } from "./mapStyleSettings";
 import {
   useComponentListItemText,
-  useIsComponentMapped,
+  getIsComponentMapped,
 } from "./utils/componentList";
 
 const useStyles = makeStyles((theme) => ({
@@ -43,7 +43,7 @@ export default function ComponentListItem({
   const classes = useStyles();
 
   const { primary, secondary } = useComponentListItemText(component);
-  const isComponentMapped = useIsComponentMapped(component);
+  const isComponentMapped = getIsComponentMapped(component);
 
   return (
     <Box

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import makeStyles from "@mui/styles/makeStyles";
+import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import List from "@mui/material/List";
@@ -9,7 +11,10 @@ import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import IconButton from "@mui/material/IconButton";
 import ListItemText from "@mui/material/ListItemText";
 import { COLORS } from "./mapStyleSettings";
-import { useComponentListItemText } from "./utils/componentList";
+import {
+  useComponentListItemText,
+  useIsComponentMapped,
+} from "./utils/componentList";
 
 const useStyles = makeStyles((theme) => ({
   nested: {
@@ -39,6 +44,7 @@ export default function ComponentListItem({
   const classes = useStyles();
 
   const { primary, secondary } = useComponentListItemText(component);
+  const isComponentMapped = useIsComponentMapped(component);
 
   return (
     <Box
@@ -73,6 +79,13 @@ export default function ComponentListItem({
           </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
+      {!isComponentMapped && (
+        <ListItem dense className={classes.listItem}>
+          <ListItemText
+            primary={<Alert severity="error">Component is not mapped</Alert>}
+          />
+        </ListItem>
+      )}
       <Collapse in={isExpanded}>
         <List component="div" disablePadding dense>
           {component.description && (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectComponentsList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ProjectComponentsList.js
@@ -8,6 +8,7 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import { isSignalComponent } from "./utils/componentList";
 import { ComponentIconByLineRepresentation } from "./utils/form";
+import { getIsComponentMapped } from "./utils/componentList";
 import theme from "src/theme/index";
 
 const ProjectComponentsList = ({
@@ -109,7 +110,9 @@ const ProjectComponentsList = ({
                     onClick={onEditMap}
                     disabled={isSignal}
                   >
-                    <EditLocationAltOutlinedIcon />
+                    <EditLocationAltOutlinedIcon
+                      color={getIsComponentMapped(component) ? undefined : "error"}
+                    />
                   </IconButton>
                 </span>
               </Tooltip>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
@@ -20,3 +20,20 @@ export const useComponentListItemText = (component) =>
     listItemText.secondary = component.location_description;
     return listItemText;
   }, [component]);
+
+/**
+ * Identify if a component is map by checking all potential feature layers
+ * for features.
+ * @param {object} component - the moped_component object
+ * @returns {object} true if any layer has features else false
+ */
+export const useIsComponentMapped = (component) =>
+  useMemo(
+    () =>
+      component.feature_drawn_points?.length > 0 ||
+      component.feature_drawn_lines?.length > 0 ||
+      component.feature_intersections?.length > 0 ||
+      component.feature_signals?.length > 0 ||
+      component.feature_street_segments?.length > 0,
+    [component]
+  );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
@@ -27,13 +27,9 @@ export const useComponentListItemText = (component) =>
  * @param {object} component - the moped_component object
  * @returns {object} true if any layer has features else false
  */
-export const useIsComponentMapped = (component) =>
-  useMemo(
-    () =>
-      component.feature_drawn_points?.length > 0 ||
-      component.feature_drawn_lines?.length > 0 ||
-      component.feature_intersections?.length > 0 ||
-      component.feature_signals?.length > 0 ||
-      component.feature_street_segments?.length > 0,
-    [component]
-  );
+export const getIsComponentMapped = (component) =>
+  component.feature_drawn_points?.length > 0 ||
+  component.feature_drawn_lines?.length > 0 ||
+  component.feature_intersections?.length > 0 ||
+  component.feature_signals?.length > 0 ||
+  component.feature_street_segments?.length > 0;


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14160

## Testing
**URL to test:** Local

1. Start your local Moped andnrun these SQL statements to delete features from components:

```SQL
delete from feature_street_segments where 1=1;
delete from feature_intersections where 1=1;
```

2. Open project 227's map: `https://localhost:3000/moped/projects/227?tab=map`

3. Observe the error alerts in the component list. Map each component and and observe the alert disappear.

4. Repeat these steps with drawn lines and drawn points.

5. What should the alert text say?  Is "Component is not mapped" ok?

<img width="724" alt="Screenshot 2023-10-07 at 2 07 59 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/6a1762d6-acba-4e26-9ac2-f91e9308770d">
 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
