### PR TITLE
Add list of components to project list view and advanced search

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1220,6 +1220,7 @@
           - line_representation
           - feature_layer_id
           - asset_feature_layer_id
+          - component_name_full
         filter: {}
     - role: moped-editor
       permission:
@@ -1231,6 +1232,7 @@
           - line_representation
           - feature_layer_id
           - asset_feature_layer_id
+          - component_name_full
         filter: {}
     - role: moped-viewer
       permission:
@@ -1242,6 +1244,7 @@
           - line_representation
           - feature_layer_id
           - asset_feature_layer_id
+          - component_name_full
         filter: {}
 - table:
     name: moped_components_subcomponents

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4908,7 +4908,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
-          - component_name_with_subtype
+          - components
         filter: {}
         allow_aggregations: true
     - role: moped-editor
@@ -4950,7 +4950,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
-          - component_name_with_subtype
+          - components
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
@@ -4992,7 +4992,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
-          - component_name_with_subtype
+          - components
         filter: {}
         allow_aggregations: true
 - table:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4908,6 +4908,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
+          - component_name_with_subtype
         filter: {}
         allow_aggregations: true
     - role: moped-editor
@@ -4949,6 +4950,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
+          - component_name_with_subtype
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
@@ -4990,6 +4992,7 @@
           - updated_at
           - knack_project_id
           - project_note_date_created
+          - component_name_with_subtype
         filter: {}
         allow_aggregations: true
 - table:

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/down.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE moped_components DROP COLUMN component_name_with_subtype;
+ALTER TABLE moped_components DROP COLUMN component_name_full;

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/down.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE moped_components DROP COLUMN component_name_with_subtype;

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE moped_components
+    ADD COLUMN component_name_with_subtype text 
+        GENERATED ALWAYS AS (component_name::text || ' - ' || component_subtype::text) STORED;
+
+COMMENT ON COLUMN moped_components.component_name_with_subtype IS 'component name concatenated with component subtype, separated by -'

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE moped_components
-    ADD COLUMN component_name_with_subtype text 
+    ADD COLUMN component_name_full text 
         GENERATED ALWAYS AS (component_name::text || ' - ' || component_subtype::text) STORED;
 
 COMMENT ON COLUMN moped_components.component_name_with_subtype IS 'component name concatenated with component subtype, separated by -'

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
@@ -2,4 +2,4 @@ ALTER TABLE moped_components
     ADD COLUMN component_name_full text 
         GENERATED ALWAYS AS (component_name::text || ' - ' || component_subtype::text) STORED;
 
-COMMENT ON COLUMN moped_components.component_name_with_subtype IS 'component name concatenated with component subtype, separated by -'
+COMMENT ON COLUMN moped_components.component_name_full IS 'component name concatenated with component subtype, separated by -'

--- a/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
+++ b/moped-database/migrations/1698783764345_add_generated_column_moped_components/up.sql
@@ -1,5 +1,9 @@
 ALTER TABLE moped_components
     ADD COLUMN component_name_full text 
-        GENERATED ALWAYS AS (component_name::text || ' - ' || component_subtype::text) STORED;
+        GENERATED ALWAYS AS
+         (CASE WHEN component_subtype IS NULL THEN component_name
+              ELSE (component_name::text || ' - ' || component_subtype::text)
+          END)
+        STORED;
 
 COMMENT ON COLUMN moped_components.component_name_full IS 'component name concatenated with component subtype, separated by -'

