### PR TITLE
Add ability to select related components on the map

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/RelatedComponentsList.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/RelatedComponentsList.js
@@ -8,7 +8,7 @@ const RelatedComponentsList = ({
   editState,
   shouldShowRelatedProjects,
   clickedComponent,
-  setClickedComponent,
+  makeClickedComponentUpdates,
   onClickZoomToComponent,
   allRelatedComponents,
   setIsClickedComponentRelated,
@@ -21,10 +21,10 @@ const RelatedComponentsList = ({
 
   const onListItemClick = (component) => {
     if (isExpanded(component)) {
-      setClickedComponent(null);
+      makeClickedComponentUpdates(null);
       setIsClickedComponentRelated(false);
     } else if (isNotCreatingOrEditing) {
-      setClickedComponent(component);
+      makeClickedComponentUpdates(component);
       setIsClickedComponentRelated(true);
     }
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -181,10 +181,17 @@ export default function MapView({
       (component) => component.project_component_id === clickedComponentId
     );
 
-    setClickedComponent(updatedClickedComponent);
-  }, [clickedComponent, projectComponents]);
+    if (!!updatedClickedComponent) {
+      setClickedComponent(updatedClickedComponent)
+    } else {
+      const updatedrelatedClickedComponent = allRelatedComponents.find(
+        (component) => component.project_component_id === clickedComponentId
+      );
+      setClickedComponent(updatedrelatedClickedComponent);
+    }
+  }, [clickedComponent, projectComponents, allRelatedComponents]);
 
-  // Keep draft component state in sync wiht clicked component (when editing)
+  // Keep draft component state in sync with clicked component (when editing)
   useEffect(() => {
     if (clickedComponent && !editState.isEditingComponent) {
       editDispatch({ type: "set_draft_component", payload: clickedComponent });

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -129,6 +129,7 @@ export default function MapView({
 
   useComponentLinkParams({
     setClickedComponent,
+    setIsClickedComponentRelated,
     projectComponents,
     allRelatedComponents,
     clickedComponent,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -292,7 +292,7 @@ export default function MapView({
                 editState={editState}
                 shouldShowRelatedProjects={shouldShowRelatedProjects}
                 clickedComponent={clickedComponent}
-                setClickedComponent={setClickedComponent}
+                makeClickedComponentUpdates={makeClickedComponentUpdates}
                 onClickZoomToComponent={onClickZoomToComponent}
                 allRelatedComponents={allRelatedComponents}
                 setIsClickedComponentRelated={setIsClickedComponentRelated}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/index.js
@@ -130,6 +130,7 @@ export default function MapView({
   useComponentLinkParams({
     setClickedComponent,
     projectComponents,
+    allRelatedComponents,
     clickedComponent,
     errorMessageDispatch,
     mapRef,
@@ -177,18 +178,15 @@ export default function MapView({
     if (clickedComponent === null) return;
 
     const clickedComponentId = clickedComponent?.project_component_id;
-    const updatedClickedComponent = projectComponents.find(
-      (component) => component.project_component_id === clickedComponentId
-    );
-
-    if (!!updatedClickedComponent) {
-      setClickedComponent(updatedClickedComponent)
-    } else {
-      const updatedrelatedClickedComponent = allRelatedComponents.find(
+    const updatedClickedComponent =
+      projectComponents.find(
+        (component) => component.project_component_id === clickedComponentId
+      ) ||
+      allRelatedComponents.find(
         (component) => component.project_component_id === clickedComponentId
       );
-      setClickedComponent(updatedrelatedClickedComponent);
-    }
+
+    setClickedComponent(updatedClickedComponent);
   }, [clickedComponent, projectComponents, allRelatedComponents]);
 
   // Keep draft component state in sync with clicked component (when editing)

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
@@ -38,6 +38,7 @@ const updateParamsWithoutRender = (queryKey, queryValue) => {
  */
 export const useComponentLinkParams = ({
   setClickedComponent,
+  setIsClickedComponentRelated,
   projectComponents,
   allRelatedComponents,
   errorMessageDispatch,
@@ -75,6 +76,12 @@ export const useComponentLinkParams = ({
         // Set clickedComponent found from params
         setClickedComponent(componentFromParams);
 
+        const isComponentRelated = allRelatedComponents.find(
+          (component) => component.project_component_id === componentParamId
+        );
+        // if component is related, the highlight color is green
+        setIsClickedComponentRelated(isComponentRelated);
+
         // Zoom to its extent
         const features = getAllComponentFeatures(componentFromParams);
         const featureCollection = { type: "FeatureCollection", features };
@@ -109,6 +116,7 @@ export const useComponentLinkParams = ({
     hasComponentSetFromUrl,
     projectComponents,
     setClickedComponent,
+    setIsClickedComponentRelated,
     allRelatedComponents,
     setHasComponentSetFromUrl,
     errorMessageDispatch,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
@@ -109,6 +109,7 @@ export const useComponentLinkParams = ({
     hasComponentSetFromUrl,
     projectComponents,
     setClickedComponent,
+    allRelatedComponents,
     setHasComponentSetFromUrl,
     errorMessageDispatch,
     mapRef,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
@@ -39,6 +39,7 @@ const updateParamsWithoutRender = (queryKey, queryValue) => {
 export const useComponentLinkParams = ({
   setClickedComponent,
   projectComponents,
+  allRelatedComponents,
   errorMessageDispatch,
   mapRef,
 }) => {
@@ -62,9 +63,13 @@ export const useComponentLinkParams = ({
 
     // Set clicked component from search parameter once projectComponents data loads
     if (projectComponents.length > 0) {
-      const componentFromParams = projectComponents.find(
-        (component) => component.project_component_id === componentParamId
-      );
+      const componentFromParams =
+        projectComponents.find(
+          (component) => component.project_component_id === componentParamId
+        ) ||
+        allRelatedComponents.find(
+          (component) => component.project_component_id === componentParamId
+        );
 
       if (componentFromParams) {
         // Set clickedComponent found from params


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/16334
https://github.com/cityofaustin/atd-data-tech/issues/16332

## Testing
**URL to test:** 

https://deploy-preview-1299--atd-moped-main.netlify.app/moped/projects/1998?tab=map


**Steps to test:**

Navigate to a project that has related components mapped, such as a project that is part of a parent project, or a project that has subprojects. 

From the components list: 
Select one of the projects components, see that the other components on the map now have gray iconography. 
Now select one of the related components, it should behave the same way as the project components. 
The component id of the component you selected should also be in the url.

Repeat the testing by selecting components from the map. Same as before, the other components should go gray, and the component id should be in the url. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
