### PR TITLE
Persist work activity column visibility in local storage

### DIFF
--- a/moped-editor/src/utils/localStorageHelpers.js
+++ b/moped-editor/src/utils/localStorageHelpers.js
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Get the user hidden column settings from local storage, clear them of
+ * outdated columns, and supplement with remaining default columns
+ * @param {Object} defaultColumnSettings - the baseline column visibility settings, where each entry
+ * is a column name with a boolean value indicating if the column should be hidden
+ * * @param {String} storageKey - the key used to get and set data from local storage
+ * @returns {Object} hidden column settings from local storage
+ */
+const getPreviousHiddenColumns = (defaultColumnSettings, storageKey) => {
+  let previousHiddenColumnSettings;
+
+  try {
+    previousHiddenColumnSettings = JSON.parse(localStorage.getItem(storageKey));
+  } catch (e) {
+    previousHiddenColumnSettings = null;
+    console.error("Error parsing project list view hidden column settings", e);
+  }
+
+  let currentHiddenColumnSettings;
+
+  // If there are no previous hidden column settings, set the default hidden columns
+  if (!previousHiddenColumnSettings) {
+    localStorage.setItem(storageKey, JSON.stringify(defaultColumnSettings));
+
+    currentHiddenColumnSettings = defaultColumnSettings;
+  } else {
+    // Use previous settings to override default hidden columns.
+    // By iterating the defaults, we also remove outdated columns no longer in config.
+    currentHiddenColumnSettings = Object.keys(defaultColumnSettings).reduce(
+      (acc, columnName) => {
+        if (previousHiddenColumnSettings.hasOwnProperty(columnName)) {
+          return {
+            ...acc,
+            [columnName]: previousHiddenColumnSettings[columnName],
+          };
+        } else {
+          return { ...acc, [columnName]: defaultColumnSettings[columnName] };
+        }
+      },
+      {}
+    );
+  }
+
+  return currentHiddenColumnSettings;
+};
+
+export const useHiddenColumnsSettings = ({
+  defaultHiddenColumnSettings,
+  storageKey,
+}) => {
+  const [hiddenColumns, setHiddenColumns] = useState({});
+
+  /*
+   * Initialize hidden columns from previous local storage
+   */
+  useEffect(() => {
+    const initialHiddenColumnSettings = getPreviousHiddenColumns(
+      defaultHiddenColumnSettings,
+      storageKey
+    );
+
+    console.log("initialHiddenColumnSettings", initialHiddenColumnSettings)
+    setHiddenColumns(initialHiddenColumnSettings);
+  }, [defaultHiddenColumnSettings, storageKey]);
+
+  /*
+   * Sync hidden columns state with local storage
+   */
+  useEffect(() => {
+    console.log("EFFECTTTEEEED", hiddenColumns)
+    localStorage.setItem(storageKey, JSON.stringify(hiddenColumns));
+  }, [hiddenColumns]);
+
+  return { hiddenColumns, setHiddenColumns };
+};

--- a/moped-editor/src/utils/localStorageHelpers.js
+++ b/moped-editor/src/utils/localStorageHelpers.js
@@ -4,7 +4,8 @@ import { useState, useEffect } from "react";
  * Get the user hidden column settings from local storage, clear them of
  * outdated columns, and supplement with remaining default columns
  * @param {Object} defaultColumnSettings - the baseline column visibility settings, where each entry
- * is a column name with a boolean value indicating if the column should be hidden
+ * is a column name with a boolean value indicating if the column should be hidden. Make
+ * sure this value has a stable object reference, ie, it should be memoized!
  * * @param {String} storageKey - the key used to get and set data from local storage
  * @returns {Object} hidden column settings from local storage
  */

--- a/moped-editor/src/utils/localStorageHelpers.js
+++ b/moped-editor/src/utils/localStorageHelpers.js
@@ -60,8 +60,6 @@ export const useHiddenColumnsSettings = ({
       defaultHiddenColumnSettings,
       storageKey
     );
-
-    console.log("initialHiddenColumnSettings", initialHiddenColumnSettings)
     setHiddenColumns(initialHiddenColumnSettings);
   }, [defaultHiddenColumnSettings, storageKey]);
 
