### PR TITLE
Fixes screen flashing when editing project data

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -209,7 +209,7 @@ const ProjectView = () => {
    */
   const { loading, error, data, refetch } = useQuery(SUMMARY_QUERY, {
     variables: { projectId, userId },
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: "network-only",
   });
 
   const isFollowing = data?.moped_user_followed_projects.length > 0;


### PR DESCRIPTION
## Associated issues
n/a

More cache = more problems! This PR strips out caching from the project view, which was having the weird effect of causing the page to reload/scroll to top when editing on the project summary.

**Steps to test:**
1. Edit various fields on the summary tab.

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
