### PR TITLE
Update project list view local storage to support new columns and clear outdated ones

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -9,7 +9,7 @@ import {
   useTableComponents,
   useColumns,
   useTableOptions,
-  useHiddenColumns,
+  useHiddenColumnsSettings,
 } from "./helpers.js";
 import { useGetProjectListView } from "./useProjectListViewQuery/useProjectListViewQuery";
 import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
@@ -91,7 +91,7 @@ const ProjectsListViewTable = () => {
   const { filters, setFilters, advancedSearchWhereString, isOr, setIsOr } =
     useAdvancedSearch();
 
-  const { hiddenColumns, setHiddenColumns } = useHiddenColumns();
+  const { hiddenColumns, setHiddenColumns } = useHiddenColumnsSettings();
 
   const { columns, columnsToReturnInQuery } = useColumns({ hiddenColumns });
 

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -142,9 +142,16 @@ export const useTableComponents = ({
 
 const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
 
-export const useHiddenColumns = () => {
+export const useHiddenColumnsSettings = () => {
+  const existingHiddenColumnSettings = JSON.parse(
+    localStorage.getItem("mopedColumnConfig")
+  );
+
+  // TODO: Take the existing hidden columns and merge them with the default hidden columns
+  // TODO: Take the existing hidden columns and remove any that are not in the default hidden columns
+
   const [hiddenColumns, setHiddenColumns] = useState(
-    JSON.parse(localStorage.getItem("mopedColumnConfig")) ?? DEFAULT_HIDDEN_COLS
+    existingHiddenColumnSettings ?? DEFAULT_HIDDEN_COLS
   );
 
   /*
@@ -171,7 +178,7 @@ export const useColumns = ({ hiddenColumns }) => {
 
     // Some columns are dependencies of other columns to render, so we need to include them
     // Ex. Rendering ProjectStatusBadge requires current_phase_key which is not a column shown in the UI
-    const columnsNeededToRender = ["current_phase_key"];
+    const columnsNeededToRender = ["project_id", "current_phase_key"];
 
     return [...columnsShownInUI, ...columnsNeededToRender];
   }, [hiddenColumns]);

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -133,8 +133,6 @@ const getExistingHiddenColumns = () => {
   return currentHiddenColumnSettings;
 };
 
-const initialHiddenColumnSettings = getExistingHiddenColumns();
-
 const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
 
 /**
@@ -186,9 +184,16 @@ export const useTableComponents = ({
   );
 
 export const useHiddenColumnsSettings = () => {
-  const [hiddenColumns, setHiddenColumns] = useState(
-    initialHiddenColumnSettings
-  );
+  const [hiddenColumns, setHiddenColumns] = useState({});
+
+  /*
+   * Initialize hidden columns from existing local storage
+   */
+  useEffect(() => {
+    console.log("running");
+    const initialHiddenColumnSettings = getExistingHiddenColumns();
+    setHiddenColumns(initialHiddenColumnSettings);
+  }, []);
 
   /*
    * Sync hidden columns state with local storage

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -147,12 +147,39 @@ export const useHiddenColumnsSettings = () => {
     localStorage.getItem("mopedColumnConfig")
   );
 
-  // TODO: Take the existing hidden columns and merge them with the default hidden columns
-  // TODO: Take the existing hidden columns and remove any that are not in the default hidden columns
+  let currentHiddenColumnSettings;
+
+  // If there are no existing hidden column settings, set the default hidden columns
+  if (!existingHiddenColumnSettings) {
+    localStorage.setItem(
+      "mopedColumnConfig",
+      JSON.stringify(DEFAULT_HIDDEN_COLS)
+    );
+
+    currentHiddenColumnSettings = DEFAULT_HIDDEN_COLS;
+  } else {
+    // Take the existing hidden columns and remove any that are not in the default hidden columns
+    currentHiddenColumnSettings = Object.entries(DEFAULT_HIDDEN_COLS).reduce(
+      (acc, [columnName, isHidden]) => {
+        if (!existingHiddenColumnSettings[columnName]) {
+          return {
+            ...acc,
+            [columnName]: DEFAULT_HIDDEN_COLS[columnName],
+          };
+        } else {
+          return { ...acc, [columnName]: isHidden };
+        }
+      },
+      {}
+    );
+  }
+
+  // TODO: Do we need to assume false unless set to true?
 
   const [hiddenColumns, setHiddenColumns] = useState(
-    existingHiddenColumnSettings ?? DEFAULT_HIDDEN_COLS
+    currentHiddenColumnSettings
   );
+  console.log(hiddenColumns);
 
   /*
    * Sync hidden columns state with local storage
@@ -163,6 +190,11 @@ export const useHiddenColumnsSettings = () => {
 
   return { hiddenColumns, setHiddenColumns };
 };
+
+// localStorage examples
+// key: mopedColumnConfig
+// value: {"current_phase":false,"interim_project_id":true,"public_process_status":true,"added_by":true,"project_tags":true,"contract_numbers":true,"contractors":true,"project_inspector":true,"project_designer":true,"completion_end_date":true,"construction_start_date":true,"funding_source_name":true,"type_name":true,"task_order":false,"project_feature":true,"parent_project_id":true,"children_project_ids":true,"project_note":false,"project_sponsor":true,"project_partner":true,"updated_at":true,"ecapris_subproject_id":true,"components":false}
+// value: {"project_team_members":false,"project_lead":true,"project_sponsor":true,"project_partner":false}
 
 /**
  * The Material Table column settings

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -14,7 +14,6 @@ import {
   DEFAULT_HIDDEN_COLS,
 } from "./ProjectsListViewQueryConf";
 import theme from "src/theme";
-import { initial } from "lodash";
 
 export const filterNullValues = (value) => {
   if (!value || value === "-") {

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -158,28 +158,25 @@ export const useHiddenColumnsSettings = () => {
 
     currentHiddenColumnSettings = DEFAULT_HIDDEN_COLS;
   } else {
-    // Take the existing hidden columns and remove any that are not in the default hidden columns
-    currentHiddenColumnSettings = Object.entries(DEFAULT_HIDDEN_COLS).reduce(
-      (acc, [columnName, isHidden]) => {
-        if (!existingHiddenColumnSettings[columnName]) {
+    // Remove outdated columns, use existing settings, and add missing default columns
+    currentHiddenColumnSettings = Object.keys(DEFAULT_HIDDEN_COLS).reduce(
+      (acc, columnName) => {
+        if (existingHiddenColumnSettings.hasOwnProperty(columnName)) {
           return {
             ...acc,
-            [columnName]: DEFAULT_HIDDEN_COLS[columnName],
+            [columnName]: existingHiddenColumnSettings[columnName],
           };
         } else {
-          return { ...acc, [columnName]: isHidden };
+          return { ...acc, [columnName]: DEFAULT_HIDDEN_COLS[columnName] };
         }
       },
       {}
     );
   }
 
-  // TODO: Do we need to assume false unless set to true?
-
   const [hiddenColumns, setHiddenColumns] = useState(
     currentHiddenColumnSettings
   );
-  console.log(hiddenColumns);
 
   /*
    * Sync hidden columns state with local storage

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -97,15 +97,22 @@ const filterComponentFullNames = (value) => {
  * outdated columns, and supplement with remaining default columns
  * @returns {Object} hidden column settings from local storage
  */
-const getExistingHiddenColumns = () => {
-  const existingHiddenColumnSettings = JSON.parse(
-    localStorage.getItem("mopedColumnConfig")
-  );
+const getPreviousHiddenColumns = () => {
+  let previousHiddenColumnSettings;
+
+  try {
+    previousHiddenColumnSettings = JSON.parse(
+      localStorage.getItem("mopedColumnConfig")
+    );
+  } catch (e) {
+    previousHiddenColumnSettings = null;
+    console.error("Error parsing project list view hidden column settings", e);
+  }
 
   let currentHiddenColumnSettings;
 
-  // If there are no existing hidden column settings, set the default hidden columns
-  if (!existingHiddenColumnSettings) {
+  // If there are no previous hidden column settings, set the default hidden columns
+  if (!previousHiddenColumnSettings) {
     localStorage.setItem(
       "mopedColumnConfig",
       JSON.stringify(DEFAULT_HIDDEN_COLS)
@@ -113,14 +120,14 @@ const getExistingHiddenColumns = () => {
 
     currentHiddenColumnSettings = DEFAULT_HIDDEN_COLS;
   } else {
-    // Use existing settings to override default hidden columns.
+    // Use previous settings to override default hidden columns.
     // By iterating the defaults, we also remove outdated columns no longer in config.
     currentHiddenColumnSettings = Object.keys(DEFAULT_HIDDEN_COLS).reduce(
       (acc, columnName) => {
-        if (existingHiddenColumnSettings.hasOwnProperty(columnName)) {
+        if (previousHiddenColumnSettings.hasOwnProperty(columnName)) {
           return {
             ...acc,
-            [columnName]: existingHiddenColumnSettings[columnName],
+            [columnName]: previousHiddenColumnSettings[columnName],
           };
         } else {
           return { ...acc, [columnName]: DEFAULT_HIDDEN_COLS[columnName] };
@@ -187,10 +194,10 @@ export const useHiddenColumnsSettings = () => {
   const [hiddenColumns, setHiddenColumns] = useState({});
 
   /*
-   * Initialize hidden columns from existing local storage
+   * Initialize hidden columns from previous local storage
    */
   useEffect(() => {
-    const initialHiddenColumnSettings = getExistingHiddenColumns();
+    const initialHiddenColumnSettings = getPreviousHiddenColumns();
     setHiddenColumns(initialHiddenColumnSettings);
   }, []);
 

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -95,8 +95,7 @@ const filterComponentFullNames = (value) => {
 /**
  * Get the user hidden column settings from local storage, clear them of
  * outdated columns, and supplement with remaining default columns
- * @returns {Object} hidden column settings from local storage cleared of
- * outdated columns and supplemented with default columns
+ * @returns {Object} hidden column settings from local storage
  */
 const getExistingHiddenColumns = () => {
   const existingHiddenColumnSettings = JSON.parse(

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -113,8 +113,8 @@ const getExistingHiddenColumns = () => {
 
     currentHiddenColumnSettings = DEFAULT_HIDDEN_COLS;
   } else {
-    // Use existing settings and add missing default columns.
-    // Using the default config as a reference removes outdated columns.
+    // Use existing settings to override default hidden columns.
+    // By iterating the defaults, we also remove outdated columns no longer in config.
     currentHiddenColumnSettings = Object.keys(DEFAULT_HIDDEN_COLS).reduce(
       (acc, columnName) => {
         if (existingHiddenColumnSettings.hasOwnProperty(columnName)) {
@@ -190,7 +190,6 @@ export const useHiddenColumnsSettings = () => {
    * Initialize hidden columns from existing local storage
    */
   useEffect(() => {
-    console.log("running");
     const initialHiddenColumnSettings = getExistingHiddenColumns();
     setHiddenColumns(initialHiddenColumnSettings);
   }, []);
@@ -217,7 +216,10 @@ export const useColumns = ({ hiddenColumns }) => {
       .filter((key) => hiddenColumns[key] === false)
       .map((key) => key);
 
-    // Some columns are dependencies of other columns to render, so we need to include them
+    // We must include project_id in every query since it is set as a keyField in the Apollo cache.
+    // See https://github.com/cityofaustin/atd-moped/blob/1ecf8745ef13277f784f3d8ba75efa13908acc73/moped-editor/src/App.js#L55
+    // See https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids
+    // Also, some columns are dependencies of other columns to render, so we need to include them.
     // Ex. Rendering ProjectStatusBadge requires current_phase_key which is not a column shown in the UI
     const columnsNeededToRender = ["project_id", "current_phase_key"];
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14708

This PR fixes a bug where outdated columns in local storage were breaking the new method of fetching only the data shown in the table. The root of the problem was that we need to clean up outdated columns in user's local storage if we want to rely on those columns to fetch data. This was luckily caught early since `task_order` changed to `task_orders` which surfaced the issue fast. 🏎️ 🙌

Below is a quick summary of the changes and the value of `mopedColumnConfig` local storage for each step.

**Previous method**
```md
// This works because we were fetching all columns every render.
{
   "task_order": false, <- This entry was never consumed by the app and ignored.
   "task_orders": false,
   ...config for any other column set previously (could be incomplete)
}
```

**The bug from [the code update to only fetch shown columns](https://github.com/cityofaustin/atd-moped/pull/1209) which queried all columns in local storage**
```md
{
   "task_order": false, <- This column was fed to the query, and 💥 since it no longer exists.
   "task_orders": false
    ...config for any other column set previously (could be incomplete)
}
```

**The fix**
```md
// Code cleans up local storage and adds settings for any columns not previously set
{
   "task_orders": false,
   ...config for the other 26 columns displayed in the table (mixture of existing user values and defaults)
}
```

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1216--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Go to the deploy preview and delete your local storage entry called `mopedColumnConfig`
2. Refresh the project list view, and you should see your `mopedColumnConfig` entry back with the 27 columns and boolean values defined in `DEFAULT_HIDDEN_COLS` in the code
3. Edit your `mopedColumnConfig` to contain:
```
{"project_team_members":false,"project_lead":true,"project_sponsor":true,"project_partner":false}
```
4. Refresh and you should see the 27 settings and the values of the columns above retained, and the rest of the selectable columns filled with default booleans.
5. Edit your `mopedColumnConfig` to contain:
```
{"current_phase":false,"interim_project_id":true,"public_process_status":true,"added_by":true,"project_tags":true,"contract_numbers":true,"contractors":true,"project_inspector":true,"project_designer":true,"completion_end_date":true,"construction_start_date":true,"funding_source_name":true,"type_name":true,"task_order":false,"project_feature":true,"parent_project_id":true,"children_project_ids":true,"project_note":false,"project_sponsor":true,"project_partner":true,"updated_at":true,"ecapris_subproject_id":true,"components":false}
```
6. Notice that this value contains a key/value pair for `task_order` which has been renamed to `task_orders`. 
7. Refresh the project list view. You should see `task_order` removed and `task_orders` added. Same as before, you should see the 27 settings and the values of the columns above retained, and the rest of the selectable columns filled with default booleans.
8. Edit your `mopedColumnConfig` to contain:
```
{"thisisnonsense": true}
```
9. Refresh and you should see the nonsense key removed and all of the 27 default settings applied.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
