### PR TITLE
Prep DB for rolling back the Access DB migration

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -145,8 +145,6 @@
   event_triggers:
     - name: activity_log_feature_drawn_lines
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -280,8 +278,6 @@
   event_triggers:
     - name: activity_log_feature_drawn_points
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -415,8 +411,6 @@
   event_triggers:
     - name: activity_log_feature_intersections
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -592,11 +586,7 @@
   event_triggers:
     - name: activity_log_feature_signals
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
-        insert:
-          columns: '*'
         update:
           columns: '*'
       retry_conf:
@@ -762,8 +752,6 @@
   event_triggers:
     - name: activity_log_feature_street_segments
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -1466,8 +1454,6 @@
   event_triggers:
     - name: activity_log_proj_component_tags
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -1580,8 +1566,6 @@
   event_triggers:
     - name: activity_log_proj_component_work_types
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -1824,8 +1808,6 @@
   event_triggers:
     - name: activity_log_moped_proj_components
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2210,8 +2192,6 @@
   event_triggers:
     - name: activity_log_moped_proj_funding
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2373,8 +2353,6 @@
   event_triggers:
     - name: activity_log_moped_proj_milestones
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2528,8 +2506,6 @@
   event_triggers:
     - name: activity_log_moped_proj_notes
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2658,8 +2634,6 @@
   event_triggers:
     - name: activity_log_moped_proj_partners
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2808,8 +2782,6 @@
   event_triggers:
     - name: activity_log_moped_proj_personnel
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -2923,8 +2895,6 @@
   event_triggers:
     - name: activity_log_moped_proj_personnel_roles
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -3082,8 +3052,6 @@
   event_triggers:
     - name: activity_log_moped_proj_phases
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -3203,8 +3171,6 @@
   event_triggers:
     - name: activity_log_moped_project_tags
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -3425,8 +3391,6 @@
   event_triggers:
     - name: activity_log_moped_proj_work_activity
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -3766,8 +3730,6 @@
   event_triggers:
     - name: activity_log_moped_project
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -3979,8 +3941,6 @@
   event_triggers:
     - name: activity_log_moped_project_files
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'
@@ -4153,8 +4113,6 @@
   event_triggers:
     - name: activity_log_moped_project_types
       definition:
-        delete:
-          columns: '*'
         enable_manual: false
         insert:
           columns: '*'

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -587,6 +587,8 @@
     - name: activity_log_feature_signals
       definition:
         enable_manual: false
+        insert:
+          columns: '*'
         update:
           columns: '*'
       retry_conf:

--- a/moped-database/migrations/1697829614737_track_migrated_projects/down.sql
+++ b/moped-database/migrations/1697829614737_track_migrated_projects/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE moped_project
+    DROP COLUMN is_migrated_from_access_db;

--- a/moped-database/migrations/1697829614737_track_migrated_projects/up.sql
+++ b/moped-database/migrations/1697829614737_track_migrated_projects/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE moped_project
+    ADD COLUMN is_migrated_from_access_db boolean NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
This PR addresses the need to be able to cleanly rollback the Access DB migration.

- Add a  field will allow us totrack any projects created through the Access DB migration so that we can delete them if needed. We can delete this column after we successfully migrate. 
- Disable Hasura event triggers on `delete` operations. We do not allow records to be deleted through Hasura except by our admin/root user. This change removes Hasura `delete` event triggers entirely, because the only conditions under which we are deleting records will be for admin purposes that we presumably to not want to track as events.

In order to completely roll back the migration we'll need to run [these commands](https://github.com/cityofaustin/atd-moped/blob/4838-jc-migrate-access-db/moped-toolbox/access_migration/migrate_data/rollback.sql). I intend to package that up as a single executable.

Steps to test
1. Just start your local DB
2. Use a SQL make sure that deleting project data does not trigger events:

```sql
-- clear all record from the event invocation lgos
truncate hdb_catalog.event_invocation_logs;

-- delete all projects;
delete from moped_project where 1=1;

-- verify no events were invoked from the deletion
select * from hdb_catalog.event_invocation_logs;
```