### PR TITLE
Hide the note type selector when creating a status update

### DIFF
--- a/moped-editor/src/views/projects/projectView/NoteInputQuill.js
+++ b/moped-editor/src/views/projects/projectView/NoteInputQuill.js
@@ -75,6 +75,7 @@ const NoteInputQuill = ({
   submitNewNote,
   submitEditNote,
   cancelNoteEdit,
+  isStatusEditModal,
 }) => {
   const classes = useStyles();
   const ref = useRef();
@@ -104,19 +105,21 @@ const NoteInputQuill = ({
           display="flex"
           style={{ justifyContent: "flex-end" }}
         >
-          <FormControl>
-            {!editingNote ? (
-              <NoteTypeRadioButtons
-                defaultValue={newNoteType}
-                onChange={(e) => setNewNoteType(e.target.value)}
-              ></NoteTypeRadioButtons>
-            ) : (
-              <NoteTypeRadioButtons
-                defaultValue={editingNoteType}
-                onChange={(e) => setEditingNoteType(e.target.value)}
-              ></NoteTypeRadioButtons>
-            )}
-          </FormControl>
+          {!isStatusEditModal && (
+            <FormControl>
+              {!editingNote ? (
+                <NoteTypeRadioButtons
+                  defaultValue={newNoteType}
+                  onChange={(e) => setNewNoteType(e.target.value)}
+                ></NoteTypeRadioButtons>
+              ) : (
+                <NoteTypeRadioButtons
+                  defaultValue={editingNoteType}
+                  onChange={(e) => setEditingNoteType(e.target.value)}
+                ></NoteTypeRadioButtons>
+              )}
+            </FormControl>
+          )}
         </Grid>
         <Grid item>
           <Box pb={2} display="flex" style={{ justifyContent: "flex-end" }}>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -101,7 +101,7 @@ const ProjectNotes = (props) => {
   const classes = useStyles();
   const userSessionData = getSessionDatabaseData();
   const [noteText, setNoteText] = useState("");
-  const [newNoteType, setNewNoteType] = useState(1);
+  const [newNoteType, setNewNoteType] = useState(isStatusEditModal ? 2 : 1);
   const [editingNoteType, setEditingNoteType] = useState(null);
   const [noteAddLoading, setNoteAddLoading] = useState(false);
   const [noteAddSuccess, setNoteAddSuccess] = useState(false);
@@ -306,6 +306,7 @@ const ProjectNotes = (props) => {
                 submitNewNote={submitNewNote}
                 submitEditNote={submitEditNote}
                 cancelNoteEdit={cancelNoteEdit}
+                isStatusEditModal={isStatusEditModal}
               />
             </Card>
           </Grid>
@@ -405,6 +406,7 @@ const ProjectNotes = (props) => {
                                   cancelNoteEdit={cancelNoteEdit}
                                   editingNoteType={editingNoteType}
                                   setEditingNoteType={setEditingNoteType}
+                                  isStatusEditModal={isStatusEditModal}
                                 />
                               ) : (
                                 <Typography


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/14381

## Testing
**URL to test:** 
https://deploy-preview-1176--atd-moped-main.netlify.app/moped/ 

**Steps to test:**
1. Go to the summary tab of a project, click on the status update.
2. You shouldn't see the note type radio buttons here when creating a new status in the modal or when editing an old status from here.
3. Test making a new status from this modal, make sure it saves correctly.
4. Test editing an old status from here and make sure it saves correctly. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
