### PR TITLE
Update the followed at projects order by as well

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -60,7 +60,7 @@ export const DASHBOARD_QUERY = gql`
         }
         moped_proj_notes(
           where: { project_note_type: { _eq: 2 }, is_deleted: { _eq: false } }
-          order_by: { date_created: desc }
+          order_by: { created_at: desc }
         ) {
           project_note_type
           project_note


### PR DESCRIPTION
## Associated issues

The dashboard in prod is not loading because the dashboard query was only fixed for projects a user is a member of, and not the followed projects

https://github.com/cityofaustin/atd-moped/pull/1280

## Testing
**URL to test:** 

https://deploy-preview-1294--atd-moped-main.netlify.app/moped/dashboard


**Steps to test:**

Load your dashboard and see projects. 

Once this is approved, I'll open a patch to fix prod. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
