### PR TITLE
Bug - Fix parent project name not showing in project list

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -493,6 +493,7 @@ export const useTableOptions = ({ queryLimit, data }) =>
         // is conflicting with the search/filter dropdown
         zIndex: 1,
         whiteSpace: "nowrap",
+        backgroundColor: "white"
       },
       columnsButton: true,
       idSynonym: "project_id",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -156,7 +156,8 @@ export const useColumns = ({ hiddenColumns }) => {
     // See https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids
     // Also, some columns are dependencies of other columns to render, so we need to include them.
     // Ex. Rendering ProjectStatusBadge requires current_phase_key which is not a column shown in the UI
-    const columnsNeededToRender = ["project_id", "current_phase_key"];
+    // Parent project Id needs the parent project name
+    const columnsNeededToRender = ["project_id", "current_phase_key", "parent_project_name"];
 
     return [...columnsShownInUI, ...columnsNeededToRender];
   }, [hiddenColumns]);


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15895

## Testing
**URL to test:** 

https://deploy-preview-1281--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

Toggle the parent project column to be visible. You should see links to the parent project summary page, if the project has a parent. Currently in prod you only see a blank space. 

While testing this, I noticed that the column headers should also have a white background, as opposed to a transparent one. This is what can happen now in prod: 
![Screenshot 2024-02-19 at 1 42 58 PM](https://github.com/cityofaustin/atd-moped/assets/12474808/46969493-de61-461c-97da-eeef1ed26f0e)

Confirm this does not happen on my preview branch. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
