### PR TITLE
Unify various logins for Moped testing and development

### DIFF
--- a/moped-database/migrations/1703786941217_modify_files_user_id_constraint/down.sql
+++ b/moped-database/migrations/1703786941217_modify_files_user_id_constraint/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE moped_project_files DROP CONSTRAINT "moped_project_files_created_by_fkey";
+
+ALTER TABLE moped_project_files ADD CONSTRAINT "moped_project_files_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."moped_users"("user_id");

--- a/moped-database/migrations/1703786941217_modify_files_user_id_constraint/up.sql
+++ b/moped-database/migrations/1703786941217_modify_files_user_id_constraint/up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE moped_project_files DROP CONSTRAINT "moped_project_files_created_by_fkey";
 
-ALTER TABLE moped_project_files ADD CONSTRAINT "moped_project_files_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."moped_users"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE moped_project_files ADD CONSTRAINT "moped_project_files_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."moped_users"("user_id") ON UPDATE CASCADE;

--- a/moped-database/migrations/1703786941217_modify_files_user_id_constraint/up.sql
+++ b/moped-database/migrations/1703786941217_modify_files_user_id_constraint/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE moped_project_files DROP CONSTRAINT "moped_project_files_created_by_fkey";
+
+ALTER TABLE moped_project_files ADD CONSTRAINT "moped_project_files_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."moped_users"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -20,10 +20,10 @@ SET row_security = off;
 -- Data for Name: moped_users; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Admin', 'Moped Admin', 1, 3, NULL, '2021-03-09 17:08:14+00', true, 'transportation.data+mopedadmin@austintexas.gov', '["moped-admin"]', NULL, false, false, 'This account is used by the DTS for automated tasks and integrations.');
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Admin', 'Moped Admin', 1, 3, NULL, '2021-03-09 17:08:14+00', true, 'admin@emailhost.xyz', '["moped-admin"]', NULL, false, false, 'This account is used by the DTS for automated tasks and integrations.');
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false, false, NULL);
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["non-login-user"]', NULL, false, true, NULL);
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Editor', 'Moped Editor', 34, 3, NULL, '2021-03-09 17:08:14+00', true, 'transportation.data+mopededitor@austintexas.gov', '["moped-editor"]', NULL, false, false, NULL);
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Editor', 'Moped Editor', 34, 3, NULL, '2021-03-09 17:08:14+00', true, 'editor@emailhost.xyz', '["moped-editor"]', NULL, false, false, NULL);
 
 
 

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -23,6 +23,7 @@ SET row_security = off;
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Admin', 'Moped Admin', 1, 3, NULL, '2021-03-09 17:08:14+00', true, 'transportation.data+mopedadmin@austintexas.gov', '["moped-admin"]', NULL, false, false, 'This account is used by the DTS for automated tasks and integrations.');
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false, false, NULL);
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["non-login-user"]', NULL, false, true, NULL);
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Editor', 'Moped Editor', 34, 3, NULL, '2021-03-09 17:08:14+00', true, 'transportation.data+mopededitor@austintexas.gov', '["moped-editor"]', NULL, false, false, NULL);
 
 
 

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -20,7 +20,7 @@ SET row_security = off;
 -- Data for Name: moped_users; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('JD', 'Maccombs', 'Software Developer', 1, 18, NULL, '2021-03-09 17:08:14+00', true, 'jd@emailhost.xyz', '["moped-admin"]', NULL, false, false, 'JD was contracted to assist with the initial Moped research and build out.');
+INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Data and Tech', 'Admin', 'Moped Admin', 1, 3, NULL, '2021-03-09 17:08:14+00', true, 'transportation.data+mopedadmin@austintexas.gov', '["moped-admin"]', NULL, false, false, 'This account is used by the DTS for automated tasks and integrations.');
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Michael', 'Chernus', 'Engineer', 3, 1, NULL, '2020-10-09 13:44:02.15918+00', false, 'mc@emailhost.xyz', '["moped-editor"]', NULL, false, false, NULL);
 INSERT INTO public.moped_users (first_name, last_name, title, user_id, workgroup_id, cognito_user_id, date_added, is_coa_staff, email, roles, picture, is_deleted, is_user_group_member, note) VALUES ('Patricia', 'Arquette', 'Engineer', 2, 1, NULL, '2020-10-09 13:44:02.159184+00', false, 'pa@emailhost.xyz', '["non-login-user"]', NULL, false, true, NULL);
 

