### PR TITLE
Ability to use basic search + filters at the same time

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -103,8 +103,7 @@ const useStyles = makeStyles((theme) => ({
  * @param {Function} setFilters - Set the current filters from useAdvancedSearch hook
  * @param {Function} handleAdvancedSearchClose - Used to close the advanced search
  * @param {Object} filtersConfig - The configuration object for the filters
- * @param {Function} setSearchFieldValue - Used to set the search field value
- * @param {Function} setSearchTerm - Used to set the search term for simple search
+ * @param {Function} resetSimpleSearch - Function to reset the simple search
  * @return {JSX.Element}
  * @constructor
  */
@@ -113,8 +112,7 @@ const Filters = ({
   setFilters,
   handleAdvancedSearchClose,
   filtersConfig,
-  setSearchFieldValue,
-  setSearchTerm,
+  resetSimpleSearch,
   isOr,
   setIsOr,
 }) => {
@@ -264,12 +262,14 @@ const Filters = ({
   };
 
   /**
-   * Clears the filters
+   * Reset search box and advanced filters
    */
-  const handleClearFilters = useCallback(() => {
+  const handleResetFilters = useCallback(() => {
     setFilterParameters([generateEmptyFilter()]);
     setFilters([]);
     setIsOr(false);
+
+    resetSimpleSearch();
 
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete(advancedSearchFilterParamName);
@@ -286,7 +286,6 @@ const Filters = ({
 
       prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
       prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
-      prevSearchParams.delete(simpleSearchParamName);
       return prevSearchParams;
     });
 
@@ -294,8 +293,8 @@ const Filters = ({
     setFilters(filterParameters);
     handleAdvancedSearchClose();
     // Clear simple search field in UI and state since we are using advanced search
-    setSearchFieldValue("");
-    setSearchTerm("");
+    // setSearchFieldValue("");
+    // setSearchTerm("");
   };
 
   const handleAndOrToggleChange = (e) => {
@@ -583,7 +582,7 @@ const Filters = ({
             fullWidth
             variant="outlined"
             startIcon={<BackspaceOutlinedIcon />}
-            onClick={handleClearFilters}
+            onClick={handleResetFilters}
           >
             Reset
           </Button>

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -15,6 +15,7 @@ import {
   Icon,
   IconButton,
   Grow,
+  Typography,
 } from "@mui/material";
 import RadioGroup from "@mui/material/RadioGroup";
 import Radio from "@mui/material/Radio";
@@ -227,23 +228,33 @@ const Filters = ({
    * @param {string} filterIndex - The index of the filter to be deleted
    */
   const handleDeleteFilterButtonClick = (filterIndex) => {
-    // Clone the state
+    // Clone the state, delete the filter index of the button clicked
     const filtersNewState = [...filterParameters];
-
-    // Delete the key (if it's there)
     filtersNewState.splice(filterIndex, 1);
-    // Finally, reset the state
-    const jsonParamString = JSON.stringify(filtersNewState);
-    setSearchParams((prevSearchParams) => {
-      prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
 
-      return prevSearchParams;
-    });
-    setFilterParameters(filtersNewState);
+    const remainingFiltersCount = filtersNewState.length;
 
-    /* Reset isOr to false (all/and) if there is only one filter left */
-    if (Object.keys(filtersNewState).length === 1) {
+    if (remainingFiltersCount === 0) {
+      setFilterParameters([]);
+      setSearchParams((prevSearchParams) => {
+        prevSearchParams.delete(advancedSearchFilterParamName);
+        prevSearchParams.delete(advancedSearchIsOrParamName);
+
+        return prevSearchParams;
+      });
+    } else if (remainingFiltersCount === 1) {
+      /* Reset isOr to false (all/and) if there is only one filter left */
+      setFilterParameters(filtersNewState);
       setIsOrToggleValue(false);
+    } else {
+      // Finally, reset the state
+      setFilterParameters(filtersNewState);
+      const jsonParamString = JSON.stringify(filtersNewState);
+      setSearchParams((prevSearchParams) => {
+        prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
+
+        return prevSearchParams;
+      });
     }
   };
 
@@ -353,7 +364,15 @@ const Filters = ({
           </IconButton>
         </Grid>
       </Grid>
-
+      {filterParameters.length === 0 ? (
+        <Grow in={true}>
+          <Grid container className={classes.filtersContainer}>
+            <Grid item xs={12} md={4} className={classes.gridItemPadding}>
+              <Typography>No filters applied</Typography>
+            </Grid>
+          </Grid>
+        </Grow>
+      ) : null}
       {filterParameters.map((filter, filterIndex) => {
         const { field: fieldName, operator, value } = filter;
 
@@ -522,39 +541,31 @@ const Filters = ({
                     ))}
                 </FormControl>
               </Grid>
-              {areMoreThanOneFilters ? (
-                <>
-                  <Hidden mdDown>
-                    <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
-                      <IconButton
-                        className={classes.deleteButton}
-                        onClick={() =>
-                          handleDeleteFilterButtonClick(filterIndex)
-                        }
-                        size="large"
-                      >
-                        <Icon className={classes.deleteIcon}>
-                          delete_outline
-                        </Icon>
-                      </IconButton>
-                    </Grid>
-                  </Hidden>
-                  <Hidden mdUp>
-                    <Grid item xs={12}>
-                      <Button
-                        fullWidth
-                        className={classes.deleteButton}
-                        variant="outlined"
-                        onClick={() =>
-                          handleDeleteFilterButtonClick(filterIndex)
-                        }
-                      >
-                        <Icon>delete_outline</Icon>
-                      </Button>
-                    </Grid>
-                  </Hidden>
-                </>
-              ) : null}
+              <>
+                <Hidden mdDown>
+                  <Grid item xs={12} md={1} style={{ textAlign: "center" }}>
+                    <IconButton
+                      className={classes.deleteButton}
+                      onClick={() => handleDeleteFilterButtonClick(filterIndex)}
+                      size="large"
+                    >
+                      <Icon className={classes.deleteIcon}>delete_outline</Icon>
+                    </IconButton>
+                  </Grid>
+                </Hidden>
+                <Hidden mdUp>
+                  <Grid item xs={12}>
+                    <Button
+                      fullWidth
+                      className={classes.deleteButton}
+                      variant="outlined"
+                      onClick={() => handleDeleteFilterButtonClick(filterIndex)}
+                    >
+                      <Icon>delete_outline</Icon>
+                    </Button>
+                  </Grid>
+                </Hidden>
+              </>
             </Grid>
           </Grow>
         );
@@ -599,7 +610,7 @@ const Filters = ({
             startIcon={<Icon>search</Icon>}
             onClick={handleApplyButtonClick}
             disabled={
-              handleApplyValidation(filterParameters, filtersConfig) != null
+              handleApplyValidation(filterParameters, filtersConfig) !== null
             }
           >
             Search

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -292,8 +292,8 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    /* If we have advanced filters, set query state values and update search params */
     if (filterParameters.length > 0) {
+      /* If we have advanced filters, set query state values and update search params */
       setSearchParams((prevSearchParams) => {
         const jsonParamString = JSON.stringify(filterParameters);
 
@@ -304,6 +304,10 @@ const Filters = ({
 
       setIsOr(isOrToggleValue);
       setFilters(filterParameters);
+    } else {
+      /* If we have no advanced filters, reset query state */
+      setFilters([]);
+      setIsOr(false);
     }
 
     handleAdvancedSearchClose();

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -29,7 +29,6 @@ import {
   advancedSearchFilterParamName,
   advancedSearchIsOrParamName,
 } from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
-import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 import {
   areAllFiltersComplete,
   checkIsValidInput,
@@ -268,14 +267,13 @@ const Filters = ({
     setFilterParameters([generateEmptyFilter()]);
     setFilters([]);
     setIsOr(false);
-
-    resetSimpleSearch();
-
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete(advancedSearchFilterParamName);
       prevSearchParams.delete(advancedSearchIsOrParamName);
     });
-  }, [setSearchParams, setFilters, setIsOr]);
+
+    resetSimpleSearch();
+  }, [setSearchParams, setFilters, setIsOr, resetSimpleSearch]);
 
   /**
    * Applies the current local state and updates the parent's state
@@ -292,9 +290,6 @@ const Filters = ({
     setIsOr(isOrToggleValue);
     setFilters(filterParameters);
     handleAdvancedSearchClose();
-    // Clear simple search field in UI and state since we are using advanced search
-    // setSearchFieldValue("");
-    // setSearchTerm("");
   };
 
   const handleAndOrToggleChange = (e) => {

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -228,14 +228,15 @@ const Filters = ({
    * @param {string} filterIndex - The index of the filter to be deleted
    */
   const handleDeleteFilterButtonClick = (filterIndex) => {
-    // Clone the state, delete the filter index of the button clicked
+    /* Clone the state, delete the filter index of the button clicked, and update filter state */
     const filtersNewState = [...filterParameters];
     filtersNewState.splice(filterIndex, 1);
+    setFilterParameters(filtersNewState);
 
     const remainingFiltersCount = filtersNewState.length;
 
     if (remainingFiltersCount === 0) {
-      setFilterParameters([]);
+      /* Clear search params since we have no advanced filters */
       setSearchParams((prevSearchParams) => {
         prevSearchParams.delete(advancedSearchFilterParamName);
         prevSearchParams.delete(advancedSearchIsOrParamName);
@@ -244,11 +245,9 @@ const Filters = ({
       });
     } else if (remainingFiltersCount === 1) {
       /* Reset isOr to false (all/and) if there is only one filter left */
-      setFilterParameters(filtersNewState);
       setIsOrToggleValue(false);
     } else {
-      // Finally, reset the state
-      setFilterParameters(filtersNewState);
+      /* Remove the details of the removed filter from search params */
       const jsonParamString = JSON.stringify(filtersNewState);
       setSearchParams((prevSearchParams) => {
         prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
@@ -293,16 +292,20 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    setSearchParams((prevSearchParams) => {
-      const jsonParamString = JSON.stringify(filterParameters);
+    /* If we have advanced filters, set query state values and update search params */
+    if (filterParameters.length > 0) {
+      setSearchParams((prevSearchParams) => {
+        const jsonParamString = JSON.stringify(filterParameters);
 
-      prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
-      prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
-      return prevSearchParams;
-    });
+        prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
+        prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
+        return prevSearchParams;
+      });
 
-    setIsOr(isOrToggleValue);
-    setFilters(filterParameters);
+      setIsOr(isOrToggleValue);
+      setFilters(filterParameters);
+    }
+
     handleAdvancedSearchClose();
   };
 
@@ -365,13 +368,11 @@ const Filters = ({
         </Grid>
       </Grid>
       {filterParameters.length === 0 ? (
-        <Grow in={true}>
-          <Grid container className={classes.filtersContainer}>
-            <Grid item xs={12} md={4} className={classes.gridItemPadding}>
-              <Typography>No filters applied</Typography>
-            </Grid>
+        <Grid container className={classes.filtersContainer}>
+          <Grid item xs={12} md={4} className={classes.gridItemPadding}>
+            <Typography>No filters applied</Typography>
           </Grid>
-        </Grow>
+        </Grid>
       ) : null}
       {filterParameters.map((filter, filterIndex) => {
         const { field: fieldName, operator, value } = filter;

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -236,6 +236,7 @@ const Filters = ({
     const jsonParamString = JSON.stringify(filtersNewState);
     setSearchParams((prevSearchParams) => {
       prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
+
       return prevSearchParams;
     });
     setFilterParameters(filtersNewState);
@@ -270,6 +271,8 @@ const Filters = ({
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete(advancedSearchFilterParamName);
       prevSearchParams.delete(advancedSearchIsOrParamName);
+
+      return prevSearchParams;
     });
 
     resetSimpleSearch();

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -95,8 +95,6 @@ const Search = ({
    * Clears the filters when switching to simple search
    */
   const handleSwitchToSearch = () => {
-    setFilters([]);
-    setIsOr(false);
     setAdvancedSearchAnchor(null);
   };
 

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import { useSearchParams } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
+import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -84,6 +86,8 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
+  let [, setSearchParams] = useSearchParams();
+
   /**
    * The contents of the search box in SearchBar
    * @type {string} searchFieldValue
@@ -106,6 +110,12 @@ const Search = ({
   const resetSimpleSearch = () => {
     setSearchFieldValue("");
     setSearchTerm("");
+
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.delete(simpleSearchParamName);
+
+      return prevSearchParams;
+    });
   };
 
   return (

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,13 +1,11 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { useSearchParams } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
-import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -86,21 +84,12 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
-  let [, setSearchParams] = useSearchParams();
-
   /**
    * The contents of the search box in SearchBar
    * @type {string} searchFieldValue
    * @function setSearchFieldValue - Sets the state of the field
    */
   const [searchFieldValue, setSearchFieldValue] = useState(searchTerm);
-
-  /**
-   * Clears the filters when switching to simple search
-   */
-  const handleSwitchToSearch = () => {
-    setAdvancedSearchAnchor(null);
-  };
 
   const toggleAdvancedSearch = () => {
     if (advancedSearchAnchor) {
@@ -115,12 +104,8 @@ const Search = ({
   };
 
   const resetSimpleSearch = () => {
-    setSearchFieldValue(null);
-    setSearchTerm(null);
-    setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete(simpleSearchParamName);
-      return prevSearchParams;
-    });
+    setSearchFieldValue("");
+    setSearchTerm("");
   };
 
   return (
@@ -144,7 +129,6 @@ const Search = ({
                 setSearchTerm={setSearchTerm}
                 queryConfig={queryConfig}
                 isOr={isOr}
-                handleSwitchToSearch={handleSwitchToSearch}
                 loading={loading}
                 filtersConfig={filtersConfig}
                 resetSimpleSearch={resetSimpleSearch}

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import { useSearchParams } from "react-router-dom";
 
 import { Box, Button, Grid, Paper, Popper } from "@mui/material";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
 import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
+import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -84,6 +86,8 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
+  let [, setSearchParams] = useSearchParams();
+
   /**
    * The contents of the search box in SearchBar
    * @type {string} searchFieldValue
@@ -98,24 +102,25 @@ const Search = ({
     setAdvancedSearchAnchor(null);
   };
 
-  /**
-   * Clears the simple search when switching to advanced filters
-   */
-  const handleSwitchToAdvancedSearch = () => {
-    setSearchTerm("");
-  };
-
   const toggleAdvancedSearch = () => {
     if (advancedSearchAnchor) {
       setAdvancedSearchAnchor(null);
     } else {
       setAdvancedSearchAnchor(divRef.current);
-      handleSwitchToAdvancedSearch();
     }
   };
 
   const handleAdvancedSearchClose = () => {
     setAdvancedSearchAnchor(null);
+  };
+
+  const resetSimpleSearch = () => {
+    setSearchFieldValue(null);
+    setSearchTerm(null);
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.delete(simpleSearchParamName);
+      return prevSearchParams;
+    });
   };
 
   return (
@@ -142,6 +147,7 @@ const Search = ({
                 handleSwitchToSearch={handleSwitchToSearch}
                 loading={loading}
                 filtersConfig={filtersConfig}
+                resetSimpleSearch={resetSimpleSearch}
               />
             </Grid>
             <Grid
@@ -185,8 +191,7 @@ const Search = ({
             setFilters={setFilters}
             handleAdvancedSearchClose={handleAdvancedSearchClose}
             filtersConfig={filtersConfig}
-            setSearchFieldValue={setSearchFieldValue}
-            setSearchTerm={setSearchTerm}
+            resetSimpleSearch={resetSimpleSearch}
             isOr={isOr}
             setIsOr={setIsOr}
           />

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -106,6 +106,7 @@ const SearchBar = ({
   handleSwitchToSearch,
   loading,
   filtersConfig,
+  resetSimpleSearch,
 }) => {
   const classes = useStyles();
   let [, setSearchParams] = useSearchParams();
@@ -124,7 +125,7 @@ const SearchBar = ({
 
   const handleSearchValueChange = (value) => {
     if (value === "" && searchFieldValue !== "") {
-      handleClearSearchResults();
+      resetSimpleSearch();
     } else {
       setSearchFieldValue(value);
     }
@@ -134,7 +135,7 @@ const SearchBar = ({
    * Handles the submission of our search form
    * @param {Object} e - The event object
    */
-  const handleSearchSubmission = (event) => {
+  const handleSearchSubmission = (event = null) => {
     // Stop if we don't have any value entered in the search field
     if (searchFieldValue.length === 0) {
       return;
@@ -155,18 +156,6 @@ const SearchBar = ({
   };
 
   /**
-   * Clears the search results
-   */
-  const handleClearSearchResults = () => {
-    setSearchTerm("");
-    setSearchFieldValue("");
-    setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete(simpleSearchParamName);
-      return prevSearchParams;
-    });
-  };
-
-  /**
    * Handles special keys typed in the search bar
    * @param {string} key - The key name being typed
    */
@@ -176,13 +165,13 @@ const SearchBar = ({
        * On Escape key, clear the search
        */
       case "Escape":
-        handleClearSearchResults();
+        resetSimpleSearch();
         break;
       /**
        * On Enter key, initialize the search
        */
       case "Enter":
-        handleSearchSubmission(null);
+        handleSearchSubmission();
         break;
 
       default:

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -147,6 +147,7 @@ const SearchBar = ({
     setSearchTerm(searchFieldValue);
     setSearchParams((prevSearchParams) => {
       prevSearchParams.set(simpleSearchParamName, searchFieldValue);
+
       return prevSearchParams;
     });
   };

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -103,7 +103,6 @@ const SearchBar = ({
   setSearchTerm,
   queryConfig,
   isOr,
-  handleSwitchToSearch,
   loading,
   filtersConfig,
   resetSimpleSearch,
@@ -135,7 +134,7 @@ const SearchBar = ({
    * Handles the submission of our search form
    * @param {Object} e - The event object
    */
-  const handleSearchSubmission = (event = null) => {
+  const handleSearchSubmission = (event) => {
     // Stop if we don't have any value entered in the search field
     if (searchFieldValue.length === 0) {
       return;
@@ -143,9 +142,6 @@ const SearchBar = ({
 
     // Prevent default behavior on any event
     if (event) event.preventDefault();
-
-    // Clear the advanced search filters
-    handleSwitchToSearch();
 
     // Update state to trigger search and set simple search param
     setSearchTerm(searchFieldValue);

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -17,10 +17,6 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import { Search as SearchIcon } from "react-feather";
 import clsx from "clsx";
-import {
-  advancedSearchFilterParamName,
-  advancedSearchIsOrParamName,
-} from "src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch";
 import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
 
 /**
@@ -153,8 +149,6 @@ const SearchBar = ({
     // Update state to trigger search and set simple search param
     setSearchTerm(searchFieldValue);
     setSearchParams((prevSearchParams) => {
-      prevSearchParams.delete(advancedSearchFilterParamName);
-      prevSearchParams.delete(advancedSearchIsOrParamName);
       prevSearchParams.set(simpleSearchParamName, searchFieldValue);
       return prevSearchParams;
     });

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -96,7 +96,7 @@ export const handleApplyValidation = (filterParameters, filtersConfig) => {
 
   if (filterParameters) {
     if (filterParameters.length === 0) {
-      feedback.push("• No filters have been added.");
+      // feedback.push("• No filters have been added.");
     } else {
       filterParameters.forEach((filter) => {
         const { field: fieldName, value, operator } = filter;

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -95,34 +95,30 @@ export const handleApplyValidation = (filterParameters, filtersConfig) => {
   let feedback = [];
 
   if (filterParameters) {
-    if (filterParameters.length === 0) {
-      // feedback.push("• No filters have been added.");
-    } else {
-      filterParameters.forEach((filter) => {
-        const { field: fieldName, value, operator } = filter;
-        const fieldConfig = filtersConfig.fields.find(
-          (field) => field.name === fieldName
-        );
-        const type = fieldConfig?.type;
+    filterParameters.forEach((filter) => {
+      const { field: fieldName, value, operator } = filter;
+      const fieldConfig = filtersConfig.fields.find(
+        (field) => field.name === fieldName
+      );
+      const type = fieldConfig?.type;
 
-        if (fieldName === null) {
-          feedback.push("• One or more fields have not been selected.");
-        }
+      if (fieldName === null) {
+        feedback.push("• One or more fields have not been selected.");
+      }
 
-        if (operator === null) {
-          feedback.push("• One or more operators have not been selected.");
-        }
+      if (operator === null) {
+        feedback.push("• One or more operators have not been selected.");
+      }
 
-        if (value === null || value.trim() === "") {
-          if (operator && !isFilterNullType(operator)) {
-            feedback.push("• One or more missing values.");
-          }
+      if (value === null || value.trim() === "") {
+        if (operator && !isFilterNullType(operator)) {
+          feedback.push("• One or more missing values.");
         }
-        if (!checkIsValidInput(filter, type)) {
-          feedback.push("• One or more invalid inputs.");
-        }
-      });
-    }
+      }
+      if (!checkIsValidInput(filter, type)) {
+        feedback.push("• One or more invalid inputs.");
+      }
+    });
   }
   return feedback.length > 0 ? feedback : null;
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -12,8 +12,6 @@ export const useGetProjectListView = ({
   advancedSearchWhereString,
 }) => {
   const { query, exportQuery } = useMemo(() => {
-    console.log({ searchWhereString, advancedSearchWhereString });
-
     const queryString = `query ProjectListView {
         project_list_view (
             limit: ${queryLimit}
@@ -63,7 +61,6 @@ export const useGetProjectListView = ({
           }
         }
       }`;
-    console.log(queryString);
     const query = gql`
       ${queryString}
     `;

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -12,22 +12,50 @@ export const useGetProjectListView = ({
   advancedSearchWhereString,
 }) => {
   const { query, exportQuery } = useMemo(() => {
+    console.log({ searchWhereString, advancedSearchWhereString });
+
     const queryString = `query ProjectListView {
         project_list_view (
             limit: ${queryLimit}
             offset: ${queryOffset}
             order_by: {${orderByColumn}: ${orderByDirection}}
             where: { 
-              ${advancedSearchWhereString ? advancedSearchWhereString : ""}
-              ${searchWhereString ? `_or: [${searchWhereString}]` : ""} 
+              ${
+                searchWhereString && advancedSearchWhereString
+                  ? `_or: [${searchWhereString}, {${advancedSearchWhereString}}]`
+                  : ""
+              }
+              ${
+                searchWhereString && !advancedSearchWhereString
+                  ? `_or: [${searchWhereString}]`
+                  : ""
+              }
+              ${
+                advancedSearchWhereString && !searchWhereString
+                  ? advancedSearchWhereString
+                  : ""
+              }
             }
         ) {
             ${columnsToReturn.join("\n")}
         },
         project_list_view_aggregate (
           where: { 
-            ${advancedSearchWhereString ? advancedSearchWhereString : ""}
-            ${searchWhereString ? `_or: [${searchWhereString}]` : ""} 
+            ${
+              searchWhereString && advancedSearchWhereString
+                ? `_or: [${searchWhereString}, {${advancedSearchWhereString}}]`
+                : ""
+            }
+            ${
+              searchWhereString && !advancedSearchWhereString
+                ? `_or: [${searchWhereString}]`
+                : ""
+            }
+            ${
+              advancedSearchWhereString && !searchWhereString
+                ? advancedSearchWhereString
+                : ""
+            }
           }
         ) {
           aggregate {
@@ -35,6 +63,7 @@ export const useGetProjectListView = ({
           }
         }
       }`;
+    console.log(queryString);
     const query = gql`
       ${queryString}
     `;

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useProjectListViewQuery.js
@@ -22,7 +22,7 @@ export const useGetProjectListView = ({
             where: { 
               ${
                 searchWhereString && advancedSearchWhereString
-                  ? `_or: [${searchWhereString}, {${advancedSearchWhereString}}]`
+                  ? `_and: [{_or: [${searchWhereString}]}, {${advancedSearchWhereString}}]`
                   : ""
               }
               ${
@@ -43,7 +43,7 @@ export const useGetProjectListView = ({
           where: { 
             ${
               searchWhereString && advancedSearchWhereString
-                ? `_or: [${searchWhereString}, {${advancedSearchWhereString}}]`
+                ? `_and: [{_or: [${searchWhereString}]}, {${advancedSearchWhereString}}]`
                 : ""
             }
             ${

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -38,7 +38,7 @@ export const useSearch = ({ queryConfig }) => {
   const [searchTerm, setSearchTerm] = useState(simpleSearchValue ?? "");
 
   const searchWhereString = useMemo(() => {
-    if (searchTerm && searchTerm !== "") {
+    if (searchTerm && searchTerm.length > 0) {
       /**
        * Iterate through all column keys, if they are searchable
        * add the to the Or list.


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15371

This PR updates the project list search box and advanced filtering to work together so users can filter down filtered rows down in either direction. The logic is:
search box term (query with OR logic between search box fields shown in placeholder text)
AND 
advanced filters (query with AND or OR logic between rows of advanced filters)

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1263--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Go to the project list view and enter a search value like **testing** in the search box and press **Enter**. You should see filtered results. Note the number of results and the search params as you continue through the steps.
2. Open the advanced filters and add a filter like **Status is potential** and click **Search.** You should see the results that match the search box term and the advanced filter that you applied.
3. Add another filter row with a filter like **Lead contains coa**, and keep the any/all radios set to **Match all filters** You should see even less results based on the filters you chose. I see one match at this point with the examples that I suggested.
4. Set the any/all radios to **Match any filters** and click **Search**. You should see your search results include more rows.
5. Add another advanced filter like **Sponsor contains coa**. You should see more rows included again.
6. Remove filters one by one and click **Search** between each one to step back through your filters until only one advanced filter is applied.
7. **I could use some feedback on the UI flow in the test steps from here and on, thanks! 🙏**
8. You should see the trash can icon next to this last filter row. We used to hide it so the last filter could not be removed.
9. Remove the last filter and you should see the text **No filters applied.**. This allows users to click the **Search** button again to get results for only the remaining search box. The **Add filter** button can also be used here to get back to advanced filtering. Click the **Search** and you should search results that are only filtered by the term in the search box.
10. Click the advanced filters icon, and you should see a new row ready to accept an advanced filter.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
