### PR TITLE
Add component hyperlinks to the activity log

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -53,11 +53,12 @@ export const formatComponentsActivity = (
 
   // delete an existing component
   if (change.description[0].field === "is_deleted") {
+    const {link, ...simpleComponentText} = componentText;
     return {
       changeIcon,
       changeText: [
         { text: "Removed a component: ", style: null },
-        componentText,
+        simpleComponentText,
       ],
     };
   }

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -21,9 +21,12 @@ export const formatComponentsActivity = (
   const changeIcon = <RoomOutlinedIcon />;
   const component =
     componentList[change.record_data.event.data.new.component_id];
+  const componentID = change.record_data.event.data.new.project_component_id;
+  const componentLink = `/moped/projects/${projectId}?tab=map&project_component_id=${componentID}`;
   const componentText = {
     text: component,
     style: "boldText",
+    link: componentLink
   };
   const phase = phaseList[change.record_data.event.data.new.phase_id];
   const subphase = subphaseList[change.record_data.event.data.new.subphase_id];
@@ -39,15 +42,11 @@ export const formatComponentsActivity = (
 
   // add a new component
   if (change.description.length === 0) {
-    const newComponentID = change.record_data.event.data.new.project_component_id;
     return {
       changeIcon,
       changeText: [
         { text: "Added a component: ", style: null },
-        {
-          ...componentText,
-          link: `/moped/projects/${projectId}?tab=map&project_component_id=${newComponentID}`,
-        },
+        componentText,
       ],
     };
   }

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -39,9 +39,16 @@ export const formatComponentsActivity = (
 
   // add a new component
   if (change.description.length === 0) {
+    const newComponentID = change.record_data.event.data.new.project_component_id;
     return {
       changeIcon,
-      changeText: [{ text: "Added a component: ", style: null }, componentText],
+      changeText: [
+        { text: "Added a component: ", style: null },
+        {
+          ...componentText,
+          link: `/moped/projects/${projectId}?tab=map&project_component_id=${newComponentID}`,
+        },
+      ],
     };
   }
 

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -24,7 +24,7 @@ export const formatComponentsActivity = (
   const componentID = change.record_data.event.data.new.project_component_id;
   const componentLink = `/moped/projects/${projectId}?tab=map&project_component_id=${componentID}`;
   const componentText = {
-    text: component,
+    text: `${component} (#${componentID})`,
     style: "boldText",
     link: componentLink
   };

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Typography, Link } from "@mui/material";
 
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   entryText: {
@@ -35,20 +35,19 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
         >
           {
             // maps through the array of objects and applies specified style to the text
-            changeText.map((changeObject, index) => (
-              changeObject.link ?
-              (
-              <span className={classes[changeObject.style]} key={index}>
-                 <Link
-                href={changeObject.link}
-                target="blank"
-              >{changeObject.text}</Link>
-              </span>) : 
-              (
+            changeText.map((changeObject, index) =>
+              changeObject.link ? (
+                <span className={classes[changeObject.style]} key={index}>
+                  <Link href={changeObject.link} target="blank">
+                    {changeObject.text}
+                  </Link>
+                </span>
+              ) : (
                 <span className={classes[changeObject.style]} key={index}>
                   {changeObject.text}
-                </span>)
-            ))
+                </span>
+              )
+            )
           }
         </Typography>
       </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Link } from "@mui/material";
 
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -36,9 +36,18 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
           {
             // maps through the array of objects and applies specified style to the text
             changeText.map((changeObject, index) => (
+              changeObject.link ?
+              (
               <span className={classes[changeObject.style]} key={index}>
-                {changeObject.text}
-              </span>
+                 <Link
+                href={changeObject.link}
+                target="blank"
+              >{changeObject.text}</Link>
+              </span>) : 
+              (
+                <span className={classes[changeObject.style]} key={index}>
+                  {changeObject.text}
+                </span>)
             ))
           }
         </Typography>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Typography, Link } from "@mui/material";
+import { NavLink as RouterLink } from "react-router-dom";
 
 import makeStyles from "@mui/styles/makeStyles";
 
@@ -38,7 +39,7 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
             changeText.map((changeObject, index) =>
               changeObject.link ? (
                 <span className={classes[changeObject.style]} key={index}>
-                  <Link href={changeObject.link} >
+                  <Link component={RouterLink} to={changeObject.link}>
                     {changeObject.text}
                   </Link>
                 </span>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityEntry.js
@@ -38,7 +38,7 @@ const ProjectActivityEntry = ({ changeIcon, changeText }) => {
             changeText.map((changeObject, index) =>
               changeObject.link ? (
                 <span className={classes[changeObject.style]} key={index}>
-                  <Link href={changeObject.link} target="blank">
+                  <Link href={changeObject.link} >
                     {changeObject.text}
                   </Link>
                 </span>

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -340,7 +340,7 @@ export const ProjectActivityLogTableMaps = {
         label: "component ID",
       },
       component_id: {
-        label: "component ID",
+        label: "component type",
       },
       description: {
         label: "description",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/14614
https://github.com/cityofaustin/atd-data-tech/issues/15119

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

https://deploy-preview-1231--atd-moped-main.netlify.app/moped/projects/1974?tab=activity_log



**Steps to test:**

Interact with a component
Check the activity log, see the component linked.


![Screenshot 2024-01-11 at 9 21 26 AM](https://github.com/cityofaustin/atd-moped/assets/12474808/cd6d72d6-24c5-44f8-b5ea-67410c6e2efa)

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
