### PR TITLE
Update bounding box limiting our geocoding scope

### DIFF
--- a/moped-editor/src/components/Maps/GeocoderControl.js
+++ b/moped-editor/src/components/Maps/GeocoderControl.js
@@ -13,7 +13,7 @@ const austinFullPurposeJurisdictionFeatureCollection = {
       name: "EPSG:4326",
     },
   },
-  bbox: [-97.940377, 30.133717, -97.578205, 30.464826],
+  bbox: [-98.182, 29.987, -97.723, 30.663],
   features: [],
 };
 

--- a/moped-editor/src/components/Maps/GeocoderControl.js
+++ b/moped-editor/src/components/Maps/GeocoderControl.js
@@ -13,7 +13,7 @@ const austinFullPurposeJurisdictionFeatureCollection = {
       name: "EPSG:4326",
     },
   },
-  bbox: [-98.182, 29.987, -97.723, 30.663],
+  bbox: [-98.182, 29.987, -97.304, 30.663],
   features: [],
 };
 


### PR DESCRIPTION
## Associated issues

This PR aims to close https://github.com/cityofaustin/atd-data-tech/issues/9311.

## Intent

Make the street name search work for any street that could reasonably be expected to be used in Moped.

## Process

The existing bounding box was smaller than the effective metropolitan area of Austin, TX. I have established a new bounding box by:

* Taking the comprehensive street network (SRID 2277, NAD83 / Texas Central (ftUS)) 
* Dissolving it into a single feature
* Taking its convex hull
* Buffering this by 1 kilometer
* Reprojecting this into WGS84
* Taking the bounding box of the resulting shape

## Visualization

Please see [this geojson file](https://gist.github.com/frankhereford/e40a89d94568cc0ea86bf114766a9e4a) for the bounding boxes visualized by the github gist system. The small one is the old bounding box and the new one is the big one.

You may also want to see the proposed bounding box in the context of the comprehensive street network:

![image](https://github.com/cityofaustin/atd-moped/assets/3653206/73ac1678-1f4b-4caa-bfef-c85e6c215963)


## Testing

Local

* Spin up the editor and database and browse to a map of any project. Search for street names that are on the outskirts of ATX. If you can find them, then it's working. Neenah Ave is specifically called out in the issue as one that didn't, but now does, work.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
