### PR TITLE
Add an activity event to track when when the Dashboard page loads

### DIFF
--- a/moped-database/migrations/1706117943942_add_dashboard_load_event/down.sql
+++ b/moped-database/migrations/1706117943942_add_dashboard_load_event/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
+
+ALTER TABLE moped_user_events
+    ADD CONSTRAINT moped_user_events_event_name_check CHECK (event_name in('app_load'));

--- a/moped-database/migrations/1706117943942_add_dashboard_load_event/down.sql
+++ b/moped-database/migrations/1706117943942_add_dashboard_load_event/down.sql
@@ -1,3 +1,5 @@
+DELETE FROM moped_user_events where event_name = 'dashboard_load';
+
 ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
 
 ALTER TABLE moped_user_events

--- a/moped-database/migrations/1706117943942_add_dashboard_load_event/up.sql
+++ b/moped-database/migrations/1706117943942_add_dashboard_load_event/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
+
+ALTER TABLE moped_user_events
+    ADD CONSTRAINT moped_user_events_event_name_check CHECK (event_name in('app_load', 'dashboard_load'));

--- a/moped-editor/src/App.js
+++ b/moped-editor/src/App.js
@@ -84,7 +84,7 @@ const App = () => {
           <ThemeProvider theme={theme}>
             <ErrorBoundary FallbackComponent={FallbackComponent}>
               <GlobalStyles />
-              <ActivityMetrics>
+              <ActivityMetrics eventName="app_load">
                 <ProjectListViewQueryContext.Provider
                   value={{ listViewQuery, setListViewQuery }}
                 >

--- a/moped-editor/src/components/ActivityMetrics.js
+++ b/moped-editor/src/components/ActivityMetrics.js
@@ -23,6 +23,6 @@ export default function ActivityMetrics({ eventName, children }) {
         error
       );
     });
-  }, [setLastSeen, isLoggedIn]);
+  }, [setLastSeen, isLoggedIn, eventName]);
   return children;
 }

--- a/moped-editor/src/components/ActivityMetrics.js
+++ b/moped-editor/src/components/ActivityMetrics.js
@@ -7,10 +7,10 @@ import { useUser } from "src/auth/user";
  * last_seen_date timestamp based on their session ID. this action happens
  * once each time this component mounts
  */
