### PR TITLE
Updates council district trigger to include "100ft" buffer

### DIFF
--- a/moped-database/migrations/1696964354076_update-council-district-trigger/down.sql
+++ b/moped-database/migrations/1696964354076_update-council-district-trigger/down.sql
@@ -1,0 +1,93 @@
+DROP TRIGGER update_feature_signals_council_district ON feature_signals;
+DROP TRIGGER update_feature_intersections_council_district ON feature_intersections;
+DROP TRIGGER update_feature_drawn_points_council_district ON feature_drawn_points;
+DROP TRIGGER update_feature_street_segments_council_district ON feature_street_segments;
+DROP TRIGGER update_feature_drawn_lines_council_district ON feature_drawn_lines;
+
+DROP FUNCTION public.update_council_district;
+
+-- create functions to mange point and line type associations
+CREATE OR REPLACE FUNCTION public.update_line_council_district()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    -- currently the moped editor never updates a geometry, it marks a feature as is_deleted
+    -- and inserts a new feature. so we should only ever see a geometry update from some
+    -- ad-hoc developer intervention
+    IF TG_OP = 'UPDATE' AND ST_Equals(NEW.geography::geometry, OLD.geography::geometry) THEN
+        -- nothing to do
+        RETURN NEW;
+    END IF;
+    -- delete previous district associations
+    -- again, because the moped editor only inserts new geometries, there will typically
+    -- not be any old feature-district associations to delete
+    DELETE FROM features_council_districts WHERE feature_id = NEW.id;
+    -- insert new district associations
+    WITH inserts_todo AS (
+        SELECT
+            NEW.id AS feature_id,
+            districts.council_district AS council_district_id
+        FROM
+            layer_council_district AS districts
+        WHERE
+            ST_Intersects(districts.geography, NEW.geography)
+        OR
+            ST_Crosses(districts.geography::geometry, NEW.geography::geometry)
+    )
+        INSERT INTO features_council_districts (feature_id, council_district_id)
+            SELECT * FROM inserts_todo;
+    RETURN NEW;
+    END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_point_council_district()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    -- currently the moped editor never updates a geometry, it marks a feature as is_deleted
+    -- and inserts a new feature. so we should only ever see a geometry update from some
+    -- ad-hoc developer intervention
+    IF TG_OP = 'UPDATE' AND ST_Equals(NEW.geography::geometry, OLD.geography::geometry) THEN
+        -- nothing to do
+        RETURN NEW;
+    END IF;
+    -- delete previous district associations
+    -- again, because the moped editor only inserts new geometries, there will be typically
+    -- not be any old feature-district associations to delete
+    DELETE FROM features_council_districts WHERE feature_id = NEW.id;
+    -- insert new district associations
+    WITH inserts_todo AS (
+        SELECT
+            NEW.id AS feature_id,
+            districts.council_district AS council_district_id
+        FROM
+            layer_council_district AS districts
+        WHERE
+            ST_Intersects(districts.geography,
+                NEW.geography)
+    ) INSERT INTO features_council_districts (feature_id, council_district_id)
+    SELECT
+        *
+    FROM
+        inserts_todo;
+    RETURN NEW;
+    END;
+$$;
+
+-- create triggers on all feature layers
+CREATE TRIGGER update_feature_signals_council_district BEFORE INSERT OR UPDATE ON feature_signals
+    FOR EACH ROW EXECUTE FUNCTION update_point_council_district();
+
+CREATE TRIGGER update_feature_intersections_council_district BEFORE INSERT OR UPDATE ON feature_intersections
+    FOR EACH ROW EXECUTE FUNCTION update_point_council_district();
+
+CREATE TRIGGER update_feature_drawn_points_council_district BEFORE INSERT OR UPDATE ON feature_drawn_points
+    FOR EACH ROW EXECUTE FUNCTION update_point_council_district();
+
+CREATE TRIGGER update_feature_street_segments_council_district BEFORE INSERT OR UPDATE ON feature_street_segments
+    FOR EACH ROW EXECUTE FUNCTION update_line_council_district();
+
+CREATE TRIGGER update_feature_drawn_lines_council_district BEFORE INSERT OR UPDATE ON feature_drawn_lines
+    FOR EACH ROW EXECUTE FUNCTION update_line_council_district();

