### PR TITLE
Adds another activity log record type for projects updated via the migration

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectUpdateMigrationActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectUpdateMigrationActivity.js
@@ -1,12 +1,12 @@
 import SwitchAccessShortcutAddOutlinedIcon from "@mui/icons-material/SwitchAccessShortcutAddOutlined";
 
-export const formatMigratedProjectActivity = () => {
+export const formatMigratedProjectUpdateActivity = () => {
   const changeIcon = <SwitchAccessShortcutAddOutlinedIcon />;
   return {
     changeIcon,
     changeText: [
       {
-        text: "Imported this project from the legacy MS Access project database",
+        text: "Imported project updates from the legacy MS Access project database",
         style: null,
       },
     ],

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -11,6 +11,7 @@ import { formatProjectTypesActivity } from "./activityLogFormatters/mopedProject
 import { formatFilesActivity } from "./activityLogFormatters/mopedFilesActivity";
 import { formatContractsActivity } from "./activityLogFormatters/mopedContractsActivity";
 import { formatMigratedProjectActivity } from "./activityLogFormatters/mopedProjectMigrationActivity";
+import { formatMigratedProjectUpdateActivity } from "./activityLogFormatters/mopedProjectUpdateMigrationActivity";
 
 export const formatActivityLogEntry = (change, lookupData, projectId) => {
   const changeText = [{ text: "Project was updated", style: null }];
@@ -70,6 +71,8 @@ export const formatActivityLogEntry = (change, lookupData, projectId) => {
       return formatContractsActivity(change);
     case "moped_project_migration":
       return formatMigratedProjectActivity(change);
+    case "moped_project_update_migration":
+      return formatMigratedProjectUpdateActivity(change);
     default:
       return { changeIcon, changeText };
   }


### PR DESCRIPTION
I've added a separate activity log entry for cases where we have updated an existing project with Access DB data. there are not going to be any other events for these, because the access DB 

Steps to test:
1. Take a look at the code
2. I'm pushing this to the Access migration [test instance](https://4838-jc-migrate-access-db--atd-moped-main.netlify.app/moped/projects). So you can check out [project ID 280](https://4838-jc-migrate-access-db--atd-moped-main.netlify.app/moped/projects/280?tab=activity_log).


Here's the new event I'm adding for projects updated via the migration:
<img width="1486" alt="Screenshot 2023-10-30 at 4 38 31 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/daae7648-3017-4099-adeb-f3889912aba2">

And here's the original event that we have for a project created through the migration:
<img width="1507" alt="Screenshot 2023-10-30 at 4 38 42 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/d4f61549-a3a6-459f-9448-e4cf898f5fbb">