@@ -69,9 +67,8 @@ export const useHiddenColumnsSettings = ({
    * Sync hidden columns state with local storage
    */
   useEffect(() => {
-    console.log("EFFECTTTEEEED", hiddenColumns)
     localStorage.setItem(storageKey, JSON.stringify(hiddenColumns));
-  }, [hiddenColumns]);
+  }, [hiddenColumns, storageKey]);
 
   return { hiddenColumns, setHiddenColumns };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -161,8 +161,8 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
         minWidth: 150,
         flex: 1,
         defaultVisible: true,
-        valueGetter: ({ row }) =>
-          row.updated_at ? new Date(row.updated_at).toLocaleDateString() : "",
+        type: "date",
+        valueGetter: ({ value }) => (value ? new Date(value) : null),
       },
     ];
   }, [deleteInProgress, onDeleteActivity, setEditActivity]);

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -17,6 +17,7 @@ import {
   DELETE_WORK_ACTIVITY,
 } from "../../../../queries/funding";
 import { currencyFormatter } from "src/utils/numberFormatters";
+import { useHiddenColumnsSettings } from "src/utils/localStorageHelpers";
 
 /** Hook that provides memoized column settings */
 const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
@@ -24,10 +25,11 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
     return [
       {
         headerName: "",
-        field: "_edit",
+        field: "Edit",
         hideable: false,
         filterable: false,
         sortable: false,
+        defaultVisible: true,
         renderCell: ({ row }) => {
           return deleteInProgress ? (
             <CircularProgress color="primary" size={20} />
@@ -55,33 +57,45 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
         headerName: "ID",
         field: "reference_id",
         minWidth: 125,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Workgroup/Contractor",
         field: "workgroup_contractor",
         minWidth: 175,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Contract #",
         field: "contract_number",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Description",
         field: "description",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Work Assignment",
         field: "work_assignment_id",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Task Order(s)",
         field: "task_orders",
+        defaultVisible: true,
+        minWidth: 150,
+        flex: 1,
         valueGetter: ({ row }) =>
           row.task_orders?.map((tk) => tk.task_order).join(", "),
-        minWidth: 150,
         renderCell: ({ row }) => (
           <div>
             {row.task_orders?.map((tk) => (
@@ -94,6 +108,8 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
         headerName: "Work Order Link",
         field: "work_order_url",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
         renderCell: ({ row }) =>
           row.work_order_url ? (
             <Link
@@ -108,13 +124,17 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
       {
         headerName: "Status",
         field: "status",
+        defaultVisible: true,
         valueGetter: ({ row }) => row.moped_work_activity_status?.name,
         minWidth: 150,
+        flex: 1,
       },
       {
         headerName: "Amount",
         field: "contract_amount",
-        minWidth: 50,
+        minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
         valueGetter: ({ row }) =>
           isNaN(parseInt(row.contract_amount))
             ? null
@@ -124,17 +144,23 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
         headerName: "Status update",
         field: "status_note",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
       },
       {
         headerName: "Updated by",
         field: "updated_by_user",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
         valueGetter: ({ row }) => getUserFullName(row.updated_by_user),
       },
       {
         headerName: "Updated at",
         field: "updated_at",
         minWidth: 150,
+        flex: 1,
+        defaultVisible: true,
         valueGetter: ({ row }) =>
           row.updated_at ? new Date(row.updated_at).toLocaleDateString() : "",
       },
@@ -179,14 +205,37 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
+  /**
+   * Initialize which columns should be visibile - must be memoized to safely
+   * be used with useHiddenColumnsSettings hook
+   */
+  const defaultHiddenColumnSettings = useMemo(
+    () =>
+      columns.reduce((settings, column) => {
+        settings[column.field] = column.defaultVisible;
+        return settings;
+      }, {}),
+    [columns]
+  );
+
+  const { hiddenColumns, setHiddenColumns } = useHiddenColumnsSettings({
+    defaultHiddenColumnSettings,
+    storageKey: "workActivityTableColumnConfig",
+  });
+
   if (loading || !data) return <CircularProgress />;
 
   return (
     <ApolloErrorHandler errors={error}>
-      <Box sx={{ width: "100%" }}>
+      <Box sx={{ width: "100%", overflow: "auto", minHeight: "700px" }}>
         <DataGrid
           autoHeight
           columns={columns}
+          columnVisibilityModel={hiddenColumns}
+          onColumnVisibilityModelChange={(newModel) =>
+            setHiddenColumns(newModel)
+          }
+          toolbar
           density="comfortable"
           disableRowSelectionOnClick
           getRowHeight={() => "auto"}

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityToolbar.js
@@ -2,14 +2,18 @@ import AddCircleIcon from "@mui/icons-material/AddCircle";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-
+import {
+  GridToolbarColumnsButton,
+  GridToolbarContainer,
+  GridToolbarFilterButton,
+} from "@mui/x-data-grid";
 /** Custom toolbar title that resembles the material table titles we use  */
 const WorkActivityToolbar = ({ onClick }) => (
-  <Box display="flex" justifyContent="space-between">
-    <Typography variant="h2" color="primary" style={{ padding: "1em" }}>
-      Work activities
-    </Typography>
-    <div style={{ padding: "1rem" }}>
+  <>
+    <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
+      <Typography variant="h2" color="primary">
+        Work activities
+      </Typography>
       <Button
         variant="contained"
         color="primary"
@@ -18,8 +22,12 @@ const WorkActivityToolbar = ({ onClick }) => (
       >
         Add Work Activity
       </Button>
-    </div>
-  </Box>
+    </Box>
+    <GridToolbarContainer sx={{ marginLeft: "1em" }}>
+      <GridToolbarColumnsButton />
+      <GridToolbarFilterButton />
+    </GridToolbarContainer>
+  </>
 );
 
 export default WorkActivityToolbar;

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -5,14 +5,13 @@ import { useQuery } from "@apollo/client";
 import Search from "../../../components/GridTable/Search";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
 import MaterialTable from "@material-table/core";
-import {
-  useTableComponents,
-  useColumns,
-  useTableOptions,
-  useHiddenColumnsSettings,
-} from "./helpers.js";
+import { useTableComponents, useColumns, useTableOptions } from "./helpers.js";
+import { useHiddenColumnsSettings } from "src/utils/localStorageHelpers";
 import { useGetProjectListView } from "./useProjectListViewQuery/useProjectListViewQuery";
-import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
+import {
+  PROJECT_LIST_VIEW_QUERY_CONFIG,
+  DEFAULT_HIDDEN_COLS,
+} from "./ProjectsListViewQueryConf";
 import { PROJECT_LIST_VIEW_FILTERS_CONFIG } from "./ProjectsListViewFiltersConf";
 import { PROJECT_LIST_VIEW_EXPORT_CONFIG } from "./ProjectsListViewExportConf";
 import { usePagination } from "./useProjectListViewQuery/usePagination";
@@ -91,7 +90,10 @@ const ProjectsListViewTable = () => {
   const { filters, setFilters, advancedSearchWhereString, isOr, setIsOr } =
     useAdvancedSearch();
 
-  const { hiddenColumns, setHiddenColumns } = useHiddenColumnsSettings();
+  const { hiddenColumns, setHiddenColumns } = useHiddenColumnsSettings({
+    defaultHiddenColumnSettings: DEFAULT_HIDDEN_COLS,
+    storageKey: "mopedColumnConfig",
+  });
 
   const { columns, columnsToReturnInQuery } = useColumns({ hiddenColumns });
 

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -9,10 +9,7 @@ import Pagination from "../../../components/GridTable/Pagination";
 import ExternalLink from "../../../components/ExternalLink";
 import ProjectStatusBadge from "../projectView/ProjectStatusBadge";
 import RenderSignalLink from "../../../components/RenderSignalLink";
-import {
-  PROJECT_LIST_VIEW_QUERY_CONFIG,
-  DEFAULT_HIDDEN_COLS,
-} from "./ProjectsListViewQueryConf";
+import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
 import theme from "src/theme";
 
 export const filterNullValues = (value) => {
@@ -92,54 +89,6 @@ const filterComponentFullNames = (value) => {
   ));
 };
 
-/**
- * Get the user hidden column settings from local storage, clear them of
- * outdated columns, and supplement with remaining default columns
- * @returns {Object} hidden column settings from local storage
- */
-const getPreviousHiddenColumns = () => {
-  let previousHiddenColumnSettings;
-
-  try {
-    previousHiddenColumnSettings = JSON.parse(
-      localStorage.getItem("mopedColumnConfig")
-    );
-  } catch (e) {
-    previousHiddenColumnSettings = null;
-    console.error("Error parsing project list view hidden column settings", e);
-  }
-
-  let currentHiddenColumnSettings;
-
-  // If there are no previous hidden column settings, set the default hidden columns
-  if (!previousHiddenColumnSettings) {
-    localStorage.setItem(
-      "mopedColumnConfig",
-      JSON.stringify(DEFAULT_HIDDEN_COLS)
-    );
-
-    currentHiddenColumnSettings = DEFAULT_HIDDEN_COLS;
-  } else {
-    // Use previous settings to override default hidden columns.
-    // By iterating the defaults, we also remove outdated columns no longer in config.
-    currentHiddenColumnSettings = Object.keys(DEFAULT_HIDDEN_COLS).reduce(
-      (acc, columnName) => {
-        if (previousHiddenColumnSettings.hasOwnProperty(columnName)) {
-          return {
-            ...acc,
-            [columnName]: previousHiddenColumnSettings[columnName],
-          };
-        } else {
-          return { ...acc, [columnName]: DEFAULT_HIDDEN_COLS[columnName] };
-        }
-      },
-      {}
-    );
-  }
-
-  return currentHiddenColumnSettings;
-};
-
 const COLUMN_CONFIG = PROJECT_LIST_VIEW_QUERY_CONFIG.columns;
 
 /**
@@ -189,27 +138,6 @@ export const useTableComponents = ({
       rowsPerPageOptions,
     ]
   );
-
-export const useHiddenColumnsSettings = () => {
-  const [hiddenColumns, setHiddenColumns] = useState({});
-
-  /*
-   * Initialize hidden columns from previous local storage
-   */
-  useEffect(() => {
-    const initialHiddenColumnSettings = getPreviousHiddenColumns();
-    setHiddenColumns(initialHiddenColumnSettings);
-  }, []);
-
-  /*
-   * Sync hidden columns state with local storage
-   */
-  useEffect(() => {
-    localStorage.setItem("mopedColumnConfig", JSON.stringify(hiddenColumns));
-  }, [hiddenColumns]);
-
-  return { hiddenColumns, setHiddenColumns };
-};
 
 /**
  * The Material Table column settings

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { NavLink as RouterLink, useLocation } from "react-router-dom";
 import { MTableHeader } from "@material-table/core";
 import Link from "@mui/material/Link";


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/15430

## Testing
**URL to test:** [Netlify](https://deploy-preview-1257--atd-moped-main.netlify.app/)

**Steps to test:**
1. Start by making sure the project list view columns are being persisted normally. Edit their visibility, refresh your page. Edit them again. Refresh your page. 
2. Now do the same thing on the **Work Activities** table (on the **Funding** tab). 
3. You can try being adversarial by manually editing your local storage value for `workActivityTableColumnConfig`. Try adding a column name that doesn't exist. or try changing the whole blob to `"pizza"`. Shouldn't be a problem.
I think that's it?

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
