### PR TITLE
Refactor filterParameters state to use search params state shape and filter config

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -237,11 +237,11 @@ const Filters = ({
       return [generateEmptyField()];
     }
   }, [filters, filtersConfig]);
-  console.log(initialFilterParameters);
 
   const [filterParameters, setFilterParameters] = useState(
     initialFilterParameters
   );
+  console.log(filterParameters);
 
   /* Track toggle value so we update the query value in handleApplyButtonClick */
   const [isOrToggleValue, setIsOrToggleValue] = useState(isOr);
@@ -448,7 +448,7 @@ const Filters = ({
    */
   const handleSearchValueChange = (filterIndex, value) => {
     // Clone the state
-    const filtersNewState = { ...filterParameters };
+    const filtersNewState = [...filterParameters];
     // Patch the new state
     filtersNewState[filterIndex].value = value;
     // Update the state

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -625,9 +625,8 @@ const Filters = ({
 
         const { label } = fieldConfig ?? {};
         // const availableOperators =
-        // const operator =
-        // const lookupTable =
-        // const lookupField =
+        const { table_name: lookupTable, field_name: lookupField } =
+          fieldConfig.lookup ?? {};
         // const type =
 
         // support check with isFilterNullType()
@@ -730,23 +729,18 @@ const Filters = ({
                     (renderAutocompleteInput(filterParameters[filterIndex]) ? (
                       <Autocomplete
                         value={value || null}
-                        options={
-                          data[filterParameters[filterIndex].lookup_table]
-                        }
+                        options={data[lookupTable]}
                         disabled={!filterParameters[filterIndex].operator}
                         getOptionLabel={(option) =>
-                          Object.hasOwn(
-                            option,
-                            filterParameters[filterIndex].lookup_field
-                          )
-                            ? option[filterParameters[filterIndex].lookup_field]
+                          Object.hasOwn(option, lookupField)
+                            ? option[lookupField]
                             : option
                         }
                         onChange={(e, value) => {
                           if (value) {
                             handleSearchValueChange(
                               filterIndex,
-                              value[filterParameters[filterIndex]?.lookup_field]
+                              value[lookupField]
                             );
                           } else {
                             // value is null when the Autocomplete selection is cleared
@@ -757,11 +751,7 @@ const Filters = ({
                           if (Object.hasOwn(value, "name")) {
                             return option.name === value.name;
                           }
-                          return (
-                            option[
-                              filterParameters[filterIndex].lookup_field
-                            ] === value
-                          );
+                          return option[lookupField] === value;
                         }}
                         renderInput={(params) => (
                           <TextField

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useMemo } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
@@ -30,10 +30,7 @@ import {
   OPERATORS_WITHOUT_SEARCH_VALUES,
 } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
 import { FiltersCommonOperators } from "./FiltersCommonOperators";
-import {
-  getDefaultOperator,
-  makeSearchParamsFromFilterParameters,
-} from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
+import { getDefaultOperator } from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
 import {
   advancedSearchFilterParamName,
   advancedSearchIsOrParamName,
@@ -195,7 +192,7 @@ const Filters = ({
     } else {
       return [generateEmptyField()];
     }
-  }, [filters, filtersConfig]);
+  }, [filters]);
 
   /**
    * The current local filter parameters so that we can store updated filters and
@@ -294,9 +291,7 @@ const Filters = ({
       filtersNewState.splice(filterIndex, 1);
     } finally {
       // Finally, reset the state
-      const searchParamsFromFilters =
-        makeSearchParamsFromFilterParameters(filtersNewState);
-      const jsonParamString = JSON.stringify(searchParamsFromFilters);
+      const jsonParamString = JSON.stringify(filtersNewState);
       setSearchParams((prevSearchParams) => {
         prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
         return prevSearchParams;
@@ -378,10 +373,8 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    const searchParamsFromFilters =
-      makeSearchParamsFromFilterParameters(filterParameters);
     setSearchParams((prevSearchParams) => {
-      const jsonParamString = JSON.stringify(searchParamsFromFilters);
+      const jsonParamString = JSON.stringify(filterParameters);
 
       prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
       prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -170,9 +170,14 @@ const Filters = ({
       (filter) => filter.name === field
     );
 
-    // Update field and operator
-    filtersNewState[filterIndex].field = fieldDetails.name;
-    filtersNewState[filterIndex].operator = getDefaultOperator(fieldDetails);
+    // Update the field and operator values or handle when the clear X icon is clicked
+    if (fieldDetails) {
+      filtersNewState[filterIndex].field = fieldDetails.name;
+      filtersNewState[filterIndex].operator = getDefaultOperator(fieldDetails);
+    } else {
+      filtersNewState[filterIndex].field = null;
+      filtersNewState[filterIndex].operator = null;
+    }
 
     // Update the state
     setFilterParameters(filtersNewState);

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -129,7 +129,7 @@ const checkIsValidInput = (filterParameter) => {
 };
 
 /**
- * It returns true if the GraphQL operator is null type and has no
+ * Returns true if the GraphQL operator is null type and has no value to search (is blank, is not blank)
  * @param {String} operator - operator to check
  * @returns {boolean}
  */
@@ -138,18 +138,25 @@ const isFilterNullType = (operator) => {
 };
 
 /**
+ * Check if a filter has complete values
+ * @param {Object} filter - contains value, field, and operator
+ * @returns {boolean}
+ */
+const isFilterComplete = (filter) => {
+  return (
+    !!filter.field &&
+    !!filter.operator &&
+    (!!filter.value || isFilterNullType(filter.operator))
+  );
+};
+
+/**
  * Check if all filters added have complete values
- * @param {Array} filterParameters - filter values, fieldd, and operatord
+ * @param {Array} filterParameters - filter values, fields, and operators
  * @returns {boolean}
  */
 const areAllFiltersComplete = (filterParameters) => {
-  return filterParameters.every((filter) => {
-    return (
-      !!filter.field &&
-      !!filter.operator &&
-      (!!filter.value || isFilterNullType(filter.operator))
-    );
-  });
+  return filterParameters.every((filter) => isFilterComplete(filter));
 };
 
 /**
@@ -209,10 +216,8 @@ const Filters = ({
   /* Track toggle value so we update the query value in handleApplyButtonClick */
   const [isOrToggleValue, setIsOrToggleValue] = useState(isOr);
 
-  /* First filter is an empty placeholder so we check for more than one filter */
+  /* Some features like all/any radios require more than one filter to appear */
   const areMoreThanOneFilters = filterParameters.length > 1;
-  const isFirstFilterIncomplete =
-    filterParameters.length === 1 && !areAllFiltersComplete(filterParameters);
 
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive
@@ -382,7 +387,7 @@ const Filters = ({
     });
 
     setIsOr(isOrToggleValue);
-    setFilters(searchParamsFromFilters);
+    setFilters(filterParameters);
     handleAdvancedSearchClose();
     // Clear simple search field in UI and state since we are using advanced search
     setSearchFieldValue("");
@@ -629,7 +634,7 @@ const Filters = ({
               <Hidden mdDown>
                 <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
                   <IconButton
-                    disabled={isFirstFilterIncomplete}
+                    disabled={!isFilterComplete(filter)}
                     className={classes.deleteButton}
                     onClick={() => handleDeleteFilterButtonClick(filterIndex)}
                     size="large"
@@ -641,7 +646,7 @@ const Filters = ({
               <Hidden mdUp>
                 <Grid item xs={12}>
                   <Button
-                    disabled={isFirstFilterIncomplete}
+                    disabled={!isFilterComplete(filter)}
                     fullWidth
                     className={classes.deleteButton}
                     variant="outlined"

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -239,6 +239,10 @@ const Filters = ({
         setIsOr(false);
         setIsOrToggleValue(false);
       }
+
+      if (filtersNewState.length === 0) {
+        handleClearFilters();
+      }
     }
   };
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -192,17 +192,16 @@ const Filters = ({
     // Clone state
     const filtersNewState = [...filterParameters];
 
-    if (operator in filtersConfig.operators) {
-      // Update operator Value
-      filtersNewState[filterIndex].operator = operator;
+    // Update operator Value
+    filtersNewState[filterIndex].operator = operator;
 
-      // if we are switching to an autocomplete input, clear the search value
-      if (shouldRenderAutocompleteInput(lookupTable, operator, loading)) {
-        filtersNewState[filterIndex].value = null;
-      }
-    } else {
-      // Reset operator value
-      filtersNewState[filterIndex].operator = null;
+    // if we are switching to an autocomplete input or using an operator
+    // without a search value, clear the search value
+    if (
+      shouldRenderAutocompleteInput(lookupTable, operator, loading) ||
+      isFilterNullType(operator)
+    ) {
+      filtersNewState[filterIndex].value = null;
     }
 
     setFilterParameters(filtersNewState);
@@ -293,7 +292,7 @@ const Filters = ({
     setSearchTerm("");
   };
 
-  const handleAndOrToggle = (e) => {
+  const handleAndOrToggleChange = (e) => {
     const isOr = e.target.value === "any";
     setIsOrToggleValue(isOr);
   };
@@ -312,7 +311,7 @@ const Filters = ({
             <RadioGroup
               row
               value={isOrToggleValue ? "any" : "all"}
-              onChange={handleAndOrToggle}
+              onChange={handleAndOrToggleChange}
             >
               <FormControlLabel
                 value="all"

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -238,9 +238,9 @@ const Filters = ({
   const [filterComplete, setFilterComplete] = useState(false);
 
   /* First filter is an empty placeholder so we check for more than one filter */
-  const areMoreThanOneFilters = Object.keys(filterParameters).length > 1;
+  const areMoreThanOneFilters = filterParameters.length > 1;
   const isFirstFilterIncomplete =
-    Object.keys(filterParameters).length === 1 && !filterComplete;
+    filterParameters.length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
     // Clone state and add empty filter
@@ -266,10 +266,11 @@ const Filters = ({
    * @param {Object} field - The field object being clicked
    */
   const handleFilterFieldMenuClick = (filterId, field) => {
+    console.log(filterId);
     // If the filter exists
     if (filterId in filterParameters) {
       // Clone state
-      const filtersNewState = { ...filterParameters };
+      const filtersNewState = [...filterParameters];
 
       // Find the field we need to gather options from
       const fieldDetails = filtersConfig.fields.find(

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -231,23 +231,20 @@ const Filters = ({
   const handleDeleteFilterButtonClick = (filterIndex) => {
     // Clone the state
     const filtersNewState = [...filterParameters];
-    // Try to delete the filter by filter index
-    try {
-      // Delete the key (if it's there)
-      filtersNewState.splice(filterIndex, 1);
-    } finally {
-      // Finally, reset the state
-      const jsonParamString = JSON.stringify(filtersNewState);
-      setSearchParams((prevSearchParams) => {
-        prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
-        return prevSearchParams;
-      });
-      setFilterParameters(filtersNewState);
 
-      /* Reset isOr to false (all/and) if there is only one filter left */
-      if (Object.keys(filtersNewState).length === 1) {
-        setIsOrToggleValue(false);
-      }
+    // Delete the key (if it's there)
+    filtersNewState.splice(filterIndex, 1);
+    // Finally, reset the state
+    const jsonParamString = JSON.stringify(filtersNewState);
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
+      return prevSearchParams;
+    });
+    setFilterParameters(filtersNewState);
+
+    /* Reset isOr to false (all/and) if there is only one filter left */
+    if (Object.keys(filtersNewState).length === 1) {
+      setIsOrToggleValue(false);
     }
   };
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -235,7 +235,6 @@ const Filters = ({
 
       /* Reset isOr to false (all/and) if there is only one filter left */
       if (Object.keys(filtersNewState).length === 1) {
-        setIsOr(false);
         setIsOrToggleValue(false);
       }
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -624,9 +624,28 @@ const Filters = ({
         );
 
         const { label, type } = fieldConfig ?? {};
-        // const availableOperators =
         const { table_name: lookupTable, field_name: lookupField } =
           fieldConfig?.lookup ?? {};
+        const operatorsSetInConfig = fieldConfig?.operators;
+        const shouldUseAllOperators =
+          operatorsSetInConfig &&
+          operatorsSetInConfig.length === 1 &&
+          fieldConfig.operators[0] === "*";
+        let availableOperators = [];
+
+        if (shouldUseAllOperators) {
+          availableOperators = Object.entries(FiltersCommonOperators)
+            .map(([filtersCommonOperator, filterCommonOperatorConfig]) => ({
+              ...filterCommonOperatorConfig,
+              id: filtersCommonOperator,
+            }))
+            .filter((operator) => operator.type === type);
+        } else if (operatorsSetInConfig) {
+          availableOperators = fieldConfig?.operators.map((operator) => ({
+            ...FiltersCommonOperators[operator],
+            id: operator,
+          }));
+        }
 
         // support check with isFilterNullType()
         // support check with renderAutocompleteInput()
@@ -688,10 +707,7 @@ const Filters = ({
                   <Select
                     variant="standard"
                     fullWidth
-                    disabled={
-                      filterParameters[filterIndex].availableOperators
-                        .length === 0
-                    }
+                    disabled={availableOperators.length === 0}
                     labelId={`filter-operator-select-${filterIndex}-label`}
                     id={`filter-operator-select-${filterIndex}`}
                     value={operator || ""}
@@ -701,20 +717,18 @@ const Filters = ({
                     label="field"
                     data-testid="operator-select"
                   >
-                    {filterParameters[filterIndex].availableOperators.map(
-                      (operator, operatorIndex) => {
-                        return (
-                          <MenuItem
-                            value={operator.id}
-                            key={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
-                            id={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
-                            data-testid={operator.label}
-                          >
-                            {operator.label}
-                          </MenuItem>
-                        );
-                      }
-                    )}
+                    {availableOperators.map((operator, operatorIndex) => {
+                      return (
+                        <MenuItem
+                          value={operator.id}
+                          key={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
+                          id={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
+                          data-testid={operator.label}
+                        >
+                          {operator.label}
+                        </MenuItem>
+                      );
+                    })}
                   </Select>
                 </FormControl>
               </Grid>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -617,6 +617,16 @@ const Filters = ({
 
       {filterParameters.map((filter, filterIndex) => {
         const isValidInput = checkIsValidInput(filterParameters[filterIndex]);
+        // TODO: Get info needed for form components from these three variables
+        // const { field, operator, value } = filter[filterIndex];
+        // const label =
+        // const availableOperators =
+        // const operator =
+        // const lookupTable =
+        // const lookupField =
+        // const type =
+
+        // TODO:
         return (
           <Grow in={true} key={`filter-grow-${filterIndex}`}>
             <Grid

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -39,6 +39,7 @@ import {
   isFilterNullType,
   shouldRenderAutocompleteInput,
 } from "./helpers";
+import { FiltersCommonOperators } from "./FiltersCommonOperators";
 
 /**
  * The styling for the filter components
@@ -363,11 +364,7 @@ const Filters = ({
           (field) => field.name === fieldName
         );
         const { label, type } = fieldConfig ?? {};
-        const operators = fieldConfig?.operators;
-        const availableOperators = getAvailableOperators(
-          operators,
-          fieldConfig
-        );
+        const operators = fieldConfig?.operators ?? [];
 
         /* If the field uses a lookup table, get the table and field names  */
         const { table_name: lookupTable, field_name: lookupField } =
@@ -434,7 +431,7 @@ const Filters = ({
                   <Select
                     variant="standard"
                     fullWidth
-                    disabled={availableOperators.length === 0}
+                    disabled={operators.length === 0}
                     labelId={`filter-operator-select-${filterIndex}-label`}
                     id={`filter-operator-select-${filterIndex}`}
                     value={operator || ""}
@@ -448,15 +445,16 @@ const Filters = ({
                     label="field"
                     data-testid="operator-select"
                   >
-                    {availableOperators.map((operator, operatorIndex) => {
+                    {operators.map((operator, operatorIndex) => {
+                      const label = FiltersCommonOperators[operator].label;
                       return (
                         <MenuItem
-                          value={operator.id}
+                          value={operator}
                           key={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
                           id={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
-                          data-testid={operator.label}
+                          data-testid={label}
                         >
-                          {operator.label}
+                          {label}
                         </MenuItem>
                       );
                     })}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -186,6 +186,7 @@ const Filters = ({
    * Handles the click event on the operator drop-down
    * @param {string} filterIndex - filterParameters index to modify
    * @param {Object} operator - The operator object being clicked
+   * @param {string} lookupTable - The lookup table name
    */
   const handleFilterOperatorClick = (filterIndex, operator, lookupTable) => {
     // Clone state

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -445,7 +445,7 @@ const Filters = ({
                     data-testid="operator-select"
                   >
                     {operators.map((operator, operatorIndex) => {
-                      const label = FiltersCommonOperators[operator].label;
+                      const label = FiltersCommonOperators[operator]?.label;
                       return (
                         <MenuItem
                           value={operator}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -618,13 +618,18 @@ const Filters = ({
       {filterParameters.map((filter, filterIndex) => {
         const isValidInput = checkIsValidInput(filterParameters[filterIndex]);
         // TODO: Get info needed for form components from these three variables
-        const { field, operator, value } = filter;
-        // const label =
+        const { field: fieldName, operator, value } = filter;
+        const fieldConfig = filtersConfig.fields.find(
+          (field) => field.name === fieldName
+        );
+
+        const { label } = fieldConfig ?? {};
         // const availableOperators =
         // const operator =
         // const lookupTable =
         // const lookupField =
         // const type =
+
         // support check with isFilterNullType()
         // support check with renderAutocompleteInput()
         return (
@@ -643,7 +648,7 @@ const Filters = ({
                   className={classes.formControl}
                 >
                   <Autocomplete
-                    value={filterParameters[filterIndex].label || null}
+                    value={label || null}
                     id={`filter-field-select-${filterIndex}`}
                     options={filtersConfig.fields}
                     getOptionLabel={(f) =>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -361,41 +361,23 @@ const Filters = ({
    * @param {Object} operator - The operator object being clicked
    */
   const handleFilterOperatorClick = (filterIndex, operator, lookupTable) => {
-    // If the filter exists
-    if (filterIndex in filterParameters) {
-      // Clone state
-      const filtersNewState = [...filterParameters];
+    // Clone state
+    const filtersNewState = [...filterParameters];
 
-      if (operator in filtersConfig.operators) {
-        // Update Operator Value
-        filtersNewState[filterIndex].operator = operator;
-        // Get the GraphQL operator details
-        filtersNewState[filterIndex].gqlOperator =
-          filtersConfig.operators[operator].operator;
-        // Copy the envelope if available
-        filtersNewState[filterIndex].envelope =
-          filtersConfig.operators[operator].envelope;
-        // Copy special null value if available
-        filtersNewState[filterIndex].specialNullValue =
-          filtersConfig.operators[operator].specialNullValue;
+    if (operator in filtersConfig.operators) {
+      // Update operator Value
+      filtersNewState[filterIndex].operator = operator;
 
-        // if we are switching to an autocomplete input, clear the search value
-        if (renderAutocompleteInput(lookupTable, operator)) {
-          filtersNewState[filterIndex].value = null;
-        }
-      } else {
-        // Reset operator values
-        filtersNewState[filterIndex].operator = null;
-        filtersNewState[filterIndex].gqlOperator = null;
-        filtersNewState[filterIndex].envelope = null;
+      // if we are switching to an autocomplete input, clear the search value
+      if (renderAutocompleteInput(lookupTable, operator)) {
+        filtersNewState[filterIndex].value = null;
       }
-
-      setFilterParameters(filtersNewState);
     } else {
-      console.debug(
-        `The filter id ${filterIndex} does not exist, ignoring click event.`
-      );
+      // Reset operator value
+      filtersNewState[filterIndex].operator = null;
     }
+
+    setFilterParameters(filtersNewState);
   };
 
   /**
@@ -537,12 +519,10 @@ const Filters = ({
   /**
    * This side effect monitors whether the user has added a complete filter
    */
+  console.log(filterParameters);
   useEffect(() => {
-    Object.keys(filterParameters).forEach((filterKey) => {
-      if (
-        !!filterParameters[filterKey].value ||
-        isFilterNullType(filterParameters[filterKey].operator)
-      ) {
+    filterParameters.forEach((filter) => {
+      if (!!filter.value || isFilterNullType(filter.operator)) {
         setFilterComplete(true);
       } else {
         setFilterComplete(false);
@@ -611,7 +591,7 @@ const Filters = ({
 
       {filterParameters.map((filter, filterIndex) => {
         const isValidInput = checkIsValidInput(filterParameters[filterIndex]);
-        // TODO: Get info needed for form components from these three variables
+        // TODO: Clean all this up
         const { field: fieldName, operator, value } = filter;
         const fieldConfig = filtersConfig.fields.find(
           (field) => field.name === fieldName

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -243,12 +243,8 @@ const Filters = ({
     Object.keys(filterParameters).length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
-    // Clone state
-    const filtersNewState = {
-      ...filterParameters,
-    };
-    // Patch new state
-    filtersNewState = [generateEmptyField()];
+    // Clone state and add empty filter
+    const filtersNewState = [...filterParameters, generateEmptyField()];
     // Update new state
     setFilterParameters(filtersNewState);
   }, [filterParameters, setFilterParameters]);

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -527,12 +527,12 @@ const Filters = ({
   };
 
   /**
-   * It returns true if the operator is null
-   * @param {object} field - The field being checked
+   * It returns true if the GraphQL operator is null type and has no
+   * @param {String} operator - operator to check
    * @returns {boolean}
    */
-  const isFilterNullType = (field) => {
-    return field.gqlOperator && field.gqlOperator.includes("is_null");
+  const isFilterNullType = (operator) => {
+    return operator && OPERATORS_WITHOUT_SEARCH_VALUES.includes(operator);
   };
 
   // TODO: We can replace this side effect by checking if each filter in filterParameters
@@ -545,9 +545,7 @@ const Filters = ({
     Object.keys(filterParameters).forEach((filterKey) => {
       if (
         !!filterParameters[filterKey].value ||
-        OPERATORS_WITHOUT_SEARCH_VALUES.includes(
-          filterParameters[filterKey].operator
-        )
+        isFilterNullType(filterParameters[filterKey].operator)
       ) {
         setFilterComplete(true);
       } else {
@@ -647,7 +645,6 @@ const Filters = ({
           }));
         }
 
-        // support check with isFilterNullType()
         // support check with renderAutocompleteInput()
         return (
           <Grow in={true} key={`filter-grow-${filterIndex}`}>
@@ -738,7 +735,7 @@ const Filters = ({
                   variant="outlined"
                   className={classes.formControl}
                 >
-                  {isFilterNullType(filterParameters[filterIndex]) !== true &&
+                  {isFilterNullType(operator) !== true &&
                     (renderAutocompleteInput(filterParameters[filterIndex]) ? (
                       <Autocomplete
                         value={value || null}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -160,7 +160,7 @@ const Filters = ({
    * @param {string} filterIndex - filterParameters index to modify
    * @param {Object} field - The field object being clicked
    */
-  const handleFilterFieldMenuClick = (filterIndex, field) => {
+  const handleFilterFieldMenuChange = (filterIndex, field) => {
     // Clone state
     const filtersNewState = [...filterParameters];
 
@@ -188,7 +188,7 @@ const Filters = ({
    * @param {Object} operator - The operator object being clicked
    * @param {string} lookupTable - The lookup table name
    */
-  const handleFilterOperatorClick = (filterIndex, operator, lookupTable) => {
+  const handleFilterOperatorChange = (filterIndex, operator, lookupTable) => {
     // Clone state
     const filtersNewState = [...filterParameters];
 
@@ -396,7 +396,7 @@ const Filters = ({
                       Object.hasOwn(f, "label") ? f.label : f
                     }
                     onChange={(e, value) => {
-                      handleFilterFieldMenuClick(filterIndex, value?.name);
+                      handleFilterFieldMenuChange(filterIndex, value?.name);
                     }}
                     isOptionEqualToValue={(option, value) => {
                       if (Object.hasOwn(value, "name")) {
@@ -436,7 +436,7 @@ const Filters = ({
                     id={`filter-operator-select-${filterIndex}`}
                     value={operator || ""}
                     onChange={(e) =>
-                      handleFilterOperatorClick(
+                      handleFilterOperatorChange(
                         filterIndex,
                         e.target.value,
                         lookupTable

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -535,6 +535,9 @@ const Filters = ({
     return field.gqlOperator && field.gqlOperator.includes("is_null");
   };
 
+  // TODO: We can replace this side effect by checking if each filter in filterParameters
+  // has a value and operator
+  // TODO: Remember to handle filters without values (OPERATORS_WITHOUT_SEARCH_VALUES)
   /**
    * This side effect monitors whether the user has added a complete filter
    */

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -266,6 +266,7 @@ const Filters = ({
    * @param {Object} field - The field object being clicked
    */
   const handleFilterFieldMenuClick = (filterId, field) => {
+    // TODO: Update to push update or empty filter into filterParameters array
     console.log(filterId);
     // If the filter exists
     if (filterId in filterParameters) {

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -25,7 +25,6 @@ import makeStyles from "@mui/styles/makeStyles";
 import { Autocomplete } from "@mui/material";
 import BackspaceOutlinedIcon from "@mui/icons-material/BackspaceOutlined";
 import { LOOKUP_TABLES_QUERY } from "../../queries/project";
-import { getDefaultOperator } from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
 import {
   advancedSearchFilterParamName,
   advancedSearchIsOrParamName,
@@ -35,6 +34,7 @@ import {
   checkIsValidInput,
   generateEmptyFilter,
   getAvailableOperators,
+  getDefaultOperator,
   handleApplyValidation,
   isFilterNullType,
   isFilterComplete,
@@ -149,7 +149,6 @@ const Filters = ({
   const [filterParameters, setFilterParameters] = useState(
     initialFilterParameters
   );
-  console.log(filterParameters);
 
   /* Track toggle value so we update the query value in handleApplyButtonClick */
   const [isOrToggleValue, setIsOrToggleValue] = useState(isOr);

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -455,21 +455,21 @@ const Filters = ({
   const handleApplyValidation = () => {
     let feedback = [];
     if (filterParameters) {
-      if (Object.keys(filterParameters).length === 0) {
+      if (filterParameters.length === 0) {
         feedback.push("• No filters have been added.");
       } else {
         Object.keys(filterParameters).forEach((filterKey) => {
-          const { field, value, gqlOperator } = filterParameters[filterKey];
+          const { field, value, operator } = filterParameters[filterKey];
           if (field === null) {
             feedback.push("• One or more fields have not been selected.");
           }
 
-          if (gqlOperator === null) {
+          if (operator === null) {
             feedback.push("• One or more operators have not been selected.");
           }
 
           if (value === null || value.trim() === "") {
-            if (gqlOperator && !gqlOperator.includes("is_null")) {
+            if (operator && !isFilterNullType(operator)) {
               feedback.push("• One or more missing values.");
             }
           }
@@ -519,7 +519,6 @@ const Filters = ({
   /**
    * This side effect monitors whether the user has added a complete filter
    */
-  console.log(filterParameters);
   useEffect(() => {
     filterParameters.forEach((filter) => {
       if (!!filter.value || isFilterNullType(filter.operator)) {

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -243,6 +243,7 @@ const Filters = ({
     filterParameters.length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
+    debugger;
     // Clone state and add empty filter
     const filtersNewState = [...filterParameters, generateEmptyField()];
     // Update new state
@@ -445,8 +446,8 @@ const Filters = ({
    * Clears the filters
    */
   const handleClearFilters = useCallback(() => {
-    setFilterParameters({});
-    setFilters({});
+    setFilterParameters([generateEmptyField()]);
+    setFilters([]);
     setIsOr(false);
 
     setSearchParams((prevSearchParams) => {
@@ -517,19 +518,6 @@ const Filters = ({
   const isFilterNullType = (field) => {
     return field.gqlOperator && field.gqlOperator.includes("is_null");
   };
-
-  /**
-   * This side effect monitors the count of filters
-   * if the count of filters is zero, then resets the state
-   */
-  useEffect(() => {
-    if (Object.keys(filterParameters).length === 0) {
-      setFilters([]);
-      handleClearFilters();
-      // Add an empty filter so the user doesn't have to click the 'add filter' button
-      generateEmptyFilter();
-    }
-  }, [filterParameters, setFilters, generateEmptyFilter, handleClearFilters]);
 
   /**
    * This side effect monitors whether the user has added a complete filter

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -266,12 +266,8 @@ const Filters = ({
   /**
    * Returns true if Field has a lookup table associated with it and operator is case sensitive
    */
-  const renderAutocompleteInput = (field) => {
-    return (
-      field.lookup_table &&
-      !loading &&
-      AUTOCOMPLETE_OPERATORS.includes(field.operator)
-    );
+  const renderAutocompleteInput = (lookupTable, operator) => {
+    return lookupTable && !loading && AUTOCOMPLETE_OPERATORS.includes(operator);
   };
 
   /**
@@ -364,7 +360,7 @@ const Filters = ({
    * @param {string} filterIndex - filterParameters index to modify
    * @param {Object} operator - The operator object being clicked
    */
-  const handleFilterOperatorClick = (filterIndex, operator) => {
+  const handleFilterOperatorClick = (filterIndex, operator, lookupTable) => {
     // If the filter exists
     if (filterIndex in filterParameters) {
       // Clone state
@@ -384,7 +380,7 @@ const Filters = ({
           filtersConfig.operators[operator].specialNullValue;
 
         // if we are switching to an autocomplete input, clear the search value
-        if (renderAutocompleteInput(filtersNewState[filterIndex])) {
+        if (renderAutocompleteInput(lookupTable, operator)) {
           filtersNewState[filterIndex].value = null;
         }
       } else {
@@ -645,7 +641,6 @@ const Filters = ({
           }));
         }
 
-        // support check with renderAutocompleteInput()
         return (
           <Grow in={true} key={`filter-grow-${filterIndex}`}>
             <Grid
@@ -709,7 +704,11 @@ const Filters = ({
                     id={`filter-operator-select-${filterIndex}`}
                     value={operator || ""}
                     onChange={(e) =>
-                      handleFilterOperatorClick(filterIndex, e.target.value)
+                      handleFilterOperatorClick(
+                        filterIndex,
+                        e.target.value,
+                        lookupTable
+                      )
                     }
                     label="field"
                     data-testid="operator-select"
@@ -736,7 +735,7 @@ const Filters = ({
                   className={classes.formControl}
                 >
                   {isFilterNullType(operator) !== true &&
-                    (renderAutocompleteInput(filterParameters[filterIndex]) ? (
+                    (renderAutocompleteInput(lookupTable, operator) ? (
                       <Autocomplete
                         value={value || null}
                         options={data[lookupTable]}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -360,8 +360,7 @@ const Filters = ({
         const operators = fieldConfig?.operators;
         const availableOperators = getAvailableOperators(
           operators,
-          fieldConfig,
-          type
+          fieldConfig
         );
 
         /* If the field uses a lookup table, get the table and field names  */

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -37,7 +37,6 @@ import {
   getDefaultOperator,
   handleApplyValidation,
   isFilterNullType,
-  isFilterComplete,
   shouldRenderAutocompleteInput,
 } from "./helpers";
 
@@ -241,10 +240,6 @@ const Filters = ({
       /* Reset isOr to false (all/and) if there is only one filter left */
       if (Object.keys(filtersNewState).length === 1) {
         setIsOrToggleValue(false);
-      }
-
-      if (filtersNewState.length === 0) {
-        handleClearFilters();
       }
     }
   };
@@ -527,31 +522,39 @@ const Filters = ({
                     ))}
                 </FormControl>
               </Grid>
-              <Hidden mdDown>
-                <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
-                  <IconButton
-                    disabled={!isFilterComplete(filter)}
-                    className={classes.deleteButton}
-                    onClick={() => handleDeleteFilterButtonClick(filterIndex)}
-                    size="large"
-                  >
-                    <Icon className={classes.deleteIcon}>delete_outline</Icon>
-                  </IconButton>
-                </Grid>
-              </Hidden>
-              <Hidden mdUp>
-                <Grid item xs={12}>
-                  <Button
-                    disabled={!isFilterComplete(filter)}
-                    fullWidth
-                    className={classes.deleteButton}
-                    variant="outlined"
-                    onClick={() => handleDeleteFilterButtonClick(filterIndex)}
-                  >
-                    <Icon>delete_outline</Icon>
-                  </Button>
-                </Grid>
-              </Hidden>
+              {areMoreThanOneFilters ? (
+                <>
+                  <Hidden mdDown>
+                    <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
+                      <IconButton
+                        className={classes.deleteButton}
+                        onClick={() =>
+                          handleDeleteFilterButtonClick(filterIndex)
+                        }
+                        size="large"
+                      >
+                        <Icon className={classes.deleteIcon}>
+                          delete_outline
+                        </Icon>
+                      </IconButton>
+                    </Grid>
+                  </Hidden>
+                  <Hidden mdUp>
+                    <Grid item xs={12}>
+                      <Button
+                        fullWidth
+                        className={classes.deleteButton}
+                        variant="outlined"
+                        onClick={() =>
+                          handleDeleteFilterButtonClick(filterIndex)
+                        }
+                      >
+                        <Icon>delete_outline</Icon>
+                      </Button>
+                    </Grid>
+                  </Hidden>
+                </>
+              ) : null}
             </Grid>
           </Grow>
         );

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -33,7 +33,6 @@ import {
   areAllFiltersComplete,
   checkIsValidInput,
   generateEmptyFilter,
-  getAvailableOperators,
   getDefaultOperator,
   handleApplyValidation,
   isFilterNullType,

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import { v4 as uuidv4 } from "uuid";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
 
@@ -101,11 +100,10 @@ const useStyles = makeStyles((theme) => ({
  * @param uuid
  * @return {Object}
  */
-const generateEmptyField = (uuid) => {
+const generateEmptyField = () => {
   /**
    * The default structure of an empty field
    * @type {Object}
-   * @property {string} id - The uuid of the field
    * @property {string} field - The name of the column
    * @property {operator} operator - The name of the operator
    * @property {string[]} availableOperators - A string array containing the names of available operators
@@ -117,7 +115,6 @@ const generateEmptyField = (uuid) => {
    * @default
    */
   const defaultNewFieldState = {
-    id: null,
     field: null,
     operator: null,
     availableOperators: [],
@@ -129,7 +126,7 @@ const generateEmptyField = (uuid) => {
     specialNullValue: null,
     label: null,
   };
-  return { ...defaultNewFieldState, id: uuid };
+  return { ...defaultNewFieldState };
 };
 
 /**
@@ -223,9 +220,7 @@ const Filters = ({
     if (filters.length > 0) {
       return makeInitialFilterParameters(filters, filtersConfig);
     } else {
-      return {
-        [uuidv4()]: generateEmptyField(uuidv4()),
-      };
+      return [generateEmptyField()];
     }
   }, [filters, filtersConfig]);
   console.log(initialFilterParameters);
@@ -248,14 +243,12 @@ const Filters = ({
     Object.keys(filterParameters).length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
-    // Generate a random UUID string
-    const uuid = uuidv4();
     // Clone state
     const filtersNewState = {
       ...filterParameters,
     };
     // Patch new state
-    filtersNewState[uuid] = generateEmptyField(uuid);
+    filtersNewState = [generateEmptyField()];
     // Update new state
     setFilterParameters(filtersNewState);
   }, [filterParameters, setFilterParameters]);

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -243,7 +243,6 @@ const Filters = ({
     filterParameters.length === 1 && !filterComplete;
 
   const generateEmptyFilter = useCallback(() => {
-    debugger;
     // Clone state and add empty filter
     const filtersNewState = [...filterParameters, generateEmptyField()];
     // Update new state
@@ -263,14 +262,14 @@ const Filters = ({
 
   /**
    * Handles the click event on the field drop-down menu
-   * @param {string} filterId - State FieldID to modify
+   * @param {string} filterIndex - filterParameters index to modify
    * @param {Object} field - The field object being clicked
    */
-  const handleFilterFieldMenuClick = (filterId, field) => {
+  const handleFilterFieldMenuClick = (filterIndex, field) => {
     // TODO: Update to push update or empty filter into filterParameters array
-    console.log(filterId);
+    console.log(filterIndex);
     // If the filter exists
-    if (filterId in filterParameters) {
+    if (filterIndex in filterParameters) {
       // Clone state
       const filtersNewState = [...filterParameters];
 
@@ -280,13 +279,13 @@ const Filters = ({
       );
 
       if (!fieldDetails) {
-        filtersNewState[filterId] = generateEmptyField(filterId);
+        filtersNewState[filterIndex] = generateEmptyField(filterIndex);
       } else {
         // Update field & type
-        filtersNewState[filterId].field = fieldDetails.name;
-        filtersNewState[filterId].type = fieldDetails.type;
-        filtersNewState[filterId].placeholder = fieldDetails.placeholder;
-        filtersNewState[filterId].label = fieldDetails.label;
+        filtersNewState[filterIndex].field = fieldDetails.name;
+        filtersNewState[filterIndex].type = fieldDetails.type;
+        filtersNewState[filterIndex].placeholder = fieldDetails.placeholder;
+        filtersNewState[filterIndex].label = fieldDetails.label;
 
         // Update Available Operators
         if (
@@ -294,7 +293,7 @@ const Filters = ({
           fieldDetails.operators[0] === "*"
         ) {
           // Add all operators and filter by specific type (defined in fieldDetails.type)
-          filtersNewState[filterId].availableOperators = Object.keys(
+          filtersNewState[filterIndex].availableOperators = Object.keys(
             filtersConfig.operators
           )
             .filter(
@@ -309,7 +308,7 @@ const Filters = ({
             });
         } else {
           // Append listed operators for that field
-          filtersNewState[filterId].availableOperators =
+          filtersNewState[filterIndex].availableOperators =
             fieldDetails.operators.map((operator) => {
               return {
                 ...filtersConfig.operators[operator],
@@ -320,71 +319,71 @@ const Filters = ({
 
         // if the field has a corresponding lookup table, add to filterState
         if (fieldDetails.lookup) {
-          filtersNewState[filterId].lookup_table =
+          filtersNewState[filterIndex].lookup_table =
             fieldDetails.lookup.table_name;
-          filtersNewState[filterId].lookup_field =
+          filtersNewState[filterIndex].lookup_field =
             fieldDetails.lookup.field_name;
         }
         // if it does not, reset the variables to null in case the user is editing an existing filter
         else {
-          filtersNewState[filterId].lookup_table = null;
-          filtersNewState[filterId].lookup_field = null;
+          filtersNewState[filterIndex].lookup_table = null;
+          filtersNewState[filterIndex].lookup_field = null;
         }
       }
 
       // Select the default operator, if not defined select first.
       if (fieldDetails) {
         const defaultOperator = getDefaultOperator(fieldDetails);
-        handleFilterOperatorClick(filterId, defaultOperator);
+        handleFilterOperatorClick(filterIndex, defaultOperator);
       }
       // Update the state
       setFilterParameters(filtersNewState);
     } else {
       console.debug(
-        `The filter id ${filterId} does not exist, ignoring click event.`
+        `The filter id ${filterIndex} does not exist, ignoring click event.`
       );
     }
   };
 
   /**
    * Handles the click event on the operator drop-down
-   * @param {string} filterId - State FieldID to modify
+   * @param {string} filterIndex - filterParameters index to modify
    * @param {Object} operator - The operator object being clicked
    */
-  const handleFilterOperatorClick = (filterId, operator) => {
+  const handleFilterOperatorClick = (filterIndex, operator) => {
     // If the filter exists
-    if (filterId in filterParameters) {
+    if (filterIndex in filterParameters) {
       // Clone state
       const filtersNewState = { ...filterParameters };
 
       if (operator in filtersConfig.operators) {
         // Update Operator Value
-        filtersNewState[filterId].operator = operator;
+        filtersNewState[filterIndex].operator = operator;
         // Get the GraphQL operator details
-        filtersNewState[filterId].gqlOperator =
+        filtersNewState[filterIndex].gqlOperator =
           filtersConfig.operators[operator].operator;
         // Copy the envelope if available
-        filtersNewState[filterId].envelope =
+        filtersNewState[filterIndex].envelope =
           filtersConfig.operators[operator].envelope;
         // Copy special null value if available
-        filtersNewState[filterId].specialNullValue =
+        filtersNewState[filterIndex].specialNullValue =
           filtersConfig.operators[operator].specialNullValue;
 
         // if we are switching to an autocomplete input, clear the search value
-        if (renderAutocompleteInput(filtersNewState[filterId])) {
-          filtersNewState[filterId].value = null;
+        if (renderAutocompleteInput(filtersNewState[filterIndex])) {
+          filtersNewState[filterIndex].value = null;
         }
       } else {
         // Reset operator values
-        filtersNewState[filterId].operator = null;
-        filtersNewState[filterId].gqlOperator = null;
-        filtersNewState[filterId].envelope = null;
+        filtersNewState[filterIndex].operator = null;
+        filtersNewState[filterIndex].gqlOperator = null;
+        filtersNewState[filterIndex].envelope = null;
       }
 
       setFilterParameters(filtersNewState);
     } else {
       console.debug(
-        `The filter id ${filterId} does not exist, ignoring click event.`
+        `The filter id ${filterIndex} does not exist, ignoring click event.`
       );
     }
   };
@@ -398,17 +397,17 @@ const Filters = ({
 
   /**
    * Deletes a filter from the state
-   * @param {string} filterId - The UUID of the filter to be deleted
+   * @param {string} filterIndex - The index of the filter to be deleted
    */
-  const handleDeleteFilterButtonClick = (filterId) => {
+  const handleDeleteFilterButtonClick = (filterIndex) => {
     // Copy the state into a new object
     const filtersNewState = {
       ...filterParameters,
     };
-    // Try to delete the filter by filterId
+    // Try to delete the filter by filter index
     try {
       // Delete the key (if it's there)
-      delete filtersNewState[filterId];
+      delete filtersNewState[filterIndex];
     } finally {
       // Finally, reset the state
       const searchParamsFromFilters =
@@ -430,14 +429,14 @@ const Filters = ({
 
   /**
    * The user will type a new search value
-   * @param {string} filterId - The FilterID uuid
+   * @param {string} filterIndex - filterParameters index to modify
    * @param {string} value - The value to assign to that filter
    */
-  const handleSearchValueChange = (filterId, value) => {
+  const handleSearchValueChange = (filterIndex, value) => {
     // Clone the state
     const filtersNewState = { ...filterParameters };
     // Patch the new state
-    filtersNewState[filterId].value = value;
+    filtersNewState[filterIndex].value = value;
     // Update the state
     setFilterParameters(filtersNewState);
   };
@@ -596,13 +595,13 @@ const Filters = ({
         </Grid>
       </Grid>
 
-      {Object.keys(filterParameters).map((filterId) => {
+      {filterParameters.map((filter, filterIndex) => {
         return (
-          <Grow in={true} key={`filter-grow-${filterId}`}>
+          <Grow in={true} key={`filter-grow-${filterIndex}`}>
             <Grid
               container
-              id={`filter-${filterId}`}
-              key={`filter-${filterId}`}
+              id={`filter-${filterIndex}`}
+              key={`filter-${filterIndex}`}
               className={classes.filtersContainer}
             >
               {/*Select Field to search from drop-down menu*/}
@@ -613,14 +612,14 @@ const Filters = ({
                   className={classes.formControl}
                 >
                   <Autocomplete
-                    value={filterParameters[filterId].label || null}
-                    id={`filter-field-select-${filterId}`}
+                    value={filterParameters[filterIndex].label || null}
+                    id={`filter-field-select-${filterIndex}`}
                     options={filtersConfig.fields}
                     getOptionLabel={(f) =>
                       Object.hasOwn(f, "label") ? f.label : f
                     }
                     onChange={(e, value) => {
-                      handleFilterFieldMenuClick(filterId, value?.name);
+                      handleFilterFieldMenuClick(filterIndex, value?.name);
                     }}
                     isOptionEqualToValue={(option, value) => {
                       if (Object.hasOwn(value, "name")) {
@@ -647,35 +646,38 @@ const Filters = ({
                   fullWidth
                   className={classes.formControl}
                 >
-                  <InputLabel id={`filter-operator-select-${filterId}-label`}>
+                  <InputLabel
+                    id={`filter-operator-select-${filterIndex}-label`}
+                  >
                     Operator
                   </InputLabel>
                   <Select
                     variant="standard"
                     fullWidth
                     disabled={
-                      filterParameters[filterId].availableOperators.length === 0
+                      filterParameters[filterIndex].availableOperators
+                        .length === 0
                     }
-                    labelId={`filter-operator-select-${filterId}-label`}
-                    id={`filter-operator-select-${filterId}`}
+                    labelId={`filter-operator-select-${filterIndex}-label`}
+                    id={`filter-operator-select-${filterIndex}`}
                     value={
-                      filterParameters[filterId].operator
-                        ? filterParameters[filterId].operator
+                      filterParameters[filterIndex].operator
+                        ? filterParameters[filterIndex].operator
                         : ""
                     }
                     onChange={(e) =>
-                      handleFilterOperatorClick(filterId, e.target.value)
+                      handleFilterOperatorClick(filterIndex, e.target.value)
                     }
                     label="field"
                     data-testid="operator-select"
                   >
-                    {filterParameters[filterId].availableOperators.map(
+                    {filterParameters[filterIndex].availableOperators.map(
                       (operator, operatorIndex) => {
                         return (
                           <MenuItem
                             value={operator.id}
-                            key={`filter-operator-select-item-${filterId}-${operatorIndex}`}
-                            id={`filter-operator-select-item-${filterId}-${operatorIndex}`}
+                            key={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
+                            id={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
                             data-testid={operator.label}
                           >
                             {operator.label}
@@ -692,29 +694,31 @@ const Filters = ({
                   variant="outlined"
                   className={classes.formControl}
                 >
-                  {isFilterNullType(filterParameters[filterId]) !== true &&
-                    (renderAutocompleteInput(filterParameters[filterId]) ? (
+                  {isFilterNullType(filterParameters[filterIndex]) !== true &&
+                    (renderAutocompleteInput(filterParameters[filterIndex]) ? (
                       <Autocomplete
-                        value={filterParameters[filterId].value || null}
-                        options={data[filterParameters[filterId].lookup_table]}
-                        disabled={!filterParameters[filterId].operator}
+                        value={filterParameters[filterIndex].value || null}
+                        options={
+                          data[filterParameters[filterIndex].lookup_table]
+                        }
+                        disabled={!filterParameters[filterIndex].operator}
                         getOptionLabel={(option) =>
                           Object.hasOwn(
                             option,
-                            filterParameters[filterId].lookup_field
+                            filterParameters[filterIndex].lookup_field
                           )
-                            ? option[filterParameters[filterId].lookup_field]
+                            ? option[filterParameters[filterIndex].lookup_field]
                             : option
                         }
                         onChange={(e, value) => {
                           if (value) {
                             handleSearchValueChange(
-                              filterId,
-                              value[filterParameters[filterId]?.lookup_field]
+                              filterIndex,
+                              value[filterParameters[filterIndex]?.lookup_field]
                             );
                           } else {
                             // value is null when the Autocomplete selection is cleared
-                            handleSearchValueChange(filterId, value);
+                            handleSearchValueChange(filterIndex, value);
                           }
                         }}
                         isOptionEqualToValue={(option, value) => {
@@ -722,8 +726,9 @@ const Filters = ({
                             return option.name === value.name;
                           }
                           return (
-                            option[filterParameters[filterId].lookup_field] ===
-                            value
+                            option[
+                              filterParameters[filterIndex].lookup_field
+                            ] === value
                           );
                         }}
                         renderInput={(params) => (
@@ -736,19 +741,19 @@ const Filters = ({
                       />
                     ) : (
                       <TextField
-                        key={`filter-search-value-${filterId}`}
-                        id={`filter-search-value-${filterId}`}
-                        disabled={!filterParameters[filterId].operator}
+                        key={`filter-search-value-${filterIndex}`}
+                        id={`filter-search-value-${filterIndex}`}
+                        disabled={!filterParameters[filterIndex].operator}
                         type={
-                          filterParameters[filterId].type
-                            ? filterParameters[filterId].type
+                          filterParameters[filterIndex].type
+                            ? filterParameters[filterIndex].type
                             : "text"
                         }
                         onChange={(e) =>
-                          handleSearchValueChange(filterId, e.target.value)
+                          handleSearchValueChange(filterIndex, e.target.value)
                         }
                         variant="outlined"
-                        value={filterParameters[filterId].value ?? ""}
+                        value={filterParameters[filterIndex].value ?? ""}
                       />
                     ))}
                 </FormControl>
@@ -758,7 +763,7 @@ const Filters = ({
                   <IconButton
                     disabled={isFirstFilterIncomplete}
                     className={classes.deleteButton}
-                    onClick={() => handleDeleteFilterButtonClick(filterId)}
+                    onClick={() => handleDeleteFilterButtonClick(filterIndex)}
                     size="large"
                   >
                     <Icon className={classes.deleteIcon}>delete_outline</Icon>
@@ -772,7 +777,7 @@ const Filters = ({
                     fullWidth
                     className={classes.deleteButton}
                     variant="outlined"
-                    onClick={() => handleDeleteFilterButtonClick(filterId)}
+                    onClick={() => handleDeleteFilterButtonClick(filterIndex)}
                   >
                     <Icon>delete_outline</Icon>
                   </Button>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -171,8 +171,15 @@ const Filters = ({
 
     // Update the field and operator values or handle when the clear X icon is clicked
     if (fieldDetails) {
+      const defaultOperator = getDefaultOperator(fieldDetails);
+
       filtersNewState[filterIndex].field = fieldDetails.name;
-      filtersNewState[filterIndex].operator = getDefaultOperator(fieldDetails);
+      filtersNewState[filterIndex].operator = defaultOperator;
+
+      // if we switch to an operator that does not need a search value, clear the value
+      if (isFilterNullType(defaultOperator)) {
+        filtersNewState[filterIndex].value = null;
+      }
     } else {
       filtersNewState[filterIndex].field = null;
       filtersNewState[filterIndex].operator = null;

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -97,7 +97,6 @@ const useStyles = makeStyles((theme) => ({
 
 /**
  * Generates a copy of an empty field
- * @param uuid
  * @return {Object}
  */
 const generateEmptyField = () => {
@@ -106,25 +105,14 @@ const generateEmptyField = () => {
    * @type {Object}
    * @property {string} field - The name of the column
    * @property {operator} operator - The name of the operator
-   * @property {string[]} availableOperators - A string array containing the names of available operators
-   * @property {string} gqlOperator - A string containing the GraphQL operator
-   * @property {string} envelope - The a pattern to use as an envelope
    * @property {string} value - The text value to be searched
-   * @property {string} type - The type of field it is (string, number, etc.)
    * @constant
    * @default
    */
   const defaultNewFieldState = {
     field: null,
     operator: null,
-    availableOperators: [],
-    gqlOperator: null,
-    envelope: null,
-    placeholder: null,
     value: null,
-    type: null,
-    specialNullValue: null,
-    label: null,
   };
   return { ...defaultNewFieldState };
 };

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -618,15 +618,15 @@ const Filters = ({
       {filterParameters.map((filter, filterIndex) => {
         const isValidInput = checkIsValidInput(filterParameters[filterIndex]);
         // TODO: Get info needed for form components from these three variables
-        // const { field, operator, value } = filter[filterIndex];
+        const { field, operator, value } = filter;
         // const label =
         // const availableOperators =
         // const operator =
         // const lookupTable =
         // const lookupField =
         // const type =
-
-        // TODO:
+        // support check with isFilterNullType()
+        // support check with renderAutocompleteInput()
         return (
           <Grow in={true} key={`filter-grow-${filterIndex}`}>
             <Grid
@@ -728,7 +728,7 @@ const Filters = ({
                   {isFilterNullType(filterParameters[filterIndex]) !== true &&
                     (renderAutocompleteInput(filterParameters[filterIndex]) ? (
                       <Autocomplete
-                        value={filterParameters[filterIndex].value || null}
+                        value={value || null}
                         options={
                           data[filterParameters[filterIndex].lookup_table]
                         }
@@ -786,7 +786,7 @@ const Filters = ({
                           handleSearchValueChange(filterIndex, e.target.value)
                         }
                         variant="outlined"
-                        value={filterParameters[filterIndex].value ?? ""}
+                        value={value ?? ""}
                       />
                     ))}
                 </FormControl>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -368,7 +368,7 @@ const Filters = ({
     // If the filter exists
     if (filterIndex in filterParameters) {
       // Clone state
-      const filtersNewState = { ...filterParameters };
+      const filtersNewState = [...filterParameters];
 
       if (operator in filtersConfig.operators) {
         // Update Operator Value
@@ -696,11 +696,7 @@ const Filters = ({
                     }
                     labelId={`filter-operator-select-${filterIndex}-label`}
                     id={`filter-operator-select-${filterIndex}`}
-                    value={
-                      filterParameters[filterIndex].operator
-                        ? filterParameters[filterIndex].operator
-                        : ""
-                    }
+                    value={operator || ""}
                     onChange={(e) =>
                       handleFilterOperatorClick(filterIndex, e.target.value)
                     }

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -271,14 +271,12 @@ const Filters = ({
    * @param {string} filterIndex - The index of the filter to be deleted
    */
   const handleDeleteFilterButtonClick = (filterIndex) => {
-    // Copy the state into a new object
-    const filtersNewState = {
-      ...filterParameters,
-    };
+    // Clone the state
+    const filtersNewState = [...filterParameters];
     // Try to delete the filter by filter index
     try {
       // Delete the key (if it's there)
-      delete filtersNewState[filterIndex];
+      filtersNewState.splice(filterIndex, 1);
     } finally {
       // Finally, reset the state
       const searchParamsFromFilters =

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -141,8 +141,7 @@ const generateEmptyField = (uuid) => {
 const makeInitialFilterParameters = (filters, filtersConfig) => {
   if (filters.length === 0) return [];
 
-  return filters.reduce((acc, filter) => {
-    const filterUUID = uuidv4();
+  return filters.map((filter) => {
     const { field, operator, value } = filter;
     const filterConfigForField = filtersConfig.fields.find(
       (fieldConfig) => fieldConfig.name === field
@@ -165,8 +164,7 @@ const makeInitialFilterParameters = (filters, filtersConfig) => {
           id: operator,
         }));
 
-    const filterParameters = {
-      id: filterUUID,
+    return {
       field,
       operator,
       availableOperators: availableOperators,
@@ -178,9 +176,7 @@ const makeInitialFilterParameters = (filters, filtersConfig) => {
       lookup_field: filterConfigForField.lookup?.field_name,
       lookup_table: filterConfigForField.lookup?.table_name,
     };
-
-    return { ...acc, [filterUUID]: filterParameters };
-  }, {});
+  });
 };
 
 /**
@@ -232,6 +228,7 @@ const Filters = ({
       };
     }
   }, [filters, filtersConfig]);
+  console.log(initialFilterParameters);
 
   const [filterParameters, setFilterParameters] = useState(
     initialFilterParameters

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -623,11 +623,10 @@ const Filters = ({
           (field) => field.name === fieldName
         );
 
-        const { label } = fieldConfig ?? {};
+        const { label, type } = fieldConfig ?? {};
         // const availableOperators =
         const { table_name: lookupTable, field_name: lookupField } =
-          fieldConfig.lookup ?? {};
-        // const type =
+          fieldConfig?.lookup ?? {};
 
         // support check with isFilterNullType()
         // support check with renderAutocompleteInput()
@@ -768,11 +767,7 @@ const Filters = ({
                         key={`filter-search-value-${filterIndex}`}
                         id={`filter-search-value-${filterIndex}`}
                         disabled={!filterParameters[filterIndex].operator}
-                        type={
-                          filterParameters[filterIndex].type === "date"
-                            ? filterParameters[filterIndex].type
-                            : null
-                        }
+                        type={type === "date" ? type : null}
                         onChange={(e) =>
                           handleSearchValueChange(filterIndex, e.target.value)
                         }

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -276,83 +276,20 @@ const Filters = ({
    * @param {Object} field - The field object being clicked
    */
   const handleFilterFieldMenuClick = (filterIndex, field) => {
-    // TODO: Update to push update or empty filter into filterParameters array
-    console.log(filterIndex);
-    // If the filter exists
-    if (filterIndex in filterParameters) {
-      // Clone state
-      const filtersNewState = [...filterParameters];
+    // Clone state
+    const filtersNewState = [...filterParameters];
 
-      // Find the field we need to gather options from
-      const fieldDetails = filtersConfig.fields.find(
-        (filter) => filter.name === field
-      );
+    // Find the field we need to gather options from
+    const fieldDetails = filtersConfig.fields.find(
+      (filter) => filter.name === field
+    );
 
-      if (!fieldDetails) {
-        filtersNewState[filterIndex] = generateEmptyField(filterIndex);
-      } else {
-        // Update field & type
-        filtersNewState[filterIndex].field = fieldDetails.name;
-        filtersNewState[filterIndex].type = fieldDetails.type;
-        filtersNewState[filterIndex].placeholder = fieldDetails.placeholder;
-        filtersNewState[filterIndex].label = fieldDetails.label;
+    // Update field and operator
+    filtersNewState[filterIndex].field = fieldDetails.name;
+    filtersNewState[filterIndex].operator = getDefaultOperator(fieldDetails);
 
-        // Update Available Operators
-        if (
-          fieldDetails.operators.length === 1 &&
-          fieldDetails.operators[0] === "*"
-        ) {
-          // Add all operators and filter by specific type (defined in fieldDetails.type)
-          filtersNewState[filterIndex].availableOperators = Object.keys(
-            filtersConfig.operators
-          )
-            .filter(
-              (operator) =>
-                filtersConfig.operators[operator].type === fieldDetails.type
-            )
-            .map((operator) => {
-              return {
-                ...filtersConfig.operators[operator],
-                ...{ id: operator },
-              };
-            });
-        } else {
-          // Append listed operators for that field
-          filtersNewState[filterIndex].availableOperators =
-            fieldDetails.operators.map((operator) => {
-              return {
-                ...filtersConfig.operators[operator],
-                ...{ id: operator },
-              };
-            });
-        }
-
-        // if the field has a corresponding lookup table, add to filterState
-        if (fieldDetails.lookup) {
-          filtersNewState[filterIndex].lookup_table =
-            fieldDetails.lookup.table_name;
-          filtersNewState[filterIndex].lookup_field =
-            fieldDetails.lookup.field_name;
-        }
-        // if it does not, reset the variables to null in case the user is editing an existing filter
-        else {
-          filtersNewState[filterIndex].lookup_table = null;
-          filtersNewState[filterIndex].lookup_field = null;
-        }
-      }
-
-      // Select the default operator, if not defined select first.
-      if (fieldDetails) {
-        const defaultOperator = getDefaultOperator(fieldDetails);
-        handleFilterOperatorClick(filterIndex, defaultOperator);
-      }
-      // Update the state
-      setFilterParameters(filtersNewState);
-    } else {
-      console.debug(
-        `The filter id ${filterIndex} does not exist, ignoring click event.`
-      );
-    }
+    // Update the state
+    setFilterParameters(filtersNewState);
   };
 
   /**

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -120,7 +120,6 @@ const Search = ({
   const toggleAdvancedSearch = () => {
     if (advancedSearchAnchor) {
       setAdvancedSearchAnchor(null);
-      handleSwitchToSearch();
     } else {
       setAdvancedSearchAnchor(divRef.current);
       handleSwitchToAdvancedSearch();

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -50,6 +50,10 @@ export const isFilterNullType = (operator) => {
 
 /**
  * Returns true if Field has a lookup table associated with it and operator is case sensitive
+ * @param {string} lookupTable -  the lookup table name
+ * @param {string} operator - The operator name
+ * @param {boolean} loading - Whether the lookup table is still loading
+ * @returns {boolean}
  */
 export const shouldRenderAutocompleteInput = (
   lookupTable,

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -1,5 +1,4 @@
 import { OPERATORS_WITHOUT_SEARCH_VALUES } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
-import { FiltersCommonOperators } from "./FiltersCommonOperators";
 import { AUTOCOMPLETE_OPERATORS } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
 
 /**

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -1,0 +1,143 @@
+import { OPERATORS_WITHOUT_SEARCH_VALUES } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
+import { FiltersCommonOperators } from "./FiltersCommonOperators";
+import { AUTOCOMPLETE_OPERATORS } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
+
+/**
+ * Generates a copy of an empty filter
+ * @return {Object}
+ */
+export const generateEmptyFilter = () => {
+  /**
+   * The default structure of an empty filter
+   * @type {Object}
+   * @property {string} field - The name of the column
+   * @property {operator} operator - The name of the operator
+   * @property {string} value - The text value to be searched
+   * @constant
+   * @default
+   */
+  const defaultNewFilterState = {
+    field: null,
+    operator: null,
+    value: null,
+  };
+  return { ...defaultNewFilterState };
+};
+
+/**
+ * Returns whether the user input value for the filterParameter is valid
+ * @param {object} filterParameter
+ * @returns {boolean}
+ */
+export const checkIsValidInput = (filterParameter, type) => {
+  // If we are testing a number type field with a non null value
+  if (type === "number" && !!filterParameter.value) {
+    // Return whether string only contains digits
+    return !/[^0-9]/.test(filterParameter.value);
+  }
+  return true; // Otherwise the input is valid
+};
+
+/**
+ * Returns true if the GraphQL operator is null type and has no value to search (is blank, is not blank)
+ * @param {String} operator - operator to check
+ * @returns {boolean}
+ */
+export const isFilterNullType = (operator) => {
+  return operator && OPERATORS_WITHOUT_SEARCH_VALUES.includes(operator);
+};
+
+/**
+ * Returns true if Field has a lookup table associated with it and operator is case sensitive
+ */
+export const shouldRenderAutocompleteInput = (
+  lookupTable,
+  operator,
+  loading
+) => {
+  return lookupTable && !loading && AUTOCOMPLETE_OPERATORS.includes(operator);
+};
+
+/**
+ * Check if a filter has complete values
+ * @param {Object} filter - contains value, field, and operator
+ * @returns {boolean}
+ */
+export const isFilterComplete = (filter) => {
+  return (
+    !!filter.field &&
+    !!filter.operator &&
+    (!!filter.value || isFilterNullType(filter.operator))
+  );
+};
+
+/**
+ * Check if all filters added have complete values
+ * @param {Array} filterParameters - filter values, fields, and operators
+ * @returns {boolean}
+ */
+export const areAllFiltersComplete = (filterParameters) => {
+  return filterParameters.every((filter) => isFilterComplete(filter));
+};
+
+/**
+ * Returns an array of strings containing messages about the filters.
+ * Returns null if no problems were found.
+ * @return {[]|null}
+ */
+export const handleApplyValidation = (filterParameters, filtersConfig) => {
+  let feedback = [];
+
+  if (filterParameters) {
+    if (filterParameters.length === 0) {
+      feedback.push("• No filters have been added.");
+    } else {
+      filterParameters.forEach((filter) => {
+        const { field: fieldName, value, operator } = filter;
+        const fieldConfig = filtersConfig.fields.find(
+          (field) => field.name === fieldName
+        );
+        const type = fieldConfig?.type;
+
+        if (fieldName === null) {
+          feedback.push("• One or more fields have not been selected.");
+        }
+
+        if (operator === null) {
+          feedback.push("• One or more operators have not been selected.");
+        }
+
+        if (value === null || value.trim() === "") {
+          if (operator && !isFilterNullType(operator)) {
+            feedback.push("• One or more missing values.");
+          }
+        }
+        if (!checkIsValidInput(filter, type)) {
+          feedback.push("• One or more invalid inputs.");
+        }
+      });
+    }
+  }
+  return feedback.length > 0 ? feedback : null;
+};
+
+export const getAvailableOperators = (operators, fieldConfig, type) => {
+  const shouldUseAllOperators =
+    operators && operators.length === 1 && fieldConfig.operators[0] === "*";
+
+  if (shouldUseAllOperators) {
+    return Object.entries(FiltersCommonOperators)
+      .map(([filtersCommonOperator, filterCommonOperatorConfig]) => ({
+        ...filterCommonOperatorConfig,
+        id: filtersCommonOperator,
+      }))
+      .filter((operator) => operator.type === type);
+  } else if (operators) {
+    return fieldConfig?.operators.map((operator) => ({
+      ...FiltersCommonOperators[operator],
+      id: operator,
+    }));
+  } else {
+    return [];
+  }
+};

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -151,3 +151,17 @@ export const getAvailableOperators = (operators, fieldConfig) => {
     return [];
   }
 };
+
+/**
+ * Return the default operator for a given field or a fallback operator if one is not defined in config
+ * @param {Object} filterConfigForField - Config for column in PROJECT_LIST_VIEW_FILTERS_CONFIG
+ * @return String
+ */
+export const getDefaultOperator = (filterConfigForField) => {
+  const { defaultOperator, operators } = filterConfigForField;
+  const fallbackOperator = operators[0];
+
+  const isDefaultOperator = Boolean(defaultOperator);
+
+  return isDefaultOperator ? defaultOperator : fallbackOperator;
+};

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -26,7 +26,8 @@ export const generateEmptyFilter = () => {
 
 /**
  * Returns whether the user input value for the filterParameter is valid
- * @param {object} filterParameter
+ * @param {object} filterParameter - filter value, field, and operator
+ * @param {string} type - type of field
  * @returns {boolean}
  */
 export const checkIsValidInput = (filterParameter, type) => {
@@ -83,6 +84,8 @@ export const areAllFiltersComplete = (filterParameters) => {
 /**
  * Returns an array of strings containing messages about the filters.
  * Returns null if no problems were found.
+ * @param {Array} filterParameters - filter values, fields, and operators
+ * @param {Object} filtersConfig - configuration for all filters to get field type
  * @return {[]|null}
  */
 export const handleApplyValidation = (filterParameters, filtersConfig) => {
@@ -121,7 +124,14 @@ export const handleApplyValidation = (filterParameters, filtersConfig) => {
   return feedback.length > 0 ? feedback : null;
 };
 
-export const getAvailableOperators = (operators, fieldConfig, type) => {
+/**
+ * Returns operators to display in the operator dropdown for the field chosen
+ * @param {Array} operators - filter values, fields, and operators
+ * @param {Object} fieldConfig - configuration for the field
+ * @return {[]|null}
+ */
+export const getAvailableOperators = (operators, fieldConfig) => {
+  const type = fieldConfig?.type;
   const shouldUseAllOperators =
     operators && operators.length === 1 && fieldConfig.operators[0] === "*";
 

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -129,34 +129,6 @@ export const handleApplyValidation = (filterParameters, filtersConfig) => {
 };
 
 /**
- * Returns operators to display in the operator dropdown for the field chosen
- * @param {Array} operators - filter values, fields, and operators
- * @param {Object} fieldConfig - configuration for the field
- * @return {[]|null}
- */
-export const getAvailableOperators = (operators, fieldConfig) => {
-  const type = fieldConfig?.type;
-  const shouldUseAllOperators =
-    operators && operators.length === 1 && fieldConfig.operators[0] === "*";
-
-  if (shouldUseAllOperators) {
-    return Object.entries(FiltersCommonOperators)
-      .map(([filtersCommonOperator, filterCommonOperatorConfig]) => ({
-        ...filterCommonOperatorConfig,
-        id: filtersCommonOperator,
-      }))
-      .filter((operator) => operator.type === type);
-  } else if (operators) {
-    return fieldConfig?.operators.map((operator) => ({
-      ...FiltersCommonOperators[operator],
-      id: operator,
-    }));
-  } else {
-    return [];
-  }
-};
-
-/**
  * Return the default operator for a given field or a fallback operator if one is not defined in config
  * @param {Object} filterConfigForField - Config for column in PROJECT_LIST_VIEW_FILTERS_CONFIG
  * @return String

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -22,6 +22,8 @@ export const OPERATORS_WITHOUT_SEARCH_VALUES = [
   "string_is_not_null",
   "string_is_not_null_special_case",
   "string_is_null_special_case",
+  "subprojects_array_is_null",
+  "subprojects_array_is_not_null",
 ];
 
 /**

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -71,7 +71,11 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       type: "number",
       defaultOperator: "number_equals",
       operators: [
-        "*", // All of them (shortcut)
+        "number_equals",
+        "number_greater_than",
+        "number_greater_than_equal_to",
+        "number_less_than",
+        "number_less_than_equal_to",
       ],
     },
     {
@@ -385,7 +389,11 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       type: "number",
       defaultOperator: "number_equals",
       operators: [
-        "*", // All of them (shortcut)
+        "number_equals",
+        "number_greater_than",
+        "number_greater_than_equal_to",
+        "number_less_than",
+        "number_less_than_equal_to",
       ],
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -24,6 +24,8 @@ export const OPERATORS_WITHOUT_SEARCH_VALUES = [
   "string_is_null_special_case",
   "subprojects_array_is_null",
   "subprojects_array_is_not_null",
+  "string_is_blank",
+  "string_is_not_blank",
 ];
 
 /**

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -43,14 +43,6 @@ export const getDefaultOperator = (filterConfigForField) => {
   return isDefaultOperator ? defaultOperator : fallbackOperator;
 };
 
-export const makeSearchParamsFromFilterParameters = (filterParameters) => {
-  return Object.values(filterParameters).map((filterParameter) => ({
-    field: filterParameter.field,
-    operator: filterParameter.operator,
-    value: filterParameter.value,
-  }));
-};
-
 /**
  * Build an array of filter strings to be used in generating the advanced search where string
  * @param {Object} filters - Stores filters assigned random id and nests column, operator, and value

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -30,20 +30,6 @@ const useMakeFilterState = (searchParams) =>
   }, [searchParams]);
 
 /**
- * Return the default operator for a given field or a fallback operator if one is not defined in config
- * @param {Object} filterConfigForField - Config for column in PROJECT_LIST_VIEW_FILTERS_CONFIG
- * @return String
- */
-export const getDefaultOperator = (filterConfigForField) => {
-  const { defaultOperator, operators } = filterConfigForField;
-  const fallbackOperator = operators[0];
-
-  const isDefaultOperator = Boolean(defaultOperator);
-
-  return isDefaultOperator ? defaultOperator : fallbackOperator;
-};
-
-/**
  * Build an array of filter strings to be used in generating the advanced search where string
  * @param {Object} filters - Stores filters assigned random id and nests column, operator, and value
  * @return Object


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15049
https://github.com/cityofaustin/atd-data-tech/issues/15074

This PR:
- updates the `filterParameters` state to have the same shape and key-value pairs (field, operator, and value) as the `filters` state that powers the query
- moves a lot of functions defined within the `Filters` component into a helpers file
- removes code that used to access configuration about a field and then store it in state so that it now accessing that configuration as needed

If you want to visualize the biggest change, run locally and log `filterParameters` in the `Filters` component as you add advanced filters. Compare what that looks like with this branch versus `main` branch.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1236--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Go to the project list view and add advanced filters
2. Test a filter with lookup tables like **Type**
3. Test editing applied filters options (choose new field option, choose new operator option, or update search value)
4. Test deleting filters with the trash can icon. A new search should not happen until you click the Search button.
5. Test clearing the first **Field** input after selecting a value by using the X icon that appears to the left of the dropdown icon. Both the **Field** and **Operator** values should clear from the UI.
6. Test resetting the filters by clicking the reset button
7. Test making edits to the url string to make sure the app doesn't break when it can't parse the URL params
8. Test filtering, clicking on a project name link in the list view, and then clicking the "< ALL PROJECTS" link to go back to the list view. Your filters should still be present.
9. Add a filter that expects a number value like **ID is** and try entering letters. You should see that the recently-added validation still works.
10. Check that the trash can delete icons and match any/all radios do not appear until more than one filter is added.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