--- a/moped-database/migrations/1698786867086_add_component_subtype_to_view/down.sql
+++ b/moped-database/migrations/1698786867086_add_component_subtype_to_view/down.sql
@@ -1,0 +1,198 @@
+DROP VIEW project_list_view;
+
+CREATE OR REPLACE VIEW public.project_list_view
+AS WITH project_person_list_lookup AS (
+    SELECT
+      mpp.project_id,
+      string_agg(DISTINCT concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members
+    FROM moped_proj_personnel mpp
+      JOIN moped_users mu ON mpp.user_id = mu.user_id
+      JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+      JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+    WHERE mpp.is_deleted = false
+      AND mppr.is_deleted = false
+    GROUP BY mpp.project_id
+  ), funding_sources_lookup AS (
+    SELECT 
+      mpf_1.project_id,
+      string_agg(mfs.funding_source_name, ', '::text) AS funding_source_name
+    FROM moped_proj_funding mpf_1
+      LEFT JOIN moped_fund_sources mfs ON mpf_1.funding_source_id = mfs.funding_source_id
+    WHERE mpf_1.is_deleted = false
+    GROUP BY mpf_1.project_id
+  ), project_type_lookup AS (
+    SELECT
+      mpt.project_id,
+      string_agg(mt.type_name, ', '::text) AS type_name
+      FROM moped_project_types mpt
+        LEFT JOIN moped_types mt ON mpt.project_type_id = mt.type_id AND mpt.is_deleted = false
+    GROUP BY mpt.project_id
+  ), child_project_lookup AS (
+    SELECT jsonb_agg(children.project_id) AS children_project_ids,
+      children.parent_project_id AS parent_id
+      FROM moped_project AS children
+        JOIN moped_project AS parent ON (parent.project_id = children.parent_project_id)
+        WHERE children.is_deleted = false
+    GROUP BY parent_id
+  ), work_activities AS (
+      SELECT
+          project_id,
+          string_agg(task_order_objects.task_order_object ->> 'display_name'::text,
+              ', '::text) AS task_order_names,
+          string_agg(task_order_objects.task_order_object ->> 'task_order'::text,
+              ', '::text) AS task_order_names_short,
+          jsonb_agg(task_order_objects.task_order_object) FILTER (WHERE task_order_objects.task_order_object IS NOT NULL) AS task_orders,
+          string_agg(DISTINCT mpwa.contractor,
+          ', '::text) AS contractors,
+          string_agg(mpwa.contract_number,
+          ', '::text) AS contract_numbers FROM moped_proj_work_activity mpwa
+      LEFT JOIN LATERAL jsonb_array_elements(mpwa.task_orders) task_order_objects (task_order_object) ON TRUE WHERE 1 = 1
+      AND mpwa.is_deleted = FALSE
+  GROUP BY
+      mpwa.project_id
+  )
+ SELECT
+    mp.project_id,
+    mp.project_name,
+    mp.project_description,
+    mp.ecapris_subproject_id,
+    mp.date_added,
+    mp.is_deleted,
+    mp.updated_at,
+    current_phase.phase_name as current_phase,
+    current_phase.phase_key as current_phase_key,
+    current_phase.phase_name_simple as current_phase_simple,
+    ppll.project_team_members,
+    me.entity_name AS project_sponsor,
+    mel.entity_name AS project_lead,
+    mpps.name AS public_process_status,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    proj_notes.project_note,
+    proj_notes.date_created as project_note_date_created,
+    work_activities.contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders,
+    (SELECT project_name
+      FROM moped_project
+      WHERE project_id = mp.parent_project_id
+    ) as parent_project_name,
+    cpl.children_project_ids,
+    string_agg(DISTINCT me2.entity_name, ', '::text) AS project_partner,
+    (SELECT JSON_AGG(json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type, 'id', feature_signals.id))
+        FROM moped_proj_components components   
+        LEFT JOIN feature_signals
+          ON (feature_signals.component_id = components.project_component_id)
+        WHERE TRUE
+          AND components.is_deleted = false
+          AND components.project_id = mp.project_id
+          AND feature_signals.signal_id is not null
+          AND feature_signals.is_deleted = false
+        ) as project_feature,
+    fsl.funding_source_name,
+    ptl.type_name,
+    ( -- get the date of the construction phase with the earliest start date
+      SELECT min(phases.phase_start)
+      FROM moped_proj_phases phases
+      WHERE true
+        AND phases.project_id = mp.project_id 
+        AND phases.phase_id = 9 -- phase_id 9 is construction
+        AND phases.is_deleted = false
+    ) AS construction_start_date,
+    ( -- get the date of the completion phase with the latest end date
+      SELECT max(phases.phase_end)
+      FROM moped_proj_phases phases
+      WHERE true 
+        AND phases.project_id = mp.project_id 
+        AND phases.phase_id = 11 -- phase_id 11 is complete
+        AND phases.is_deleted = false
+      ) AS completion_end_date,
+    ( -- get me a list of the inspectors for this project
+      SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+      FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+      WHERE 1 = 1
+        AND mpr.project_role_name = 'Inspector'::text
+        AND mpp.is_deleted = false
+        AND mppr.is_deleted = false
+        AND mpp.project_id = mp.project_id
+      GROUP BY mpp.project_id) AS project_inspector,
+    ( -- get me a list of the designers for this project
+      SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+      FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+      WHERE 1 = 1
+        AND mpr.project_role_name = 'Designer'::text
+        AND mpp.is_deleted = false
+        AND mppr.is_deleted = false
+        AND mpp.project_id = mp.project_id
+      GROUP BY mpp.project_id) AS project_designer,
+    ( -- get me all of the tags added to a project
+    SELECT string_agg(tags.name, ', '::text) AS string_agg
+      FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+      WHERE 1 = 1
+        AND ptags.is_deleted = false
+        AND ptags.project_id = mp.project_id
+      GROUP BY ptags.project_id) AS project_tags,
+    concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by
+   FROM moped_project mp
+     LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
+     LEFT JOIN funding_sources_lookup fsl ON fsl.project_id = mp.project_id
+     LEFT JOIN project_type_lookup ptl ON ptl.project_id = mp.project_id
+     LEFT JOIN moped_entity me ON me.entity_id = mp.project_sponsor
+     LEFT JOIN moped_entity mel ON mel.entity_id = mp.project_lead_id
+     LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
+     LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
+     LEFT JOIN work_activities on work_activities.project_id = mp.project_id
+     LEFT JOIN moped_users added_by_user ON mp.added_by = added_by_user.user_id
+     LEFT JOIN current_phase_view current_phase on mp.project_id = current_phase.project_id
+     LEFT JOIN moped_public_process_statuses mpps ON mpps.id = mp.public_process_status_id
+     LEFT JOIN child_project_lookup cpl on cpl.parent_id = mp.project_id
+     LEFT JOIN LATERAL
+      (
+        SELECT mpn.project_note, mpn.date_created
+        FROM moped_proj_notes mpn
+        WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
+        ORDER BY mpn.date_created DESC
+        LIMIT 1
+      ) as proj_notes on true
+  WHERE
+    mp.is_deleted = false
+  GROUP BY
+    mp.project_id, 
+    mp.project_name, 
+    mp.project_description, 
+    ppll.project_team_members, 
+    mp.ecapris_subproject_id, 
+    mp.date_added,
+    mp.is_deleted,
+    me.entity_name,
+    mel.entity_name,
+    mp.updated_at,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    current_phase.phase_name,
+    current_phase.phase_key,
+    current_phase.phase_name_simple,
+    ptl.type_name,
+    fsl.funding_source_name,
+    added_by_user.first_name,
+    added_by_user.last_name,
+    mpps.name,
+    cpl.children_project_ids,
+    proj_notes.project_note,
+    proj_notes.date_created,
+    work_activities.contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders;

