### PR TITLE
Backfill phase start/end date confirmation status

### DIFF
--- a/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/down.sql
+++ b/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/down.sql
@@ -1,2 +1,2 @@
-UPDATE moped_proj_phases SET is_phase_start_confirmed = false WHERE phase_start <= current_date;
-UPDATE moped_proj_phases SET is_phase_end_confirmed = false WHERE phase_end <= current_date;
+-- can't undo
+select 0;

--- a/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/down.sql
+++ b/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/down.sql
@@ -1,0 +1,2 @@
+UPDATE moped_proj_phases SET is_phase_start_confirmed = false WHERE phase_start <= current_date;
+UPDATE moped_proj_phases SET is_phase_end_confirmed = false WHERE phase_end <= current_date;

--- a/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/up.sql
+++ b/moped-database/migrations/1698070704301_backfill_confirmed_phase_dates/up.sql
@@ -1,0 +1,3 @@
+UPDATE moped_proj_phases SET is_phase_start_confirmed = true WHERE phase_start <= current_date;
+UPDATE moped_proj_phases SET is_phase_end_confirmed = true WHERE phase_end <= current_date;
+


### PR DESCRIPTION
## Associated issues

from https://github.com/cityofaustin/atd-data-tech/issues/14350: 

Since we https://github.com/cityofaustin/atd-data-tech/issues/14300 - we need to backfill the existing project phases based on the same logic. For both phase_start and phase_end, if the date is today or earlier it's corresponding confirmation flag can be set to true.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**

I tested by loading prod data, running the migrations and then checking 
`select phase_start, is_phase_start_confirmed, project_phase_id from moped_proj_phases mpp where phase_start > current_date` and `select phase_start, is_phase_start_confirmed, project_phase_id from moped_proj_phases mpp where phase_start < current_date` to see if they made sense. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
