### PR TITLE
Create new moped subcomponent, zicla barriers

### DIFF
--- a/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/down.sql
+++ b/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/down.sql
@@ -1,0 +1,12 @@
+DELETE FROM moped_components_subcomponents WHERE id IN (
+    SELECT
+        mcs.id
+    FROM 
+        moped_components_subcomponents mcs 
+    JOIN 
+        moped_subcomponents ms ON ms.subcomponent_id = mcs.subcomponent_id
+    WHERE 
+        subcomponent_name = 'Protection Type - ZICLA Barriers')
+
+DELETE FROM moped_subcomponents WHERE subcomponent_name = 'Protection Type - ZICLA Barriers';
+

--- a/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/down.sql
+++ b/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/down.sql
@@ -6,7 +6,7 @@ DELETE FROM moped_components_subcomponents WHERE id IN (
     JOIN 
         moped_subcomponents ms ON ms.subcomponent_id = mcs.subcomponent_id
     WHERE 
-        subcomponent_name = 'Protection Type - ZICLA Barriers')
+        subcomponent_name = 'Protection Type - ZICLA Barriers');
 
-DELETE FROM moped_subcomponents WHERE subcomponent_name = 'Protection Type - ZICLA Barriers';
+DELETE FROM moped_subcomponents WHERE subcomponent_name = 'Protection Type - ZICLA Barriers'
 

--- a/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/up.sql
+++ b/moped-database/migrations/1700067187681_add_zicla_barriers_subcomponent/up.sql
@@ -1,0 +1,22 @@
+INSERT INTO moped_subcomponents (subcomponent_name) VALUES ('Protection Type - ZICLA Barriers');
+
+
+WITH inserts_todo AS (
+    SELECT
+        mcs.component_id
+    FROM 
+        moped_components_subcomponents mcs 
+    JOIN 
+        moped_subcomponents ms ON ms.subcomponent_id = mcs.subcomponent_id
+    WHERE 
+        subcomponent_name LIKE 'Protection Type%'
+    GROUP BY 
+        mcs.component_id
+    )
+INSERT INTO moped_components_subcomponents (component_id, subcomponent_id)
+SELECT
+    inserts_todo.component_id, ms.subcomponent_id
+FROM
+    inserts_todo
+    -- gets the component id of the new subcomponent we created
+    LEFT JOIN moped_subcomponents ms ON ms.subcomponent_name = 'Protection Type - ZICLA Barriers';


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/14556

## Testing

run locally

**Steps to test:**

You can see which components have the new zicla barriers as potential subcomponents
```sql
select mc.component_id, mc.component_name_full, ms.subcomponent_name 
from moped_components_subcomponents mcs 
join moped_subcomponents ms  on ms.subcomponent_id = mcs.subcomponent_id
join moped_components mc on mc.component_id =mcs.component_id 
where ms.subcomponent_name = 'Protection Type - ZICLA Barriers'
order by component_id
```

And also check in the editor that the subcomponent options appear for these components 
<img src="https://github.com/cityofaustin/atd-moped/assets/12474808/5148fd54-655a-465b-86e6-2f651a39329a" width="350px">

```sql
select count(*) from moped_components_subcomponents mcs where component_id = 36 
```

Before down migration the answer should be 13, afterwards 12! bakers dozen -> dozen


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
