### PR TITLE
create task order backfill script

### DIFF
--- a/moped-toolbox/backfill-task-orders/backfill_task_orders.py
+++ b/moped-toolbox/backfill-task-orders/backfill_task_orders.py
@@ -1,0 +1,95 @@
+"""Migrates moped_project.task_order to moped_proj_work activities.task_orders"""
+import argparse
+import json
+import requests
+from secrets import HASURA
+
+
+PROJECT_TASK_ORDER_QUERY = """
+{
+  moped_project(where: {is_deleted: {_eq: false}, _and: {task_order: {_is_null: false}}}) {
+    project_id
+    task_order
+  }
+}
+"""
+
+INSERT_WORK_ACTIVITY_MUTATION = """
+mutation InsertWorkActivities($objects: [moped_proj_work_activity_insert_input!]!) {
+  insert_moped_proj_work_activity(objects: $objects) {
+    affected_rows
+  }
+}
+"""
+
+
+def make_hasura_request(*, query, variables, env):
+    """Fetch data from hasura
+
+    Args:
+        query (str): the hasura query
+        variables : variables needed in the query
+        env (str): the environment name, which will be used to access secrets
+
+    Raises:
+        ValueError: If no data is returned
+
+    Returns:
+        dict: Hasura JSON response data
+    """
+    token = HASURA["token"][env]
+    endpoint = HASURA["hasura_graphql_endpoint"][env]
+    headers = {
+        "Authorization": token,
+        "content-type": "application/json",
+        "X-Hasura-Role": "moped-admin",
+    }
+    payload = {"query": query, "variables": variables}
+    res = requests.post(endpoint, json=payload, headers=headers)
+    res.raise_for_status()
+    data = res.json()
+    try:
+        return data["data"]
+    except KeyError:
+        raise ValueError(data)
+
+
+def main(env):
+    inserts = []
+    projects = make_hasura_request(
+        query=PROJECT_TASK_ORDER_QUERY, env=env, variables=None
+    )["moped_project"]
+    for proj in projects:
+        project_id = proj["project_id"]
+        task_orders = proj["task_order"]
+        if not task_orders:
+            # shoudl never happen because of filter
+            continue
+        inserts.append({"project_id": project_id, "task_orders": task_orders})
+
+    print(f"Inserting {len(inserts)} records...")
+
+    insert_count = make_hasura_request(
+        query=INSERT_WORK_ACTIVITY_MUTATION, variables={"objects": inserts}, env=env
+    )["insert_moped_proj_work_activity"]["affected_rows"]
+
+    print(f"✅ Inserted {insert_count} records")
+
+    with open("results.json", "w") as fout:
+        json.dump(projects, fout)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-e",
+        "--env",
+        type=str,
+        choices=["local", "staging", "prod"],
+        default="local",
+        help=f"Environment",
+    )
+
+    args = parser.parse_args()
+
+    main(args.env)

--- a/moped-toolbox/backfill-task-orders/secrets_template.py
+++ b/moped-toolbox/backfill-task-orders/secrets_template.py
@@ -1,0 +1,8 @@
+HASURA = {
+    "hasura_graphql_endpoint": {
+        "local": "http://localhost:8080/v1/graphql",
+    },
+    "token": {
+        "local": "Bearer blah.blah.blah",
+    },
+}


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14246

## Testing
**URL to test:**  Local

1. Start local with production data
2. Login to local editor with JD's login and copy your `Authorization` token from the graphql request headers.
3. Save `secrets_template.py` as `secrets.py` and add your auth token to the `local` entry.
4. Fix your user ID in the prod database: 

 ```sql
update moped_users set user_id = 1 where first_name = 'JD';
```

5. from a python environment with `requests` installed, run the script

```shell
$ python backfill_task_orders.py -e local
```
6. Success!

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
