### PR TITLE
Persist search term in project list URL parameters

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -29,6 +29,7 @@ import {
   advancedSearchFilterParamName,
   advancedSearchIsOrParamName,
 } from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
+import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 import {
   areAllFiltersComplete,
   checkIsValidInput,
@@ -285,6 +286,7 @@ const Filters = ({
 
       prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
       prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
+      prevSearchParams.delete(simpleSearchParamName);
       return prevSearchParams;
     });
 

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -97,11 +97,7 @@ const Search = ({
   const handleSwitchToSearch = () => {
     setFilters([]);
     setIsOr(false);
-    // setSearchParams((prevSearchParams) => {
-    //   prevSearchParams.delete(advancedSearchFilterParamName);
-    //   prevSearchParams.delete(advancedSearchIsOrParamName);
-    //   return prevSearchParams;
-    // });
+    toggleAdvancedSearch();
   };
 
   /**

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -7,10 +7,6 @@ import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
-import {
-  advancedSearchFilterParamName,
-  advancedSearchIsOrParamName,
-} from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -101,22 +97,20 @@ const Search = ({
    * Clears the filters when switching to simple search
    */
   const handleSwitchToSearch = () => {
-    setFilters({});
+    setFilters([]);
     setIsOr(false);
-    setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete(advancedSearchFilterParamName);
-      prevSearchParams.delete(advancedSearchIsOrParamName);
-      return prevSearchParams;
-    });
+    // setSearchParams((prevSearchParams) => {
+    //   prevSearchParams.delete(advancedSearchFilterParamName);
+    //   prevSearchParams.delete(advancedSearchIsOrParamName);
+    //   return prevSearchParams;
+    // });
   };
 
   /**
-   * Clears the simple search when switching to filters
+   * Clears the simple search and its search param when switching to filters
    */
   const handleSwitchToAdvancedSearch = () => {
     setSearchTerm("");
-
-    // TODO: Remove simple search params here
   };
 
   const toggleAdvancedSearch = () => {

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -97,11 +97,11 @@ const Search = ({
   const handleSwitchToSearch = () => {
     setFilters([]);
     setIsOr(false);
-    toggleAdvancedSearch();
+    setAdvancedSearchAnchor(null);
   };
 
   /**
-   * Clears the simple search and its search param when switching to filters
+   * Clears the simple search when switching to advanced filters
    */
   const handleSwitchToAdvancedSearch = () => {
     setSearchTerm("");

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -115,6 +115,8 @@ const Search = ({
    */
   const handleSwitchToAdvancedSearch = () => {
     setSearchTerm("");
+
+    // TODO: Remove simple search params here
   };
 
   const toggleAdvancedSearch = () => {

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { useSearchParams } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
@@ -83,7 +82,6 @@ const Search = ({
   loading,
 }) => {
   const classes = useStyles();
-  let [, setSearchParams] = useSearchParams();
   const divRef = React.useRef();
 
   /**

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -17,6 +17,10 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import { Search as SearchIcon } from "react-feather";
 import clsx from "clsx";
+import {
+  advancedSearchFilterParamName,
+  advancedSearchIsOrParamName,
+} from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
 import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 /**
@@ -149,6 +153,8 @@ const SearchBar = ({
     // Update state to trigger search and set simple search param
     setSearchTerm(searchFieldValue);
     setSearchParams((prevSearchParams) => {
+      prevSearchParams.delete(advancedSearchFilterParamName);
+      prevSearchParams.delete(advancedSearchIsOrParamName);
       prevSearchParams.set(simpleSearchParamName, searchFieldValue);
       return prevSearchParams;
     });

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -127,7 +127,6 @@ const SearchBar = ({
   };
 
   const handleSearchValueChange = (value) => {
-    console.log(value, value === "" && searchFieldValue !== "");
     if (value === "" && searchFieldValue !== "") {
       handleClearSearchResults();
     } else {

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { useSearchParams } from "react-router-dom";
 
 import {
   Button,
@@ -16,6 +17,7 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import { Search as SearchIcon } from "react-feather";
 import clsx from "clsx";
+import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 /**
  * The styling for the search bar components
@@ -106,6 +108,7 @@ const SearchBar = ({
   filtersConfig,
 }) => {
   const classes = useStyles();
+  let [, setSearchParams] = useSearchParams();
 
   /**
    * Attempts to retrieve the default placeholder for the search input field
@@ -143,9 +146,12 @@ const SearchBar = ({
     // Clear the advanced search filters
     handleSwitchToSearch();
 
-    // Update state if we are ready, triggers search.
+    // Update state to trigger search and set simple search param
     setSearchTerm(searchFieldValue);
-    // TODO: Set search params here
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.set(simpleSearchParamName, searchFieldValue);
+      return prevSearchParams;
+    });
   };
 
   /**

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -145,6 +145,7 @@ const SearchBar = ({
 
     // Update state if we are ready, triggers search.
     setSearchTerm(searchFieldValue);
+    // TODO: Set search params here
   };
 
   /**

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -166,6 +166,10 @@ const SearchBar = ({
   const handleClearSearchResults = () => {
     setSearchTerm("");
     setSearchFieldValue("");
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.delete(simpleSearchParamName, searchFieldValue);
+      return prevSearchParams;
+    });
   };
 
   /**

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -127,6 +127,7 @@ const SearchBar = ({
   };
 
   const handleSearchValueChange = (value) => {
+    console.log(value, value === "" && searchFieldValue !== "");
     if (value === "" && searchFieldValue !== "") {
       handleClearSearchResults();
     } else {
@@ -167,7 +168,7 @@ const SearchBar = ({
     setSearchTerm("");
     setSearchFieldValue("");
     setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete(simpleSearchParamName, searchFieldValue);
+      prevSearchParams.delete(simpleSearchParamName);
       return prevSearchParams;
     });
   };

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -341,7 +341,7 @@ const NavigationSearchInput = ({ input404Class }) => {
               <Box className={classes.searchResults}>
                 {called && !loading && (
                   <NavigationSearchResults
-                    results={data.project_list_view}
+                    results={data?.project_list_view || []}
                     handleDropdownClose={handleDropdownClose}
                     searchTerm={searchTerm}
                   />

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchResults.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchResults.js
@@ -61,7 +61,7 @@ const NavigationSearchResults = ({
           <ListItemLink
             to={`/moped/projects?search=${searchTerm}`}
             onClick={handleDropdownClose}
-            relative="path"
+            reloadDocument
           >
             <ListItemText primary="More results" />
             <ArrowForwardIosIcon className={classes.listItemSecondaryAction} />

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchResults.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchResults.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Divider, List, ListItem, ListItemText } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import { Link as RouterLink } from "react-router-dom";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 
@@ -55,13 +55,13 @@ const NavigationSearchResults = ({
         </ListItemLink>
       ))}
       {results.length > 5 && (
+        // Link to project list view with simple search populated
         <>
           <Divider />
           <ListItemLink
-            to={`/moped/projects/`}
-            // send searchTerm in location state
-            state={{ searchTerm: searchTerm }}
+            to={`/moped/projects?search=${searchTerm}`}
             onClick={handleDropdownClose}
+            relative="path"
           >
             <ListItemText primary="More results" />
             <ArrowForwardIosIcon className={classes.listItemSecondaryAction} />

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -1,6 +1,9 @@
 import { useState, useMemo } from "react";
 import { useLocation } from "react-router-dom";
 
+/* Name of simple search URL parameter */
+export const simpleSearchParamName = "search";
+
 /**
  * Attempts to retrieve a valid graphql search value, for example when searching on an
  * integer/float field but providing it a string, this function returns the value configured

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 /* Name of simple search URL parameter */
 export const simpleSearchParamName = "search";
@@ -31,10 +31,11 @@ export const getSearchValue = (column, value, queryConfig) => {
 };
 
 export const useSearch = ({ queryConfig }) => {
-  // create URLSearchParams from url
-  const navigationSearchTerm = useLocation()?.state?.searchTerm;
+  /* Get simple search from search params if it exists */
+  let [searchParams] = useSearchParams();
+  const simpleSearchValue = searchParams.get(simpleSearchParamName);
 
-  const [searchTerm, setSearchTerm] = useState(navigationSearchTerm ?? "");
+  const [searchTerm, setSearchTerm] = useState(simpleSearchValue ?? "");
 
   const searchWhereString = useMemo(() => {
     if (searchTerm && searchTerm !== "") {


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15206

This PR adds a `search` param that is set by the project list view search box. It maintains the current way that we use either the search box or the advanced filter individually and never combine the two when filtering the project list results.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. In the search box at the top of the project list view, enter a search term like **lamar** and press enter. You should see matching results in the view.
2. Check the url and you should see the search parameter like `https://localhost:3000/moped/projects?search=lamar`
3. Open the advanced filters by clicking the filter button in the search box
4. Add a filter like **Name contains kramer** and click "Search". The search box should clear, the url should no longer have a param called `search`, and it should be replaced with the `filters` and `isOr` params for the advanced search
5. Type another term in the search box like **braker** and press enter. You should see the `filters` and `isOr` params removed from the url and the `search` param added. The list view should show matches for your search term.
6. Click into the search box while it is populated and clear it by backspacing until it is blank. When it is blank, you should see the `search` param removed from the url and have all of the projects listed again.
7. Click the global search magnifying glass icon next to the **New Project** button
8. Enter a search term like **mueller** and then click the **More results** link at the end of the list. You should be redirected to the project list view with the search box populated and the `search` param in the url populated with **mueller**. The project list view should show matching results.
9. Click the **Name** link of a row in the results and navigate to the project details. In the top left corner of the project details, click the **< ALL PROJECTS** link, and you should navigate back to the project list view with the previous search term in the search box and `search` param in the url.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
