### PR TITLE
Use alternate Mapbox error fix

### DIFF
--- a/moped-editor/package-lock.json
+++ b/moped-editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atd-moped-editor",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atd-moped-editor",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@apollo/client": "^3.8.9",
@@ -65,7 +65,6 @@
         "react-scripts": "^5.0.1",
         "styled-components": "^5.3.11",
         "uuid": "^8.3.2",
-        "worker-loader": "^3.0.8",
         "yup": "^0.29.3"
       },
       "devDependencies": {
@@ -34384,25 +34383,6 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.6.0"
-      }
-    },
-    "node_modules/worker-loader": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
-      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -96,7 +96,6 @@
     "react-scripts": "^5.0.1",
     "styled-components": "^5.3.11",
     "uuid": "^8.3.2",
-    "worker-loader": "^3.0.8",
     "yup": "^0.29.3"
   },
   "engines": {

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -27,16 +27,18 @@
   },
   "browserslist": {
     "production": [
-      ">0.3%",
-      "not ie 11",
+      ">0.2%",
       "not dead",
-      "not op_mini all"
+      "not op_mini all",
+      "not safari < 10",
+      "not chrome < 51",
+      "not android < 5",
+      "not ie < 12"
     ],
     "development": [
-      ">0.3%",
-      "not ie 11",
-      "not dead",
-      "not op_mini all"
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
     ]
   },
   "dependencies": {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -38,12 +38,6 @@ import {
 import { getClickedFeatureFromMap } from "./utils/onMapClick";
 import { useHasMapLoaded } from "./utils/useHasMapLoaded";
 
-// See https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
-import mapboxgl from "mapbox-gl";
-mapboxgl.workerClass =
-  // eslint-disable-next-line import/no-webpack-loader-syntax
-  require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
-
 export default function TheMap({
   projectComponents,
   allRelatedComponents,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -63,10 +63,7 @@ const ProjectSummaryMap = ({ data }) => {
             setBasemapKey={setBasemapKey}
           />
           <NavigationControl position="bottom-left" showCompass={false} />
-          <BaseMapSourceAndLayers
-            basemapKey={basemapKey}
-            setBasemapKey={setBasemapKey}
-          />
+          <BaseMapSourceAndLayers basemapKey={basemapKey} />
           {/* Wait until the map loads and components-placeholder layer is ready to target */}
           {hasMapLoaded && (
             <>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryMap.js
@@ -53,7 +53,7 @@ const ProjectSummaryMap = ({ data }) => {
           ref={mapRef}
           initialViewState={initialViewState}
           style={{ width: "100%", height: "60vh" }}
-          mapStyle={basemaps.streets.mapStyle}
+          mapStyle={basemaps[basemapKey].mapStyle}
           {...mapParameters}
           cooperativeGestures={true}
           onLoad={onMapLoad}
@@ -63,7 +63,10 @@ const ProjectSummaryMap = ({ data }) => {
             setBasemapKey={setBasemapKey}
           />
           <NavigationControl position="bottom-left" showCompass={false} />
-          <BaseMapSourceAndLayers basemapKey={basemapKey} />
+          <BaseMapSourceAndLayers
+            basemapKey={basemapKey}
+            setBasemapKey={setBasemapKey}
+          />
           {/* Wait until the map loads and components-placeholder layer is ready to target */}
           {hasMapLoaded && (
             <>


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/16245

When we first added `react-map-gl` v7 during the project components overhaul, there was a error that was fixed using the workaround described [in the code here](https://github.com/cityofaustin/atd-moped/blob/f3720efe86f9cd5d39818fe42bf7f85e04fa4ec7/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js#L41-L45). This implements the recommended fix, and it is the same one used map upgrade in https://github.com/cityofaustin/atd-vz-data/pull/1398.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1296--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to a project and makes sure the map loads and shows the components related to the project. Test the street/satellite layer toggle, the zoom controls, and that scrolling the page doesn't zoom the map.
2. Go to the Map tab
   - Test the map zoom controls and layer toggle
   - Test the geocoder by entering a street or location in Austin and navigate to it by selecting an option
   - Test creating a new component by selecting from the selectable layers and by drawing
   - Test editing an existing component by selecting from the selectable layers and by drawing
   - Test deleting a component
   - Test the clicking the magnifier icon in the side bar component list to zoom to an existing component' features

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
