### PR TITLE
fixes error clearing proj component description

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -56,7 +56,7 @@ const validationSchema = yup.object().shape({
   subphase: yup.object().nullable().optional(),
   tags: yup.array().optional(),
   completionDate: yup.date().nullable().optional(),
-  description: yup.string(),
+  description: yup.string().nullable(),
   work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
   signal: yup.object().nullable(),
@@ -82,6 +82,9 @@ const ComponentForm = ({
   });
 
   const areFormErrors = Object.keys(errors).length > 0;
+
+  console.log(errors);
+  console.log(isDirty);
 
   // Get and format component and subcomponent options
   const { data: optionsData, error } = useQuery(GET_COMPONENTS_FORM_OPTIONS);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -83,7 +83,6 @@ const ComponentForm = ({
 
   const areFormErrors = Object.keys(errors).length > 0;
 
-
   // Get and format component and subcomponent options
   const { data: optionsData, error } = useQuery(GET_COMPONENTS_FORM_OPTIONS);
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -56,7 +56,7 @@ const validationSchema = yup.object().shape({
   subphase: yup.object().nullable().optional(),
   tags: yup.array().optional(),
   completionDate: yup.date().nullable().optional(),
-  description: yup.string().nullable(),
+  description: yup.string().nullable().optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
   signal: yup.object().nullable(),
@@ -83,8 +83,6 @@ const ComponentForm = ({
 
   const areFormErrors = Object.keys(errors).length > 0;
 
-  console.log(errors);
-  console.log(isDirty);
 
   // Get and format component and subcomponent options
   const { data: optionsData, error } = useQuery(GET_COMPONENTS_FORM_OPTIONS);


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/14768

this pr allows the description field to be nullable/optional so users can clear descriptions without breaking form validation

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1221--atd-moped-main.netlify.app/

**Steps to test:**
- Create a component and fill in the Description field
- Edit the component by removing the text from the description field
- The form's save button should remain enabled and you should be able to save this change

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
