### PR TITLE
Add audit fields to moped_project_files table

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.7'
 services:
     hasura:
-        image: hasura/graphql-engine:v2.37.0
+        image: hasura/graphql-engine:v2.37.1
         restart: always
         depends_on:
             - moped-pgsql

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4236,6 +4236,9 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - is_scanned
@@ -4254,6 +4257,9 @@
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - is_scanned

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4231,7 +4231,7 @@
         foreign_key_constraint_on: project_id
     - name: moped_user
       using:
-        foreign_key_constraint_on: created_by
+        foreign_key_constraint_on: created_by_user_id
   insert_permissions:
     - role: moped-admin
       permission:
@@ -4239,7 +4239,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_id
@@ -4249,7 +4249,7 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
     - role: moped-editor
       permission:
@@ -4257,7 +4257,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_id
@@ -4267,15 +4267,15 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
   select_permissions:
     - role: moped-admin
       permission:
         columns:
           - api_response
-          - create_date
-          - created_by
+          - created_at
+          - created_by_user_id
           - file_description
           - file_key
           - file_metadata
@@ -4294,7 +4294,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_file_id
@@ -4305,7 +4305,7 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
         filter: {}
     - role: moped-viewer
@@ -4313,7 +4313,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_file_id
@@ -4324,7 +4324,7 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
         filter: {}
   update_permissions:
@@ -4333,7 +4333,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_id
@@ -4343,7 +4343,7 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
         filter: {}
         check: null
@@ -4352,7 +4352,7 @@
         columns:
           - is_deleted
           - is_scanned
-          - created_by
+          - created_by_user_id
           - file_size
           - file_type
           - project_id
@@ -4362,7 +4362,7 @@
           - file_description
           - file_key
           - file_name
-          - create_date
+          - created_at
           - file_url
         filter: {}
         check: null
@@ -4387,7 +4387,7 @@
           action: transform
           template: |-
             {
-              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input! ) { insert_moped_activity_log_one(object: $object) { activity_id } }",
               "variables": {
                 "object": {
                   "record_id": {{ $body.event.data.new.project_file_id }},
@@ -4398,9 +4398,7 @@
                   "description": [{"newSchema": "true"}],
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
-                },
-                "updated_at": {{$body.created_at}},
-                "project_id": {{$body.event.data.new.project_id}}
+                }
               }
             }
         method: POST

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4353,6 +4353,8 @@
           - file_url
         filter: {}
         check: null
+        set:
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
         columns:
@@ -4372,6 +4374,8 @@
           - file_url
         filter: {}
         check: null
+        set:
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_moped_project_files
       definition:

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/down.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/down.sql
@@ -1,6 +1,6 @@
-ALTER TABLE moped_proj_files RENAME COLUMN created_at TO create_date;
-ALTER TABLE moped_proj_files RENAME COLUMN created_by_user_id TO created_by;
-ALTER TABLE moped_proj_files DROP COLUMN updated_at;
-ALTER TABLE moped_proj_files DROP COLUMN updated_by_user_id;
+ALTER TABLE moped_project_files RENAME COLUMN created_at TO create_date;
+ALTER TABLE moped_project_files RENAME COLUMN created_by_user_id TO created_by;
+ALTER TABLE moped_project_files DROP COLUMN updated_at;
+ALTER TABLE moped_project_files DROP COLUMN updated_by_user_id;
 
-DROP TRIGGER update_moped_proj_files_and_project_audit_fields ON moped_proj_files;
+DROP TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files;

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/down.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE moped_proj_files RENAME COLUMN created_at TO create_date;
+ALTER TABLE moped_proj_files RENAME COLUMN created_by_user_id TO created_by;
+ALTER TABLE moped_proj_files DROP COLUMN updated_at;
+ALTER TABLE moped_proj_files DROP COLUMN updated_by_user_id;
+
+DROP TRIGGER update_moped_proj_files_and_project_audit_fields ON moped_proj_files;

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
@@ -17,4 +17,4 @@ OR UPDATE ON moped_project_files
 FOR EACH ROW
 EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
 
-COMMENT ON TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_phases table.';
+COMMENT ON TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_files table.';

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
@@ -1,20 +1,20 @@
-ALTER TABLE moped_proj_files RENAME COLUMN create_date TO created_at;
-ALTER TABLE moped_proj_files RENAME COLUMN created_by TO created_by_user_id;
+ALTER TABLE moped_project_files RENAME COLUMN create_date TO created_at;
+ALTER TABLE moped_project_files RENAME COLUMN created_by TO created_by_user_id;
 
-ALTER TABLE moped_proj_files ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE moped_project_files ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
 
-ALTER TABLE moped_proj_files
+ALTER TABLE moped_project_files
 ADD COLUMN updated_by_user_id INTEGER
 CONSTRAINT updated_by_user_fkey REFERENCES moped_users (user_id);
 
 
-COMMENT ON COLUMN moped_proj_files.updated_at IS 'Timestamp when the record was last updated';
-COMMENT ON COLUMN moped_proj_files.updated_by_user_id IS 'ID of the user who last updated the record';
+COMMENT ON COLUMN moped_project_files.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN moped_project_files.updated_by_user_id IS 'ID of the user who last updated the record';
 
-CREATE TRIGGER update_moped_proj_files_and_project_audit_fields
+CREATE TRIGGER update_moped_project_files_and_project_audit_fields
 BEFORE INSERT
-OR UPDATE ON moped_proj_files
+OR UPDATE ON moped_project_files
 FOR EACH ROW
 EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
 
