### PR TITLE
Add work activity fields to activity log formatter

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -12,7 +12,7 @@ export const formatContractsActivity = (change) => {
     style: "boldText",
   };
 
-  // add a new contract
+  // add a new work activity
   if (change.description.length === 0) {
     if (contractor) {
       // with contractor populated
@@ -21,26 +21,26 @@ export const formatContractsActivity = (change) => {
         changeText: [
           { text: "Added ", style: null },
           contractorText,
-          { text: " as a new contract", style: null },
+          { text: " as a new work activity", style: null },
         ],
       };
     } else {
       // without contractor populated
       return {
         changeIcon,
-        changeText: [{ text: "Added a new contract", style: null }],
+        changeText: [{ text: "Added a new work activity", style: null }],
       };
     }
   }
 
-  // delete an existing contract
+  // delete an existing work activity
   if (change.description[0].field === "is_deleted") {
     if (contractor) {
       // with contractor populated
       return {
         changeIcon,
         changeText: [
-          { text: "Removed the contract for ", style: null },
+          { text: "Removed the work activity for ", style: null },
           contractorText,
         ],
       };
@@ -48,7 +48,7 @@ export const formatContractsActivity = (change) => {
       // without contractor populated
       return {
         changeIcon,
-        changeText: [{ text: "Removed a contract", style: null }],
+        changeText: [{ text: "Removed a work activity", style: null }],
       };
     }
   }
@@ -82,7 +82,7 @@ export const formatContractsActivity = (change) => {
     return {
       changeIcon,
       changeText: [
-        { text: "Edited the contract for ", style: null },
+        { text: "Edited the work activity for ", style: null },
         contractorText,
         { text: " by updating the ", style: null },
         {
@@ -96,7 +96,7 @@ export const formatContractsActivity = (change) => {
     return {
       changeIcon,
       changeText: [
-        { text: "Edited a contract by updating the ", style: null },
+        { text: "Edited a work activity by updating the ", style: null },
         {
           text: changes.join(", "),
           style: "boldText",

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -1,8 +1,9 @@
 import AssignmentIndIconOutlined from "@mui/icons-material/AssignmentIndOutlined";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
+import {isEqual} from "lodash"
 
 export const formatContractsActivity = (change) => {
-  const entryMap = ProjectActivityLogTableMaps["moped_proj_contract"];
+  const entryMap = ProjectActivityLogTableMaps["moped_proj_work_activity"];
 
   const changeIcon = <AssignmentIndIconOutlined />;
   const contractor = change.record_data.event.data.new.contractor;
@@ -61,7 +62,13 @@ export const formatContractsActivity = (change) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    // typeof(null) resolves as "object", check that field is not null before checking if object
+    // task orders are in arrays
+    if (!!newRecord[field] && typeof newRecord[field] === "object") {
+      if (!isEqual(newRecord[field], oldRecord[field])) {
+        changes.push(entryMap.fields[field]?.label);
+      }
+    } else if (newRecord[field] !== oldRecord[field] && field !== "updated_at") {
       changes.push(entryMap.fields[field]?.label);
     }
   });

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -29,7 +29,7 @@ export const formatContractsActivity = (change) => {
     return {
       changeIcon,
       changeText: [
-        { text: "Removed the work activity for ", style: null },
+        { text: "Removed work activity ", style: null },
         referenceIdText,
       ],
     };
@@ -62,7 +62,7 @@ export const formatContractsActivity = (change) => {
   return {
     changeIcon,
     changeText: [
-      { text: "Edited the work activity for ", style: null },
+      { text: "Edited work activity ", style: null },
       referenceIdText,
       { text: " by updating the ", style: null },
       {

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -6,51 +6,33 @@ export const formatContractsActivity = (change) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_work_activity"];
 
   const changeIcon = <AssignmentIndIconOutlined />;
-  const contractor = change.record_data.event.data.new.contractor;
-  const contractorText = {
-    text: contractor,
+  const referenceID = change.record_data.event.data.new.reference_id;
+  const referenceIdText = {
+    text: referenceID,
     style: "boldText",
   };
 
   // add a new work activity
   if (change.description.length === 0) {
-    if (contractor) {
-      // with contractor populated
-      return {
-        changeIcon,
-        changeText: [
-          { text: "Added ", style: null },
-          contractorText,
-          { text: " as a new work activity", style: null },
-        ],
-      };
-    } else {
-      // without contractor populated
-      return {
-        changeIcon,
-        changeText: [{ text: "Added a new work activity", style: null }],
-      };
-    }
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Added ", style: null },
+        referenceIdText,
+        { text: " as a new work activity", style: null },
+      ],
+    };
   }
 
   // delete an existing work activity
   if (change.description[0].field === "is_deleted") {
-    if (contractor) {
-      // with contractor populated
-      return {
-        changeIcon,
-        changeText: [
-          { text: "Removed the work activity for ", style: null },
-          contractorText,
-        ],
-      };
-    } else {
-      // without contractor populated
-      return {
-        changeIcon,
-        changeText: [{ text: "Removed a work activity", style: null }],
-      };
-    }
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Removed the work activity for ", style: null },
+        referenceIdText,
+      ],
+    };
   }
 
   // Multiple fields in the moped_proj_contract table can be updated at once
@@ -77,31 +59,16 @@ export const formatContractsActivity = (change) => {
     }
   });
 
-  if (contractor) {
-    // with contractor populated
-    return {
-      changeIcon,
-      changeText: [
-        { text: "Edited the work activity for ", style: null },
-        contractorText,
-        { text: " by updating the ", style: null },
-        {
-          text: changes.join(", "),
-          style: "boldText",
-        },
-      ],
-    };
-  } else {
-    // without contractor populated
-    return {
-      changeIcon,
-      changeText: [
-        { text: "Edited a work activity by updating the ", style: null },
-        {
-          text: changes.join(", "),
-          style: "boldText",
-        },
-      ],
-    };
-  }
+  return {
+    changeIcon,
+    changeText: [
+      { text: "Edited the work activity for ", style: null },
+      referenceIdText,
+      { text: " by updating the ", style: null },
+      {
+        text: changes.join(", "),
+        style: "boldText",
+      },
+    ],
+  };
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -1,6 +1,6 @@
 import AssignmentIndIconOutlined from "@mui/icons-material/AssignmentIndOutlined";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
-import {isEqual} from "lodash"
+import { isEqual } from "lodash";
 
 export const formatContractsActivity = (change) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_work_activity"];
@@ -59,6 +59,7 @@ export const formatContractsActivity = (change) => {
   const oldRecord = change.record_data.event.data.old;
 
   let changes = [];
+  const fieldsToSkip = ["updated_at", "updated_by_user_id"];
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
@@ -68,7 +69,10 @@ export const formatContractsActivity = (change) => {
       if (!isEqual(newRecord[field], oldRecord[field])) {
         changes.push(entryMap.fields[field]?.label);
       }
-    } else if (newRecord[field] !== oldRecord[field] && field !== "updated_at") {
+    } else if (
+      newRecord[field] !== oldRecord[field] &&
+      !fieldsToSkip.includes(field)
+    ) {
       changes.push(entryMap.fields[field]?.label);
     }
   });

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
+import { isEqual } from "lodash";
 
 import {
   Box,
@@ -153,7 +154,11 @@ const usePrepareActivityData = (activityData) =>
           const oldData = outputEvent.record_data.event.data.old;
           let changedField = "";
           Object.keys(newData).forEach((key) => {
-            if (newData[key] !== oldData[key]) {
+            if (!!newData[key] && typeof newData[key] === "object") {
+              if (!isEqual(newData[key], oldData[key])) {
+                changedField = key;
+              }
+            } else if (newData[key] !== oldData[key] && key !== "updated_at") {
               changedField = key;
             }
           });

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -535,7 +535,7 @@ export const ProjectActivityLogTableMaps = {
         label: "ID",
       },
       contractor: {
-        label: "workgroup / contractor",
+        label: "workgroup/contractor",
       },
       contract_number: {
         label: "contract number",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -352,11 +352,11 @@ export const ProjectActivityLogTableMaps = {
         label: "completion date",
       },
       location_description: {
-        label: "location description"
+        label: "location description",
       },
       srts_id: {
-        label: "Safe Routes to School infrastructure plan record identifier"
-      }
+        label: "Safe Routes to School infrastructure plan record identifier",
+      },
     },
   },
   moped_project_files: {
@@ -528,36 +528,7 @@ export const ProjectActivityLogTableMaps = {
       },
     },
   },
-  moped_proj_contract: {
-    label: "Contract",
-    fields: {
-      id: {
-        label: "ID",
-      },
-      contractor: {
-        label: "contractor",
-      },
-      contract_number: {
-        label: "contract number",
-      },
-      description: {
-        label: "description",
-      },
-      project_id: {
-        label: "project ID",
-      },
-      work_assignment_id: {
-        label: "work assignment ID",
-      },
-      contract_amount: {
-        label: "contract amount",
-      },
-      is_deleted: {
-        label: "is deleted",
-      },
-    },
-  },
-    moped_proj_work_activity: {
+  moped_proj_work_activity: {
     label: "Contract",
     fields: {
       id: {
@@ -585,7 +556,7 @@ export const ProjectActivityLogTableMaps = {
         label: "is deleted",
       },
       interim_work_activity_id: {
-        label: "interim work activity ID"
+        label: "interim work activity ID",
       },
       implementation_workgroup: {
         label: "implementation workgroup",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -565,13 +565,13 @@ export const ProjectActivityLogTableMaps = {
         label: "task orders",
       },
       status_id: {
-        label: "status ID",
+        label: "status",
       },
       status_note: {
         label: "status note",
       },
       work_order_url: {
-        label: "work order URL",
+        label: "work order link",
       },
     },
   },

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -557,4 +557,51 @@ export const ProjectActivityLogTableMaps = {
       },
     },
   },
+    moped_proj_work_activity: {
+    label: "Contract",
+    fields: {
+      id: {
+        label: "ID",
+      },
+      contractor: {
+        label: "contractor",
+      },
+      contract_number: {
+        label: "contract number",
+      },
+      description: {
+        label: "description",
+      },
+      project_id: {
+        label: "project ID",
+      },
+      work_assignment_id: {
+        label: "work assignment ID",
+      },
+      contract_amount: {
+        label: "contract amount",
+      },
+      is_deleted: {
+        label: "is deleted",
+      },
+      interim_work_activity_id: {
+        label: "interim work activity ID"
+      },
+      implementation_workgroup: {
+        label: "implementation workgroup",
+      },
+      task_orders: {
+        label: "task orders",
+      },
+      status_id: {
+        label: "status ID",
+      },
+      status_note: {
+        label: "status note",
+      },
+      work_order_url: {
+        label: "work order URL",
+      },
+    },
+  },
 };

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -535,7 +535,7 @@ export const ProjectActivityLogTableMaps = {
         label: "ID",
       },
       contractor: {
-        label: "contractor",
+        label: "workgroup / contractor",
       },
       contract_number: {
         label: "contract number",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13000

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1155--atd-moped-main.netlify.app/moped/projects/1759?tab=activity_log



**Steps to test:**

Add and edit work activities, check the activity tag to see that the new columns appear. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