--- a/moped-database/migrations/1698786867086_add_component_subtype_to_view/up.sql
+++ b/moped-database/migrations/1698786867086_add_component_subtype_to_view/up.sql
@@ -1,0 +1,206 @@
+CREATE OR REPLACE VIEW public.project_list_view
+AS WITH project_person_list_lookup AS (
+    SELECT
+      mpp.project_id,
+      string_agg(DISTINCT concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members
+    FROM moped_proj_personnel mpp
+      JOIN moped_users mu ON mpp.user_id = mu.user_id
+      JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+      JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+    WHERE mpp.is_deleted = false
+      AND mppr.is_deleted = false
+    GROUP BY mpp.project_id
+  ), funding_sources_lookup AS (
+    SELECT 
+      mpf_1.project_id,
+      string_agg(mfs.funding_source_name, ', '::text) AS funding_source_name
+    FROM moped_proj_funding mpf_1
+      LEFT JOIN moped_fund_sources mfs ON mpf_1.funding_source_id = mfs.funding_source_id
+    WHERE mpf_1.is_deleted = false
+    GROUP BY mpf_1.project_id
+  ), project_type_lookup AS (
+    SELECT
+      mpt.project_id,
+      string_agg(mt.type_name, ', '::text) AS type_name
+      FROM moped_project_types mpt
+        LEFT JOIN moped_types mt ON mpt.project_type_id = mt.type_id AND mpt.is_deleted = false
+    GROUP BY mpt.project_id
+  ), child_project_lookup AS (
+    SELECT jsonb_agg(children.project_id) AS children_project_ids,
+      children.parent_project_id AS parent_id
+      FROM moped_project AS children
+        JOIN moped_project AS parent ON (parent.project_id = children.parent_project_id)
+        WHERE children.is_deleted = false
+    GROUP BY parent_id
+  ), work_activities AS (
+      SELECT
+          project_id,
+          string_agg(task_order_objects.task_order_object ->> 'display_name'::text,
+              ', '::text) AS task_order_names,
+          string_agg(task_order_objects.task_order_object ->> 'task_order'::text,
+              ', '::text) AS task_order_names_short,
+          jsonb_agg(task_order_objects.task_order_object) FILTER (WHERE task_order_objects.task_order_object IS NOT NULL) AS task_orders,
+          string_agg(DISTINCT mpwa.contractor,
+          ', '::text) AS contractors,
+          string_agg(mpwa.contract_number,
+          ', '::text) AS contract_numbers FROM moped_proj_work_activity mpwa
+      LEFT JOIN LATERAL jsonb_array_elements(mpwa.task_orders) task_order_objects (task_order_object) ON TRUE WHERE 1 = 1
+      AND mpwa.is_deleted = FALSE
+  GROUP BY
+      mpwa.project_id
+  ), moped_proj_components_subtypes AS (
+    SELECT
+      mpc.project_id,
+      string_agg(DISTINCT mc.component_name_with_subtype, ', '::text) AS component_name_with_subtype
+    FROM moped_proj_components mpc 
+    LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id 
+    GROUP BY mpc.project_id
+  )
+ SELECT
+    mp.project_id,
+    mp.project_name,
+    mp.project_description,
+    mp.ecapris_subproject_id,
+    mp.date_added,
+    mp.is_deleted,
+    mp.updated_at,
+    current_phase.phase_name as current_phase,
+    current_phase.phase_key as current_phase_key,
+    current_phase.phase_name_simple as current_phase_simple,
+    ppll.project_team_members,
+    me.entity_name AS project_sponsor,
+    mel.entity_name AS project_lead,
+    mpps.name AS public_process_status,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    proj_notes.project_note,
+    proj_notes.date_created as project_note_date_created,
+    work_activities.contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders,
+    (SELECT project_name
+      FROM moped_project
+      WHERE project_id = mp.parent_project_id
+    ) as parent_project_name,
+    cpl.children_project_ids,
+    string_agg(DISTINCT me2.entity_name, ', '::text) AS project_partner,
+    (SELECT JSON_AGG(json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type, 'id', feature_signals.id))
+        FROM moped_proj_components components   
+        LEFT JOIN feature_signals
+          ON (feature_signals.component_id = components.project_component_id)
+        WHERE TRUE
+          AND components.is_deleted = false
+          AND components.project_id = mp.project_id
+          AND feature_signals.signal_id is not null
+          AND feature_signals.is_deleted = false
+        ) as project_feature,
+    fsl.funding_source_name,
+    ptl.type_name,
+    ( -- get the date of the construction phase with the earliest start date
+      SELECT min(phases.phase_start)
+      FROM moped_proj_phases phases
+      WHERE true
+        AND phases.project_id = mp.project_id 
+        AND phases.phase_id = 9 -- phase_id 9 is construction
+        AND phases.is_deleted = false
+    ) AS construction_start_date,
+    ( -- get the date of the completion phase with the latest end date
+      SELECT max(phases.phase_end)
+      FROM moped_proj_phases phases
+      WHERE true 
+        AND phases.project_id = mp.project_id 
+        AND phases.phase_id = 11 -- phase_id 11 is complete
+        AND phases.is_deleted = false
+      ) AS completion_end_date,
+    ( -- get me a list of the inspectors for this project
+      SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+      FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+      WHERE 1 = 1
+        AND mpr.project_role_name = 'Inspector'::text
+        AND mpp.is_deleted = false
+        AND mppr.is_deleted = false
+        AND mpp.project_id = mp.project_id
+      GROUP BY mpp.project_id) AS project_inspector,
+    ( -- get me a list of the designers for this project
+      SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+      FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+      WHERE 1 = 1
+        AND mpr.project_role_name = 'Designer'::text
+        AND mpp.is_deleted = false
+        AND mppr.is_deleted = false
+        AND mpp.project_id = mp.project_id
+      GROUP BY mpp.project_id) AS project_designer,
+    ( -- get me all of the tags added to a project
+    SELECT string_agg(tags.name, ', '::text) AS string_agg
+      FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+      WHERE 1 = 1
+        AND ptags.is_deleted = false
+        AND ptags.project_id = mp.project_id
+      GROUP BY ptags.project_id) AS project_tags,
+    concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by,
+    mpcs.component_name_with_subtype
+   FROM moped_project mp
+     LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
+     LEFT JOIN funding_sources_lookup fsl ON fsl.project_id = mp.project_id
+     LEFT JOIN project_type_lookup ptl ON ptl.project_id = mp.project_id
+     LEFT JOIN moped_entity me ON me.entity_id = mp.project_sponsor
+     LEFT JOIN moped_entity mel ON mel.entity_id = mp.project_lead_id
+     LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
+     LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
+     LEFT JOIN work_activities on work_activities.project_id = mp.project_id
+     LEFT JOIN moped_users added_by_user ON mp.added_by = added_by_user.user_id
+     LEFT JOIN current_phase_view current_phase on mp.project_id = current_phase.project_id
+     LEFT JOIN moped_public_process_statuses mpps ON mpps.id = mp.public_process_status_id
+     LEFT JOIN child_project_lookup cpl on cpl.parent_id = mp.project_id
+     LEFT JOIN moped_proj_components_subtypes mpcs on mpcs.project_id = mp.project_id
+     LEFT JOIN LATERAL
+      (
+        SELECT mpn.project_note, mpn.date_created
+        FROM moped_proj_notes mpn
+        WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
+        ORDER BY mpn.date_created DESC
+        LIMIT 1
+      ) as proj_notes on true
+  WHERE
+    mp.is_deleted = false
+  GROUP BY
+    mp.project_id, 
+    mp.project_name, 
+    mp.project_description, 
+    ppll.project_team_members, 
+    mp.ecapris_subproject_id, 
+    mp.date_added,
+    mp.is_deleted,
+    me.entity_name,
+    mel.entity_name,
+    mp.updated_at,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    current_phase.phase_name,
+    current_phase.phase_key,
+    current_phase.phase_name_simple,
+    ptl.type_name,
+    mpcs.component_name_with_subtype,
+    fsl.funding_source_name,
+    added_by_user.first_name,
+    added_by_user.last_name,
+    mpps.name,
+    cpl.children_project_ids,
+    proj_notes.project_note,
+    proj_notes.date_created,
+    work_activities.contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders;

