### PR TITLE
Handle when queryString from react router state is null

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -175,7 +175,8 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
-  const { queryString: previousProjectListViewQueryString } = location.state;
+  const { queryString: previousProjectListViewQueryString = null } =
+    location.state;
   const allProjectsLink = !previousProjectListViewQueryString
     ? "/moped/projects"
     : `/moped/projects${previousProjectListViewQueryString}`;

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -175,8 +175,10 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
-  const { queryString: previousProjectListViewQueryString = null } =
-    location.state;
+  const locationState = location?.state;
+  const previousProjectListViewQueryString = locationState
+    ? locationState.previousProjectListViewQueryString
+    : null;
   const allProjectsLink = !previousProjectListViewQueryString
     ? "/moped/projects"
     : `/moped/projects${previousProjectListViewQueryString}`;


### PR DESCRIPTION
## Associated issues

This patches a bug where the project view would WSOD after the redirect that happens when creating a new project. The lack of React Router state was not being handled in `ProjectView`.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1201--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Create a new project
2. When redirected to the new project view, you should see the project view load and not a WSOD

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
