### PR TITLE
Show location description in draft/edit component list item

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/DraftComponentList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/DraftComponentList.js
@@ -18,8 +18,7 @@ const DraftComponentList = ({
     <>
       {shouldShowCreateListItem && (
         <DraftComponentListItem
-          primaryText={createState.draftComponent.component_name}
-          secondaryText={createState.draftComponent.component_subtype}
+          component={createState.draftComponent}
           onSave={onSaveDraftComponent}
           onCancel={onCancelComponentCreate}
           saveButtonDisabled={!createState.draftComponent?.features.length > 0}
@@ -28,12 +27,7 @@ const DraftComponentList = ({
       )}
       {shouldShowEditListItem && (
         <DraftComponentListItem
-          primaryText={
-            editState.draftEditComponent?.moped_components?.component_name
-          }
-          secondaryText={
-            editState.draftEditComponent?.moped_components?.component_subtype
-          }
+          component={editState.draftEditComponent}
           onSave={onSaveEditedComponent}
           onCancel={onCancelComponentMapEdit}
           saveButtonDisabled={!doesDraftEditComponentHaveFeatures}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/DraftComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/DraftComponentListItem.js
@@ -6,15 +6,17 @@ import ListItemText from "@mui/material/ListItemText";
 import Cancel from "@mui/icons-material/Cancel";
 import CheckCircle from "@mui/icons-material/CheckCircle";
 import { COLORS } from "./mapStyleSettings";
+import { useComponentListItemText } from "./utils/componentList";
 
 const DraftComponentListItem = ({
-  primaryText,
-  secondaryText,
+  component,
   onSave,
   onCancel,
   saveButtonText,
   saveButtonDisabled,
 }) => {
+  const { primary, secondary } = useComponentListItemText(component);
+
   return (
     <Box
       borderLeft={7}
@@ -23,7 +25,7 @@ const DraftComponentListItem = ({
       }}
     >
       <ListItem dense>
-        <ListItemText primary={primaryText} secondary={secondaryText} />
+        <ListItemText primary={primary} secondary={secondary} />
       </ListItem>
       <ListItem dense>
         <ListItemText

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/componentList.js
@@ -12,8 +12,13 @@ export const isSignalComponent = (component) =>
 export const useComponentListItemText = (component) =>
   useMemo(() => {
     const listItemText = { primary: "", secondary: "-" };
-    const componentName = component?.moped_components?.component_name;
-    const componentSubtype = component?.moped_components?.component_subtype;
+    // New components that are being created don't have a moped_components property
+    const componentName = component?.moped_components
+      ? component?.moped_components?.component_name
+      : component?.component_name;
+    const componentSubtype = component?.moped_components
+      ? component?.moped_components?.component_subtype
+      : component?.component_subtype;
     listItemText.primary = componentSubtype
       ? `${componentName} - ${componentSubtype}`
       : componentName;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/14166

## Testing
**URL to test:** 
https://deploy-preview-1156--atd-moped-main.netlify.app/moped/projects/1759?tab=activity_log

**Steps to test:**
1. Go to a projects map view.
2. Create a new component with a location description. When mapping the component in create mode, the component list item should have the Component Type - Subtype on the first line, and the second line should have the location description, similar to the non-editing state of a components list item.
![image](https://github.com/cityofaustin/atd-moped/assets/67130963/879a14fa-a9cb-4211-be24-cfdb65f7ef83)
4. Save the component and test editing it. The above should also be true.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