--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -100,10 +100,7 @@ export const initializeUserDBObject = (userObject) => {
       body: JSON.stringify({
         query: ACCOUNT_USER_PROFILE_GET_PLAIN,
         variables: {
-          userId:
-            config.env.APP_ENVIRONMENT === "local"
-              ? 1
-              : getDatabaseId(userObject),
+          userId: getDatabaseId(userObject),
         },
       }),
     }).then((res) => {

--- a/moped-editor/src/views/account/AccountView/Profile.js
+++ b/moped-editor/src/views/account/AccountView/Profile.js
@@ -35,7 +35,6 @@ import {
 import { useMutation, useQuery } from "@apollo/client";
 import CDNAvatar from "../../../components/CDN/Avatar";
 import { DeleteForever } from "@mui/icons-material";
-import config from "../../../config";
 
 const useStyles = makeStyles(() => ({
   root: {},
@@ -62,7 +61,7 @@ const Profile = ({ className, ...rest }) => {
 
   const { loading, error, data, refetch } = useQuery(ACCOUNT_USER_PROFILE_GET, {
     variables: {
-      userId: config.env.APP_ENVIRONMENT === "local" ? 1 : getDatabaseId(user),
+      userId: getDatabaseId(user),
     },
   });
 

--- a/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/README.md
+++ b/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/README.md
@@ -1,0 +1,17 @@
+
+# Decrypting and encrypting claims stored in DynamoDB
+
+In DynamoDB, we have tables that store the claims of users in a Fernet-key encrypted
+format. The staging and production tables have their own Fernet keys used for encryption,
+and they can be found in the 1PW entries mentioned in the script. This script helps us 
+decrypt existing claims, update if needed, and then encrypt them again.
+
+1. To decrypt the string stored in the `claims` field, run:
+```shell
+$ python3 claims.py -a decrypt -k <the Fernet key>
+```
+2. Edit the decrypted output as needed and, then, to encrypt, run:
+```shell
+$ python3 claims.py -a encrypt -k <the Fernet key>
+```
+3. Update the `claims` field value for the row in the DynamoDB table

--- a/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/claims.py
+++ b/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/claims.py
@@ -6,7 +6,6 @@ find the environment specific Fernet keys in the 1Password entries named
 'Moped - Staging - Encryption Key - Secrets Manager - Cognito'
 """
 import argparse
-import json
 from cryptography.fernet import Fernet
 
 

--- a/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/claims.py
+++ b/moped-toolbox/encrypt_or_decrypt_dynamo_db_claims/claims.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Helper to decrypt, edit, and then encrypt Dynamo DB claims. You can 
+find the environment specific Fernet keys in the 1Password entries named
+'Moped - Production - Encryption Key - Secrets Manager - Cognito' and
+'Moped - Staging - Encryption Key - Secrets Manager - Cognito'
+"""
+import argparse
+import json
+from cryptography.fernet import Fernet
+
+
+def encrypt(key):
+    token = input("Enter the claims to encrypt:")
+
+    f = Fernet(key)
+    byte_string_input = token.encode()
+    byte_string_output = f.encrypt(byte_string_input)
+    print("\nPlace this in the Dynamo DB table claims field\n")
+    print(str(byte_string_output, encoding="utf-8"))
+
+
+def decrypt(key):
+    token = input("Enter the encrypted claims to decrypt from: ")
+
+    f = Fernet(key)
+    byte_string = f.decrypt(token)
+    string = str(byte_string, encoding="utf-8")
+    print("\nDecrypted claims to edit and then encrypt:")
+    print(f"\n{string}")
+
+
+def main(args):
+    if args.action == "encrypt":
+        encrypt(args.key)
+    elif args.action == "decrypt":
+        decrypt(args.key)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-a",
+        "--action",
+        required=True,
+        type=str,
+        choices=["encrypt", "decrypt"],
+        help=f"Encrypt or decrypt the claims",
+    )
+    parser.add_argument(
+        "-k",
+        "--key",
+        type=str,
+        required=True,
+        help=f"The Fernet key for the environment",
+    )
+
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15039

This PR:
- updates the seed data to match up with the staging admin and editor users stored in 1PW
- adds a migration that fixes a foreign key constraint issue that is blocking the final task in the issue above
- adds a script to help encrypt/decrypt our user claims (also part of the final task in the issue above)

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start Moped locally (using `./hasura-cluster start` and not from production data)
2. Log in using the username/pw stored in the 1PW entry called **Moped Local Editor User Login**
3. Add a status or note to a project or anything else that is tracked in the activity log
4. You should see that there is no foreign key error and that the activity log shows the correct user for the update you made
5. Now, log in using the 1PW entry called **Moped Staging & Production Test Editor** and repeat the same steps
6. Last, start Moped locally with production data
7. Using a DB client, execute the following statement:
```sql
UPDATE moped_users SET user_id = 1 WHERE email = 'transportation.data+mopedadmin@austintexas.gov';
```
8. Do y'all think the last step should happen in a migration? It would have no effect on staging since the record with this email in staging is already `user_id` 1. We just already have to do a manual operation on the production DynamoDB table to make everything match up so I lumped it in with manual changes.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
