### PR TITLE
Fix project view link back to project list view with previous filters

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -99,7 +99,8 @@ const Search = ({
     setFilters({});
     setIsOr(false);
     setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete("filters");
+      prevSearchParams.delete("filter");
+      prevSearchParams.delete("isOr");
       return prevSearchParams;
     });
   };

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -175,14 +175,16 @@ const ProjectView = () => {
   let [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const activeTab = useActiveTabIndex(searchParams.get("tab"));
+  const classes = useStyles();
+
+  /* Create link back to previous filters using queryString state passed with React Router */
   const locationState = location?.state;
   const previousProjectListViewQueryString = locationState
-    ? locationState.previousProjectListViewQueryString
+    ? locationState.queryString
     : null;
   const allProjectsLink = !previousProjectListViewQueryString
     ? "/moped/projects"
     : `/moped/projects${previousProjectListViewQueryString}`;
-  const classes = useStyles();
   /**
    * @constant {boolean} isEditing - When true, it signals a child component we want to edit the project name
    * @constant {boolean} dialogOpen - When true, the dialog shows


### PR DESCRIPTION
## Associated issues
This fixes the key to access the state passed with React Router. It was the wrong name so the value was `undefined`. 😑 Also, the `filter` and `isOr` query string parameters were not clearing in the url when switching from advanced search to simple search so I patched that up while I was at it.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1205--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Create a new project and make sure the project list view loads after the redirect
2. Go to the project list view and add advanced filters
3. Click on the project link or parent project link and make sure that your filters are retained when you click "< ALL PROJECTS" on the project view page
4. When linked back to the project list view with advanced filters active, enter a search value into the simple search box and press Enter. You should see the advanced filters clear and no query string parameters in the url

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
