### PR TITLE
Ability to advanced search using multiple filters as "or"/"any" condition

### DIFF
--- a/.github/workflows/atd_moped_etl_arcgis_docker.yml
+++ b/.github/workflows/atd_moped_etl_arcgis_docker.yml
@@ -5,7 +5,7 @@ on:
       - main
       - production
     paths:
-      - ".github/workflows/build_docker_images.yml"
+      - ".github/workflows/atd_moped_etl_arcgis_docker.yml"
       - "moped-etl/arcgis/**"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -14,6 +14,8 @@ jobs:
     name: Build AGOL ETL docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -25,6 +27,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
-          context: moped-etl/arcgis
           push: true
           tags: atddocker/atd-moped-etl-arcgis:${{ github.ref_name }}
+          context: ./moped-etl/arcgis

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -21,6 +21,8 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 
 import { Autocomplete } from "@mui/material";
+import { ToggleButton } from "@mui/material";
+import { ToggleButtonGroup } from "@mui/material";
 import BackspaceOutlinedIcon from "@mui/icons-material/BackspaceOutlined";
 import { LOOKUP_TABLES_QUERY } from "../../queries/project";
 
@@ -138,6 +140,8 @@ const Filters = ({
   filtersConfig,
   setSearchFieldValue,
   setSearchTerm,
+  isOr,
+  setIsOr,
 }) => {
   /**
    * The styling of the search bar
@@ -459,14 +463,41 @@ const Filters = ({
 
   return (
     <Grid>
-      <Grid container justifyContent={"flex-end"}>
-        <IconButton
-          onClick={handleAdvancedSearchClose}
-          className={classes.closeButton}
-          size="large"
+      <Grid container className={classes.gridItemPadding}>
+        <Grid
+          item
+          xs={6}
+          className={classes.filtersContainer}
+          display="flex"
+          justifyContent="flex-start"
         >
-          <Icon fontSize={"small"}>close</Icon>
-        </IconButton>
+          <ToggleButtonGroup
+            color="primary"
+            size="small"
+            value={isOr ? "any" : "all"}
+            exclusive
+            onChange={(e) => setIsOr(e.target.value === "any")}
+            aria-label="And or toggle"
+          >
+            <ToggleButton value="all">all</ToggleButton>
+            <ToggleButton value="any">any</ToggleButton>
+          </ToggleButtonGroup>
+        </Grid>
+        <Grid
+          item
+          xs={6}
+          className={classes.filtersContainer}
+          display="flex"
+          justifyContent="flex-end"
+        >
+          <IconButton
+            onClick={handleAdvancedSearchClose}
+            className={classes.closeButton}
+            size="large"
+          >
+            <Icon fontSize={"small"}>close</Icon>
+          </IconButton>
+        </Grid>
       </Grid>
       {Object.keys(filterParameters).map((filterId) => {
         return (

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -483,11 +483,14 @@ const Filters = ({
   };
 
   console.log(filterParameters);
+  /* First filter is an empty placeholder so we check for more than one filter */
+  const areMoreThanOneFilters = Object.keys(filterParameters).length > 1;
+  const isFirstFilterComplete =
+    Object.keys(filterParameters).length === 1 && filterComplete;
 
   return (
     <Grid>
-      {/* First filter is an empty placeholder so we check for more than one filter */}
-      {Object.keys(filterParameters).length > 1 ? (
+      {areMoreThanOneFilters ? (
         <Grid container className={classes.gridItemPadding}>
           <Grid
             item
@@ -698,10 +701,7 @@ const Filters = ({
               <Hidden mdDown>
                 <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
                   <IconButton
-                    disabled={
-                      Object.keys(filterParameters).length === 1 &&
-                      !filterComplete
-                    }
+                    disabled={!isFirstFilterComplete}
                     className={classes.deleteButton}
                     onClick={() => handleDeleteFilterButtonClick(filterId)}
                     size="large"
@@ -713,10 +713,7 @@ const Filters = ({
               <Hidden mdUp>
                 <Grid item xs={12}>
                   <Button
-                    disabled={
-                      Object.keys(filterParameters).length === 1 &&
-                      !filterComplete
-                    }
+                    disabled={!isFirstFilterComplete}
                     fullWidth
                     className={classes.deleteButton}
                     variant="outlined"
@@ -746,17 +743,15 @@ const Filters = ({
           </Button>
         </Grid>
         <Grid item xs={12} md={1}>
-          {Object.keys(filterParameters).length > 0 && (
-            <Button
-              className={classes.bottomButton}
-              fullWidth
-              variant="outlined"
-              startIcon={<BackspaceOutlinedIcon />}
-              onClick={handleClearFilters}
-            >
-              Reset
-            </Button>
-          )}
+          <Button
+            className={classes.bottomButton}
+            fullWidth
+            variant="outlined"
+            startIcon={<BackspaceOutlinedIcon />}
+            onClick={handleClearFilters}
+          >
+            Reset
+          </Button>
         </Grid>
         <Hidden mdDown>
           <Grid item xs={12} md={7}>
@@ -764,20 +759,18 @@ const Filters = ({
           </Grid>
         </Hidden>
         <Grid item xs={12} md={2}>
-          {Object.keys(filterParameters).length > 0 && (
-            <Grow in={handleApplyValidation() === null}>
-              <Button
-                fullWidth
-                className={classes.applyButton}
-                variant="contained"
-                color="primary"
-                startIcon={<Icon>search</Icon>}
-                onClick={handleApplyButtonClick}
-              >
-                Search
-              </Button>
-            </Grow>
-          )}
+          <Grow in={handleApplyValidation() === null}>
+            <Button
+              fullWidth
+              className={classes.applyButton}
+              variant="contained"
+              color="primary"
+              startIcon={<Icon>search</Icon>}
+              onClick={handleApplyButtonClick}
+            >
+              Search
+            </Button>
+          </Grow>
         </Grid>
       </Grid>
     </Grid>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -333,6 +333,15 @@ const Filters = ({
     generateEmptyFilter();
   };
 
+  const pushFilterParamsToHistory = () => {
+    const filtersValue = filterQuery.get("filter");
+    const isOrValue = filterQuery.get("isOr") || false;
+
+    if (filters) {
+      history.push(`${queryPath}?filter=${filtersValue}&isOr=${isOrValue}`);
+    }
+  };
+
   /**
    * Deletes a filter from the state
    * @param {string} filterId - The UUID of the filter to be deleted
@@ -349,7 +358,7 @@ const Filters = ({
     } finally {
       // Finally, reset the state
       filterQuery.set("filter", btoa(JSON.stringify(filtersNewState)));
-      history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
+      pushFilterParamsToHistory();
       setFilterParameters(filtersNewState);
     }
   };
@@ -374,8 +383,8 @@ const Filters = ({
   const handleClearFilters = () => {
     setFilterParameters({});
     setFilters({});
-    filterQuery.set("filter", btoa(JSON.stringify({})));
-    history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
+    filterQuery.delete("filter");
+    filterQuery.delete("isOr");
   };
 
   /**
@@ -415,7 +424,7 @@ const Filters = ({
    */
   const handleApplyButtonClick = () => {
     filterQuery.set("filter", btoa(JSON.stringify(filterParameters)));
-    history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
+    pushFilterParamsToHistory();
     setFilters(filterParameters);
     handleAdvancedSearchClose();
     // Clear simple search field in UI and state since we are using advanced search
@@ -466,6 +475,7 @@ const Filters = ({
     setIsOr(isOr);
 
     filterQuery.set("isOr", isOr);
+    pushFilterParamsToHistory();
   };
 
   return (

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -380,14 +380,14 @@ const Filters = ({
   /**
    * Clears the filters
    */
-  const handleClearFilters = () => {
+  const handleClearFilters = useCallback(() => {
     setFilterParameters({});
     setFilters({});
     setIsOr(false);
     filterQuery.delete("filter");
     filterQuery.delete("isOr");
     history.push(queryPath);
-  };
+  }, [filterQuery, history, queryPath, setFilters, setIsOr]);
 
   /**
    * Returns an array of strings containing messages about the filters.

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -337,7 +337,6 @@ const Filters = ({
   const handleAddFilterButtonClick = () => {
     generateEmptyFilter();
   };
-  console.log(isOr);
 
   /**
    * Deletes a filter from the state

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -348,11 +348,7 @@ const Filters = ({
       delete filtersNewState[filterId];
     } finally {
       // Finally, reset the state
-      filterQuery.set(
-        "filter",
-        btoa(JSON.stringify({ ...filtersNewState, isOr }))
-      );
-      console.log(filtersNewState);
+      filterQuery.set("filter", btoa(JSON.stringify(filtersNewState)));
       history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
       setFilterParameters(filtersNewState);
     }
@@ -377,7 +373,7 @@ const Filters = ({
    */
   const handleClearFilters = () => {
     setFilterParameters({});
-    setFilters({ isOr: false });
+    setFilters({});
     filterQuery.set("filter", btoa(JSON.stringify({})));
     history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
   };
@@ -418,11 +414,7 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    filterQuery.set(
-      "filter",
-      btoa(JSON.stringify({ ...filterParameters, isOr }))
-    );
-    console.log(filterParameters);
+    filterQuery.set("filter", btoa(JSON.stringify(filterParameters)));
     history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
     setFilters(filterParameters);
     handleAdvancedSearchClose();

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -161,6 +161,9 @@ const Filters = ({
    */
   const [filterParameters, setFilterParameters] = useState(filters);
 
+  /* Track toggle value so we update the query value in handleApplyButtonClick */
+  const [isOrToggleValue, setIsOrToggleValue] = useState(isOr);
+
   /**
    * Tracks whether the user has added a complete filter
    */
@@ -424,10 +427,11 @@ const Filters = ({
   const handleApplyButtonClick = () => {
     setSearchParams((prevSearchParams) => {
       prevSearchParams.set("filter", btoa(JSON.stringify(filterParameters)));
-      prevSearchParams.set("isOr", isOr);
+      prevSearchParams.set("isOr", isOrToggleValue);
       return prevSearchParams;
     });
 
+    setIsOr(isOrToggleValue);
     setFilters(filterParameters);
     handleAdvancedSearchClose();
     // Clear simple search field in UI and state since we are using advanced search
@@ -476,12 +480,7 @@ const Filters = ({
 
   const handleAndOrToggle = (e) => {
     const isOr = e.target.value === "any";
-    setIsOr(isOr);
-
-    setSearchParams((prevSearchParams) => {
-      prevSearchParams.set("isOr", isOr);
-      return prevSearchParams;
-    });
+    setIsOrToggleValue(isOr);
   };
 
   return (
@@ -497,7 +496,7 @@ const Filters = ({
           {areMoreThanOneFilters ? (
             <RadioGroup
               row
-              value={isOr ? "any" : "all"}
+              value={isOrToggleValue ? "any" : "all"}
               onChange={handleAndOrToggle}
             >
               <FormControlLabel

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -461,6 +461,13 @@ const Filters = ({
     });
   }, [filterParameters]);
 
+  const handleAndOrToggle = (e) => {
+    const isOr = e.target.value === "any";
+    setIsOr(isOr);
+
+    filterQuery.set("isOr", isOr);
+  };
+
   return (
     <Grid>
       <Grid container className={classes.gridItemPadding}>
@@ -476,7 +483,7 @@ const Filters = ({
             size="small"
             value={isOr ? "any" : "all"}
             exclusive
-            onChange={(e) => setIsOr(e.target.value === "any")}
+            onChange={handleAndOrToggle}
             aria-label="And or toggle"
           >
             <ToggleButton value="all">all</ToggleButton>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -17,12 +17,13 @@ import {
   IconButton,
   Grow,
 } from "@mui/material";
+import RadioGroup from "@mui/material/RadioGroup";
+import Radio from "@mui/material/Radio";
+import FormControlLabel from "@mui/material/FormControlLabel";
 
 import makeStyles from "@mui/styles/makeStyles";
 
 import { Autocomplete } from "@mui/material";
-import { ToggleButton } from "@mui/material";
-import { ToggleButtonGroup } from "@mui/material";
 import BackspaceOutlinedIcon from "@mui/icons-material/BackspaceOutlined";
 import { LOOKUP_TABLES_QUERY } from "../../queries/project";
 
@@ -481,44 +482,62 @@ const Filters = ({
     pushFilterParamsToHistory();
   };
 
+  console.log(filterParameters);
+
   return (
     <Grid>
-      <Grid container className={classes.gridItemPadding}>
-        <Grid
-          item
-          xs={6}
-          className={classes.filtersContainer}
-          display="flex"
-          justifyContent="flex-start"
-        >
-          <ToggleButtonGroup
-            color="primary"
-            size="small"
-            value={isOr ? "any" : "all"}
-            exclusive
-            onChange={handleAndOrToggle}
-            aria-label="And or toggle"
+      {/* First filter is an empty placeholder so we check for more than one filter */}
+      {Object.keys(filterParameters).length > 1 ? (
+        <Grid container className={classes.gridItemPadding}>
+          <Grid
+            item
+            xs={6}
+            className={classes.filtersContainer}
+            display="flex"
+            justifyContent="flex-start"
           >
-            <ToggleButton value="all">all</ToggleButton>
-            <ToggleButton value="any">any</ToggleButton>
-          </ToggleButtonGroup>
-        </Grid>
-        <Grid
-          item
-          xs={6}
-          className={classes.filtersContainer}
-          display="flex"
-          justifyContent="flex-end"
-        >
-          <IconButton
-            onClick={handleAdvancedSearchClose}
-            className={classes.closeButton}
-            size="large"
+            <RadioGroup
+              row
+              value={isOr ? "any" : "all"}
+              onChange={handleAndOrToggle}
+            >
+              <FormControlLabel
+                value="all"
+                control={<Radio />}
+                label={
+                  <span>
+                    Match <strong>all</strong> filters
+                  </span>
+                }
+              />
+              <FormControlLabel
+                value="any"
+                control={<Radio />}
+                label={
+                  <span>
+                    Match <strong>any</strong> filters
+                  </span>
+                }
+              />
+            </RadioGroup>
+          </Grid>
+          <Grid
+            item
+            xs={6}
+            className={classes.filtersContainer}
+            display="flex"
+            justifyContent="flex-end"
           >
-            <Icon fontSize={"small"}>close</Icon>
-          </IconButton>
+            <IconButton
+              onClick={handleAdvancedSearchClose}
+              className={classes.closeButton}
+              size="large"
+            >
+              <Icon fontSize={"small"}>close</Icon>
+            </IconButton>
+          </Grid>
         </Grid>
-      </Grid>
+      ) : null}
       {Object.keys(filterParameters).map((filterId) => {
         return (
           <Grow in={true} key={`filter-grow-${filterId}`}>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -168,8 +168,8 @@ const Filters = ({
 
   /* First filter is an empty placeholder so we check for more than one filter */
   const areMoreThanOneFilters = Object.keys(filterParameters).length > 1;
-  const isFirstFilterComplete =
-    Object.keys(filterParameters).length === 1 && filterComplete;
+  const isFirstFilterIncomplete =
+    Object.keys(filterParameters).length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
     // Generate a random UUID string
@@ -486,15 +486,15 @@ const Filters = ({
 
   return (
     <Grid>
-      {areMoreThanOneFilters ? (
-        <Grid container className={classes.gridItemPadding}>
-          <Grid
-            item
-            xs={6}
-            className={classes.filtersContainer}
-            display="flex"
-            justifyContent="flex-start"
-          >
+      <Grid container className={classes.gridItemPadding}>
+        <Grid
+          item
+          xs={6}
+          className={classes.filtersContainer}
+          display="flex"
+          justifyContent="flex-start"
+        >
+          {areMoreThanOneFilters ? (
             <RadioGroup
               row
               value={isOr ? "any" : "all"}
@@ -519,24 +519,25 @@ const Filters = ({
                 }
               />
             </RadioGroup>
-          </Grid>
-          <Grid
-            item
-            xs={6}
-            className={classes.filtersContainer}
-            display="flex"
-            justifyContent="flex-end"
-          >
-            <IconButton
-              onClick={handleAdvancedSearchClose}
-              className={classes.closeButton}
-              size="large"
-            >
-              <Icon fontSize={"small"}>close</Icon>
-            </IconButton>
-          </Grid>
+          ) : null}
         </Grid>
-      ) : null}
+        <Grid
+          item
+          xs={6}
+          className={classes.filtersContainer}
+          display="flex"
+          justifyContent="flex-end"
+        >
+          <IconButton
+            onClick={handleAdvancedSearchClose}
+            className={classes.closeButton}
+            size="large"
+          >
+            <Icon fontSize={"small"}>close</Icon>
+          </IconButton>
+        </Grid>
+      </Grid>
+
       {Object.keys(filterParameters).map((filterId) => {
         return (
           <Grow in={true} key={`filter-grow-${filterId}`}>
@@ -697,7 +698,7 @@ const Filters = ({
               <Hidden mdDown>
                 <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
                   <IconButton
-                    disabled={!isFirstFilterComplete}
+                    disabled={isFirstFilterIncomplete}
                     className={classes.deleteButton}
                     onClick={() => handleDeleteFilterButtonClick(filterId)}
                     size="large"
@@ -709,7 +710,7 @@ const Filters = ({
               <Hidden mdUp>
                 <Grid item xs={12}>
                   <Button
-                    disabled={!isFirstFilterComplete}
+                    disabled={isFirstFilterIncomplete}
                     fullWidth
                     className={classes.deleteButton}
                     variant="outlined"

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -348,7 +348,11 @@ const Filters = ({
       delete filtersNewState[filterId];
     } finally {
       // Finally, reset the state
-      filterQuery.set("filter", btoa(JSON.stringify(filtersNewState)));
+      filterQuery.set(
+        "filter",
+        btoa(JSON.stringify({ ...filtersNewState, isOr }))
+      );
+      console.log(filtersNewState);
       history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
       setFilterParameters(filtersNewState);
     }
@@ -373,7 +377,7 @@ const Filters = ({
    */
   const handleClearFilters = () => {
     setFilterParameters({});
-    setFilters({});
+    setFilters({ isOr: false });
     filterQuery.set("filter", btoa(JSON.stringify({})));
     history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
   };
@@ -414,7 +418,11 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    filterQuery.set("filter", btoa(JSON.stringify(filterParameters)));
+    filterQuery.set(
+      "filter",
+      btoa(JSON.stringify({ ...filterParameters, isOr }))
+    );
+    console.log(filterParameters);
     history.push(`${queryPath}?filter=${filterQuery.get("filter")}`);
     setFilters(filterParameters);
     handleAdvancedSearchClose();

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -337,6 +337,7 @@ const Filters = ({
   const handleAddFilterButtonClick = () => {
     generateEmptyFilter();
   };
+  console.log(isOr);
 
   /**
    * Deletes a filter from the state
@@ -358,6 +359,12 @@ const Filters = ({
         return prevSearchParams;
       });
       setFilterParameters(filtersNewState);
+
+      /* Reset isOr to false (all/and) if there is only one filter left */
+      if (Object.keys(filtersNewState).length === 1) {
+        setIsOr(false);
+        setIsOrToggleValue(false);
+      }
     }
   };
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -337,7 +337,7 @@ const Filters = ({
     const filtersValue = filterQuery.get("filter");
     const isOrValue = filterQuery.get("isOr") || false;
 
-    if (filters) {
+    if (filtersValue) {
       history.push(`${queryPath}?filter=${filtersValue}&isOr=${isOrValue}`);
     }
   };
@@ -383,8 +383,10 @@ const Filters = ({
   const handleClearFilters = () => {
     setFilterParameters({});
     setFilters({});
+    setIsOr(false);
     filterQuery.delete("filter");
     filterQuery.delete("isOr");
+    history.push(queryPath);
   };
 
   /**
@@ -448,10 +450,11 @@ const Filters = ({
   useEffect(() => {
     if (Object.keys(filterParameters).length === 0) {
       setFilters(filterParameters);
+      handleClearFilters();
       // Add an empty filter so the user doesn't have to click the 'add filter' button
       generateEmptyFilter();
     }
-  }, [filterParameters, setFilters, generateEmptyFilter]);
+  }, [filterParameters, setFilters, generateEmptyFilter, handleClearFilters]);
 
   /**
    * This side effect monitors whether the user has added a complete filter

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -198,8 +198,8 @@ const Search = ({
             color="primary"
             value={isOr ? "or" : "and"}
             exclusive
-            onChange={(e) => setIsOr(e.value === "or")}
-            aria-label="Platform"
+            onChange={(e) => setIsOr(e.target.value === "or")}
+            aria-label="And or toggle"
           >
             <ToggleButton value="and">and</ToggleButton>
             <ToggleButton value="or">or</ToggleButton>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -148,6 +148,7 @@ const Search = ({
                 searchTerm={searchTerm}
                 setSearchTerm={setSearchTerm}
                 queryConfig={queryConfig}
+                isOr={isOr}
               />
             </Grid>
             <Grid

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { createBrowserHistory } from "history";
-import { useLocation } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
@@ -53,8 +52,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const history = createBrowserHistory();
-
 /**
  * Renders a table search component with a search bar and search filters
  * @param {Object} filters - The current filters from useAdvancedSearch hook
@@ -73,7 +70,6 @@ const history = createBrowserHistory();
 const Search = ({
   filters,
   setFilters,
-  filterQuery,
   parentData = null,
   advancedSearchAnchor,
   setAdvancedSearchAnchor,
@@ -86,7 +82,7 @@ const Search = ({
   setIsOr,
 }) => {
   const classes = useStyles();
-  const queryPath = useLocation().pathname;
+  let [, setSearchParams] = useSearchParams();
   const divRef = React.useRef();
 
   /**
@@ -101,8 +97,10 @@ const Search = ({
    */
   const handleSwitchToSearch = () => {
     setFilters({});
-    filterQuery.delete("filter");
-    history.replace(`${queryPath}?`);
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.delete("filters");
+      return prevSearchParams;
+    });
   };
 
   /**
@@ -190,8 +188,6 @@ const Search = ({
           <Filters
             filters={filters}
             setFilters={setFilters}
-            filterQuery={filterQuery}
-            history={history}
             handleAdvancedSearchClose={handleAdvancedSearchClose}
             filtersConfig={filtersConfig}
             setSearchFieldValue={setSearchFieldValue}

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -3,7 +3,15 @@ import PropTypes from "prop-types";
 import { createBrowserHistory } from "history";
 import { useLocation } from "react-router-dom";
 
-import { Box, Button, Grid, Paper, Popper } from "@mui/material";
+import {
+  Box,
+  Button,
+  Grid,
+  Paper,
+  Popper,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
@@ -82,6 +90,8 @@ const Search = ({
   queryConfig,
   filtersConfig,
   handleExportButtonClick,
+  isOr,
+  setIsOr,
 }) => {
   const classes = useStyles();
   const queryPath = useLocation().pathname;
@@ -184,6 +194,16 @@ const Search = ({
         className={classes.advancedSearchRoot}
       >
         <Paper className={classes.advancedSearchPaper}>
+          <ToggleButtonGroup
+            color="primary"
+            value={isOr ? "or" : "and"}
+            exclusive
+            onChange={(e) => setIsOr(e.value === "or")}
+            aria-label="Platform"
+          >
+            <ToggleButton value="and">and</ToggleButton>
+            <ToggleButton value="or">or</ToggleButton>
+          </ToggleButtonGroup>
           <Filters
             filters={filters}
             setFilters={setFilters}

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -3,15 +3,7 @@ import PropTypes from "prop-types";
 import { createBrowserHistory } from "history";
 import { useLocation } from "react-router-dom";
 
-import {
-  Box,
-  Button,
-  Grid,
-  Paper,
-  Popper,
-  ToggleButton,
-  ToggleButtonGroup,
-} from "@mui/material";
+import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
@@ -49,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   advancedSearchPaper: {
-    paddingTop: "0px",
+    paddingTop: theme.spacing(1),
     paddingRight: theme.spacing(2),
     paddingBottom: theme.spacing(2),
     paddingLeft: theme.spacing(2),
@@ -194,16 +186,6 @@ const Search = ({
         className={classes.advancedSearchRoot}
       >
         <Paper className={classes.advancedSearchPaper}>
-          <ToggleButtonGroup
-            color="primary"
-            value={isOr ? "or" : "and"}
-            exclusive
-            onChange={(e) => setIsOr(e.target.value === "or")}
-            aria-label="And or toggle"
-          >
-            <ToggleButton value="and">and</ToggleButton>
-            <ToggleButton value="or">or</ToggleButton>
-          </ToggleButtonGroup>
           <Filters
             filters={filters}
             setFilters={setFilters}
@@ -213,6 +195,8 @@ const Search = ({
             filtersConfig={filtersConfig}
             setSearchFieldValue={setSearchFieldValue}
             setSearchTerm={setSearchTerm}
+            isOr={isOr}
+            setIsOr={setIsOr}
           />
         </Paper>
       </Popper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { createBrowserHistory } from "history";
+import { useSearchParams } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
@@ -97,6 +97,7 @@ const Search = ({
    */
   const handleSwitchToSearch = () => {
     setFilters({});
+    setIsOr(false);
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete("filters");
       return prevSearchParams;
@@ -147,6 +148,7 @@ const Search = ({
                 setSearchTerm={setSearchTerm}
                 queryConfig={queryConfig}
                 isOr={isOr}
+                handleSwitchToSearch={handleSwitchToSearch}
               />
             </Grid>
             <Grid

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -76,6 +76,7 @@ const SearchBar = ({
   advancedSearchAnchor,
   setSearchTerm,
   queryConfig,
+  isOr,
 }) => {
   const classes = useStyles();
 
@@ -201,7 +202,7 @@ const SearchBar = ({
       {filterStateActive && (
         <Box className={classes.filtersList}>
           <Typography align="right" className={classes.filtersText}>
-            Filtered by{" "}
+            Filtered by {isOr ? "any" : "all"}{" "}
             <span className={classes.filtersSpan}>{`${filtersApplied.join(
               ", "
             )}`}</span>

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -77,6 +77,7 @@ const SearchBar = ({
   setSearchTerm,
   queryConfig,
   isOr,
+  handleSwitchToSearch,
 }) => {
   const classes = useStyles();
 
@@ -112,6 +113,9 @@ const SearchBar = ({
 
     // Prevent default behavior on any event
     if (event) event.preventDefault();
+
+    // Clear the advanced search filters
+    handleSwitchToSearch();
 
     // Update state if we are ready, triggers search.
     setSearchTerm(searchFieldValue);

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -175,9 +175,10 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
-  const previousFilters = location.state?.filters;
+  const { filters: previousFilters, isOr: previousIsOr } = location.state;
+  console.log(location.state);
   const allProjectsLink = !!previousFilters
-    ? `/moped/projects?filter=${previousFilters}`
+    ? `/moped/projects?filter=${previousFilters}&isOr=${previousIsOr}`
     : "/moped/projects";
   const classes = useStyles();
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -175,10 +175,10 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
-  const { filters: previousFilters, isOr: previousIsOr } = location.state;
-  const allProjectsLink = !!previousFilters
-    ? `/moped/projects?filter=${previousFilters}&isOr=${previousIsOr}`
-    : "/moped/projects";
+  const { queryString: previousProjectListViewQueryString } = location.state;
+  const allProjectsLink = !previousProjectListViewQueryString
+    ? "/moped/projects"
+    : `/moped/projects${previousProjectListViewQueryString}`;
   const classes = useStyles();
   /**
    * @constant {boolean} isEditing - When true, it signals a child component we want to edit the project name

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -176,7 +176,6 @@ const ProjectView = () => {
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
   const { filters: previousFilters, isOr: previousIsOr } = location.state;
-  console.log(location.state);
   const allProjectsLink = !!previousFilters
     ? `/moped/projects?filter=${previousFilters}&isOr=${previousIsOr}`
     : "/moped/projects";

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -140,14 +140,8 @@ const ProjectsListViewTable = () => {
     queryConfig: PROJECT_LIST_VIEW_QUERY_CONFIG,
   });
 
-  const {
-    filterQuery,
-    filters,
-    setFilters,
-    advancedSearchWhereString,
-    isOr,
-    setIsOr,
-  } = useAdvancedSearch();
+  const { filters, setFilters, advancedSearchWhereString, isOr, setIsOr } =
+    useAdvancedSearch();
 
   const linkStateFilters = useMemo(() => {
     return Object.keys(filters).length ? btoa(JSON.stringify(filters)) : false;
@@ -264,7 +258,6 @@ const ProjectsListViewTable = () => {
           parentData={data}
           filters={filters}
           setFilters={setFilters}
-          filterQuery={filterQuery}
           advancedSearchAnchor={advancedSearchAnchor}
           setAdvancedSearchAnchor={setAdvancedSearchAnchor}
           searchTerm={searchTerm}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -141,7 +141,7 @@ const ProjectsListViewTable = () => {
   });
 
   const { filterQuery, filters, setFilters, advancedSearchWhereString } =
-    useAdvancedSearch();
+    useAdvancedSearch({ isOr: true });
 
   const linkStateFilters = useMemo(() => {
     return Object.keys(filters).length ? btoa(JSON.stringify(filters)) : false;
@@ -243,7 +243,7 @@ const ProjectsListViewTable = () => {
   }, [data]);
 
   /**
-   * Store the most recent version of the query in app context so that it 
+   * Store the most recent version of the query in app context so that it
    * can be refetched elswhere
    */
   useEffect(() => {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -143,13 +143,8 @@ const ProjectsListViewTable = () => {
   const { filters, setFilters, advancedSearchWhereString, isOr, setIsOr } =
     useAdvancedSearch();
 
-  const linkStateFilters = useMemo(() => {
-    return Object.keys(filters).length ? btoa(JSON.stringify(filters)) : false;
-  }, [filters]);
-
   const columns = useColumns({
     hiddenColumns,
-    linkStateFilters,
     classes,
   });
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -140,8 +140,14 @@ const ProjectsListViewTable = () => {
     queryConfig: PROJECT_LIST_VIEW_QUERY_CONFIG,
   });
 
-  const { filterQuery, filters, setFilters, advancedSearchWhereString } =
-    useAdvancedSearch({ isOr: true });
+  const {
+    filterQuery,
+    filters,
+    setFilters,
+    advancedSearchWhereString,
+    isOr,
+    setIsOr,
+  } = useAdvancedSearch();
 
   const linkStateFilters = useMemo(() => {
     return Object.keys(filters).length ? btoa(JSON.stringify(filters)) : false;
@@ -266,6 +272,8 @@ const ProjectsListViewTable = () => {
           queryConfig={PROJECT_LIST_VIEW_QUERY_CONFIG}
           filtersConfig={PROJECT_LIST_VIEW_FILTERS_CONFIG}
           handleExportButtonClick={handleExportButtonClick}
+          isOr={isOr}
+          setIsOr={setIsOr}
         />
         {/*Main Table Body*/}
         <Paper className={classes.paper}>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  useContext,
-  useCallback,
-} from "react";
+import React, { useState, useEffect, useContext, useCallback } from "react";
 import { Box, Card, CircularProgress, Container, Paper } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { useQuery } from "@apollo/client";

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { NavLink as RouterLink, useSearchParams } from "react-router-dom";
+import { NavLink as RouterLink, useLocation } from "react-router-dom";
 import { MTableHeader } from "@material-table/core";
 import typography from "../../../theme/typography";
 import parse from "html-react-parser";
@@ -129,9 +129,8 @@ export const useTableComponents = ({
  * The Material Table column settings
  */
 export const useColumns = ({ hiddenColumns, classes }) => {
-  const [searchParams] = useSearchParams();
-  const linkStateFilters = searchParams.get("filter");
-  const linkStateIsOr = searchParams.get("isOr") === "true" ? true : false;
+  const location = useLocation();
+  const queryString = location.search;
 
   const columns = useMemo(
     () => [
@@ -147,7 +146,7 @@ export const useColumns = ({ hiddenColumns, classes }) => {
         render: (entry) => (
           <RouterLink
             to={`/moped/projects/${entry.project_id}`}
-            state={{ filters: linkStateFilters, isOr: linkStateIsOr }}
+            state={{ queryString }}
             className={classes.colorPrimary}
           >
             {entry.project_name}
@@ -400,7 +399,7 @@ export const useColumns = ({ hiddenColumns, classes }) => {
         render: (entry) => (
           <RouterLink
             to={`/moped/projects/${entry.parent_project_id}`}
-            state={{ filters: linkStateFilters, isOr: linkStateIsOr }}
+            state={{ queryString }}
             className={classes.colorPrimary}
           >
             {entry.parent_project_name}
@@ -418,7 +417,7 @@ export const useColumns = ({ hiddenColumns, classes }) => {
         emptyValue: "-",
       },
     ],
-    [hiddenColumns, linkStateFilters, linkStateIsOr, classes]
+    [hiddenColumns, queryString, classes]
   );
   return columns;
 };

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -418,7 +418,7 @@ export const useColumns = ({ hiddenColumns, classes }) => {
         emptyValue: "-",
       },
     ],
-    [hiddenColumns, linkStateFilters, classes]
+    [hiddenColumns, linkStateFilters, linkStateIsOr, classes]
   );
   return columns;
 };

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { NavLink as RouterLink } from "react-router-dom";
+import { NavLink as RouterLink, useSearchParams } from "react-router-dom";
 import { MTableHeader } from "@material-table/core";
 import typography from "../../../theme/typography";
 import parse from "html-react-parser";
@@ -128,8 +128,12 @@ export const useTableComponents = ({
 /**
  * The Material Table column settings
  */
-export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
-  useMemo(
+export const useColumns = ({ hiddenColumns, classes }) => {
+  const [searchParams] = useSearchParams();
+  const linkStateFilters = searchParams.get("filter");
+  const linkStateIsOr = searchParams.get("isOr") === "true" ? true : false;
+
+  const columns = useMemo(
     () => [
       {
         title: "ID",
@@ -143,7 +147,7 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
         render: (entry) => (
           <RouterLink
             to={`/moped/projects/${entry.project_id}`}
-            state={{ filters: linkStateFilters }}
+            state={{ filters: linkStateFilters, isOr: linkStateIsOr }}
             className={classes.colorPrimary}
           >
             {entry.project_name}
@@ -396,7 +400,7 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
         render: (entry) => (
           <RouterLink
             to={`/moped/projects/${entry.parent_project_id}`}
-            state={{ filters: linkStateFilters }}
+            state={{ filters: linkStateFilters, isOr: linkStateIsOr }}
             className={classes.colorPrimary}
           >
             {entry.parent_project_name}
@@ -416,6 +420,8 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
     ],
     [hiddenColumns, linkStateFilters, classes]
   );
+  return columns;
+};
 
 /**
  * Defines various Material Table options

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 
 const useFilterQuery = (locationSearch) =>
   useMemo(() => {
@@ -66,11 +66,12 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 
 export const useAdvancedSearch = () => {
   /* Get advanced filters settings from search params if they exist */
+  let [searchParams] = useSearchParams();
   const filterQuery = useFilterQuery(useLocation().search);
-  const initialFilterState = useMakeFilterState(filterQuery);
+  const initialFilterState = useMakeFilterState(searchParams);
 
   /* Determine or/any from search params if it exists */
-  const isOrFromSearchParams = filterQuery.get("isOr");
+  const isOrFromSearchParams = searchParams.get("isOr");
   const initialIsOrState = isOrFromSearchParams === "true" ? true : false;
   const [isOr, setIsOr] = useState(initialIsOrState);
 

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -62,8 +62,7 @@ const makeAdvancedSearchWhereString = (filters) =>
       }
       return `${field}: { ${gqlOperator}: ${value} }`;
     })
-    .filter((value) => value !== null)
-    .join(", ");
+    .filter((value) => value !== null);
 
 export const useAdvancedSearch = () => {
   const [isOr, setIsOr] = useState(false);
@@ -81,10 +80,14 @@ export const useAdvancedSearch = () => {
 
   const advancedSearchWhereString = useMemo(() => {
     if (isOr) {
+      // Ex. _or: [{project_lead: {_eq: "COA ATD Project Delivery"}}, {project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}}]
       const advancedFilters = makeAdvancedSearchWhereString(filters);
-      return `_or: { ${advancedFilters} }`;
+      const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);
+      return `_or: [ ${bracketedFilters.join(",")} ]`;
     } else {
-      return makeAdvancedSearchWhereString(filters);
+      // Ex. project_lead: {_eq: "COA ATD Project Delivery"}, project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}
+      const advancedFilters = makeAdvancedSearchWhereString(filters);
+      return advancedFilters.join(", ");
     }
   }, [filters, isOr]);
 

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -1,27 +1,22 @@
 import { useState, useMemo } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
-
-const useFilterQuery = (locationSearch) =>
-  useMemo(() => {
-    return new URLSearchParams(locationSearch);
-  }, [locationSearch]);
+import { useSearchParams } from "react-router-dom";
 
 /**
  * if filter exists in url, decodes base64 string and returns as object
  * Used to initialize filter state
  * @return Object
  */
-const useMakeFilterState = (filterQuery) =>
+const useMakeFilterState = (searchParams) =>
   useMemo(() => {
-    if (Array.from(filterQuery).length > 0) {
+    if (Array.from(searchParams).length > 0) {
       try {
-        return JSON.parse(atob(filterQuery.get("filter")));
+        return JSON.parse(atob(searchParams.get("filter")));
       } catch {
         return {};
       }
     }
     return {};
-  }, [filterQuery]);
+  }, [searchParams]);
 
 /**
  * Build an array of filter strings to be used in generating the advanced search where string
@@ -67,7 +62,6 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 export const useAdvancedSearch = () => {
   /* Get advanced filters settings from search params if they exist */
   let [searchParams] = useSearchParams();
-  const filterQuery = useFilterQuery(useLocation().search);
   const initialFilterState = useMakeFilterState(searchParams);
 
   /* Determine or/any from search params if it exists */
@@ -98,7 +92,6 @@ export const useAdvancedSearch = () => {
   }, [filters, isOr]);
 
   return {
-    filterQuery,
     filters,
     setFilters,
     advancedSearchWhereString,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -65,10 +65,14 @@ const makeAdvancedSearchWhereFilters = (filters) =>
     .filter((value) => value !== null);
 
 export const useAdvancedSearch = () => {
-  const [isOr, setIsOr] = useState(false);
-
+  /* Get advanced filters settings from search params if they exist */
   const filterQuery = useFilterQuery(useLocation().search);
   const initialFilterState = useMakeFilterState(filterQuery);
+
+  /* Determine or/any from search params if it exists */
+  const isOrFromSearchParams = filterQuery.get("isOr");
+  const initialIsOrState = isOrFromSearchParams === "true" ? true : false;
+  const [isOr, setIsOr] = useState(initialIsOrState);
 
   /**
    * Stores filters assigned random id and nests column, operator, and value.

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -65,7 +65,7 @@ const makeAdvancedSearchWhereString = (filters) =>
     .filter((value) => value !== null)
     .join(", ");
 
-export const useAdvancedSearch = () => {
+export const useAdvancedSearch = ({ isOr }) => {
   const filterQuery = useFilterQuery(useLocation().search);
   const initialFilterState = useMakeFilterState(filterQuery);
 
@@ -77,10 +77,10 @@ export const useAdvancedSearch = () => {
    */
   const [filters, setFilters] = useState(initialFilterState);
 
-  const advancedSearchWhereString = useMemo(
-    () => makeAdvancedSearchWhereString(filters),
-    [filters]
-  );
+  const advancedSearchWhereString = useMemo(() => {
+    return makeAdvancedSearchWhereString(filters);
+  }, [filters, isOr]);
+  console.log(advancedSearchWhereString);
 
   return {
     filterQuery,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -65,7 +65,9 @@ const makeAdvancedSearchWhereString = (filters) =>
     .filter((value) => value !== null)
     .join(", ");
 
-export const useAdvancedSearch = ({ isOr }) => {
+export const useAdvancedSearch = () => {
+  const [isOr, setIsOr] = useState(false);
+
   const filterQuery = useFilterQuery(useLocation().search);
   const initialFilterState = useMakeFilterState(filterQuery);
 
@@ -87,5 +89,7 @@ export const useAdvancedSearch = ({ isOr }) => {
     filters,
     setFilters,
     advancedSearchWhereString,
+    isOr,
+    setIsOr,
   };
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -24,11 +24,11 @@ const useMakeFilterState = (filterQuery) =>
   }, [filterQuery]);
 
 /**
- * Build the advanced search part of the graphql query using the filter state.
+ * Build an array of filter strings to be used in generating the advanced search where string
  @ param {Object} filters - Stores filters assigned random id and nests column, operator, and value
  * @return Object
  */
-const makeAdvancedSearchWhereString = (filters) =>
+const makeAdvancedSearchWhereFilters = (filters) =>
   Object.keys(filters)
     .map((filter) => {
       let { envelope, field, gqlOperator, value, type, specialNullValue } =
@@ -79,14 +79,15 @@ export const useAdvancedSearch = () => {
   const [filters, setFilters] = useState(initialFilterState);
 
   const advancedSearchWhereString = useMemo(() => {
+    const advancedFilters = makeAdvancedSearchWhereFilters(filters);
+    if (advancedFilters.length === 0) return null;
+
     if (isOr) {
       // Ex. _or: [{project_lead: {_eq: "COA ATD Project Delivery"}}, {project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}}]
-      const advancedFilters = makeAdvancedSearchWhereString(filters);
       const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);
-      return `_or: [ ${bracketedFilters.join(",")} ]`;
+      return `_or: [${bracketedFilters.join(",")}]`;
     } else {
       // Ex. project_lead: {_eq: "COA ATD Project Delivery"}, project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}
-      const advancedFilters = makeAdvancedSearchWhereString(filters);
       return advancedFilters.join(", ");
     }
   }, [filters, isOr]);

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -80,9 +80,13 @@ export const useAdvancedSearch = () => {
   const [filters, setFilters] = useState(initialFilterState);
 
   const advancedSearchWhereString = useMemo(() => {
-    return makeAdvancedSearchWhereString(filters);
+    if (isOr) {
+      const advancedFilters = makeAdvancedSearchWhereString(filters);
+      return `_or: { ${advancedFilters} }`;
+    } else {
+      return makeAdvancedSearchWhereString(filters);
+    }
   }, [filters, isOr]);
-  console.log(advancedSearchWhereString);
 
   return {
     filterQuery,

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -12,7 +12,7 @@ export const useGetProjectListView = ({
   advancedSearchWhereString,
 }) => {
   const { query, exportQuery } = useMemo(() => {
-    const query = gql`query ProjectListView {
+    const queryString = `query ProjectListView {
         project_list_view (
             limit: ${queryLimit}
             offset: ${queryOffset}
@@ -35,8 +35,11 @@ export const useGetProjectListView = ({
           }
         }
       }`;
+    const query = gql`
+      ${queryString}
+    `;
 
-    const exportQuery = gql`{
+    const exportQueryString = gql`{
       project_list_view (
           order_by: {${orderByColumn}: ${orderByDirection}}
           where: { 
@@ -57,6 +60,9 @@ export const useGetProjectListView = ({
         }
       }
     }`;
+    const exportQuery = gql`
+      ${exportQueryString}
+    `;
 
     return { query, exportQuery };
   }, [


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/11282

This PR:
- adds an advanced search radio group to select either **and** or **or** logic
- updates `useAdvancedSearch` to handle and apply that logic to the advanced filters in the GraphQL query
- updates the code to use React Router [useSearchParams](https://reactrouter.com/en/main/hooks/use-search-params#usesearchparams) to manage the url query strings

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1187--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to the project list view in the deploy preview
2. Add an advanced filter by click the filter icon in the search box
3. Try searching for:
- **ALL**
- **Lead is COA ATD Project Delivery**
- **Sponsor is COA ATD Active Transportation & Street Design**
- Notice that there are radios for **all** and **any** above the advanced filter rows. Keep it as **all**
- You should see one result that created that is named **#11282 test project** that matches both of the filters
- Check the url and you should see two query parameters: **filter** (with the encoded filter string) and **isOr** which should have the value of **false**
4. Now, try searching for:
- **ANY**
- **Lead is COA ATD Project Delivery**
- **Sponsor is COA ATD Active Transportation & Street Design**
- Change the radios to match **any**
- You should see many results that meet either of the two filters
- Check the url and you should see two query parameters: **filter** (with the encoded filter string) and **isOr** which should have the value of **true**
5. Try combinations of advanced filters like **projects where Arterial Management is either the Lead, Sponsor, or a Partner** from the issue, and try to break it! (You might run into https://github.com/cityofaustin/atd-data-tech/issues/14495 - that fix is coming in the next PR)
6. Try copying your url with **filter** and **isOr** parameters into a different tab and the UI should reflect the advanced filters stored in the encoded string with the correct any/all option selected in the radio buttons
7. Try applying advanced filters to the view and then entering a search string into the search box and pressing enter. You should see the advanced filter UI reset and the query parameters removed.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
