### PR TITLE
Exclude audit field from project phase event trigger listener

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3469,7 +3469,21 @@
         insert:
           columns: '*'
         update:
-          columns: '*'
+          columns:
+            - is_phase_start_confirmed
+            - is_phase_end_confirmed
+            - created_at
+            - phase_start
+            - phase_end
+            - is_deleted
+            - project_id
+            - created_by_user_id
+            - updated_by_user_id
+            - subphase_id
+            - phase_description
+            - is_current_phase
+            - project_phase_id
+            - phase_id
       retry_conf:
         interval_sec: 10
         num_retries: 0


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/15856

## Testing
**URL to test:**  Local

**Steps to test:**
1. Create a project phase
2. Edit the phase you created, but only fill in the Status update field
3. Does the activity log ok? 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
