### PR TITLE
adds phase start and end confirmation to activity log

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -53,16 +53,11 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
     if (newRecord[field] !== oldRecord[field]) {
-      // phase end and start confirmed are in the moped_proj_phases table but not in the UI
-      // ignore changes to that field until its visually represented to users
-      if (
-        field !== "is_phase_end_confirmed" &&
-        field !== "is_phase_start_confirmed"
-      ) {
-        changes.push(entryMap.fields[field]?.label);
-      }
+      changes.push(entryMap.fields[field]?.label);
     }
   });
+
+  console.log(changes);
 
   return {
     changeIcon,

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -52,12 +52,10 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    if (newRecord[field] !== oldRecord[field] && !!entryMap.fields[field]) {
       changes.push(entryMap.fields[field]?.label);
     }
   });
-
-  console.log(changes);
 
   return {
     changeIcon,

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -52,8 +52,12 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field] && !!entryMap.fields[field]) {
-      changes.push(entryMap.fields[field]?.label);
+    if (newRecord[field] !== oldRecord[field]) {
+      // filter out fields that are not listed in the activity log table maps to prevent
+      // automated field updates (created at, updated at, etc.) from entering the array
+      if (!!entryMap.fields[field]) {
+        changes.push(entryMap.fields[field]?.label);
+      }
     }
   });
 


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/15397

this pr adds phase start and phase end confirmation updates to the activity log. it also fixes a small bug that was responsible for displaying extra commas in the activity log for phase updates.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1261--atd-moped-main.netlify.app/

**Steps to test:**
- go to a project's timeline, select a phase and invert the checkbox booleans for the phase start and phase end 'confirmed' values
- you should see these changes cleanly reflected in the activity log ✨

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
