### PR TITLE
Fix bug Project summary data persisted when navigating between parent/child projects

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -51,8 +51,6 @@ const useStyles = makeStyles((theme) => ({
 const ProjectNameEditable = (props) => {
   const classes = useStyles();
 
-  console.log("this is Project Name Editable, props.projectName: ", props.projectName)
-
   const DEFAULT_SNACKBAR_STATE = {
     open: false,
     message: null,

--- a/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameEditable.js
@@ -51,6 +51,8 @@ const useStyles = makeStyles((theme) => ({
 const ProjectNameEditable = (props) => {
   const classes = useStyles();
 
+  console.log("this is Project Name Editable, props.projectName: ", props.projectName)
+
   const DEFAULT_SNACKBAR_STATE = {
     open: false,
     message: null,

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -209,7 +209,7 @@ const ProjectView = () => {
    */
   const { loading, error, data, refetch } = useQuery(SUMMARY_QUERY, {
     variables: { projectId, userId },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
   });
 
   const isFollowing = data?.moped_user_followed_projects.length > 0;

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -209,6 +209,7 @@ const ProjectView = () => {
    */
   const { loading, error, data, refetch } = useQuery(SUMMARY_QUERY, {
     variables: { projectId, userId },
+    fetchPolicy: "no-cache",
   });
 
   const isFollowing = data?.moped_user_followed_projects.length > 0;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/14487

## Testing
**URL to test:** 
https://deploy-preview-1192--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

https://deploy-preview-1192--atd-moped-main.netlify.app/moped/projects/1926
Visit this project. Click its parent project link. Check that the project title, description, sponsors etc. reload between projects. Use the back button in your browser to navigate back, the project should reload. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