-export default function ActivityMetrics({ children }) {
+export default function ActivityMetrics({ eventName, children }) {
   const { user } = useUser();
   const [setLastSeen] = useMutation(INSERT_USER_EVENT, {
-    variables: { event_name: "app_load" },
+    variables: { event_name: eventName },
   });
   const isLoggedIn = !!user;
   useEffect(() => {
@@ -19,7 +19,7 @@ export default function ActivityMetrics({ children }) {
     }
     setLastSeen().catch((error) => {
       console.error(
-        "Failed to set the last seen date for the current user.",
+        `Failed to log the '${eventName}' event for the current user.`,
         error
       );
     });

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -18,7 +18,7 @@ import MaterialTable from "@material-table/core";
 import makeStyles from "@mui/styles/makeStyles";
 
 import Page from "src/components/Page";
-
+import ActivityMetrics from "src/components/ActivityMetrics";
 import RenderFieldLink from "../../components/RenderFieldLink";
 import DashboardStatusModal from "./DashboardStatusModal";
 import DashboardTimelineModal from "./DashboardTimelineModal";
@@ -260,77 +260,81 @@ const DashboardView = () => {
   };
 
   return (
-    <Page title={"Dashboard"}>
-      <Container maxWidth="xl">
-        <Card className={classes.cardWrapper}>
-          <Grid className={classes.root}>
-            <Box pl={3} pt={3}>
-              <Grid className={classes.greeting}>
-                <Typography className={classes.greetingText}>
-                  <strong>{`Good ${getTimeOfDay(curHr)}, ${userName}!`}</strong>
-                </Typography>
-                <Typography variant="h1" className={classes.date}>
-                  {dateFormatted}
-                </Typography>
-              </Grid>
-            </Box>
-            <Box px={3} py={3}>
-              <Grid>
-                <AppBar className={classes.appBar} position="static">
-                  <Tabs
-                    classes={{ indicator: classes.indicatorColor }}
-                    value={activeTab}
-                    onChange={handleChange}
-                  >
-                    {TABS.map((tab, i) => {
-                      return (
-                        <Tab
-                          className={classes.selectedTab}
-                          key={tab.label}
-                          label={tab.label}
-                          {...a11yProps(i)}
-                        />
-                      );
-                    })}
-                  </Tabs>
-                </AppBar>
-                {loading ? (
-                  <CircularProgress />
-                ) : (
-                  <MaterialTable
-                    columns={columns}
-                    data={selectedData}
-                    localization={{
-                      body: {
-                        emptyDataSourceMessage: (
-                          <Typography>
-                            {TABS[activeTab].label === "Following" &&
-                              "No projects to display. You have not followed any current projects."}
-                            {TABS[activeTab].label === "My projects" &&
-                              "No projects to display. You are not listed as a Team Member on any current projects."}
-                          </Typography>
-                        ),
-                      },
-                    }}
-                    options={{
-                      search: false,
-                      toolbar: false,
-                      tableLayout: "fixed",
-                      ...(selectedData.length < 51 && {
-                        paging: false,
-                      }),
-                      pageSize: 50,
-                      pageSizeOptions: [10, 50, 100],
-                      idSynonym: "project_id",
-                    }}
-                  />
-                )}
-              </Grid>
-            </Box>
-          </Grid>
-        </Card>
-      </Container>
-    </Page>
+    <ActivityMetrics eventName="dashboard_load">
+      <Page title={"Dashboard"}>
+        <Container maxWidth="xl">
+          <Card className={classes.cardWrapper}>
+            <Grid className={classes.root}>
+              <Box pl={3} pt={3}>
+                <Grid className={classes.greeting}>
+                  <Typography className={classes.greetingText}>
+                    <strong>{`Good ${getTimeOfDay(
+                      curHr
+                    )}, ${userName}!`}</strong>
+                  </Typography>
+                  <Typography variant="h1" className={classes.date}>
+                    {dateFormatted}
+                  </Typography>
+                </Grid>
+              </Box>
+              <Box px={3} py={3}>
+                <Grid>
+                  <AppBar className={classes.appBar} position="static">
+                    <Tabs
+                      classes={{ indicator: classes.indicatorColor }}
+                      value={activeTab}
+                      onChange={handleChange}
+                    >
+                      {TABS.map((tab, i) => {
+                        return (
+                          <Tab
+                            className={classes.selectedTab}
+                            key={tab.label}
+                            label={tab.label}
+                            {...a11yProps(i)}
+                          />
+                        );
+                      })}
+                    </Tabs>
+                  </AppBar>
+                  {loading ? (
+                    <CircularProgress />
+                  ) : (
+                    <MaterialTable
+                      columns={columns}
+                      data={selectedData}
+                      localization={{
+                        body: {
+                          emptyDataSourceMessage: (
+                            <Typography>
+                              {TABS[activeTab].label === "Following" &&
+                                "No projects to display. You have not followed any current projects."}
+                              {TABS[activeTab].label === "My projects" &&
+                                "No projects to display. You are not listed as a Team Member on any current projects."}
+                            </Typography>
+                          ),
+                        },
+                      }}
+                      options={{
+                        search: false,
+                        toolbar: false,
+                        tableLayout: "fixed",
+                        ...(selectedData.length < 51 && {
+                          paging: false,
+                        }),
+                        pageSize: 50,
+                        pageSizeOptions: [10, 50, 100],
+                        idSynonym: "project_id",
+                      }}
+                    />
+                  )}
+                </Grid>
+              </Box>
+            </Grid>
+          </Card>
+        </Container>
+      </Page>
+    </ActivityMetrics>
   );
 };
 


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/15392

## Testing
**URL to test:** Local
You will use your SQL client to inspect activity events as they are logged.

1. Start Moped locally. Log out, so that you're looking at the login screen.
2. Open your SQL client, and delete any records in the `moped_user_events` table:

```sql
DELETE FROM moped_user_events WHERE TRUE;
``` 
3. Login to Moped. There should now be one event in the `moped_user_events` table. The event name should be `app_load`.
4. Navigate to the **Dashboard** page. There should now be a second event in the `moped_user_events` table with the name `dashboard_load`.
5. While still on the **Dashboard** page, refresh the page in your browser. This will create two new events: `app_load` and `dashboard_load`.
6. Now navigate to the **Staff** page and verify that no new activity events have been created.
 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
