### PR TITLE
Add phase name - simple to data dictionary

### DIFF
--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -5,6 +5,7 @@ export const TABLE_LOOKUPS_QUERY = gql`
     moped_phases(order_by: { phase_order: asc }) {
       phase_id
       phase_name
+      phase_name_simple
       phase_description
       phase_order
       moped_subphases {

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -169,6 +169,10 @@ export const SETTINGS = [
         label: "Phase name",
       },
       {
+        key: "phase_name_simple",
+        label: "Phase name - simple",
+      },
+      {
         key: "phase_description",
         label: "Description",
       },


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/15377

## Testing
**URL to test:** [Netlify](https://deploy-preview-1253--atd-moped-main.netlify.app/)

On the data dictionary, look at the **Phase name - simple** column of the **Phases** section.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
