### PR TITLE
Restores ability to use back button from the project map tab

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -228,7 +228,14 @@ const ProjectView = () => {
   const handleChange = useCallback(
     (event, newTab) => {
       if (newTab === 0) refetch();
-      setSearchParams({ tab: TABS[newTab].param });
+      const newTabParam = TABS[newTab].param;
+      setSearchParams(
+        { tab: TABS[newTab].param },
+        // replace history unless navigating to the map tab
+        // so users can use their browser's back button
+        // to return to project summary page
+        { replace: newTabParam !== "map" }
+      );
     },
     [refetch, setSearchParams]
   );

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -161,7 +161,8 @@ const DEFAULT_SNACKBAR_STATE = {
  */
 const useActiveTabIndex = (tabName) =>
   useMemo(() => {
-    return tabName ? TABS.findIndex((tab) => tab.param === tabName) || 0 : 0;
+    const activeTabIndex = TABS.findIndex((tab) => tab.param === tabName);
+    return activeTabIndex > -1 ? activeTabIndex : 0;
   }, [tabName]);
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -133,11 +133,6 @@ function a11yProps(index) {
   };
 }
 
-const useQueryParams = (search) =>
-  useMemo(() => {
-    return new URLSearchParams(search);
-  }, [search]);
-
 const TABS = [
   { label: "Summary", Component: ProjectSummary, param: "summary" },
   { label: "Map", Component: MapView, param: "map" },
@@ -244,7 +239,6 @@ const ProjectView = () => {
    * The mutation to soft-delete the project
    */
   const [archiveProject] = useMutation(PROJECT_ARCHIVE);
-  // and sets phases in moped_proj_phases as is_current_phase: false
   const [followProject] = useMutation(PROJECT_FOLLOW);
   const [unfollowProject] = useMutation(PROJECT_UNFOLLOW);
 

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -148,6 +148,12 @@ const TABS = [
   },
 ];
 
+const DEFAULT_SNACKBAR_STATE = {
+  open: false,
+  message: "Default State",
+  severity: "warning",
+};
+
 /**
  * Get the index of the currently active tab
  * @param {*} tabName - a `tab` name from the url search string
@@ -168,21 +174,12 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
-
-  const classes = useStyles();
   const previousFilters = location.state?.filters;
   const allProjectsLink = !!previousFilters
     ? `/moped/projects?filter=${previousFilters}`
     : "/moped/projects";
-
-  const DEFAULT_SNACKBAR_STATE = {
-    open: false,
-    message: "Default State",
-    severity: "warning",
-  };
-
+  const classes = useStyles();
   /**
-   * @constant {int} activeTab - The number of the active tab
    * @constant {boolean} isEditing - When true, it signals a child component we want to edit the project name
    * @constant {boolean} dialogOpen - When true, the dialog shows
    * @constant {dict} dialogState - Contains the 'title', 'body' and 'actions' as either string or JSX

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -219,15 +219,8 @@ const ProjectView = () => {
    */
   const handleChange = useCallback(
     (event, newTab) => {
+      setSearchParams({ tab: TABS[newTab].param });
       if (newTab === 0) refetch();
-      const newTabParam = TABS[newTab].param;
-      setSearchParams(
-        { tab: TABS[newTab].param },
-        // replace history unless navigating to the map tab
-        // so users can use their browser's back button
-        // to return to project summary page
-        { replace: newTabParam !== "map" }
-      );
     },
     [refetch, setSearchParams]
   );


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/14434

## Testing
**URL to test:**  Netlify

1. Visit the project summary for any project. Click around on the map tab, then use your browser's back button to return to the previous tab.
2. Repeat, but use the "Close Map" button to return to the project summary tab.
3. Finally, try navigating to each tab, then use your browser's back button a bunch to make sure you are returned to each previous tab correctly.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
