### PR TITLE
escapes double quotes and backslash in search

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -244,7 +244,7 @@ const NavigationSearchInput = ({ input404Class }) => {
         const { operator, quoted, envelope } =
           projectSearchQuery.current.config.columns[column].search;
         const searchValue = getSearchValue(
-          projectSearchQuery.current,
+          projectSearchQuery.current.config,
           column,
           searchTerm
         );

--- a/moped-editor/src/utils/gridTableHelpers.js
+++ b/moped-editor/src/utils/gridTableHelpers.js
@@ -7,12 +7,12 @@
  * @param {*} value - The value in question
  * @returns {*} - The value output
  */
-export const getSearchValue = (query, column, value) => {
+export const getSearchValue = (queryConfig, column, value) => {
   // Retrieve the type of field (string, float, int, etc)
-  const type = query.config.columns[column].type.toLowerCase();
+  const type = queryConfig.columns[column].type.toLowerCase();
   // Get the invalidValueDefault in the search config object
   const invalidValueDefault =
-    query.config.columns[column].search?.invalidValueDefault ?? null;
+    queryConfig.columns[column].search?.invalidValueDefault ?? null;
   // If the type is number of float, attempt to parse as such
   if (["number", "float", "double"].includes(type)) {
     value = Number.parseFloat(value) || invalidValueDefault;
@@ -20,6 +20,10 @@ export const getSearchValue = (query, column, value) => {
   // If integer, attempt to parse as integer
   if (["int", "integer"].includes(type)) {
     value = Number.parseInt(value) || invalidValueDefault;
+  }
+  // If string, remove unrecognized graphQL characters (double-quotes or backslash)
+  if (typeof value === "string") {
+    value = value.replace(/"|\\/g, "");
   }
   // Any other value types are pass-through for now
   return value;

--- a/moped-editor/src/utils/gridTableHelpers.js
+++ b/moped-editor/src/utils/gridTableHelpers.js
@@ -7,12 +7,20 @@
  * @param {*} value - The value in question
  * @returns {*} - The value output
  */
+
+export const parseGqlString = (value) => {
+  // Remove unrecognized graphQL characters (double-quotes or backslash)
+  value = value.replace(/"|\\/g, "");
+  return value;
+};
+
 export const getSearchValue = (queryConfig, column, value) => {
   // Retrieve the type of field (string, float, int, etc)
   const type = queryConfig.columns[column].type.toLowerCase();
   // Get the invalidValueDefault in the search config object
   const invalidValueDefault =
     queryConfig.columns[column].search?.invalidValueDefault ?? null;
+
   // If the type is number of float, attempt to parse as such
   if (["number", "float", "double"].includes(type)) {
     value = Number.parseFloat(value) || invalidValueDefault;
@@ -21,9 +29,9 @@ export const getSearchValue = (queryConfig, column, value) => {
   if (["int", "integer"].includes(type)) {
     value = Number.parseInt(value) || invalidValueDefault;
   }
-  // If string, remove unrecognized graphQL characters (double-quotes or backslash)
+  // If string, parse as string
   if (typeof value === "string") {
-    value = value.replace(/"|\\/g, "");
+    value = parseGqlString(value);
   }
   // Any other value types are pass-through for now
   return value;

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -77,7 +77,7 @@ const makeAdvancedSearchWhereFilters = (filters) =>
           if (type === "array") {
             value = `[${value}]`;
           } else if (!["number", "boolean"].includes(type)) {
-            value = `"${value.replace(/"|\\/g, '')}"`;
+            value = `"${value.replace(/"|\\/g, "")}"`;
           }
         } else {
           // We don't have a value
@@ -110,10 +110,7 @@ export const useAdvancedSearch = () => {
     const advancedFilters = makeAdvancedSearchWhereFilters(filters);
     if (advancedFilters.length === 0) return null;
 
-    const bracketedFilters = advancedFilters.map((filter) => {
-      console.log(filter);
-      return `{ ${filter} }`;
-    });
+    const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);
 
     if (isOr) {
       // Ex. _or: [{project_lead: {_eq: "COA ATD Project Delivery"}}, {project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}}]

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -72,11 +72,12 @@ const makeAdvancedSearchWhereFilters = (filters) =>
           value = envelope ? envelope.replace("{VALUE}", value) : value;
 
           // If it is a number or boolean, it does not need quotation marks
-          // Otherwise, add quotation marks for the query to identify as string
+          // Otherwise, remove unrecognized graphQL characters (double-quotes or backslash)
+          // and add quotation marks for the query to identify as string
           if (type === "array") {
             value = `[${value}]`;
           } else if (!["number", "boolean"].includes(type)) {
-            value = `"${value}"`;
+            value = `"${value.replace(/"|\\/g, '')}"`;
           }
         } else {
           // We don't have a value
@@ -109,7 +110,10 @@ export const useAdvancedSearch = () => {
     const advancedFilters = makeAdvancedSearchWhereFilters(filters);
     if (advancedFilters.length === 0) return null;
 
-    const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);
+    const bracketedFilters = advancedFilters.map((filter) => {
+      console.log(filter);
+      return `{ ${filter} }`;
+    });
 
     if (isOr) {
       // Ex. _or: [{project_lead: {_eq: "COA ATD Project Delivery"}}, {project_sponsor: {_eq: "COA ATD Active Transportation & Street Design"}}]

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { PROJECT_LIST_VIEW_FILTERS_CONFIG } from "../ProjectsListViewFiltersConf";
 import { FiltersCommonOperators } from "src/components/GridTable/FiltersCommonOperators";
+import { parseGqlString } from "src/utils/gridTableHelpers";
 
 /* Names of advanced search URL parameters */
 export const advancedSearchFilterParamName = "filters";
@@ -72,12 +73,11 @@ const makeAdvancedSearchWhereFilters = (filters) =>
           value = envelope ? envelope.replace("{VALUE}", value) : value;
 
           // If it is a number or boolean, it does not need quotation marks
-          // Otherwise, remove unrecognized graphQL characters (double-quotes or backslash)
-          // and add quotation marks for the query to identify as string
+          // Otherwise, parse as string and add quotation marks for the query to identify as string
           if (type === "array") {
             value = `[${value}]`;
           } else if (!["number", "boolean"].includes(type)) {
-            value = `"${value.replace(/"|\\/g, "")}"`;
+            value = `"${parseGqlString(value)}"`;
           }
         } else {
           // We don't have a value

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -26,6 +26,10 @@ export const getSearchValue = (column, value, queryConfig) => {
   if (["int", "integer"].includes(type)) {
     value = Number.parseInt(value) || invalidValueDefault;
   }
+  // If string, remove unrecognized graphQL characters
+  if (typeof(value) === "string") {
+    value = value.replace(/"|\\/g, '')
+  }
   // Any other value types are pass-through for now
   return value;
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -26,7 +26,7 @@ export const getSearchValue = (column, value, queryConfig) => {
   if (["int", "integer"].includes(type)) {
     value = Number.parseInt(value) || invalidValueDefault;
   }
-  // If string, remove unrecognized graphQL characters
+  // If string, remove unrecognized graphQL characters (double-quotes or backslash)
   if (typeof(value) === "string") {
     value = value.replace(/"|\\/g, '')
   }

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useSearch.js
@@ -1,38 +1,9 @@
 import { useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { getSearchValue } from "src/utils/gridTableHelpers";
 
 /* Name of simple search URL parameter */
 export const simpleSearchParamName = "search";
-
-/**
- * Attempts to retrieve a valid graphql search value, for example when searching on an
- * integer/float field but providing it a string, this function returns the value configured
- * in the invalidValueDefault field in the search object, or null.
- * @param {string} column - The name of the column to search
- * @param {*} value - The value in question
- * @returns {*} - The value output
- */
-export const getSearchValue = (column, value, queryConfig) => {
-  // Retrieve the type of field (string, float, int, etc)
-  const type = queryConfig.columns[column].type.toLowerCase();
-  // Get the invalidValueDefault in the search config object
-  const invalidValueDefault =
-    queryConfig.columns[column].search?.invalidValueDefault ?? null;
-  // If the type is number of float, attempt to parse as such
-  if (["number", "float", "double"].includes(type)) {
-    value = Number.parseFloat(value) || invalidValueDefault;
-  }
-  // If integer, attempt to parse as integer
-  if (["int", "integer"].includes(type)) {
-    value = Number.parseInt(value) || invalidValueDefault;
-  }
-  // If string, remove unrecognized graphQL characters (double-quotes or backslash)
-  if (typeof(value) === "string") {
-    value = value.replace(/"|\\/g, '')
-  }
-  // Any other value types are pass-through for now
-  return value;
-};
 
 export const useSearch = ({ queryConfig }) => {
   /* Get simple search from search params if it exists */
@@ -52,7 +23,7 @@ export const useSearch = ({ queryConfig }) => {
         .map((column) => {
           const { operator, quoted, envelope } =
             queryConfig.columns[column].search;
-          const searchValue = getSearchValue(column, searchTerm, queryConfig);
+          const searchValue = getSearchValue(queryConfig, column, searchTerm);
           const graphqlSearchValue = quoted
             ? `"${envelope.replace("{VALUE}", searchValue)}"`
             : searchValue;


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15050

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1289--atd-moped-main.netlify.app/

**Steps to test:**
- try searching a double-quote (") and/or a backslash (\\) in the nav search bar, it should react as if you searched an empty query
- try searching a normal query using an integer and/or a string and confirm it works as expected
- repeat the steps above using the main search bar above the table
- repeat the steps above using the advanced search ``name`` ``contains`` field

---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
