### PR TITLE
Disables zoom animation on initial map load

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -41,6 +41,7 @@ export const fitBoundsOptions = {
   zoomToExtent: {
     maxZoom: 15,
     padding: 50,
+    duration: 0,
   },
   zoomToClickedComponent: {
     maxZoom: 19,


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14278

## Testing
**URL to test:** [Netlify](https://deploy-preview-1165--atd-moped-main.netlify.app/moped/projects)

Browse some projects. The summary map should render the project extent without animated zooming.

Similarly, project map should render the project extent without animation. Clicking the mag icon in the component list should trigger an animated zoom-in.

When you close the project map, the summary map should still render without animated zooming 👍 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
