### PR TITLE
add child project council districts to summary tab

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3581,6 +3581,15 @@
           table:
             name: moped_proj_work_activity
             schema: public
+    - name: project_geography
+      using:
+        manual_configuration:
+          column_mapping:
+            project_id: project_id
+          insertion_order: null
+          remote_table:
+            name: project_geography
+            schema: public
     - name: moped_project_types
       using:
         foreign_key_constraint_on:

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -141,6 +141,11 @@ export const SUMMARY_QUERY = gql`
         is_deleted: { _eq: false }
       }
     ) {
+      project_geography(
+      where: { is_deleted: { _eq: false } }
+    ) {
+        council_districts
+      }
       moped_proj_components(where: { is_deleted: { _eq: false } }) {
         ...projectComponentFields
       }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -128,6 +128,9 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
 
   const [snackbarState, setSnackbarState] = useState(false);
 
+  const childProjectGeography = data?.childProjects.map(
+    (project) => project.project_geography[0]
+  );
   /**
    * Updates the state of snackbar state
    * @param {String|JSX.Element} message - The message to be displayed
@@ -301,6 +304,7 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
                 <ProjectSummaryCouncilDistricts
                   classes={classes}
                   projectGeography={data.project_geography}
+                  childProjectGeography={childProjectGeography}
                 />
               </Grid>
               <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Grid, Typography } from "@mui/material";
 
 // reduce the array of geography objects into an array of city council districts
-const getCouncilDistricts = (data) => {
+const reduceDistricts = (data) => {
   const initialValue = [];
   const districts = data.reduce(
     (acc, component) => [...acc, component["council_districts"]],
@@ -11,9 +11,15 @@ const getCouncilDistricts = (data) => {
 
   // flatten the array of arrays and remove empty districts
   const districtsArray = districts.flat().filter((d) => d);
+  return districtsArray;
+};
 
+const getAllCouncilDistricts = (projectGeography, childProjectGeography) => {
+  const projectDistricts = reduceDistricts(projectGeography);
+  const childDistricts = reduceDistricts(childProjectGeography);
+  const allDistricts = projectDistricts.concat(childDistricts);
   // sort in ascending order and use Set to only return unique districts
-  return [...new Set(districtsArray.sort((a, b) => a - b))];
+  return [...new Set(allDistricts.sort((a, b) => a - b))];
 };
 
 /**
@@ -23,7 +29,11 @@ const getCouncilDistricts = (data) => {
  * @returns {JSX.Element}
  * @constructor
  */
-const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
+const ProjectSummaryCouncilDistricts = ({
+  projectGeography,
+  classes,
+  childProjectGeography,
+}) => {
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Typography className={classes.fieldLabel}>
@@ -31,7 +41,9 @@ const ProjectSummaryCouncilDistricts = ({ projectGeography, classes }) => {
       </Typography>
       <Box className={classes.fieldBox}>
         <Typography className={classes.fieldLabelTextNoHover}>
-          {getCouncilDistricts(projectGeography).join(", ")}
+          {getAllCouncilDistricts(projectGeography, childProjectGeography).join(
+            ", "
+          )}
         </Typography>
       </Box>
     </Grid>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/14305

## Testing
**URL to test:** 

because there is a change to the metadata, you will have to test this locally

**Steps to test:**

Create a project with no mapped components, but with child projects that have mapped components. Or if you are using prod data, https://localhost:3000/moped/projects/509. The summary tab has council districts

![Screenshot 2023-10-24 at 9 39 07 AM](https://github.com/cityofaustin/atd-moped/assets/12474808/218ec320-ace2-4319-ab14-64b387fbf971)

Also test a project with mapped components that also has child projects with mapped components, and a project without any child projects

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