--- a/moped-database/migrations/1698786867086_add_component_subtype_to_view/up.sql
+++ b/moped-database/migrations/1698786867086_add_component_subtype_to_view/up.sql
@@ -51,7 +51,7 @@ AS WITH project_person_list_lookup AS (
   ), moped_proj_components_subtypes AS (
     SELECT
       mpc.project_id,
-      string_agg(DISTINCT mc.component_name_with_subtype, ', '::text) AS component_name_with_subtype
+      string_agg(DISTINCT mc.component_name_full, ', '::text) AS components
     FROM moped_proj_components mpc 
     LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id 
     GROUP BY mpc.project_id
@@ -148,7 +148,7 @@ AS WITH project_person_list_lookup AS (
         AND ptags.project_id = mp.project_id
       GROUP BY ptags.project_id) AS project_tags,
     concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by,
-    mpcs.component_name_with_subtype
+    mpcs.components
    FROM moped_project mp
      LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
      LEFT JOIN funding_sources_lookup fsl ON fsl.project_id = mp.project_id
@@ -191,7 +191,7 @@ AS WITH project_person_list_lookup AS (
     current_phase.phase_key,
     current_phase.phase_name_simple,
     ptl.type_name,
-    mpcs.component_name_with_subtype,
+    mpcs.components,
     fsl.funding_source_name,
     added_by_user.first_name,
     added_by_user.last_name,

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -52,7 +52,7 @@ AS WITH project_person_list_lookup AS (
   ), moped_proj_components_subtypes AS (
     SELECT
       mpc.project_id,
-      string_agg(DISTINCT mc.component_name_with_subtype, ', '::text) AS component_name_with_subtype
+      string_agg(DISTINCT mc.component_name_full, ', '::text) AS components
     FROM moped_proj_components mpc 
     LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id 
     GROUP BY mpc.project_id
@@ -149,7 +149,7 @@ AS WITH project_person_list_lookup AS (
         AND ptags.project_id = mp.project_id
       GROUP BY ptags.project_id) AS project_tags,
     concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by,
-    mpcs.component_name_with_subtype
+    mpcs.components
    FROM moped_project mp
      LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
      LEFT JOIN funding_sources_lookup fsl ON fsl.project_id = mp.project_id
@@ -192,7 +192,7 @@ AS WITH project_person_list_lookup AS (
     current_phase.phase_key,
     current_phase.phase_name_simple,
     ptl.type_name,
-    mpcs.component_name_with_subtype,
+    mpcs.components,
     fsl.funding_source_name,
     added_by_user.first_name,
     added_by_user.last_name,

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityToolbar.js
@@ -3,7 +3,7 @@ import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 
-/** Custom toolbar title that resmbles the material table titles we use  */
+/** Custom toolbar title that resembles the material table titles we use  */
 const WorkActivityToolbar = ({ onClick }) => (
   <Box display="flex" justifyContent="space-between">
     <Typography variant="h2" color="primary" style={{ padding: "1em" }}>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -97,7 +97,7 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
     label: "Has subprojects",
     filter: resolveHasSubprojects,
   },
-  component_name_with_subtype: {
+  components: {
     label: "Components"
   }
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -98,6 +98,6 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
     filter: resolveHasSubprojects,
   },
   component_name_with_subtype: {
-    label: "Component name and subtype"
+    label: "Components"
   }
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -97,4 +97,7 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
     label: "Has subprojects",
     filter: resolveHasSubprojects,
   },
+  component_name_with_subtype: {
+    label: "Component name and subtype"
+  }
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -367,6 +367,21 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       type: "array",
       operators: ["subprojects_array_is_null", "subprojects_array_is_not_null"],
     },
+    {
+      name: "component_name_with_subtype",
+      label: "Components",
+      placeholder: "component",
+      type: "string",
+      operators: [
+        "string_contains_case_insensitive",
+        "string_begins_with_case_insensitive",
+        "string_ends_with_case_insensitive",
+        "string_equals_case_sensitive",
+        "string_does_not_equal_case_sensitive",
+        "string_is_null",
+        "string_is_not_null",
+      ],
+    },
   ],
 
   operators: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -374,8 +374,6 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       type: "string",
       operators: [
         "string_contains_case_insensitive",
-        "string_begins_with_case_insensitive",
-        "string_ends_with_case_insensitive",
         "string_is_null",
         "string_is_not_null",
       ],

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -376,8 +376,6 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_contains_case_insensitive",
         "string_begins_with_case_insensitive",
         "string_ends_with_case_insensitive",
-        "string_equals_case_sensitive",
-        "string_does_not_equal_case_sensitive",
         "string_is_null",
         "string_is_not_null",
       ],

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -368,7 +368,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       operators: ["subprojects_array_is_null", "subprojects_array_is_not_null"],
     },
     {
-      name: "component_name_with_subtype",
+      name: "components",
       label: "Components",
       placeholder: "component",
       type: "string",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -241,6 +241,9 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
     parent_project_name: {
       type: "string",
     },
+    component_name_with_subtype: {
+      type: "string",
+    }
   },
   // This object gets consumed into the GQLAbstract system, and here is the single, un-nested order_by directive. ✅
   order_by: { updated_at: "desc" },

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -241,7 +241,7 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
     parent_project_name: {
       type: "string",
     },
