### PR TITLE
Set location description when creating a new signal project

### DIFF
--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -179,6 +179,7 @@ export const generateProjectComponent = (
 
   return {
     component_id: componentDef.component_id,
+    location_description: signalRecord.location_name.trim(),
     feature_signals: {
       data: [signalRecord],
     },


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14247

## Testing
**URL to test:** Netlify....

**Steps to test:**
1. Create a new project with a signal
2. Open the project map and verify the signal component has the location description populated

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
