### PR TITLE
Handle child projects with no components/geography

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -128,9 +128,10 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
 
   const [snackbarState, setSnackbarState] = useState(false);
 
-  const childProjectGeography = data?.childProjects.map(
-    (project) => project.project_geography[0]
-  );
+  /* Not all child components have components and geography data */
+  const childProjectGeography = data?.childProjects
+    .filter((project) => project.project_geography.length > 0)
+    .map((project) => project.project_geography[0]);
   /**
    * Updates the state of snackbar state
    * @param {String|JSX.Element} message - The message to be displayed

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -18,7 +18,6 @@ const reduceDistricts = (data) => {
 };
 
 const getAllCouncilDistricts = (projectGeography, childProjectGeography) => {
-  console.log(childProjectGeography);
   const projectDistricts = reduceDistricts(projectGeography);
   const childDistricts = reduceDistricts(childProjectGeography);
   const allDistricts = projectDistricts.concat(childDistricts);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -18,6 +18,7 @@ const reduceDistricts = (data) => {
 };
 
 const getAllCouncilDistricts = (projectGeography, childProjectGeography) => {
+  console.log(childProjectGeography);
   const projectDistricts = reduceDistricts(projectGeography);
   const childDistricts = reduceDistricts(childProjectGeography);
   const allDistricts = projectDistricts.concat(childDistricts);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryCouncilDistricts.js
@@ -1,13 +1,16 @@
 import React from "react";
 import { Box, Grid, Typography } from "@mui/material";
 
-// reduce the array of geography objects into an array of city council districts
+// reduce the array of project_geography objects into an array of city council districts
 const reduceDistricts = (data) => {
   const initialValue = [];
-  const districts = data.reduce(
-    (acc, component) => [...acc, component["council_districts"]],
-    initialValue
-  );
+  const districts = data.reduce((acc, geography) => {
+    /* Not all components have geography data */
+    const geographyCouncilDistricts = geography
+      ? geography["council_districts"]
+      : [];
+    return [...acc, geographyCouncilDistricts];
+  }, initialValue);
 
   // flatten the array of arrays and remove empty districts
   const districtsArray = districts.flat().filter((d) => d);


### PR DESCRIPTION
## Associated issues

Quick patch to handle child projects with no components. No components means no row in `project_geography` so we were trying to access properties of an array that looked like `[undefined]`. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Go to https://deploy-preview-1181--atd-moped-main.netlify.app/moped/projects/1933 and the summary page should load without WSOD.
2. Go to https://moped.austinmobility.io/moped/projects/1933 and you will see a WSOD.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
