### PR TITLE
Use project list view query hooks for csv export

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersCommonOperators.js
+++ b/moped-editor/src/components/GridTable/FiltersCommonOperators.js
@@ -1,4 +1,4 @@
-export const GridTableFiltersCommonOperators = {
+export const FiltersCommonOperators = {
   string_contains_case_insensitive: {
     operator: "_ilike",
     label: "contains",
@@ -156,7 +156,7 @@ export const GridTableFiltersCommonOperators = {
     envelope: null,
     type: "string",
   },
-    string_does_not_equal_case_sensitive: {
+  string_does_not_equal_case_sensitive: {
     operator: "_neq",
     label: "is not",
     description: "Field content does not equal string (case-sensitive)",

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -57,7 +57,6 @@ const history = createBrowserHistory();
 
 /**
  * Renders a table search component with a search bar and search filters
- * * @param {GQLAbstract} query - The GQLAbstract object as provided by the parent component
  * @param {Object} filters - The current filters from useAdvancedSearch hook
  * @param {Function} setFilters - Set the current filters from useAdvancedSearch hook
  * @param {Object} parentData - Response data (if any) from the parent component
@@ -72,7 +71,6 @@ const history = createBrowserHistory();
  * @constructor
  */
 const Search = ({
-  query,
   filters,
   setFilters,
   filterQuery,
@@ -161,7 +159,7 @@ const Search = ({
               {queryConfig.showExport && (
                 <Button
                   disabled={
-                    (parentData?.[query.config.table] ?? []).length === 0
+                    (parentData?.[queryConfig.table] ?? []).length === 0
                   }
                   className={classes.downloadCsvButton}
                   onClick={handleExportButtonClick}
@@ -187,7 +185,6 @@ const Search = ({
       >
         <Paper className={classes.advancedSearchPaper}>
           <Filters
-            query={query}
             filters={filters}
             setFilters={setFilters}
             filterQuery={filterQuery}

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,28 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { createBrowserHistory } from "history";
 import { useLocation } from "react-router-dom";
 
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Grid,
-  Paper,
-  Popper,
-} from "@mui/material";
+import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
-import { useLazyQuery } from "@apollo/client";
-import { format } from "date-fns";
-import Papa from "papaparse";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -82,6 +82,7 @@ const history = createBrowserHistory();
  * @param {Function} setSearchTerm - Set the current search term from useSearch hook
  * @param {Object} queryConfig - The query configuration for the current table
  * @param {Object} filtersConfig - The filters configuration for the current table
+ * @param {Function} handleExportButtonClick - The function to handle the export button click
  * @return {JSX.Element}
  * @constructor
  */
@@ -97,6 +98,7 @@ const Search = ({
   setSearchTerm,
   queryConfig,
   filtersConfig,
+  handleExportButtonClick,
 }) => {
   const classes = useStyles();
   const queryPath = useLocation().pathname;
@@ -108,103 +110,6 @@ const Search = ({
    * @function setSearchFieldValue - Sets the state of the field
    */
   const [searchFieldValue, setSearchFieldValue] = useState(searchTerm);
-
-  /**
-   * When True, the download csv dialog is open.
-   * @type {boolean} dialogOpen
-   * @function setDialogOpen - Sets the state of dialogOpen
-   * @default false
-   */
-  const [dialogOpen, setDialogOpen] = useState(false);
-
-  /**
-   * When True, the download happens.
-   * @type {boolean} downloading
-   * @function setDownloading - Sets the state of downloading
-   * @default false
-   */
-  const [downloading, setDownloading] = useState(false);
-
-  /**
-   * Instantiates getExport, loading and data variables
-   * @function getExport - It is called to load the data
-   * @property {boolean} loading - True whenever the data is being loaded
-   * @property {object} data - The data as retrieved from query (if available)
-   */
-  let [getExport, { called, stopPolling, loading, data }] = useLazyQuery(
-    query.queryCSV(Object.keys(query.config.export).join(" \n")),
-    // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
-    query.config.useQuery
-  );
-
-  /**
-   * Downloads the contents of fileContents into a file
-   * @param {string} fileContents
-   */
-  const downloadFile = (fileContents) => {
-    const exportFileName =
-      "moped-" + query.table + format(Date.now(), "yyyy-MM-dd'T'HH:mm:ssxxx");
-    const blob = new Blob([fileContents], { type: "text/csv;charset=utf-8;" });
-    const link = document.createElement("a");
-    if (link.download !== undefined) {
-      link.style.visibility = "hidden";
-      link.setAttribute("href", URL.createObjectURL(blob));
-      link.setAttribute("download", exportFileName);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      setDownloading(false);
-    }
-  };
-
-  /**
-   * Builds a record entry given a specific configuration and filters
-   * @param {object} record - The record to build
-   * @return {object}
-   */
-  const buildRecordEntry = (record) => {
-    // Allocate an empty object
-    const entry = {};
-    // For each column in the export configuration
-    Object.keys(query.config.export).forEach((column) => {
-      // column label and data formatting function
-      const { label, filter } = query.config.export[column];
-      // Determine the new column name, if available.
-      const newColumnName = label ? label : column;
-      // If there is a filter, use it. Assign the value to the new column name.
-      entry[newColumnName] = filter ? filter(record[column]) : record[column];
-    });
-    return entry;
-  };
-
-  /**
-   * Returns an array of objects (each object is a row and each key of that object is a column in the export file)
-   * @param {array} data - Data returned from DB with nested data structures
-   * @returns {array}
-   */
-  const formatExportData = (data) => {
-    if (data) {
-      return data.map((record) => {
-        return buildRecordEntry(record);
-      });
-    }
-    return [];
-  };
-
-  /**
-   * Handles export button (to open the csv download dialog)
-   */
-  const handleExportButtonClick = () => {
-    setDialogOpen(true);
-  };
-
-  /**
-   * Handles the closing of the dialog
-   */
-  const handleDialogClose = () => {
-    if (called) stopPolling();
-    setDialogOpen(false);
-  };
 
   /**
    * Clears the filters when switching to simple search
@@ -235,34 +140,6 @@ const Search = ({
   const handleAdvancedSearchClose = () => {
     setAdvancedSearchAnchor(null);
   };
-
-  /**
-   * Update the export whenever limit or selectall change
-   */
-  useEffect(
-    () => {
-      if (dialogOpen && !downloading) {
-        query.limit = 0;
-        getExport();
-        setDownloading(true);
-      }
-
-      if (dialogOpen && downloading && data && !loading) {
-        const formattedData = formatExportData(data[query.table]);
-        // use the papaparse library to "unparse" a json object to csv
-        // escapeFormulae: "field values that begin with =, +, -, @, \t, or \r, will be prepended with a ' to defend
-        // against injection attacks because Excel and LibreOffice will automatically parse such cells as formulae."
-        const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
-        setTimeout(() => {
-          // Update the state
-          setDialogOpen(false);
-          downloadFile(csvString);
-        }, 1500);
-      }
-    },
-    // eslint-disable-next-line
-    [dialogOpen, downloading, loading, query.limit, getExport]
-  );
 
   return (
     <div>
@@ -296,7 +173,7 @@ const Search = ({
               lg={2}
               className={classes.downloadButtonGrid}
             >
-              {query.config.showExport && (
+              {queryConfig.showExport && (
                 <Button
                   disabled={
                     (parentData?.[query.config.table] ?? []).length === 0
@@ -337,30 +214,6 @@ const Search = ({
           />
         </Paper>
       </Popper>
-      <Dialog
-        open={dialogOpen}
-        onClose={handleDialogClose}
-        aria-labelledby="form-dialog-title"
-      >
-        <DialogTitle id="form-dialog-title"> </DialogTitle>
-        <DialogContent>
-          <Grid container spacing={3}>
-            <Grid item xs={2} lg={2}>
-              <CircularProgress />
-            </Grid>
-            <Grid item xs={10} lg={10}>
-              <DialogContentText>
-                Preparing download, please wait.
-              </DialogContentText>
-            </Grid>
-          </Grid>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleDialogClose} color="primary">
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
     </div>
   );
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListView.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListView.js
@@ -2,11 +2,6 @@ import React from "react";
 
 import makeStyles from "@mui/styles/makeStyles";
 import Page from "src/components/Page";
-
-// Abstract
-import GQLAbstract from "../../../libs/GQLAbstract";
-
-import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
 import ProjectsListViewTable from "./ProjectsListViewTable";
 
 // Styles
@@ -19,12 +14,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
- * Load Query Configuration as a mutable object
- * @type {GQLAbstract}
- */
-let projectsQuery = new GQLAbstract(PROJECT_LIST_VIEW_QUERY_CONFIG);
-
-/**
  * Projects List View
  * @return {JSX.Element}
  * @constructor
@@ -34,7 +23,7 @@ const ProjectsListView = () => {
 
   return (
     <Page className={classes.root} title="Projects">
-      <ProjectsListViewTable title={"Projects"} query={projectsQuery} />
+      <ProjectsListViewTable title={"Projects"} />
     </Page>
   );
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -1,4 +1,4 @@
-import { GridTableFiltersCommonOperators } from "../../../components/GridTable/GridTableFiltersCommonOperators";
+import { FiltersCommonOperators } from "../../../components/GridTable/FiltersCommonOperators";
 
 /**
  * Filter Configuration
@@ -370,6 +370,6 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
   ],
 
   operators: {
-    ...GridTableFiltersCommonOperators,
+    ...FiltersCommonOperators,
   },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -21,6 +21,7 @@ import parse from "html-react-parser";
 import { useGetProjectListView } from "./useProjectListViewQuery/useProjectListViewQuery";
 import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
 import { PROJECT_LIST_VIEW_FILTERS_CONFIG } from "./ProjectsListViewFiltersConf";
+import { PROJECT_LIST_VIEW_EXPORT_CONFIG } from "./ProjectsListViewExportConf";
 import { usePagination } from "./useProjectListViewQuery/usePagination";
 import { useOrderBy } from "./useProjectListViewQuery/useOrderBy";
 import { useSearch } from "./useProjectListViewQuery/useSearch";
@@ -445,7 +446,7 @@ const ProjectsListViewTable = ({ query }) => {
 
   const { query: projectListViewQuery } = useGetProjectListView({
     columnsToReturn,
-    queryConfig: PROJECT_LIST_VIEW_QUERY_CONFIG,
+    exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
     queryLimit,
     queryOffset,
     orderByColumn,
@@ -458,7 +459,10 @@ const ProjectsListViewTable = ({ query }) => {
     fetchPolicy: "cache-first",
   });
 
-  const { handleExportButtonClick } = useCsvExport({ query });
+  const { handleExportButtonClick } = useCsvExport({
+    query,
+    exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
+  });
 
   const sortByColumnIndex = columns.findIndex(
     (column) => column.field === orderByColumn

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -123,7 +123,7 @@ const buildStatusBadge = ({ phaseName, phaseKey }) => (
  * @return {JSX.Element}
  * @constructor
  */
-const ProjectsListViewTable = ({ query }) => {
+const ProjectsListViewTable = () => {
   const classes = useStyles();
 
   // anchor element for advanced search popper in Search to "attach" to
@@ -521,7 +521,6 @@ const ProjectsListViewTable = ({ query }) => {
         />
         <Search
           parentData={data}
-          query={query}
           filters={filters}
           setFilters={setFilters}
           filterQuery={filterQuery}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -463,15 +463,14 @@ const ProjectsListViewTable = () => {
     fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy,
   });
 
-  const { handleExportButtonClick, dialogOpen, handleDialogClose } =
-    useCsvExport({
-      query: exportQuery,
-      exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
-      queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
-      fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy,
-      limit: queryLimit,
-      setQueryLimit,
-    });
+  const { handleExportButtonClick, dialogOpen } = useCsvExport({
+    query: exportQuery,
+    exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
+    queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
+    fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy,
+    limit: queryLimit,
+    setQueryLimit,
+  });
 
   const sortByColumnIndex = columns.findIndex(
     (column) => column.field === orderByColumn
@@ -515,10 +514,7 @@ const ProjectsListViewTable = () => {
   return (
     <ApolloErrorHandler error={error}>
       <Container maxWidth={false} className={classes.root}>
-        <CsvDownloadDialog
-          dialogOpen={dialogOpen}
-          handleDialogClose={handleDialogClose}
-        />
+        <CsvDownloadDialog dialogOpen={dialogOpen} />
         <Search
           parentData={data}
           filters={filters}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -444,8 +444,9 @@ const ProjectsListViewTable = ({ query }) => {
 
   const columnsToReturn = Object.keys(PROJECT_LIST_VIEW_QUERY_CONFIG.columns);
 
-  const { query: projectListViewQuery } = useGetProjectListView({
+  const { query: projectListViewQuery, exportQuery } = useGetProjectListView({
     columnsToReturn,
+    exportColumnsToReturn: Object.keys(PROJECT_LIST_VIEW_EXPORT_CONFIG),
     exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
     queryLimit,
     queryOffset,
@@ -460,8 +461,11 @@ const ProjectsListViewTable = ({ query }) => {
   });
 
   const { handleExportButtonClick } = useCsvExport({
-    query,
+    query: exportQuery,
     exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
+    queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
+    fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery,
+    limit: queryLimit,
   });
 
   const sortByColumnIndex = columns.findIndex(

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -26,7 +26,10 @@ import { usePagination } from "./useProjectListViewQuery/usePagination";
 import { useOrderBy } from "./useProjectListViewQuery/useOrderBy";
 import { useSearch } from "./useProjectListViewQuery/useSearch";
 import { useAdvancedSearch } from "./useProjectListViewQuery/useAdvancedSearch";
-import { useCsvExport } from "./useProjectListViewQuery/useCsvExport";
+import {
+  useCsvExport,
+  CsvDownloadDialog,
+} from "./useProjectListViewQuery/useCsvExport";
 
 /**
  * GridTable Style
@@ -460,13 +463,15 @@ const ProjectsListViewTable = ({ query }) => {
     fetchPolicy: "cache-first",
   });
 
-  const { handleExportButtonClick } = useCsvExport({
-    query: exportQuery,
-    exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
-    queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
-    fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery,
-    limit: queryLimit,
-  });
+  const { handleExportButtonClick, dialogOpen, handleDialogClose } =
+    useCsvExport({
+      query: exportQuery,
+      exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
+      queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
+      fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery,
+      limit: queryLimit,
+      setQueryLimit,
+    });
 
   const sortByColumnIndex = columns.findIndex(
     (column) => column.field === orderByColumn
@@ -510,6 +515,10 @@ const ProjectsListViewTable = ({ query }) => {
   return (
     <ApolloErrorHandler error={error}>
       <Container maxWidth={false} className={classes.root}>
+        <CsvDownloadDialog
+          dialogOpen={dialogOpen}
+          handleDialogClose={handleDialogClose}
+        />
         <Search
           parentData={data}
           query={query}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -460,7 +460,7 @@ const ProjectsListViewTable = () => {
   });
 
   const { data, loading, error } = useQuery(projectListViewQuery, {
-    fetchPolicy: "cache-first",
+    fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy,
   });
 
   const { handleExportButtonClick, dialogOpen, handleDialogClose } =
@@ -468,7 +468,7 @@ const ProjectsListViewTable = () => {
       query: exportQuery,
       exportConfig: PROJECT_LIST_VIEW_EXPORT_CONFIG,
       queryTableName: PROJECT_LIST_VIEW_QUERY_CONFIG.table,
-      fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery,
+      fetchPolicy: PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy,
       limit: queryLimit,
       setQueryLimit,
     });

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -25,6 +25,7 @@ import { usePagination } from "./useProjectListViewQuery/usePagination";
 import { useOrderBy } from "./useProjectListViewQuery/useOrderBy";
 import { useSearch } from "./useProjectListViewQuery/useSearch";
 import { useAdvancedSearch } from "./useProjectListViewQuery/useAdvancedSearch";
+import { useCsvExport } from "./useProjectListViewQuery/useCsvExport";
 
 /**
  * GridTable Style
@@ -457,6 +458,8 @@ const ProjectsListViewTable = ({ query }) => {
     fetchPolicy: "cache-first",
   });
 
+  const { handleExportButtonClick } = useCsvExport({ query });
+
   const sortByColumnIndex = columns.findIndex(
     (column) => column.field === orderByColumn
   );
@@ -511,6 +514,7 @@ const ProjectsListViewTable = ({ query }) => {
           setSearchTerm={setSearchTerm}
           queryConfig={PROJECT_LIST_VIEW_QUERY_CONFIG}
           filtersConfig={PROJECT_LIST_VIEW_FILTERS_CONFIG}
+          handleExportButtonClick={handleExportButtonClick}
         />
         {/*Main Table Body*/}
         <Paper className={classes.paper}>

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { format } from "date-fns";
 import Papa from "papaparse";
@@ -98,8 +98,6 @@ export const useCsvExport = ({
   exportConfig,
   queryTableName,
   fetchPolicy,
-  limit,
-  setQueryLimit,
 }) => {
   /**
    * When True, the download csv dialog is open.
@@ -110,20 +108,12 @@ export const useCsvExport = ({
   const [dialogOpen, setDialogOpen] = useState(false);
 
   /**
-   * When True, the download happens.
-   * @type {boolean} downloading
-   * @function setDownloading - Sets the state of downloading
-   * @default false
-   */
-  const [downloading, setDownloading] = useState(false);
-
-  /**
    * Instantiates getExport, loading and data variables
    * @function getExport - It is called to load the data
    * @property {boolean} loading - True whenever the data is being loaded
    * @property {object} data - The data as retrieved from query (if available)
    */
-  let [getExport, { loading, data }] = useLazyQuery(
+  let [getExport] = useLazyQuery(
     query,
     // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
     {

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -44,9 +44,8 @@ export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => (
  * Downloads the contents of fileContents into a file
  * @param {string} fileContents
  */
-const downloadFile = (fileContents, queryTableName) => {
-  const exportFileName =
-    "moped-" + queryTableName + format(Date.now(), "yyyy-MM-dd'T'HH:mm:ssxxx");
+const downloadFile = (fileContents) => {
+  const exportFileName = `moped_projects_${format(Date.now(), "yyyy-MM-dd")}`;
   const blob = new Blob([fileContents], { type: "text/csv;charset=utf-8;" });
   const link = document.createElement("a");
   if (link.download !== undefined) {
@@ -62,6 +61,7 @@ const downloadFile = (fileContents, queryTableName) => {
 /**
  * Builds a record entry given a specific configuration and filters
  * @param {object} record - The record to build
+ * @param {object} exportConfig - The export configuration
  * @return {object}
  */
 const buildRecordEntry = (record, exportConfig) => {
@@ -82,6 +82,7 @@ const buildRecordEntry = (record, exportConfig) => {
 /**
  * Returns an array of objects (each object is a row and each key of that object is a column in the export file)
  * @param {array} data - Data returned from DB with nested data structures
+ * @param {object} exportConfig - The export configuration
  * @returns {array}
  */
 const formatExportData = (data, exportConfig) => {
@@ -129,7 +130,7 @@ export const useCsvExport = ({
         exportConfig
       );
       const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
-      downloadFile(csvString, queryTableName);
+      downloadFile(csvString);
       setDialogOpen(false);
     });
   };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -108,28 +108,23 @@ export const useCsvExport = ({
   const [dialogOpen, setDialogOpen] = useState(false);
 
   /**
-   * Instantiates getExport, loading and data variables
+   * Instantiates getExport and data variables
    * @function getExport - It is called to load the data
-   * @property {boolean} loading - True whenever the data is being loaded
    * @property {object} data - The data as retrieved from query (if available)
    */
-  let [getExport] = useLazyQuery(
-    query,
-    // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
-    {
-      ...fetchPolicy,
-      //   When data is returned, format, parse, and download CSV
-      onCompleted: (data) => {
-        const formattedData = formatExportData(
-          data[queryTableName],
-          exportConfig
-        );
-        const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
-        downloadFile(csvString, queryTableName);
-        setDialogOpen(false);
-      },
-    }
-  );
+  const [getExport] = useLazyQuery(query, {
+    ...fetchPolicy,
+    //   When data is returned, format, parse, and download CSV
+    onCompleted: (data) => {
+      const formattedData = formatExportData(
+        data[queryTableName],
+        exportConfig
+      );
+      const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
+      downloadFile(csvString, queryTableName);
+      setDialogOpen(false);
+    },
+  });
 
   /**
    * Handles export button (to open the csv download dialog)

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -13,7 +13,7 @@ import {
   Grid,
 } from "@mui/material";
 
-export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => {
+export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => (
   <Dialog
     open={dialogOpen}
     onClose={handleDialogClose}
@@ -37,8 +37,8 @@ export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => {
         Cancel
       </Button>
     </DialogActions>
-  </Dialog>;
-};
+  </Dialog>
+);
 
 /**
  * Downloads the contents of fileContents into a file
@@ -99,6 +99,7 @@ export const useCsvExport = ({
   queryTableName,
   fetchPolicy,
   limit,
+  setQueryLimit,
 }) => {
   /**
    * When True, the download csv dialog is open.
@@ -122,7 +123,6 @@ export const useCsvExport = ({
    * @property {boolean} loading - True whenever the data is being loaded
    * @property {object} data - The data as retrieved from query (if available)
    */
-  console.log(query);
   let [getExport, { called, stopPolling, loading, data }] = useLazyQuery(
     query,
     // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
@@ -150,7 +150,6 @@ export const useCsvExport = ({
   useEffect(
     () => {
       if (dialogOpen && !downloading) {
-        limit = 0;
         getExport();
         setDownloading(true);
       }
@@ -173,8 +172,8 @@ export const useCsvExport = ({
       }
     },
     // eslint-disable-next-line
-    [dialogOpen, downloading, loading, limit, getExport]
+    [dialogOpen, downloading, loading, limit, getExport, setQueryLimit]
   );
 
-  return { handleExportButtonClick };
+  return { handleExportButtonClick, dialogOpen, handleDialogClose };
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -3,10 +3,8 @@ import { useLazyQuery } from "@apollo/client";
 import { format } from "date-fns";
 import Papa from "papaparse";
 import {
-  Button,
   CircularProgress,
   Dialog,
-  DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
@@ -32,11 +30,6 @@ export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => (
         </Grid>
       </Grid>
     </DialogContent>
-    <DialogActions>
-      <Button onClick={handleDialogClose} color="primary">
-        Cancel
-      </Button>
-    </DialogActions>
   </Dialog>
 );
 

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -11,12 +11,8 @@ import {
   Grid,
 } from "@mui/material";
 
-export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => (
-  <Dialog
-    open={dialogOpen}
-    onClose={handleDialogClose}
-    aria-labelledby="form-dialog-title"
-  >
+export const CsvDownloadDialog = ({ dialogOpen }) => (
+  <Dialog open={dialogOpen} aria-labelledby="form-dialog-title">
     <DialogTitle id="form-dialog-title"> </DialogTitle>
     <DialogContent>
       <Grid container spacing={3}>
@@ -124,7 +120,7 @@ export const useCsvExport = ({
       );
       const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
       downloadFile(csvString);
-      setDialogOpen(false);
+      handleDialogClose();
     });
   };
 
@@ -135,5 +131,5 @@ export const useCsvExport = ({
     setDialogOpen(false);
   };
 
-  return { handleExportButtonClick, dialogOpen, handleDialogClose };
+  return { handleExportButtonClick, dialogOpen };
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -1,0 +1,43 @@
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+} from "@mui/material";
+
+export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => {
+  <Dialog
+    open={dialogOpen}
+    onClose={handleDialogClose}
+    aria-labelledby="form-dialog-title"
+  >
+    <DialogTitle id="form-dialog-title"> </DialogTitle>
+    <DialogContent>
+      <Grid container spacing={3}>
+        <Grid item xs={2} lg={2}>
+          <CircularProgress />
+        </Grid>
+        <Grid item xs={10} lg={10}>
+          <DialogContentText>
+            Preparing download, please wait.
+          </DialogContentText>
+        </Grid>
+      </Grid>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={handleDialogClose} color="primary">
+        Cancel
+      </Button>
+    </DialogActions>
+  </Dialog>;
+};
+
+const useCsvExport = () => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return { dialogOpen };
+};

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -36,8 +36,131 @@ export const CsvDownloadDialog = ({ dialogOpen, handleDialogClose }) => {
   </Dialog>;
 };
 
-const useCsvExport = () => {
+/**
+ * Downloads the contents of fileContents into a file
+ * @param {string} fileContents
+ */
+const downloadFile = (fileContents) => {
+  const exportFileName =
+    "moped-" + query.table + format(Date.now(), "yyyy-MM-dd'T'HH:mm:ssxxx");
+  const blob = new Blob([fileContents], { type: "text/csv;charset=utf-8;" });
+  const link = document.createElement("a");
+  if (link.download !== undefined) {
+    link.style.visibility = "hidden";
+    link.setAttribute("href", URL.createObjectURL(blob));
+    link.setAttribute("download", exportFileName);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setDownloading(false);
+  }
+};
+
+/**
+ * Builds a record entry given a specific configuration and filters
+ * @param {object} record - The record to build
+ * @return {object}
+ */
+const buildRecordEntry = (record) => {
+  // Allocate an empty object
+  const entry = {};
+  // For each column in the export configuration
+  Object.keys(query.config.export).forEach((column) => {
+    // column label and data formatting function
+    const { label, filter } = query.config.export[column];
+    // Determine the new column name, if available.
+    const newColumnName = label ? label : column;
+    // If there is a filter, use it. Assign the value to the new column name.
+    entry[newColumnName] = filter ? filter(record[column]) : record[column];
+  });
+  return entry;
+};
+
+/**
+ * Returns an array of objects (each object is a row and each key of that object is a column in the export file)
+ * @param {array} data - Data returned from DB with nested data structures
+ * @returns {array}
+ */
+const formatExportData = (data) => {
+  if (data) {
+    return data.map((record) => {
+      return buildRecordEntry(record);
+    });
+  }
+  return [];
+};
+
+export const useCsvExport = ({ query, exportConfig }) => {
+  /**
+   * When True, the download csv dialog is open.
+   * @type {boolean} dialogOpen
+   * @function setDialogOpen - Sets the state of dialogOpen
+   * @default false
+   */
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  return { dialogOpen };
+  /**
+   * When True, the download happens.
+   * @type {boolean} downloading
+   * @function setDownloading - Sets the state of downloading
+   * @default false
+   */
+  const [downloading, setDownloading] = useState(false);
+
+  /**
+   * Instantiates getExport, loading and data variables
+   * @function getExport - It is called to load the data
+   * @property {boolean} loading - True whenever the data is being loaded
+   * @property {object} data - The data as retrieved from query (if available)
+   */
+  let [getExport, { called, stopPolling, loading, data }] = useLazyQuery(
+    query.queryCSV(Object.keys(query.config.export).join(" \n")),
+    // Temporary fix for https://github.com/apollographql/react-apollo/issues/3361
+    query.config.useQuery
+  );
+
+  /**
+   * Handles export button (to open the csv download dialog)
+   */
+  const handleExportButtonClick = () => {
+    setDialogOpen(true);
+  };
+
+  /**
+   * Handles the closing of the dialog
+   */
+  const handleDialogClose = () => {
+    if (called) stopPolling();
+    setDialogOpen(false);
+  };
+
+  /**
+   * Update the export whenever limit or selectall change
+   */
+  useEffect(
+    () => {
+      if (dialogOpen && !downloading) {
+        query.limit = 0;
+        getExport();
+        setDownloading(true);
+      }
+
+      if (dialogOpen && downloading && data && !loading) {
+        const formattedData = formatExportData(data[query.table]);
+        // use the papaparse library to "unparse" a json object to csv
+        // escapeFormulae: "field values that begin with =, +, -, @, \t, or \r, will be prepended with a ' to defend
+        // against injection attacks because Excel and LibreOffice will automatically parse such cells as formulae."
+        const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
+        setTimeout(() => {
+          // Update the state
+          setDialogOpen(false);
+          downloadFile(csvString);
+        }, 1500);
+      }
+    },
+    // eslint-disable-next-line
+    [dialogOpen, downloading, loading, query.limit, getExport]
+  );
+
+  return { handleExportButtonClick };
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -113,7 +113,7 @@ export const useCsvExport = ({
    * @property {object} data - The data as retrieved from query (if available)
    */
   const [getExport] = useLazyQuery(query, {
-    ...fetchPolicy,
+    fetchPolicy: fetchPolicy,
     //   When data is returned, format, parse, and download CSV
     onCompleted: (data) => {
       const formattedData = formatExportData(

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -114,16 +114,6 @@ export const useCsvExport = ({
    */
   const [getExport] = useLazyQuery(query, {
     fetchPolicy: fetchPolicy,
-    //   When data is returned, format, parse, and download CSV
-    onCompleted: (data) => {
-      const formattedData = formatExportData(
-        data[queryTableName],
-        exportConfig
-      );
-      const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
-      downloadFile(csvString, queryTableName);
-      setDialogOpen(false);
-    },
   });
 
   /**
@@ -131,9 +121,17 @@ export const useCsvExport = ({
    */
   const handleExportButtonClick = () => {
     setDialogOpen(true);
-    setTimeout(() => {
-      getExport();
-    }, 1500);
+
+    // Fetch data and format, parse, and download CSV when returned
+    getExport().then(({ data }) => {
+      const formattedData = formatExportData(
+        data[queryTableName],
+        exportConfig
+      );
+      const csvString = Papa.unparse(formattedData, { escapeFormulae: true });
+      downloadFile(csvString, queryTableName);
+      setDialogOpen(false);
+    });
   };
 
   /**

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -1,3 +1,8 @@
+import React, { useEffect } from "react";
+import { useLazyQuery } from "@apollo/client";
+import { format } from "date-fns";
+import Papa from "papaparse";
+
 import {
   Button,
   CircularProgress,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -38,8 +38,6 @@ export const useGetProjectListView = ({
 
     const exportQuery = gql`{
       project_list_view (
-          limit: ${queryLimit}
-          offset: ${queryOffset}
           order_by: {${orderByColumn}: ${orderByDirection}}
           where: { 
             ${advancedSearchWhereString ? advancedSearchWhereString : ""}

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -3,6 +3,7 @@ import { gql } from "apollo-boost";
 
 export const useGetProjectListView = ({
   columnsToReturn,
+  exportColumnsToReturn,
   queryLimit,
   queryOffset,
   orderByColumn,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -46,7 +46,7 @@ export const useGetProjectListView = ({
             ${searchWhereString ? `_or: [${searchWhereString}]` : ""} 
           }
       ) {
-          ${columnsToReturn.join("\n")}
+          ${exportColumnsToReturn.join("\n")}
       },
       project_list_view_aggregate (
         where: { 
@@ -65,6 +65,7 @@ export const useGetProjectListView = ({
     queryLimit,
     queryOffset,
     columnsToReturn,
+    exportColumnsToReturn,
     orderByColumn,
     orderByDirection,
     searchWhereString,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -10,8 +10,8 @@ export const useGetProjectListView = ({
   searchWhereString,
   advancedSearchWhereString,
 }) => {
-  const query = useMemo(() => {
-    return gql`{
+  const { query, exportQuery } = useMemo(() => {
+    const query = gql`{
         project_list_view (
             limit: ${queryLimit}
             offset: ${queryOffset}
@@ -34,6 +34,32 @@ export const useGetProjectListView = ({
           }
         }
       }`;
+
+    const exportQuery = gql`{
+      project_list_view (
+          limit: ${queryLimit}
+          offset: ${queryOffset}
+          order_by: {${orderByColumn}: ${orderByDirection}}
+          where: { 
+            ${advancedSearchWhereString ? advancedSearchWhereString : ""}
+            ${searchWhereString ? `_or: [${searchWhereString}]` : ""} 
+          }
+      ) {
+          ${columnsToReturn.join("\n")}
+      },
+      project_list_view_aggregate (
+        where: { 
+          ${advancedSearchWhereString ? advancedSearchWhereString : ""}
+          ${searchWhereString ? `_or: [${searchWhereString}]` : ""} 
+        }
+      ) {
+        aggregate {
+          count
+        }
+      }
+    }`;
+
+    return { query, exportQuery };
   }, [
     queryLimit,
     queryOffset,
@@ -46,5 +72,6 @@ export const useGetProjectListView = ({
 
   return {
     query,
+    exportQuery,
   };
 };


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14068

This PR ports the existing CSV export generation into a custom hook. Lots of the existing logic was reused but moved out of the `Search` component.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Spin up the stack locally [with production data](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-MIQvl_rKnZ_-wHRdp4J/dev-guides/how-tos/how-to-load-production-data-into-a-local-instance). Seed data can be used but there will be fewer projects to test this feature on. You can also compare prod exports to the export that come out of this branch if you use prod data.
2. Try exporting data with different order by columns
3. Try exporting data with simple search filters applied
4. Try exporting data with advanced search filters applied
5. You should see the number of records in the export match the total number of results returned and filtered down to your searches.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
