### PR TITLE
Fixes "last seen" sorting on staff list

### DIFF
--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -90,8 +90,8 @@ const staffColumns = [
   {
     headerName: "Last seen",
     field: "last_seen_date",
-    valueGetter: (props) =>
-      props.value ? new Date(props.value).toLocaleString() : "",
+    type: "date",
+    valueGetter: (props) => (props.value ? new Date(props.value) : null),
     width: 200,
   },
 ];


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/15380

## Testing
**URL to test:** [Netlify](https://deploy-preview-1248--atd-moped-main.netlify.app/)


**Steps to test:**
Go to the **Staff** view and sort the **Last seen** column. Look at it 👀 🧠  

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
