### PR TITLE
Exclude audit fields from proj component event

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2032,7 +2032,20 @@
         insert:
           columns: '*'
         update:
-          columns: '*'
+          columns:
+            - interim_project_component_id
+            - project_component_id
+            - location_description
+            - component_id
+            - is_deleted
+            - phase_id
+            - completion_date
+            - project_id
+            - created_at
+            - subphase_id
+            - created_by_user_id
+            - description
+            - srts_id
       retry_conf:
         interval_sec: 10
         num_retries: 0

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -128,6 +128,11 @@ export const formatComponentsActivity = (
     }
   });
 
+  // handle an edge case where only ignored fields were edited
+  if (changes.length === 0) {
+    return { changeIcon: null, changeText: null };
+  }
+
   return {
     changeIcon,
     changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -1,6 +1,14 @@
 import RoomOutlinedIcon from "@mui/icons-material/RoomOutlined";
 import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
 
+/** Fields which do not need to be rendered in the activity log */
+const CHANGE_FIELDS_TO_IGNORE = [
+  "updated_by_user_id",
+  "created_by_user_id",
+  "created_at",
+  "updated_at",
+];
+
 export const formatComponentsActivity = (
   change,
   componentList,
@@ -113,6 +121,9 @@ export const formatComponentsActivity = (
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
     if (newRecord[field] !== oldRecord[field]) {
+      if (CHANGE_FIELDS_TO_IGNORE.includes(field)) {
+        return;
+      }
       changes.push(entryMap.fields[field]?.label);
     }
   });

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -230,6 +230,11 @@ const ProjectActivityLog = () => {
                     lookupData,
                     projectId
                   );
+                  // allows log formatters to return a `null` changeText, causing the
+                  // event to not be rendered at all
+                  if (!changeText) {
+                    return null;
+                  }
                   return (
                     <TableRow key={change.activity_id}>
                       <TableCell

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -363,6 +363,19 @@ export const ProjectActivityLogTableMaps = {
       srts_id: {
         label: "Safe Routes to School infrastructure plan record identifier",
       },
+      // we don't render these audit fields in the activity log UI
+      created_at: {
+        label: "creation date"
+      },
+      created_by_user_id: {
+        label: "created by user"
+      },
+      updated_at: {
+        label: "update date"
+      },
+      updated_by_user_id: {
+        label: "updated by user"
+      }
     },
   },
   moped_project_files: {


### PR DESCRIPTION
## Associated issues

Ooops, we do not want our activity log event trigger to fire when a component's updated_at/updated_by column.

<img width="1509" alt="Screenshot 2023-11-14 at 2 34 38 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/cbca95e9-e309-4230-b290-80ef1796639b">


<img width="1494" alt="Screenshot 2023-11-14 at 2 23 28 PM" src="https://github.com/cityofaustin/atd-moped/assets/14793120/c316e783-634d-499b-aba9-bc3c2298fd4f">


## Testing
**URL to test:** Local

1. Create and edit components.
2. Check the activity log to verify your changes are being tracked.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