-    component_name_with_subtype: {
+    components: {
       type: "string",
     }
   },

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -87,7 +87,7 @@ const DEFAULT_HIDDEN_COLS = {
   interim_project_id: true,
   children_project_ids: true,
   parent_project_id: true,
-  component_name_with_subtype: true,
+  components: true,
 };
 
 /**

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -239,7 +239,7 @@ const ProjectsListViewTable = () => {
   useEffect(() => {
     const storedConfig = JSON.parse(localStorage.getItem("mopedColumnConfig"));
     if (storedConfig) {
-      setHiddenColumns(storedConfig);
+      setHiddenColumns({...DEFAULT_HIDDEN_COLS, ...storedConfig });
     }
   }, [data]);
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -87,6 +87,7 @@ const DEFAULT_HIDDEN_COLS = {
   interim_project_id: true,
   children_project_ids: true,
   parent_project_id: true,
+  component_name_with_subtype: true,
 };
 
 /**

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -390,8 +390,8 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
       },
       {
         title: "Components",
-        field: "component_name_with_subtype",
-        hidden: hiddenColumns["component_name_with_subtype"],
+        field: "components",
+        hidden: hiddenColumns["components"],
         emptyValue: "-",
       },
       {

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -77,6 +77,15 @@ export const resolveHasSubprojects = (array) => {
   return "No";
 };
 
+const filterComponentFullNames = (value) => {
+  const componentNamesArray = value.components.split(",");
+  return componentNamesArray.map((comp) => (
+    <span key={comp} style={{ display: "block" }}>
+      {comp}
+    </span>
+  ));
+};
+
 /**
  * Various custom components for Material Table
  */
@@ -393,6 +402,7 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
         field: "components",
         hidden: hiddenColumns["components"],
         emptyValue: "-",
+        render: (entry) => filterComponentFullNames(entry),
       },
       {
         title: "Parent project",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -389,6 +389,12 @@ export const useColumns = ({ hiddenColumns, linkStateFilters, classes }) =>
         emptyValue: "-",
       },
       {
+        title: "Components",
+        field: "component_name_with_subtype",
+        hidden: hiddenColumns["component_name_with_subtype"],
+        emptyValue: "-",
+      },
+      {
         title: "Parent project",
         field: "parent_project_id",
         hidden: hiddenColumns["parent_project_id"],


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/14301

## Testing
**URL to test:** 

local

**Steps to test:**

Spin up the database /  run the new migrations. Toggle the "components" column to visible in the project list table, you should see a comma delimited list of each projects components. 

Use the advanced search to see how many projects contain a Signal or a PHB by searching the Components field. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
