### PR TITLE
replace moped_proj_notes rest connectors with db triggers

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2810,7 +2810,7 @@
         foreign_key_constraint_on: project_id
     - name: moped_user
       using:
-        foreign_key_constraint_on: added_by_user_id
+        foreign_key_constraint_on: created_by_user_id
   insert_permissions:
     - role: moped-admin
       permission:
@@ -2819,7 +2819,6 @@
           created_by_user_id: x-hasura-user-db-id
           updated_by_user_id: x-hasura-user-db-id
         columns:
-          - added_by_user_id
           - is_deleted
           - phase_id
           - project_id
@@ -2833,7 +2832,6 @@
           created_by_user_id: x-hasura-user-db-id
           updated_by_user_id: x-hasura-user-db-id
         columns:
-          - added_by_user_id
           - is_deleted
           - phase_id
           - project_id
@@ -2844,7 +2842,6 @@
     - role: moped-admin
       permission:
         columns:
-          - added_by_user_id
           - created_at
           - created_by_user_id
           - is_deleted
@@ -2860,7 +2857,6 @@
     - role: moped-editor
       permission:
         columns:
-          - added_by_user_id
           - created_at
           - created_by_user_id
           - is_deleted
@@ -2876,7 +2872,6 @@
     - role: moped-viewer
       permission:
         columns:
-          - added_by_user_id
           - created_at
           - created_by_user_id
           - is_deleted
@@ -2893,7 +2888,6 @@
     - role: moped-admin
       permission:
         columns:
-          - added_by_user_id
           - is_deleted
           - phase_id
           - project_id
@@ -2907,7 +2901,6 @@
     - role: moped-editor
       permission:
         columns:
-          - added_by_user_id
           - is_deleted
           - phase_id
           - project_id

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2815,63 +2815,78 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - added_by_user_id
-          - date_created
           - is_deleted
           - phase_id
           - project_id
           - project_note
           - project_note_type
+        comment: No insert permissions on audit fields
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - added_by_user_id
-          - date_created
           - is_deleted
           - phase_id
           - project_id
           - project_note
           - project_note_type
+        comment: No insert permissions on audit fields
   select_permissions:
     - role: moped-admin
       permission:
         columns:
           - added_by_user_id
-          - date_created
+          - created_at
+          - created_by_user_id
           - is_deleted
           - phase_id
           - project_id
           - project_note
           - project_note_id
           - project_note_type
+          - updated_at
+          - updated_by_user_id
         filter: {}
         allow_aggregations: true
     - role: moped-editor
       permission:
         columns:
           - added_by_user_id
-          - date_created
+          - created_at
+          - created_by_user_id
           - is_deleted
           - phase_id
           - project_id
           - project_note
           - project_note_id
           - project_note_type
+          - updated_at
+          - updated_by_user_id
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
       permission:
         columns:
           - added_by_user_id
-          - date_created
+          - created_at
+          - created_by_user_id
           - is_deleted
           - phase_id
           - project_id
           - project_note
           - project_note_id
           - project_note_type
+          - updated_at
+          - updated_by_user_id
         filter: {}
         allow_aggregations: true
   update_permissions:
@@ -2879,7 +2894,6 @@
       permission:
         columns:
           - added_by_user_id
-          - date_created
           - is_deleted
           - phase_id
           - project_id
@@ -2887,11 +2901,13 @@
           - project_note_type
         filter: {}
         check: null
+        set:
+          updated_by_user_id: x-hasura-user-db-id
+        comment: No update permissions on audit fields
     - role: moped-editor
       permission:
         columns:
           - added_by_user_id
-          - date_created
           - is_deleted
           - phase_id
           - project_id
@@ -2899,6 +2915,9 @@
           - project_note_type
         filter: {}
         check: null
+        set:
+          updated_by_user_id: x-hasura-user-db-id
+        comment: No update permissions on audit fields
   event_triggers:
     - name: activity_log_moped_proj_notes
       definition:
