### PR TITLE
Advanced filters with number inputs can break gql query with allowed characters

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -173,6 +173,11 @@ const Filters = ({
    */
   const [filterComplete, setFilterComplete] = useState(false);
 
+  /**
+   * Tracks whether the field input value is invalid
+   */
+  const [isInvalidInput, setIsInvalidInput] = useState(false);
+
   /* First filter is an empty placeholder so we check for more than one filter */
   const areMoreThanOneFilters = Object.keys(filterParameters).length > 1;
   const isFirstFilterIncomplete =
@@ -373,7 +378,11 @@ const Filters = ({
    * @param {string} filterId - The FilterID uuid
    * @param {string} value - The value to assign to that filter
    */
-  const handleSearchValueChange = (filterId, value) => {
+  const handleSearchValueChange = (filterId, value, type) => {
+    // Validate input for number type fields and set state accordingly
+    type === "number" && isNaN(value)
+      ? setIsInvalidInput(true)
+      : setIsInvalidInput(false);
     // Clone the state
     const filtersNewState = { ...filterParameters };
     // Patch the new state
@@ -685,16 +694,22 @@ const Filters = ({
                       />
                     ) : (
                       <TextField
+                        error={isInvalidInput(filter)}
+                        helperText={isInvalidInput ? "Invalid input" : ""}
                         key={`filter-search-value-${filterId}`}
                         id={`filter-search-value-${filterId}`}
                         disabled={!filterParameters[filterId].operator}
                         type={
-                          filterParameters[filterId].type
+                          filterParameters[filterId].type === "date"
                             ? filterParameters[filterId].type
-                            : "text"
+                            : null
                         }
                         onChange={(e) =>
-                          handleSearchValueChange(filterId, e.target.value)
+                          handleSearchValueChange(
+                            filterId,
+                            e.target.value,
+                            filterParameters[filterId].type
+                          )
                         }
                         variant="outlined"
                         value={filterParameters[filterId].value ?? ""}
@@ -763,18 +778,17 @@ const Filters = ({
           </Grid>
         </Hidden>
         <Grid item xs={12} md={2}>
-          <Grow in={handleApplyValidation() === null}>
-            <Button
-              fullWidth
-              className={classes.applyButton}
-              variant="contained"
-              color="primary"
-              startIcon={<Icon>search</Icon>}
-              onClick={handleApplyButtonClick}
-            >
-              Search
-            </Button>
-          </Grow>
+          <Button
+            fullWidth
+            className={classes.applyButton}
+            variant="contained"
+            color="primary"
+            startIcon={<Icon>search</Icon>}
+            onClick={handleApplyButtonClick}
+            disabled={isInvalidInput || handleApplyValidation() != null}
+          >
+            Search
+          </Button>
         </Grid>
       </Grid>
     </Grid>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -173,11 +173,6 @@ const Filters = ({
    */
   const [filterComplete, setFilterComplete] = useState(false);
 
-  /**
-   * Tracks whether the field input value is invalid
-   */
-  const [isInvalidInput, setIsInvalidInput] = useState(false);
-
   /* First filter is an empty placeholder so we check for more than one filter */
   const areMoreThanOneFilters = Object.keys(filterParameters).length > 1;
   const isFirstFilterIncomplete =
@@ -378,11 +373,7 @@ const Filters = ({
    * @param {string} filterId - The FilterID uuid
    * @param {string} value - The value to assign to that filter
    */
-  const handleSearchValueChange = (filterId, value, type) => {
-    // Validate input for number type fields and set state accordingly
-    type === "number" && isNaN(value)
-      ? setIsInvalidInput(true)
-      : setIsInvalidInput(false);
+  const handleSearchValueChange = (filterId, value) => {
     // Clone the state
     const filtersNewState = { ...filterParameters };
     // Patch the new state
@@ -430,6 +421,9 @@ const Filters = ({
             if (gqlOperator && !gqlOperator.includes("is_null")) {
               feedback.push("• One or more missing values.");
             }
+          }
+          if (checkIsInvalidInput(filterParameters[filterKey])) {
+            feedback.push("• One or more invalid inputs.");
           }
         });
       }
@@ -500,6 +494,16 @@ const Filters = ({
     setIsOrToggleValue(isOr);
   };
 
+  /**
+   * Returns whether the user input value for the filterParameter is valid
+   * @param {object} filterParameter
+   * @returns {boolean}
+   */
+  const checkIsInvalidInput = (filterParameter) => {
+    // Validate input for number type fields
+    return filterParameter.type === "number" && isNaN(filterParameter.value);
+  };
+
   return (
     <Grid>
       <Grid container className={classes.gridItemPadding}>
@@ -555,6 +559,7 @@ const Filters = ({
       </Grid>
 
       {Object.keys(filterParameters).map((filterId) => {
+        const isInvalidInput = checkIsInvalidInput(filterParameters[filterId]);
         return (
           <Grow in={true} key={`filter-grow-${filterId}`}>
             <Grid
@@ -705,11 +710,7 @@ const Filters = ({
                             : null
                         }
                         onChange={(e) =>
-                          handleSearchValueChange(
-                            filterId,
-                            e.target.value,
-                            filterParameters[filterId].type
-                          )
+                          handleSearchValueChange(filterId, e.target.value)
                         }
                         variant="outlined"
                         value={filterParameters[filterId].value ?? ""}
@@ -785,7 +786,7 @@ const Filters = ({
             color="primary"
             startIcon={<Icon>search</Icon>}
             onClick={handleApplyButtonClick}
-            disabled={isInvalidInput || handleApplyValidation() != null}
+            disabled={handleApplyValidation() != null}
           >
             Search
           </Button>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -694,7 +694,7 @@ const Filters = ({
                       />
                     ) : (
                       <TextField
-                        error={isInvalidInput(filter)}
+                        error={isInvalidInput}
                         helperText={isInvalidInput ? "Invalid input" : ""}
                         key={`filter-search-value-${filterId}`}
                         id={`filter-search-value-${filterId}`}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -124,6 +124,20 @@ const generateEmptyField = (uuid) => {
 };
 
 /**
+ * Returns whether the user input value for the filterParameter is valid
+ * @param {object} filterParameter
+ * @returns {boolean}
+ */
+const checkIsValidInput = (filterParameter) => {
+  // If we are testing a number type field with a non null value
+  if (filterParameter.type === "number" && !!filterParameter.value) {
+    // Return whether string only contains digits
+    return !/[^0-9]/.test(filterParameter.value);
+  }
+  return true; // Otherwise the input is valid
+};
+
+/**
  * Filter Search Component aka Advanced Search
  * @param {Object} filters - The current filters from useAdvancedSearch hook
  * @param {Function} setFilters - Set the current filters from useAdvancedSearch hook
@@ -417,12 +431,12 @@ const Filters = ({
             feedback.push("• One or more operators have not been selected.");
           }
 
-          if (value === null || value === "") {
+          if (value === null || value.trim() === "") {
             if (gqlOperator && !gqlOperator.includes("is_null")) {
               feedback.push("• One or more missing values.");
             }
           }
-          if (checkIsInvalidInput(filterParameters[filterKey])) {
+          if (!checkIsValidInput(filterParameters[filterKey])) {
             feedback.push("• One or more invalid inputs.");
           }
         });
@@ -494,16 +508,6 @@ const Filters = ({
     setIsOrToggleValue(isOr);
   };
 
-  /**
-   * Returns whether the user input value for the filterParameter is valid
-   * @param {object} filterParameter
-   * @returns {boolean}
-   */
-  const checkIsInvalidInput = (filterParameter) => {
-    // Validate input for number type fields
-    return filterParameter.type === "number" && isNaN(filterParameter.value);
-  };
-
   return (
     <Grid>
       <Grid container className={classes.gridItemPadding}>
@@ -559,7 +563,7 @@ const Filters = ({
       </Grid>
 
       {Object.keys(filterParameters).map((filterId) => {
-        const isInvalidInput = checkIsInvalidInput(filterParameters[filterId]);
+        const isValidInput = checkIsValidInput(filterParameters[filterId]);
         return (
           <Grow in={true} key={`filter-grow-${filterId}`}>
             <Grid
@@ -699,8 +703,8 @@ const Filters = ({
                       />
                     ) : (
                       <TextField
-                        error={isInvalidInput}
-                        helperText={isInvalidInput ? "Invalid input" : ""}
+                        error={!isValidInput}
+                        helperText={!isValidInput ? "Must be a number" : ""}
                         key={`filter-search-value-${filterId}`}
                         id={`filter-search-value-${filterId}`}
                         disabled={!filterParameters[filterId].operator}

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -15,7 +15,7 @@ export const currencyFormatter = new Intl.NumberFormat("en-US", {
  * @param {String} number - Number string
  * @return {String} Number string with decimal removed and trailing numbers trimmed
  */
-export const removeDecimalsAndTrailingNumbers = number =>
+export const removeDecimalsAndTrailingNumbers = (number) =>
   number.replace(/[.](.*)/g, "");
 
 /**
@@ -23,4 +23,4 @@ export const removeDecimalsAndTrailingNumbers = number =>
  * @param {String} number - Number string
  * @return {String} Number string with only 0-9 integer characters
  */
-export const removeNonIntegers = number => number.replace(/[^0-9]/g, "");
+export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/14582

## Testing
**URL to test:** 
https://deploy-preview-1225--atd-moped-main.netlify.app/moped/ 

**Steps to test:**
1. [Current behavior](https://moped.austinmobility.io/moped/projects) for number type filter fields such as ID is that if you type something like "1e1" into the input, the search button will appear after the second `1` and the user can search with this invalid input causing an ugly graphql error to slip into the UI.
2. Now in the deploy preview try to replicate that error. You should find that the search button is disabled until valid input is entered. If invalid input is entered the text box will turn red and give the user an error warning and the search button disables again.
3. Also test adding multiple filters, make one of them have incorrect input. Only the input text box for that field should be red and show the message "Invalid input"


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