--- a/moped-database/migrations/1696964354076_update-council-district-trigger/up.sql
+++ b/moped-database/migrations/1696964354076_update-council-district-trigger/up.sql
@@ -1,0 +1,59 @@
+-- drop existing triggers
+DROP TRIGGER update_feature_signals_council_district ON feature_signals;
+DROP TRIGGER update_feature_intersections_council_district ON feature_intersections;
+DROP TRIGGER update_feature_drawn_points_council_district ON feature_drawn_points;
+DROP TRIGGER update_feature_street_segments_council_district ON feature_street_segments;
+DROP TRIGGER update_feature_drawn_lines_council_district ON feature_drawn_lines;
+
+-- drop old functions
+DROP FUNCTION public.update_line_council_district;
+
+DROP FUNCTION public.update_point_council_district;
+
+-- create one function
+CREATE FUNCTION public.update_council_district() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    -- currently the moped editor never updates a geometry, it marks a feature as is_deleted
+    -- and inserts a new feature. so we should only ever see a geometry update from some
+    -- ad-hoc developer intervention
+    IF TG_OP = 'UPDATE' AND ST_Equals(NEW.geography::geometry, OLD.geography::geometry) THEN
+        -- nothing to do
+        RETURN NEW;
+    END IF;
+    -- delete previous district associations
+    -- again, because the moped editor only inserts new geometries, there will typically
+    -- not be any old feature-district associations to delete
+    DELETE FROM features_council_districts WHERE feature_id = NEW.id;
+    -- insert new district associations
+    WITH inserts_todo AS (
+        SELECT
+            NEW.id AS feature_id,
+            districts.council_district AS council_district_id
+        FROM
+            layer_council_district AS districts
+        WHERE
+            ST_Distance(districts.geography, NEW.geography, true) < 33
+    )
+        INSERT INTO features_council_districts (feature_id, council_district_id)
+            SELECT * FROM inserts_todo;
+    RETURN NEW;
+    END;
+$$;
+
+-- restore triggers
+CREATE TRIGGER update_feature_signals_council_district BEFORE INSERT OR UPDATE ON feature_signals
+    FOR EACH ROW EXECUTE FUNCTION update_council_district();
+
+CREATE TRIGGER update_feature_intersections_council_district BEFORE INSERT OR UPDATE ON feature_intersections
+    FOR EACH ROW EXECUTE FUNCTION update_council_district();
+
+CREATE TRIGGER update_feature_drawn_points_council_district BEFORE INSERT OR UPDATE ON feature_drawn_points
+    FOR EACH ROW EXECUTE FUNCTION update_council_district();
+
+CREATE TRIGGER update_feature_street_segments_council_district BEFORE INSERT OR UPDATE ON feature_street_segments
+    FOR EACH ROW EXECUTE FUNCTION update_council_district();
+
+CREATE TRIGGER update_feature_drawn_lines_council_district BEFORE INSERT OR UPDATE ON feature_drawn_lines
+    FOR EACH ROW EXECUTE FUNCTION update_council_district();

--- a/moped-toolbox/backfill_council_district/backfill_council_district.sql
+++ b/moped-toolbox/backfill_council_district/backfill_council_district.sql
@@ -1,0 +1,42 @@
+-- see also moped-database/migrations/1696964354076_update-council-district-trigger
+DELETE FROM features_council_districts WHERE 1 = 1;
+
+WITH features_union AS (
+    SELECT
+        id,
+        geography
+    FROM
+        feature_signals
+    UNION ALL
+    SELECT
+        id,
+        geography
+    FROM
+        feature_intersections
+    UNION ALL
+    SELECT
+        id,
+        geography
+    FROM
+        feature_drawn_points
+    UNION ALL
+    SELECT
+        id,
+        geography
+    FROM
+        feature_street_segments
+    UNION ALL
+    SELECT
+        id,
+        geography
+    FROM
+        feature_drawn_lines
+) INSERT INTO features_council_districts (feature_id, council_district_id) (
+        SELECT
+            features_union.id AS feature_id,
+            districts.council_district AS council_district_id
+        FROM
+            features_union
+        LEFT JOIN layer_council_district AS districts ON ST_Distance(districts.geography, features_union.geography, TRUE) < 33
+    WHERE
+        districts.council_district IS NOT NULL);


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13915

## Testing
**URL to test:** Local

1. You are going to create project components that are near multiple council districts. An easy way to do this is to inspect the `council_district` column of the [open traffic signals dataset](https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Signals-and-Pedestrian-Signals/p53x-x73x/data) to find some signals that have multiple district associations. For example, create signal components using the following signals:
- `419: BRODIE LN / WILLIAM CANNON DR` - districts 5 & 8
- `427: STASSNEY LN / 35 SVRD` - districts 2 & 3
- `488: MANOR RD / BERKMAN DR` - districts 1 & 9
2. As you add/remove these signals, navigate to the project summary tab and observe the council districts listed below the map.
3. Now you need to test intersection points, street segments, drawn points, and drawn lines. You can create point and line components in the vicinity of the signal components you tested. As before, you can add/remove components and observe the changes on the summary tab.
4. Lastly, use your sql client to run the backfill operation in  `moped-toolbox/backfill_council_district/backfill_council_district.sql`


<img width="584" alt="a" src="https://github.com/cityofaustin/atd-moped/assets/14793120/47239c6a-1b78-49b5-b13c-23e76ae695c2">
<img width="317" alt="n" src="https://github.com/cityofaustin/atd-moped/assets/14793120/a2aeef77-32bc-4052-851f-f159734c2acd">


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