-COMMENT ON TRIGGER update_moped_proj_files_and_project_audit_fields ON moped_proj_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_phases table.';
+COMMENT ON TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_phases table.';

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
@@ -1,0 +1,20 @@
+ALTER TABLE moped_proj_files RENAME COLUMN create_date TO created_at;
+ALTER TABLE moped_proj_files RENAME COLUMN created_by TO created_by_user_id;
+
+ALTER TABLE moped_proj_files ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE moped_proj_files
+ADD COLUMN updated_by_user_id INTEGER
+CONSTRAINT updated_by_user_fkey REFERENCES moped_users (user_id);
+
+
+COMMENT ON COLUMN moped_proj_files.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN moped_proj_files.updated_by_user_id IS 'ID of the user who last updated the record';
+
+CREATE TRIGGER update_moped_proj_files_and_project_audit_fields
+BEFORE INSERT
+OR UPDATE ON moped_proj_files
+FOR EACH ROW
+EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
+
+COMMENT ON TRIGGER update_moped_proj_files_and_project_audit_fields ON moped_proj_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_phases table.';

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
@@ -17,4 +17,4 @@ OR UPDATE ON moped_project_files
 FOR EACH ROW
 EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
 
-COMMENT ON TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_files table.';
+COMMENT ON TRIGGER update_moped_project_files_and_project_audit_fields ON moped_project_files IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_project_files table.';

--- a/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
+++ b/moped-database/migrations/1709753345334_audit_fields_proj_files/up.sql
@@ -1,7 +1,7 @@
 ALTER TABLE moped_project_files RENAME COLUMN create_date TO created_at;
 ALTER TABLE moped_project_files RENAME COLUMN created_by TO created_by_user_id;
 
-ALTER TABLE moped_project_files ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE moped_project_files ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE DEFAULT now();
 
 ALTER TABLE moped_project_files
 ADD COLUMN updated_by_user_id INTEGER

--- a/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
+++ b/moped-editor/src/components/FileUpload/FileUploadDialogSingle.js
@@ -10,6 +10,7 @@ import {
   TextField,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   InputLabel,
   Select,
   MenuItem,
@@ -204,6 +205,7 @@ const FileUploadDialogSingle = (props) => {
                 <MenuItem value={3}>Estimates</MenuItem>
                 <MenuItem value={4}>Other</MenuItem>
               </Select>
+              <FormHelperText>Required</FormHelperText>
             </FormControl>
 
             <TextField

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -662,8 +662,8 @@ export const PROJECT_FILE_ATTACHMENTS = gql`
       file_size
       file_metadata
       file_description
-      create_date
-      created_by
+      created_at
+      created_by_user_id
       file_url
       moped_user {
         user_id

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -263,7 +263,7 @@ const ProjectFiles = (props) => {
           id="file_description"
           name="file_description"
           value={props?.value ?? ""}
-          onChange={(e) => props.onChange(e.target.value.trim())}
+          onChange={(e) => props.onChange(e.target.value)}
         />
       ),
     },
@@ -392,7 +392,7 @@ const ProjectFiles = (props) => {
                   fileId: newData.project_file_id,
                   fileType: newData.file_type,
                   fileName: newData.file_name || null,
-                  fileDescription: newData.file_description || null,
+                  fileDescription: newData.file_description.trim() || null,
                   fileUrl: newData.file_url || null,
                 },
               }).then(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -114,7 +114,6 @@ const ProjectFiles = (props) => {
           file_key: fileDataBundle?.key,
           file_size: fileDataBundle?.file?.fileSize ?? 0,
           file_url: fileDataBundle?.url,
-          created_by: getDatabaseId(user),
         },
       },
     })
@@ -273,7 +272,7 @@ const ProjectFiles = (props) => {
       cellStyle: { fontFamily: typography.fontFamily },
       render: (record) => (
         <span>
-          {record?.created_by
+          {record?.created_by_user_id
             ? record?.moped_user?.first_name +
               " " +
               record?.moped_user?.last_name
@@ -285,13 +284,13 @@ const ProjectFiles = (props) => {
       title: "Date uploaded",
       cellStyle: { fontFamily: typography.fontFamily },
       customSort: (a, b) =>
-        new Date(a?.create_date ?? 0) - new Date(b?.create_date ?? 0),
+        new Date(a?.created_at ?? 0) - new Date(b?.created_at ?? 0),
       render: (record) => (
         <span>
-          {record?.create_date
+          {record?.created_at
             ? `${formatTimeStampTZType(
-                record.create_date
-              )}, ${makeFullTimeFromTimeStampTZ(record.create_date)}`
+                record.created_at
+              )}, ${makeFullTimeFromTimeStampTZ(record.created_at)}`
             : "N/A"}
         </span>
       ),

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -38,7 +38,7 @@ import {
   PROJECT_FILE_ATTACHMENTS_UPDATE,
   PROJECT_FILE_ATTACHMENTS_CREATE,
 } from "../../../queries/project";
-import { getJwt, getDatabaseId, useUser } from "../../../auth/user";
+import { getJwt, useUser } from "../../../auth/user";
 import downloadFileAttachment from "../../../utils/downloadFileAttachment";
 import { PAGING_DEFAULT_COUNT } from "../../../constants/tables";
 import {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -186,7 +186,7 @@ const ProjectsListViewTable = () => {
         <Paper className={classes.paper}>
           <Box
             sx={{
-              height: "70vh",
+              height: "75vh",
               minHeight: "400px",
               marginTop: "14px",
             }}


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/16156

## Testing
**URL to test:** 
local

**Steps to test:**

Edit the description of an existing file. Check that your id is the updated by user id and that the updated timestamp works, and that the project itself has a last updated timestamp that matches. 

Add a new file by using the file url option, you can use a random url or comment like "in g drive", and check that the audit fields make sense. 


Note: I merged Tilly's recent work into this, so its using the new and improved trigger function

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
