### PR TITLE
Help menu icons are not hyperlinked

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -141,18 +141,18 @@ const DropdownMenu = ({
           Account
         </MenuItem>
         <Divider />
-        <MenuItem onClick={handleDropdownClose}>
-          <ListItemIcon>{arcGISLink.Icon}</ListItemIcon>
-          <Link
-            href={arcGISLink.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            color="inherit"
-            underline="none"
-          >
+        <Link
+          href={arcGISLink.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="inherit"
+          underline="none"
+        >
+          <MenuItem onClick={handleDropdownClose}>
+            <ListItemIcon>{arcGISLink.Icon}</ListItemIcon>
             {arcGISLink.title}
-          </Link>
-        </MenuItem>
+          </MenuItem>
+        </Link>
         <Divider />
         <span className={classes.helpHeader}>
           <Typography variant="button" color="textSecondary">
@@ -162,20 +162,20 @@ const DropdownMenu = ({
         {helpItems.map((item) => {
           if (item.linkType === "external") {
             return (
-              <MenuItem key={item.link} onClick={handleDropdownClose}>
-                <ListItemIcon>
-                  {item.Icon || <OpenInNewIcon fontSize="small" />}
-                </ListItemIcon>
-                <Link
-                  href={item.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  color="inherit"
-                  underline="none"
-                >
+              <Link
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+                underline="none"
+              >
+                <MenuItem key={item.link} onClick={handleDropdownClose}>
+                  <ListItemIcon>
+                    {item.Icon || <OpenInNewIcon fontSize="small" />}
+                  </ListItemIcon>
                   {item.title}
-                </Link>
-              </MenuItem>
+                </MenuItem>
+              </Link>
             );
           }
           if (item.linkType === "internal") {

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/DropdownMenu.js
@@ -163,13 +163,14 @@ const DropdownMenu = ({
           if (item.linkType === "external") {
             return (
               <Link
+                key={item.link}
                 href={item.link}
                 target="_blank"
                 rel="noopener noreferrer"
                 color="inherit"
                 underline="none"
               >
-                <MenuItem key={item.link} onClick={handleDropdownClose}>
+                <MenuItem onClick={handleDropdownClose}>
                   <ListItemIcon>
                     {item.Icon || <OpenInNewIcon fontSize="small" />}
                   </ListItemIcon>

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -72,22 +72,22 @@ const MobileDropdownMenu = () => {
           </MenuItem>
         ))}
         {/* ArcGIS Map link */}
-        <MenuItem
-          key={arcGISLink.link}
-          onClick={() => {
-            handleMobileClose();
-          }}
+        <Link
+          href={arcGISLink.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="inherit"
+          underline="none"
         >
-          <Link
-            href={arcGISLink.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            color="inherit"
-            underline="none"
+          <MenuItem
+            key={arcGISLink.link}
+            onClick={() => {
+              handleMobileClose();
+            }}
           >
             {arcGISLink.title}
-          </Link>
-        </MenuItem>
+          </MenuItem>
+        </Link>
         <MenuItem key="help" onClick={setShowSubMenu}>
           Help
           {subMenu ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -97,17 +97,17 @@ const MobileDropdownMenu = () => {
             {helpItems.map((item) => {
               if (item.linkType === "external") {
                 return (
-                  <MenuItem key={item.link} onClick={handleMobileClose}>
-                    <Link
-                      href={item.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      color="inherit"
-                      underline="none"
-                    >
+                  <Link
+                    href={item.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    color="inherit"
+                    underline="none"
+                  >
+                    <MenuItem key={item.link} onClick={handleMobileClose}>
                       {item.title}
-                    </Link>
-                  </MenuItem>
+                    </MenuItem>
+                  </Link>
                 );
               }
               if (item.linkType === "internal") {

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/MobileDropdownMenu.js
@@ -98,13 +98,14 @@ const MobileDropdownMenu = () => {
               if (item.linkType === "external") {
                 return (
                   <Link
+                    key={item.link}
                     href={item.link}
                     target="_blank"
                     rel="noopener noreferrer"
                     color="inherit"
                     underline="none"
                   >
-                    <MenuItem key={item.link} onClick={handleMobileClose}>
+                    <MenuItem onClick={handleMobileClose}>
                       {item.title}
                     </MenuItem>
                   </Link>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/15036

## Testing
**URL to test:** 
https://deploy-preview-1244--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Click on the help menu navbar, test clicking on the icons of each menu item. Clicking on the icon should redirect you. Also clicking on the very edge of the menu item should redirect you.
2. Now test on mobile. Before this update clicking on the very edge of the menu item wouldn't redirect you, now it should.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