@@ -2920,7 +2939,7 @@
           action: transform
           template: |-
             {
-              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",
               "variables": {
                 "object": {
                   "record_id": {{ $body.event.data.new.project_note_id }},
@@ -2931,9 +2950,7 @@
                   "description": [{"newSchema": "true"}],
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
-                },
-                "updated_at": {{$body.created_at}},
-                "project_id": {{$body.event.data.new.project_id}}
+                }
               }
             }
         template_engine: Kriti
@@ -3430,8 +3447,6 @@
   update_permissions:
     - role: moped-admin
       permission:
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_current_phase
           - is_deleted
@@ -3445,10 +3460,10 @@
           - is_phase_end_confirmed
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_current_phase
           - is_deleted
@@ -3462,6 +3477,8 @@
           - is_phase_end_confirmed
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_moped_proj_phases
       definition:

--- a/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/down.sql
+++ b/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/down.sql
@@ -1,6 +1,5 @@
 ALTER TABLE public.moped_proj_notes RENAME COLUMN created_at TO date_created;
-ALTER TABLE public.moped_proj_notes RENAME COLUMN created_at TO date_added;
-ALTER TABLE public.moped_proj_notes DROP COLUMN created_by_user_id;
+ALTER TABLE public.moped_proj_notes RENAME COLUMN created_by_user_id TO added_by_user_id;
 ALTER TABLE public.moped_proj_notes DROP COLUMN updated_at;
 ALTER TABLE public.moped_proj_notes DROP COLUMN updated_by_user_id;
 

--- a/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/down.sql
+++ b/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.moped_proj_notes RENAME COLUMN created_at TO date_created;
+ALTER TABLE public.moped_proj_notes RENAME COLUMN created_at TO date_added;
+ALTER TABLE public.moped_proj_notes DROP COLUMN created_by_user_id;
+ALTER TABLE public.moped_proj_notes DROP COLUMN updated_at;
+ALTER TABLE public.moped_proj_notes DROP COLUMN updated_by_user_id;
+
+DROP TRIGGER update_moped_proj_notes_and_project_audit_fields ON moped_proj_notes;

--- a/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/up.sql
+++ b/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE moped_proj_notes RENAME COLUMN date_created TO created_at;
+ALTER TABLE moped_proj_notes ADD COLUMN created_by_user_id INTEGER
+ NULL;
+ALTER TABLE moped_proj_notes ADD COLUMN updated_at TIMESTAMPTZ
+ NULL;
+ALTER TABLE moped_proj_notes ADD COLUMN updated_by_user_id INTEGER
+ NULL;
+
+COMMENT ON COLUMN moped_proj_notes.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN moped_proj_notes.updated_by_user_id IS 'ID of the user who last updated the record';
+
+CREATE TRIGGER update_moped_proj_notes_and_project_audit_fields
+BEFORE INSERT OR UPDATE ON moped_proj_notes
+FOR EACH ROW
+EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
+
+COMMENT ON TRIGGER update_moped_proj_notes_and_project_audit_fields ON moped_proj_notes IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_notes table.';

--- a/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/up.sql
+++ b/moped-database/migrations/1708036428508_alter_table_public_moped_proj_notes_alter_column_date_created/up.sql
@@ -1,6 +1,5 @@
 ALTER TABLE moped_proj_notes RENAME COLUMN date_created TO created_at;
