### PR TITLE
14693 Adds visual feedback while refetching table data

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -80,6 +80,7 @@ const Search = ({
   handleExportButtonClick,
   isOr,
   setIsOr,
+  loading
 }) => {
   const classes = useStyles();
   let [, setSearchParams] = useSearchParams();
@@ -150,6 +151,7 @@ const Search = ({
                 queryConfig={queryConfig}
                 isOr={isOr}
                 handleSwitchToSearch={handleSwitchToSearch}
+                loading={loading}
               />
             </Grid>
             <Grid

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -11,6 +11,7 @@ import {
   Icon,
   IconButton,
   Typography,
+  CircularProgress,
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { Search as SearchIcon } from "react-feather";
@@ -100,6 +101,7 @@ const SearchBar = ({
   queryConfig,
   isOr,
   handleSwitchToSearch,
+  loading,
 }) => {
   const classes = useStyles();
 
@@ -206,6 +208,11 @@ const SearchBar = ({
           ),
           endAdornment: (
             <InputAdornment position="end">
+              {!!loading && (
+                <IconButton>
+                  <CircularProgress size="2rem" />
+                </IconButton>
+              )}
               <IconButton
                 onClick={toggleAdvancedSearch}
                 className={clsx({

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -124,6 +124,7 @@ const ProjectsListViewTable = () => {
 
   const {
     data: projectListViewData,
+    loading,
     error,
     refetch,
   } = useQuery(projectListViewQuery, {
@@ -183,7 +184,7 @@ const ProjectsListViewTable = () => {
 
   const tableComponents = useTableComponents({
     data,
-    projectListViewData,
+    loading,
     queryLimit,
     queryOffset,
     setQueryLimit,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -221,6 +221,7 @@ const ProjectsListViewTable = () => {
           handleExportButtonClick={handleExportButtonClick}
           isOr={isOr}
           setIsOr={setIsOr}
+          loading={loading}
         />
         {/*Main Table Body*/}
         <Paper className={classes.paper}>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -183,6 +183,7 @@ const ProjectsListViewTable = () => {
 
   const tableComponents = useTableComponents({
     data,
+    projectListViewData,
     queryLimit,
     queryOffset,
     setQueryLimit,

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { NavLink as RouterLink, useLocation } from "react-router-dom";
-import { MTableHeader } from "@material-table/core";
-import Link from "@mui/material/Link";
+import { MTableHeader, MTableToolbar } from "@material-table/core";
+import { Box, Link, CircularProgress } from "@mui/material";
 import typography from "../../../theme/typography";
 import parse from "html-react-parser";
 import { formatDateType, formatTimeStampTZType } from "src/utils/dateAndTime";
@@ -147,6 +147,7 @@ const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
  */
 export const useTableComponents = ({
   data,
+  projectListViewData,
   queryLimit,
   queryOffset,
   setQueryLimit,
@@ -176,9 +177,27 @@ export const useTableComponents = ({
           orderDirection={orderByDirection}
         />
       ),
+      Toolbar: (props) => (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
+          <Box sx={{ mt: 2, ml: 2 }}>
+            {/* If there is previous data but no current data (i.e., useQuery
+              is refetching the data, then display a progress spinner) */}
+            {!!data && !projectListViewData && <CircularProgress />}
+          </Box>
+          <Box>
+            <MTableToolbar {...props} />
+          </Box>
+        </Box>
+      ),
     }),
     [
       data,
+      projectListViewData,
       queryLimit,
       queryOffset,
       setQueryLimit,

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { NavLink as RouterLink, useLocation } from "react-router-dom";
-import MTableHeader from "@material-table/core";
+import { MTableHeader } from "@material-table/core";
 import Link from "@mui/material/Link";
 import typography from "../../../theme/typography";
 import parse from "html-react-parser";

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -147,7 +147,7 @@ const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
  */
 export const useTableComponents = ({
   data,
-  projectListViewData,
+  loading,
   queryLimit,
   queryOffset,
   setQueryLimit,
@@ -185,9 +185,8 @@ export const useTableComponents = ({
           }}
         >
           <Box sx={{ mt: 2, ml: 2 }}>
-            {/* If there is previous data but no current data (i.e., useQuery
-              is refetching the data, then display a progress spinner) */}
-            {!!data && !projectListViewData && <CircularProgress />}
+            {/* Display a spinner if data is loading */}
+            {loading && <CircularProgress />}
           </Box>
           <Box>
             <MTableToolbar {...props} />
@@ -197,7 +196,7 @@ export const useTableComponents = ({
     }),
     [
       data,
-      projectListViewData,
+      loading,
       queryLimit,
       queryOffset,
       setQueryLimit,

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { NavLink as RouterLink, useLocation } from "react-router-dom";
-import { MTableHeader, MTableToolbar } from "@material-table/core";
-import { Box, Link, CircularProgress } from "@mui/material";
+import MTableHeader from "@material-table/core";
+import Link from "@mui/material/Link";
 import typography from "../../../theme/typography";
 import parse from "html-react-parser";
 import { formatDateType, formatTimeStampTZType } from "src/utils/dateAndTime";
@@ -147,7 +147,6 @@ const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
  */
 export const useTableComponents = ({
   data,
-  loading,
   queryLimit,
   queryOffset,
   setQueryLimit,
@@ -180,7 +179,6 @@ export const useTableComponents = ({
     }),
     [
       data,
-      loading,
       queryLimit,
       queryOffset,
       setQueryLimit,

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -177,22 +177,6 @@ export const useTableComponents = ({
           orderDirection={orderByDirection}
         />
       ),
-      Toolbar: (props) => (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-          }}
-        >
-          <Box sx={{ mt: 2, ml: 2 }}>
-            {/* Display a spinner if data is loading */}
-            {loading && <CircularProgress />}
-          </Box>
-          <Box>
-            <MTableToolbar {...props} />
-          </Box>
-        </Box>
-      ),
     }),
     [
       data,


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/14693

this pr adds a loading spinner when refetching data on the projects list table, specifically when the user searches (regular and advanced) or toggles on a new column

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1218--atd-moped-main.netlify.app/

**Steps to test:**
- go to the projects list view
- open dev tools and set throttling to slow 3g (you might have to make a custom throttling profile to slow network activity down enough to see the loading spinner)
- run a regular search, you should see a spinner pop up briefly in the top left corner of the table above the headers
- follow the same procedure with an advanced filter (try searching 'status' for a single character)
- follow the same procedure by toggling off all but one column, then adding one like 'status' or 'components' (these take a little longer to return than some of the others)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
