### PR TITLE
Fix special case null value handling in advanced search

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersCommonOperators.js
+++ b/moped-editor/src/components/GridTable/FiltersCommonOperators.js
@@ -49,22 +49,6 @@ export const FiltersCommonOperators = {
     specialNullValue: '""',
     type: "string",
   },
-  string_is_null_special_case: {
-    operator: "_is_null",
-    label: "is blank",
-    description: "Selected field does not have meaningful content",
-    envelope: "true",
-    specialNullValue: '"None"',
-    type: "string",
-  },
-  string_is_not_null_special_case: {
-    operator: "_is_null",
-    label: "is not blank",
-    description: "String field does not match special null value",
-    envelope: "false",
-    specialNullValue: '"None"',
-    type: "string",
-  },
   string_begins_with_case_insensitive: {
     operator: "_ilike",
     label: "begins with",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -176,8 +176,8 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_ends_with_case_insensitive",
         "string_equals_case_insensitive",
         "string_does_not_equal_case_insensitive",
-        "string_is_null_special_case",
-        "string_is_not_null_special_case",
+        "string_is_null",
+        "string_is_not_null",
       ],
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -157,8 +157,8 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_ends_with_case_insensitive",
         "string_equals_case_insensitive",
         "string_does_not_equal_case_insensitive",
-        "string_is_null_special_case",
-        "string_is_not_null_special_case",
+        "string_is_null",
+        "string_is_not_null",
       ],
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -20,8 +20,6 @@ export const AUTOCOMPLETE_OPERATORS = [
 export const OPERATORS_WITHOUT_SEARCH_VALUES = [
   "string_is_null",
   "string_is_not_null",
-  "string_is_not_null_special_case",
-  "string_is_null_special_case",
   "subprojects_array_is_null",
   "subprojects_array_is_not_null",
   "string_is_blank",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -217,19 +217,17 @@ export const useColumns = ({ hiddenColumns }) => {
         title: "Lead",
         field: "project_lead",
         hidden: hiddenColumns["project_lead"],
+        emptyValue: "-",
         editable: "never",
         cellStyle: { whiteSpace: "noWrap" },
-        render: (entry) =>
-          entry.project_lead === null ? "-" : entry.project_lead,
       },
       {
         title: "Sponsor",
         field: "project_sponsor",
         hidden: hiddenColumns["project_sponsor"],
+        emptyValue: "-",
         editable: "never",
         cellStyle: { whiteSpace: "noWrap" },
-        render: (entry) =>
-          entry.project_sponsor === "None" ? "-" : entry.project_sponsor,
       },
       {
         title: "Partners",


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15052

We have some code that used to handle "special cases" where we received the string `None` from the the project list DB view instead of `null` like many of the other columns. These special cases no longer exist due to enhancements to the DB view over time ✨ so we no longer need to handle them.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1262--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. In staging or production and one filter at a time, apply the following and note the count of the results that you see:
- **Lead is blank** - 0 results in production (as of end of day 1/30/24)
- **Lead is not blank** - 3106 results in production out of 3293 total projects
- **Sponsor is blank** - 0 results in production
- **Sponsor is not blank** - 370 results in production out of 3293 total projects
2. Notice that the **is blank** filters return nothing and not the missing part of the whole. Also, the GraphQL queries sent in the network requests are filtering on `_eq` or `_neq` to `None` (string)
3. Test the same queries locally or on the deploy preview and see that **is blank** and **is not blank** return a number of results that adds up to the total number of records in the unfiltered list. Also, the GraphQL queries sent in the network requests are filtering on `_eq` or `_neq` to `null`
4. Finally, notice that the blank cells of both **Lead** and **Sponsor** show `-` in the table

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
