### PR TITLE
fixes deleting phase in activity log

### DIFF
--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -219,10 +219,10 @@ LEFT JOIN project_district_association districts ON mp.project_id = districts.pr
 LEFT JOIN LATERAL (
     SELECT
         mpn.project_note,
-        mpn.date_created
+        mpn.created_at AS date_created
     FROM moped_proj_notes mpn
     WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
-    ORDER BY mpn.date_created DESC
+    ORDER BY mpn.created_at DESC
     LIMIT 1
 ) proj_status_update ON true
 WHERE mp.is_deleted = false

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -37,19 +37,8 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
 
   let changes = [];
 
-  // loop through fields to check for differences, push label onto changes Array
-  Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
-      // filter out fields that are not listed in the activity log table maps to prevent
-      // automated field updates (created at, updated at, etc.) from entering the array
-      if (!!entryMap.fields[field]) {
-        changes.push(entryMap.fields[field]?.label);
-      }
-    }
-  });
-
-  // if the changes array includes a deletion that supersedes any other changes
-  if (changes.includes("is deleted")) {
+  // if the record has been deleted that supersedes any other changes
+  if (newRecord["is_deleted"] === true) {
     return {
       changeIcon,
       changeText: [
@@ -60,6 +49,17 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       ],
     };
   }
+
+  // loop through fields to check for differences, push label onto changes Array
+  Object.keys(newRecord).forEach((field) => {
+    if (newRecord[field] !== oldRecord[field]) {
+      // filter out fields that are not listed in the activity log table maps to prevent
+      // automated field updates (created at, updated at, etc.) from entering the array
+      if (!!entryMap.fields[field]) {
+        changes.push(entryMap.fields[field]?.label);
+      }
+    }
+  });
 
   // else render the array as a list of changed fields
   return {

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -30,19 +30,6 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
     };
   }
 
-  // delete an existing phase
-  if (change.description[0].field === "is_deleted") {
-    return {
-      changeIcon,
-      changeText: [
-        { text: "Deleted the phase ", style: null },
-        phaseText,
-        // include subphase name if one exists
-        ...(subphase ? [subphaseText] : []),
-      ],
-    };
-  }
-
   // Multiple fields in the moped_proj_phases table can be updated at once
   // We list the fields changed in the activity log, this gathers the fields changed
   const newRecord = change.record_data.event.data.new;
@@ -60,6 +47,19 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
       }
     }
   });
+
+  // if the changes array includes a deletion that supersedes any other changes
+  if (changes.includes("is deleted")) {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Deleted the phase ", style: null },
+        phaseText,
+        // include subphase name if one exists
+        ...(subphase ? [subphaseText] : []),
+      ],
+    };
+  }
 
   return {
     changeIcon,

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -61,6 +61,7 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
     };
   }
 
+  // else render the array as a list of changed fields
   return {
     changeIcon,
     changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -61,7 +61,6 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
     }
   });
 
-  // else render the array as a list of changed fields
   return {
     changeIcon,
     changeText: [

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -131,7 +131,8 @@ const useLookupTables = (data) =>
 /** Fields which do not need to be rendered in the activity log */
 const CHANGE_FIELDS_TO_IGNORE = [
   "updated_by_user_id",
-  "updated_at"
+  "updated_at",
+  "is_current_phase"
 ];
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -131,7 +131,7 @@ const useLookupTables = (data) =>
 /** Fields which do not need to be rendered in the activity log */
 const CHANGE_FIELDS_TO_IGNORE = [
   "updated_by_user_id",
-  "updated_at",
+  "updated_at"
 ];
 
 /**

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -132,7 +132,6 @@ const useLookupTables = (data) =>
 const CHANGE_FIELDS_TO_IGNORE = [
   "updated_by_user_id",
   "updated_at",
-  "is_current_phase"
 ];
 
 /**


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15932

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1287--atd-moped-main.netlify.app/

**Steps to test:**
- delete a current phase from a project's timeline
- delete a non-current phase from a project's timeline
- check the activity log, the two actions should render the same "x Deleted the phase x"

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
