### PR TITLE
Current phase value is not correct when editing a current phase

### DIFF
--- a/moped-editor/src/components/forms/ControlledSwitch.js
+++ b/moped-editor/src/components/forms/ControlledSwitch.js
@@ -4,37 +4,21 @@ import { Controller } from "react-hook-form";
 
 /**
  * A react-hook-form wrapper of the MUI Switch component
- * @param {Function} register - react-hook-form `register` function from useForm - required
+ * @param {object} control - react-hook-form `control` object from useController - required
  * @param {string} name - unique field name which be used in react-hook-form data object
  * @param {string} label - the label to render next to the checkbox
- * @param {Function} onChange - an optional custom onChange handler
+ * @param {Function} customOnChange - an optional custom onChange handler
  * @param {object} switchProps additional optional MUI switch props
  * @return {JSX.Element}
  */
-const RegisteredSwitch = ({
-  name,
-  // register,
+const ControlledSwitch = ({
   control,
+  name,
   label,
   customOnChange,
   ...switchProps
 }) => {
-  // const { value, ...registerProps } = register(name, {
-  //   ...(onChange && { onChange }),
-  // });
-
   return (
-    // <FormControlLabel
-    //   label={label}
-    //   control={
-    // <Switch
-    //   {...registerProps}
-    //   checked={value}
-    //   color="primary"
-    //   inputProps={{ "aria-label": "primary checkbox" }}
-    //   {...switchProps}
-    // />
-    // />
     <Controller
       name={name}
       control={control}
@@ -54,4 +38,4 @@ const RegisteredSwitch = ({
   );
 };
 
-export default RegisteredSwitch;
+export default ControlledSwitch;

--- a/moped-editor/src/components/forms/RegisteredSwitch.js
+++ b/moped-editor/src/components/forms/RegisteredSwitch.js
@@ -1,5 +1,6 @@
 import Switch from "@mui/material/Switch";
 import FormControlLabel from "@mui/material/FormControlLabel";
+import { Controller } from "react-hook-form";
 
 /**
  * A react-hook-form wrapper of the MUI Switch component
@@ -12,24 +13,43 @@ import FormControlLabel from "@mui/material/FormControlLabel";
  */
 const RegisteredSwitch = ({
   name,
-  register,
+  // register,
+  control,
   label,
-  onChange,
+  customOnChange,
   ...switchProps
 }) => {
+  // const { value, ...registerProps } = register(name, {
+  //   ...(onChange && { onChange }),
+  // });
+
   return (
-    <FormControlLabel
-      label={label}
-      control={
-        <Switch
-          {...register(name, {
-            ...(onChange && { onChange }),
-          })}
-          color="primary"
-          inputProps={{ "aria-label": "primary checkbox" }}
-          {...switchProps}
+    // <FormControlLabel
+    //   label={label}
+    //   control={
+    // <Switch
+    //   {...registerProps}
+    //   checked={value}
+    //   color="primary"
+    //   inputProps={{ "aria-label": "primary checkbox" }}
+    //   {...switchProps}
+    // />
+    // />
+    <Controller
+      name={name}
+      control={control}
+      render={({ field: { onChange, value } }) => (
+        <FormControlLabel
+          control={
+            <Switch
+              checked={value}
+              onChange={customOnChange ? customOnChange : onChange}
+              {...switchProps}
+            />
+          }
+          label={label}
         />
-      }
+      )}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
@@ -14,7 +14,7 @@ import ControlledAutocomplete from "src/components/forms/ControlledAutocomplete"
 import ControlledDateField from "src/components/forms/ControlledDateField";
 import ControlledTextInput from "src/components/forms/ControlledTextInput";
 import ControlledCheckbox from "src/components/forms/ControlledCheckbox";
-import RegisteredSwitch from "src/components/forms/RegisteredSwitch";
+import ControlledSwitch from "src/components/forms/ControlledSwitch";
 import {
   phaseValidationSchema,
   onSubmitPhase,
@@ -41,7 +41,6 @@ const ProjectPhaseForm = ({
   const userSessionData = getSessionDatabaseData();
 
   const defaultValues = useDefaultValues(phase);
-  console.log(defaultValues);
 
   /** initialize react hook form with validation */
   const {
@@ -50,7 +49,6 @@ const ProjectPhaseForm = ({
     watch,
     setValue,
     formState: { isDirty, errors: formErrors },
-    register,
   } = useForm({
     defaultValues,
     resolver: yupResolver(phaseValidationSchema),
@@ -59,7 +57,8 @@ const ProjectPhaseForm = ({
   const subphases = useSubphases(watch("phase_id"), phases);
 
   const isCurrentPhase = watch("is_current_phase");
-  console.log(isCurrentPhase);
+  console.log("isCurrentPhase", isCurrentPhase);
+  console.log("isDirty", isDirty);
 
   useResetDependentFieldOnParentFieldChange({
     parentValue: watch("phase_id"),
@@ -158,9 +157,9 @@ const ProjectPhaseForm = ({
       today.setHours(0, 0, 0, 0);
 
       setValue("phase_start", today);
-      setValue("is_current_phase", isCurrentPhase);
+      setValue("is_current_phase", isCurrentPhase, { shouldDirty: true });
     } else {
-      setValue("is_current_phase", isCurrentPhase);
+      setValue("is_current_phase", isCurrentPhase, { shouldDirty: true });
     }
   };
 
@@ -234,9 +233,8 @@ const ProjectPhaseForm = ({
         </Grid>
         <Grid item container justifyContent="flex-start">
           <FormControl>
-            <RegisteredSwitch
+            <ControlledSwitch
               name="is_current_phase"
-              // register={register}
               control={control}
               label="Current phase"
               onChange={onChangeCurrentPhase}

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
@@ -235,7 +235,7 @@ const ProjectPhaseForm = ({
               name="is_current_phase"
               control={control}
               label="Current phase"
-              onChange={onChangeCurrentPhase}
+              customOnChange={onChangeCurrentPhase}
             />
             <FormHelperText>
               Set this phase as the project's current phase

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
@@ -41,6 +41,7 @@ const ProjectPhaseForm = ({
   const userSessionData = getSessionDatabaseData();
 
   const defaultValues = useDefaultValues(phase);
+  console.log(defaultValues);
 
   /** initialize react hook form with validation */
   const {
@@ -58,6 +59,7 @@ const ProjectPhaseForm = ({
   const subphases = useSubphases(watch("phase_id"), phases);
 
   const isCurrentPhase = watch("is_current_phase");
+  console.log(isCurrentPhase);
 
   useResetDependentFieldOnParentFieldChange({
     parentValue: watch("phase_id"),
@@ -156,9 +158,9 @@ const ProjectPhaseForm = ({
       today.setHours(0, 0, 0, 0);
 
       setValue("phase_start", today);
-      return isCurrentPhase;
+      setValue("is_current_phase", isCurrentPhase);
     } else {
-      return isCurrentPhase;
+      setValue("is_current_phase", isCurrentPhase);
     }
   };
 
@@ -234,7 +236,8 @@ const ProjectPhaseForm = ({
           <FormControl>
             <RegisteredSwitch
               name="is_current_phase"
-              register={register}
+              // register={register}
+              control={control}
               label="Current phase"
               onChange={onChangeCurrentPhase}
             />

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseForm.js
@@ -57,8 +57,6 @@ const ProjectPhaseForm = ({
   const subphases = useSubphases(watch("phase_id"), phases);
 
   const isCurrentPhase = watch("is_current_phase");
-  console.log("isCurrentPhase", isCurrentPhase);
-  console.log("isDirty", isDirty);
 
   useResetDependentFieldOnParentFieldChange({
     parentValue: watch("phase_id"),


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15529

This PR fixes an issue where recent updates to the Phase form in the Timeline tab broke the default values from showing up in the form for existing phases to be edited.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1265--atd-moped-main.netlify.app/

**Steps to test:**
**Same steps as last time but the last step covers the regression that this PR fixes**

1. Go to a project's **Timeline** tab
2. Add a new phase and, before you choose a start date, toggle the **Current phase** switch
3. You should see the start date autofill with today's date and see the **Confirmed** checkbox checked next to it
4. Before saving, add some text to the **Status Update** text box
5. Save and you should see your new phase in the table with the current phase checked in the row and no asterisk next to the start date. The current status badge of the project next to the project name should change too.
6. Go to the **Notes** tab, and you should see your status update along with a phase badge that matches the phase that you just added
7. Last, edit an existing phase with a start date in the **Timeline** tab and toggle **Current phase** switch back and forth. It should have no effect on the start date.
8. When editing, make sure that the **Current phase** switch correctly matches the value of the row in the phase table. This was the regression.

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
