### PR TITLE
Update various component geometry types

### DIFF
--- a/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
@@ -2,6 +2,9 @@ update moped_components set line_representation = false, feature_layer_id = 5 wh
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 27;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 40;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 48;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 50;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 47;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 58;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 2;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 21;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
@@ -2,7 +2,6 @@ update moped_components set line_representation = false, feature_layer_id = 5 wh
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 27;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 40;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 48;
-update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 59;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 2;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 21;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
@@ -2,8 +2,9 @@ update moped_components set line_representation = false, feature_layer_id = 5 wh
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 27;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 40;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 48;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 49;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 50;
-update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 47;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 57;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 58;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 2;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 21;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
@@ -1,0 +1,10 @@
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 25;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 27;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 40;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 48;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 59;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 75;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 2;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 21;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 35;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 45;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/down.sql
@@ -3,7 +3,6 @@ update moped_components set line_representation = false, feature_layer_id = 5 wh
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 40;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 48;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 59;
-update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 75;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 2;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 21;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
@@ -3,7 +3,6 @@ update moped_components set line_representation = true, feature_layer_id = 4 whe
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 40;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 48;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 59;
-update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 75;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 2;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 21;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
@@ -2,6 +2,9 @@ update moped_components set line_representation = true, feature_layer_id = 4 whe
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 27;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 40;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 48;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 50;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 47;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 58;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 2;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 21;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
@@ -1,0 +1,10 @@
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 25;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 27;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 40;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 48;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 59;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 75;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 2;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 21;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 35;
+update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 45;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
@@ -2,7 +2,6 @@ update moped_components set line_representation = true, feature_layer_id = 4 whe
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 27;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 40;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 48;
-update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 59;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 2;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 21;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 35;

--- a/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
+++ b/moped-database/migrations/1698257789139_update_component_geom_type/up.sql
@@ -2,8 +2,9 @@ update moped_components set line_representation = true, feature_layer_id = 4 whe
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 27;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 40;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 48;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 49;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 50;
-update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 47;
+update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 57;
 update moped_components set line_representation = true, feature_layer_id = 4 where component_id = 58;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 2;
 update moped_components set line_representation = false, feature_layer_id = 5 where component_id = 21;

--- a/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
@@ -2,3 +2,10 @@
 DELETE from public.moped_components WHERE
         moped_components.component_name = 'Signage'
         AND moped_components.component_subtype = 'linear';
+
+-- reset coponent id sequence
+SELECT
+    setval('moped_components_component_id_seq', (
+            SELECT
+                max(component_id)
+                FROM moped_components));

--- a/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
@@ -1,7 +1,7 @@
 -- delete component (will cascade to component_work_types)
 DELETE from public.moped_components WHERE
         moped_components.component_name = 'Signage'
-        AND moped_components.component_subtype = 'linear';
+        AND moped_components.component_subtype = 'Linear';
 
 -- reset coponent id sequence
 SELECT

--- a/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/down.sql
@@ -1,0 +1,4 @@
+-- delete component (will cascade to component_work_types)
+DELETE from public.moped_components WHERE
+        moped_components.component_name = 'Signage'
+        AND moped_components.component_subtype = 'linear';

--- a/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
@@ -1,4 +1,4 @@
--- reset coponent id to max componet ID: it appears to be corrupted
+-- reset coponent id sequence to max component ID
 SELECT
     setval('moped_components_component_id_seq', (
             SELECT

--- a/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
@@ -1,3 +1,10 @@
+-- reset coponent id to max componet ID: it appears to be corrupted
+SELECT
+    setval('moped_components_component_id_seq', (
+            SELECT
+                max(component_id)
+                FROM moped_components));
+
 -- create new component
 INSERT INTO public.moped_components (
         component_name,

--- a/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
@@ -1,0 +1,28 @@
+-- create new component
+INSERT INTO public.moped_components (
+        component_name,
+        component_subtype,
+        line_representation,
+        feature_layer_id
+    ) VALUES
+    ('Signage', 'linear', TRUE, 4 );
+
+-- assign available work types to it
+WITH inserts_todo AS (
+    SELECT
+        id AS work_type_id,
+        component_id
+    FROM (
+        values('new'),
+            ('modification'),
+            ('maintenance_repair')) AS data (work_type_key)
+        LEFT JOIN moped_components ON TRUE
+        LEFT JOIN moped_work_types mwt ON data.work_type_key = mwt.key
+    WHERE
+        moped_components.component_name = 'Signage'
+        AND moped_components.component_subtype = 'linear'
+) INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    *
+FROM
+    inserts_todo;

--- a/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
+++ b/moped-database/migrations/1698428471744_create_signage_line_component/up.sql
@@ -1,4 +1,4 @@
--- reset coponent id sequence to max component ID
+-- reset component id sequence to max component ID
 SELECT
     setval('moped_components_component_id_seq', (
             SELECT
@@ -12,7 +12,7 @@ INSERT INTO public.moped_components (
         line_representation,
         feature_layer_id
     ) VALUES
-    ('Signage', 'linear', TRUE, 4 );
+    ('Signage', 'Linear', TRUE, 4 );
 
 -- assign available work types to it
 WITH inserts_todo AS (

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "1.36.0",
+  "version": "1.35.1",
   "homepage": "/moped",
   "private": false,
   "repository": {


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/14408

After this change, I will manually update project components in Moped that need to be re-mapped against their new geometry type. This query will reveal that todo list:

```sql
SELECT
    *
FROM
    moped_proj_components mpc
    LEFT JOIN moped_components mc ON mc.component_id = mpc.component_id
WHERE
    mpc.component_id in (25, 27, 40, 48, 49, 50, 57, 58, 2, 21, 35, 45);
```

## Testing

**URL to test:**  Local

1. Create any of the component types listed in the issue. They should follow the following geometry type:
 
- Dynamic Speed Display Device - line
- Highway - Access Ramp - line
- Pavement Marking - School Zone - line
- Speed Management - Speed Cushions (Asphalt) - line
- Speed Management - Speed Cushions (Rubber) - line
- Speed Management - Speed Humps - line
- Pavement Marking - Sharrows - line
- Pavement Marking - Sharrows (Wide Curb Lane) - line
- Access Control - Driveway Modification - point
- Bike Lane - Turn Lane - point
- Placemaking - point
- Sidewalk - Ramps - point

2. Observe that we have a new **Signage - linear** component type.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
