### PR TITLE
Update activity log handler to represent restoring a project

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -67,7 +67,7 @@ export const formatComponentsActivity = (
     return {
       changeIcon,
       changeText: [
-        { text: "Restored a component: ", style: null },
+        { text: "Restored a deleted component: ", style: null },
         simpleComponentText,
       ],
     };

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -54,13 +54,24 @@ export const formatComponentsActivity = (
   // delete an existing component
   if (change.description[0].field === "is_deleted") {
     const {link, ...simpleComponentText} = componentText;
+    if (change.record_data.event.data.new.is_deleted) {
+      return {
+        changeIcon,
+        changeText: [
+          { text: "Removed a component: ", style: null },
+          simpleComponentText,
+        ],
+      };
+    }
+    // if is_deleted is false, and the change is in the activity log, we restored a soft delete
     return {
       changeIcon,
       changeText: [
-        { text: "Removed a component: ", style: null },
+        { text: "Restored a component: ", style: null },
         simpleComponentText,
       ],
     };
+
   }
 
   if (change.description[0].field === "project_id") {


### PR DESCRIPTION
## Associated issues

No issue, but as I was restoring deleted components from https://mobility.austin.gov/moped/projects/2854?tab=activity_log, I realized that our activity log never expected to handle undeleting. 

## Testing
https://deploy-preview-1282--atd-moped-main.netlify.app/moped/projects/1925?tab=activity_log

**Steps to test:**

See this one project's activity. i deleted a component, and then restored it. Unlike in prod, it does not say "removed" multiple times. 

**note** I'd like to get this into a patch release this week