### PR TITLE
Ignore updated by user id in activity log

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -46,7 +46,7 @@ export const formatProjectActivity = (change, lookupList) => {
             style: null,
           },
           {
-            text: entryMap.fields[changedField].label,
+            text: entryMap.fields[changedField]?.label,
             style: "boldText",
           },
         ],
@@ -59,7 +59,7 @@ export const formatProjectActivity = (change, lookupList) => {
         changeIcon,
         changeText: [
           {
-            text: `Removed ${entryMap.fields[changedField].label} `,
+            text: `Removed ${entryMap.fields[changedField]?.label} `,
             style: null,
           },
         ],
@@ -71,7 +71,7 @@ export const formatProjectActivity = (change, lookupList) => {
       changeIcon,
       changeText: [
         {
-          text: `Changed ${entryMap.fields[changedField].label} to `,
+          text: `Changed ${entryMap.fields[changedField]?.label} to `,
           style: null,
         },
         {
@@ -89,7 +89,7 @@ export const formatProjectActivity = (change, lookupList) => {
         changeIcon,
         changeText: [
           {
-            text: `Changed ${entryMap.fields[changedField].label} `,
+            text: `Changed ${entryMap.fields[changedField]?.label} `,
             style: null,
           },
         ],
@@ -124,7 +124,7 @@ export const formatProjectActivity = (change, lookupList) => {
       changeText: [
         {
           text: `
-          Changed ${entryMap.fields[changedField].label}
+          Changed ${entryMap.fields[changedField]?.label}
           to `,
           style: null,
         },

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -128,6 +128,12 @@ const useLookupTables = (data) =>
     return lookupData;
   }, [data]);
 
+/** Fields which do not need to be rendered in the activity log */
+const CHANGE_FIELDS_TO_IGNORE = [
+  "updated_by_user_id",
+  "updated_at"
+];
+
 /**
  * Updates the description field with newData and oldData
  * Makes sure the project creation event is the last in the returned Array
@@ -158,7 +164,7 @@ const usePrepareActivityData = (activityData) =>
               if (!isEqual(newData[key], oldData[key])) {
                 changedField = key;
               }
-            } else if (newData[key] !== oldData[key] && key !== "updated_at") {
+            } else if (newData[key] !== oldData[key] && !CHANGE_FIELDS_TO_IGNORE.includes(key)) {
               changedField = key;
             }
           });


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/15120

## Testing
**URL to test:** 
https://deploy-preview-1234--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

Sign in as a user, create a project. 
Sign in as a different user and edit that project. 
The activity log should only show the actual changes, and make no mention of "updated by", or show undefined labels. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