-ALTER TABLE moped_proj_notes ADD COLUMN created_by_user_id INTEGER
- NULL;
+ALTER TABLE moped_proj_notes RENAME COLUMN added_by_user_id TO created_by_user_id;
 ALTER TABLE moped_proj_notes ADD COLUMN updated_at TIMESTAMPTZ
  NULL;
 ALTER TABLE moped_proj_notes ADD COLUMN updated_by_user_id INTEGER

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -100,8 +100,8 @@ INSERT INTO public.moped_proj_milestones (project_milestone_id, project_id, desc
 -- Data for Name: moped_proj_notes; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (2, '<p>This is a status update</p>', '2022-11-12 18:08:55.845376+00', 227, 1, 2, false);
-INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (3, '<p>This is an internal note</p>', '2022-11-12 18:14:16.640873+00', 227, 1, 1, false);
+INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, created_by_user_id, project_note_type, is_deleted) VALUES (2, '<p>This is a status update</p>', '2022-11-12 18:08:55.845376+00', 227, 1, 2, false);
+INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, created_by_user_id, project_note_type, is_deleted) VALUES (3, '<p>This is an internal note</p>', '2022-11-12 18:14:16.640873+00', 227, 1, 1, false);
 
 
 --

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -100,8 +100,8 @@ INSERT INTO public.moped_proj_milestones (project_milestone_id, project_id, desc
 -- Data for Name: moped_proj_notes; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_proj_notes (project_note_id, project_note, date_created, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (2, '<p>This is a status update</p>', '2022-11-12 18:08:55.845376+00', 227, 1, 2, false);
-INSERT INTO public.moped_proj_notes (project_note_id, project_note, date_created, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (3, '<p>This is an internal note</p>', '2022-11-12 18:14:16.640873+00', 227, 1, 1, false);
+INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (2, '<p>This is a status update</p>', '2022-11-12 18:08:55.845376+00', 227, 1, 2, false);
+INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, project_id, added_by_user_id, project_note_type, is_deleted) VALUES (3, '<p>This is an internal note</p>', '2022-11-12 18:14:16.640873+00', 227, 1, 1, false);
 
 
 --

--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -27,7 +27,7 @@ export const DASHBOARD_QUERY = gql`
         }
         moped_proj_notes(
           where: { project_note_type: { _eq: 2 }, is_deleted: { _eq: false } }
-          order_by: { date_created: desc }
+          order_by: { created_at: desc }
         ) {
           moped_user {
             first_name

--- a/moped-editor/src/queries/notes.js
+++ b/moped-editor/src/queries/notes.js
@@ -4,7 +4,7 @@ export const NOTES_QUERY = gql`
   query GetProjectNotes($projectNoteConditions: moped_proj_notes_bool_exp!) {
     moped_proj_notes(
       where: $projectNoteConditions
-      order_by: { date_created: desc }
+      order_by: { created_at: desc }
     ) {
       moped_user {
         first_name
@@ -12,7 +12,7 @@ export const NOTES_QUERY = gql`
       }
       project_note
       project_id
-      date_created
+      created_at
       project_note_id
       project_note_type
       is_deleted

--- a/moped-editor/src/queries/notes.js
+++ b/moped-editor/src/queries/notes.js
@@ -16,7 +16,7 @@ export const NOTES_QUERY = gql`
       project_note_id
       project_note_type
       is_deleted
-      added_by_user_id
+      created_by_user_id
       moped_phase {
         phase_key
         phase_name

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -52,7 +52,7 @@ export const SUMMARY_QUERY = gql`
       }
       moped_proj_notes(
         where: { project_note_type: { _eq: 2 }, is_deleted: { _eq: false } }
-        order_by: { date_created: desc }
+        order_by: { created_at: desc }
       ) {
         project_note_id
         project_note
@@ -60,7 +60,7 @@ export const SUMMARY_QUERY = gql`
           first_name
           last_name
         }
-        date_created
+        created_at
       }
       moped_project_types(where: { is_deleted: { _eq: false } }) {
         id

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -181,17 +181,11 @@ export const ProjectActivityLogTableMaps = {
       project_note_id: {
         label: "note ID",
       },
-      date_created: {
-        label: "date created",
-      },
       project_note: {
         label: "note",
       },
       is_deleted: {
         label: "is deleted",
-      },
-      added_by_user_id: {
-        label: "added by user ID",
       },
       project_note_type: {
         label: "note type",

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -353,7 +353,7 @@ const ProjectNotes = (props) => {
                      * Only allow the user who wrote the status to edit it
                      */
                     const editableNote =
-                      userSessionData.user_id === item.added_by_user_id;
+                      userSessionData.user_id === item.created_by_user_id;
                     return (
                       <React.Fragment key={item.project_note_id}>
                         <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -192,7 +192,7 @@ const ProjectNotes = (props) => {
           {
             project_note: DOMPurify.sanitize(noteText),
             project_id: projectId,
-            added_by_user_id: Number(userSessionData.user_id),
+            // added_by_user_id: Number(userSessionData.user_id),
             project_note_type: newNoteType,
             phase_id: currentPhaseId,
           },
@@ -376,9 +376,9 @@ const ProjectNotes = (props) => {
                                   className={classes.noteDate}
                                 >
                                   {` - ${makeUSExpandedFormDateFromTimeStampTZ(
-                                    item.date_created
+                                    item.created_at
                                   )} ${makeHourAndMinutesFromTimeStampTZ(
-                                    item.date_created
+                                    item.created_at
                                   )}`}
                                 </Typography>
                                 <Typography

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -192,7 +192,6 @@ const ProjectNotes = (props) => {
           {
             project_note: DOMPurify.sanitize(noteText),
             project_id: projectId,
-            // added_by_user_id: Number(userSessionData.user_id),
             project_note_type: newNoteType,
             phase_id: currentPhaseId,
           },

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
@@ -192,6 +192,7 @@ export const onSubmitPhase = ({
         {
           project_note: DOMPurify.sanitize(noteData.status_update),
           project_id,
+          created_by_user_id: noteData.user_id,
           project_note_type: STATUS_UPDATE_TYPE_ID,
           phase_id: is_current_phase ? phase_id : currentPhaseIds[0],
         },

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
@@ -192,7 +192,6 @@ export const onSubmitPhase = ({
         {
           project_note: DOMPurify.sanitize(noteData.status_update),
           project_id,
-          added_by_user_id: noteData.user_id,
           project_note_type: STATUS_UPDATE_TYPE_ID,
           phase_id: is_current_phase ? phase_id : currentPhaseIds[0],
         },

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/helpers.js
@@ -192,7 +192,6 @@ export const onSubmitPhase = ({
         {
           project_note: DOMPurify.sanitize(noteData.status_update),
           project_id,
-          created_by_user_id: noteData.user_id,
           project_note_type: STATUS_UPDATE_TYPE_ID,
           phase_id: is_current_phase ? phase_id : currentPhaseIds[0],
         },

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryStatusUpdate.js
@@ -25,7 +25,7 @@ const ProjectSummaryStatusUpdate = ({ projectId, data, refetch, classes }) => {
     data.moped_project[0].moped_proj_phases[0]?.moped_phase.phase_id;
 
   const dateCreated = formatRelativeDate(
-    data.moped_project[0].moped_proj_notes[0]?.date_created
+    data.moped_project[0].moped_proj_notes[0]?.created_at
   );
 
   return (

--- a/moped-toolbox/knack_migration/1_prepare_projects.py
+++ b/moped-toolbox/knack_migration/1_prepare_projects.py
@@ -40,7 +40,7 @@ def build_note(note, user_name, user_id, note_type=2):
         # project note types are hardcoded. see here: https://github.com/cityofaustin/atd-moped/blob/main/moped-editor/src/views/projects/projectView/ProjectNotes.js#L321
         "project_note_type": note_type,
         "added_by": user_name,
-        "added_by_user_id": user_id,
+        "created_by_user_id": user_id,
         "project_note": note,
     }
 

--- a/moped-toolbox/random_project_seeds/index.js
+++ b/moped-toolbox/random_project_seeds/index.js
@@ -82,7 +82,7 @@ const randomProjectType = () => ({
 const randomNote = () => ({
   project_note: randomString(200),
   project_note_type: randomArrElement(lookups.project_note_types),
-  added_by_user_id: randomArrElement(lookups.users),
+  created_by_user_id: randomArrElement(lookups.users),
 });
 
 const randomTag = () => ({


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/15489

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local

**Steps to test:**
- go to a project's notes section and add a note
- confirm that the update is registered in the activity log
- edit the note and check the activity log
- go to the new note record in the db and confirm the created_at, updated_at, created_by_user_id and updated_by_user_id columns are correct. there should no longer be a date_added or added_by_user_id column
- delete the note and confirm in the activity log
- confirm in the db that the record was set to `is_deleted` is `true`
- try adding a note from the project summary page status update modal
- try adding a note from the phases table

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
