### PR TITLE
Configure additional audit field triggers for component work types and component tags

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2650,7 +2650,7 @@
           - milestone_order
           - project_id
           - is_deleted
-        comment: No insert permissions on audit fields
+      comment: No insert permissions on audit fields
     - role: moped-editor
       permission:
         check: {}
@@ -2666,7 +2666,7 @@
           - milestone_order
           - project_id
           - is_deleted
-        comment: No insert permissions on audit fields
+      comment: No insert permissions on audit fields
   select_permissions:
     - role: moped-admin
       permission:
@@ -2735,7 +2735,7 @@
         check: {}
         set:
           updated_by_user_id: x-hasura-user-db-id
-        comment: No update permissions on audit fields
+      comment: No update permissions on audit fields
     - role: moped-editor
       permission:
         columns:
@@ -2751,7 +2751,7 @@
         check: {}
         set:
           updated_by_user_id: x-hasura-user-db-id
-        comment: No update permissions on audit fields
+      comment: No update permissions on audit fields
   event_triggers:
     - name: activity_log_moped_proj_milestones
       definition:
@@ -2824,7 +2824,7 @@
           - project_id
           - project_note
           - project_note_type
-        comment: No insert permissions on audit fields
+      comment: No insert permissions on audit fields
     - role: moped-editor
       permission:
         check: {}
@@ -2837,7 +2837,7 @@
           - project_id
           - project_note
           - project_note_type
-        comment: No insert permissions on audit fields
+      comment: No insert permissions on audit fields
   select_permissions:
     - role: moped-admin
       permission:
@@ -2897,7 +2897,7 @@
         check: null
         set:
           updated_by_user_id: x-hasura-user-db-id
-        comment: No update permissions on audit fields
+      comment: No update permissions on audit fields
     - role: moped-editor
       permission:
         columns:
@@ -2910,7 +2910,7 @@
         check: null
         set:
           updated_by_user_id: x-hasura-user-db-id
-        comment: No update permissions on audit fields
+      comment: No update permissions on audit fields
   event_triggers:
     - name: activity_log_moped_proj_notes
       definition:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1749,6 +1749,9 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
@@ -1756,6 +1759,9 @@
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
@@ -1788,20 +1794,24 @@
   update_permissions:
     - role: moped-admin
       permission:
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
           - project_component_id
         filter: {}
-        check: {}
     - role: moped-editor
       permission:
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
           - project_component_id
         filter: {}
-        check: {}
   event_triggers:
     - name: activity_log_proj_component_tags
       definition:
@@ -1861,6 +1871,9 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+        created_by_user_id: x-hasura-user-db-id
+        updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
@@ -1868,6 +1881,9 @@
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
@@ -1900,20 +1916,24 @@
   update_permissions:
     - role: moped-admin
       permission:
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
           - work_type_id
         filter: {}
-        check: {}
     - role: moped-editor
       permission:
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
           - work_type_id
         filter: {}
-        check: {}
   event_triggers:
     - name: activity_log_proj_component_work_types
       definition:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1770,48 +1770,60 @@
     - role: moped-admin
       permission:
         columns:
-          - is_deleted
           - component_tag_id
+          - created_at
+          - created_by_user_id
           - id
+          - is_deleted
           - project_component_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
     - role: moped-editor
       permission:
         columns:
-          - is_deleted
           - component_tag_id
+          - created_at
+          - created_by_user_id
           - id
+          - is_deleted
           - project_component_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
     - role: moped-viewer
       permission:
         columns:
-          - is_deleted
           - component_tag_id
+          - created_at
+          - created_by_user_id
           - id
+          - is_deleted
           - project_component_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
   update_permissions:
     - role: moped-admin
       permission:
-        check: {}
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
           - project_component_id
         filter: {}
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
-        check: {}
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - component_tag_id
           - is_deleted
           - project_component_id
         filter: {}
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_proj_component_tags
       definition:
@@ -1872,8 +1884,8 @@
       permission:
         check: {}
         set:
-        created_by_user_id: x-hasura-user-db-id
-        updated_by_user_id: x-hasura-user-db-id
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
@@ -1892,48 +1904,60 @@
     - role: moped-admin
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - id
-          - project_component_id
-          - work_type_id
           - is_deleted
+          - project_component_id
+          - updated_at
+          - updated_by_user_id
+          - work_type_id
         filter: {}
     - role: moped-editor
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - id
-          - project_component_id
-          - work_type_id
           - is_deleted
+          - project_component_id
+          - updated_at
+          - updated_by_user_id
+          - work_type_id
         filter: {}
     - role: moped-viewer
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - id
-          - project_component_id
-          - work_type_id
           - is_deleted
+          - project_component_id
+          - updated_at
+          - updated_by_user_id
+          - work_type_id
         filter: {}
   update_permissions:
     - role: moped-admin
       permission:
-        check: {}
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
           - work_type_id
         filter: {}
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
-        check: {}
-        set:
-          updated_by_user_id: x-hasura-user-db-id
         columns:
           - is_deleted
           - project_component_id
           - work_type_id
         filter: {}
+        check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_proj_component_work_types
       definition:

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
@@ -1,5 +1,6 @@
 -- Remove trigger to update audit fields on insert or update of moped_proj_component_work_types
 DROP TRIGGER moped_proj_component_work_types_parent_audit_log_trigger ON moped_proj_component_work_types;
+DROP TRIGGER set_moped_proj_component_work_types_updated_at ON moped_proj_component_work_types;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_work_types
@@ -15,6 +16,7 @@ DROP COLUMN updated_at;
 
 -- Remove trigger to update audit fields on insert or update of moped_proj_component_tags
 DROP TRIGGER moped_proj_component_tags_parent_audit_log_trigger ON moped_proj_component_tags;
+DROP TRIGGER set_moped_proj_component_tags_updated_at ON moped_proj_component_tags;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_tags
@@ -27,3 +29,5 @@ DROP COLUMN created_at,
 DROP COLUMN created_by_user_id,
 DROP COLUMN updated_by_user_id,
 DROP COLUMN updated_at;
+
+DROP FUNCTION update_component_attributes_parent_records_audit_logs;

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
@@ -1,0 +1,23 @@
+-- Add fk constraints on user audit fields
+ALTER TABLE moped_proj_component_work_types
+DROP CONSTRAINT project_component_work_types_created_by_fkey,
+DROP CONSTRAINT project_component_work_types_updated_by_fkey;
+
+-- Remove audit columns to moped_proj_component_work_types
+ALTER TABLE moped_proj_component_work_types
+DROP COLUMN created_at,
+DROP COLUMN created_by_user_id,
+DROP COLUMN updated_by_user_id,
+DROP COLUMN updated_at;
+
+-- Add fk constraints on user audit fields
+ALTER TABLE moped_proj_component_tags
+DROP CONSTRAINT project_component_tags_created_by_fkey,
+DROP CONSTRAINT project_component_tags_updated_by_fkey;
+
+-- Add audit columns to moped_proj_component_tags
+ALTER TABLE moped_proj_component_tags
+DROP COLUMN created_at,
+DROP COLUMN created_by_user_id,
+DROP COLUMN updated_by_user_id,
+DROP COLUMN updated_at;

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/down.sql
@@ -1,3 +1,6 @@
+-- Remove trigger to update audit fields on insert or update of moped_proj_component_work_types
+DROP TRIGGER moped_proj_component_work_types_parent_audit_log_trigger ON moped_proj_component_work_types;
+
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_work_types
 DROP CONSTRAINT project_component_work_types_created_by_fkey,
@@ -9,6 +12,9 @@ DROP COLUMN created_at,
 DROP COLUMN created_by_user_id,
 DROP COLUMN updated_by_user_id,
 DROP COLUMN updated_at;
+
+-- Remove trigger to update audit fields on insert or update of moped_proj_component_tags
+DROP TRIGGER moped_proj_component_tags_parent_audit_log_trigger ON moped_proj_component_tags;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_tags

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
@@ -22,6 +22,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+COMMENT ON FUNCTION update_component_attributes_parent_records_audit_logs() IS 'Function to update parent audit fields on update/insert into component attribute tables';
+
 -- Audit updates to moped_proj_component_work_types
 -- Add audit columns to moped_proj_component_work_types
 ALTER TABLE moped_proj_component_work_types
@@ -29,6 +31,11 @@ ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 ADD COLUMN created_by_user_id INT4 NULL,
 ADD COLUMN updated_by_user_id INT4 NULL,
 ADD COLUMN updated_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN moped_proj_component_work_types.created_by_user_id IS 'ID of the user who created the record';
+COMMENT ON COLUMN moped_proj_component_work_types.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN moped_proj_component_work_types.updated_by_user_id IS 'ID of the user who last updated the record';
+COMMENT ON COLUMN moped_proj_component_work_types.updated_at IS 'Timestamp when the record was last updated';
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_work_types
@@ -40,6 +47,8 @@ CREATE TRIGGER moped_proj_component_work_types_parent_audit_log_trigger
 AFTER INSERT OR UPDATE ON moped_proj_component_work_types
 FOR EACH ROW
 EXECUTE FUNCTION update_component_attributes_parent_records_audit_logs();
+
+COMMENT ON TRIGGER moped_proj_component_work_types_parent_audit_log_trigger ON moped_proj_component_work_types IS 'Trigger to execute the update_component_attributes_parent_records_audit_logs function before each update operation on the moped_proj_component_work_types table.';
 
 CREATE TRIGGER set_moped_proj_component_work_types_updated_at
 BEFORE INSERT OR UPDATE ON moped_proj_component_work_types
@@ -54,6 +63,11 @@ ADD COLUMN created_by_user_id INT4 NULL,
 ADD COLUMN updated_by_user_id INT4 NULL,
 ADD COLUMN updated_at TIMESTAMPTZ NULL;
 
+COMMENT ON COLUMN moped_proj_component_tags.created_by_user_id IS 'ID of the user who created the record';
+COMMENT ON COLUMN moped_proj_component_tags.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN moped_proj_component_tags.updated_by_user_id IS 'ID of the user who last updated the record';
+COMMENT ON COLUMN moped_proj_component_tags.updated_at IS 'Timestamp when the record was last updated';
+
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_tags
 ADD CONSTRAINT project_component_tags_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
@@ -64,6 +78,8 @@ CREATE TRIGGER moped_proj_component_tags_parent_audit_log_trigger
 AFTER INSERT OR UPDATE ON moped_proj_component_tags
 FOR EACH ROW
 EXECUTE FUNCTION update_component_attributes_parent_records_audit_logs();
+
+COMMENT ON TRIGGER moped_proj_component_tags_parent_audit_log_trigger ON moped_proj_component_tags IS 'Trigger to execute the update_component_attributes_parent_records_audit_logs function before each update operation on the moped_proj_component_tags table.';
 
 CREATE TRIGGER set_moped_proj_component_tags_updated_at
 BEFORE INSERT OR UPDATE ON moped_proj_component_tags

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
@@ -1,0 +1,23 @@
+-- Add audit columns to moped_proj_component_work_types
+ALTER TABLE moped_proj_component_work_types
+ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
+ADD COLUMN created_by_user_id int4 NULL,
+ADD COLUMN updated_by_user_id int4 NULL,
+ADD COLUMN updated_at timestamptz NULL;
+
+-- Add fk constraints on user audit fields
+ALTER TABLE moped_proj_component_work_types
+ADD CONSTRAINT project_component_work_types_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users(user_id),
+ADD CONSTRAINT project_component_work_types_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users(user_id);
+
+-- Add audit columns to moped_proj_component_tags
+ALTER TABLE moped_proj_component_tags
+ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
+ADD COLUMN created_by_user_id int4 NULL,
+ADD COLUMN updated_by_user_id int4 NULL,
+ADD COLUMN updated_at timestamptz NULL;
+
+-- Add fk constraints on user audit fields
+ALTER TABLE moped_proj_component_tags
+ADD CONSTRAINT project_component_tags_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users(user_id),
+ADD CONSTRAINT project_component_tags_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users(user_id);

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
@@ -1,3 +1,4 @@
+-- Audit updates to moped_proj_component_work_types
 -- Add audit columns to moped_proj_component_work_types
 ALTER TABLE moped_proj_component_work_types
 ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
@@ -7,9 +8,16 @@ ADD COLUMN updated_at timestamptz NULL;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_work_types
-ADD CONSTRAINT project_component_work_types_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users(user_id),
-ADD CONSTRAINT project_component_work_types_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users(user_id);
+ADD CONSTRAINT project_component_work_types_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
+ADD CONSTRAINT project_component_work_types_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users (user_id);
 
+-- Add trigger to update audit fields on insert or update of moped_proj_component_work_types
+CREATE TRIGGER moped_proj_component_work_types_parent_audit_log_trigger
+AFTER INSERT OR UPDATE ON moped_proj_component_work_types
+FOR EACH ROW
+EXECUTE FUNCTION update_parent_records_audit_logs();
+
+-- Audit updates to moped_proj_component_tags
 -- Add audit columns to moped_proj_component_tags
 ALTER TABLE moped_proj_component_tags
 ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
@@ -19,5 +27,11 @@ ADD COLUMN updated_at timestamptz NULL;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_tags
-ADD CONSTRAINT project_component_tags_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users(user_id),
-ADD CONSTRAINT project_component_tags_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users(user_id);
+ADD CONSTRAINT project_component_tags_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
+ADD CONSTRAINT project_component_tags_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users (user_id);
+
+-- Add triggers to update audit fields on insert or update of moped_proj_component_tags
+CREATE TRIGGER moped_proj_component_tags_parent_audit_log_trigger
+AFTER INSERT OR UPDATE ON moped_proj_component_tags
+FOR EACH ROW
+EXECUTE FUNCTION update_parent_records_audit_logs();

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
@@ -1,29 +1,58 @@
+-- Creating or replacing a function to update audit logs in parent records
+CREATE OR REPLACE FUNCTION update_component_attributes_parent_records_audit_logs()
+RETURNS TRIGGER AS $$
+DECLARE
+  project_id_variable INTEGER;
+  query TEXT;
+BEGIN
+  
+  -- Update the project component with the current timestamp and user ID
+  UPDATE moped_proj_components
+  SET updated_at = NEW.updated_at, updated_by_user_id = NEW.updated_by_user_id
+  WHERE project_component_id = NEW.project_component_id
+  RETURNING project_id INTO project_id_variable;
+
+  -- Update the parent project record with the current timestamp and user ID
+  UPDATE moped_project
+  SET updated_at = NEW.updated_at, updated_by_user_id = NEW.updated_by_user_id
+  WHERE project_id = project_id_variable;
+
+  -- Return the updated record
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 -- Audit updates to moped_proj_component_work_types
 -- Add audit columns to moped_proj_component_work_types
 ALTER TABLE moped_proj_component_work_types
-ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
-ADD COLUMN created_by_user_id int4 NULL,
-ADD COLUMN updated_by_user_id int4 NULL,
-ADD COLUMN updated_at timestamptz NULL;
+ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+ADD COLUMN created_by_user_id INT4 NULL,
+ADD COLUMN updated_by_user_id INT4 NULL,
+ADD COLUMN updated_at TIMESTAMPTZ NULL;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_work_types
 ADD CONSTRAINT project_component_work_types_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
 ADD CONSTRAINT project_component_work_types_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users (user_id);
 
--- Add trigger to update audit fields on insert or update of moped_proj_component_work_types
+-- Add triggers to update audit fields on insert or update of moped_proj_component_work_types
 CREATE TRIGGER moped_proj_component_work_types_parent_audit_log_trigger
 AFTER INSERT OR UPDATE ON moped_proj_component_work_types
 FOR EACH ROW
-EXECUTE FUNCTION update_parent_records_audit_logs();
+EXECUTE FUNCTION update_component_attributes_parent_records_audit_logs();
+
+CREATE TRIGGER set_moped_proj_component_work_types_updated_at
+BEFORE INSERT OR UPDATE ON moped_proj_component_work_types
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
 
 -- Audit updates to moped_proj_component_tags
 -- Add audit columns to moped_proj_component_tags
 ALTER TABLE moped_proj_component_tags
-ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
-ADD COLUMN created_by_user_id int4 NULL,
-ADD COLUMN updated_by_user_id int4 NULL,
-ADD COLUMN updated_at timestamptz NULL;
+ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+ADD COLUMN created_by_user_id INT4 NULL,
+ADD COLUMN updated_by_user_id INT4 NULL,
+ADD COLUMN updated_at TIMESTAMPTZ NULL;
 
 -- Add fk constraints on user audit fields
 ALTER TABLE moped_proj_component_tags
@@ -34,4 +63,9 @@ ADD CONSTRAINT project_component_tags_updated_by_fkey FOREIGN KEY (updated_by_us
 CREATE TRIGGER moped_proj_component_tags_parent_audit_log_trigger
 AFTER INSERT OR UPDATE ON moped_proj_component_tags
 FOR EACH ROW
-EXECUTE FUNCTION update_parent_records_audit_logs();
+EXECUTE FUNCTION update_component_attributes_parent_records_audit_logs();
+
+CREATE TRIGGER set_moped_proj_component_tags_updated_at
+BEFORE INSERT OR UPDATE ON moped_proj_component_tags
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();

--- a/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1711054060504_add_component_work_types_tags_audit_fields/up.sql
@@ -30,7 +30,7 @@ ALTER TABLE moped_proj_component_work_types
 ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 ADD COLUMN created_by_user_id INT4 NULL,
 ADD COLUMN updated_by_user_id INT4 NULL,
-ADD COLUMN updated_at TIMESTAMPTZ NULL;
+ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
 
 COMMENT ON COLUMN moped_proj_component_work_types.created_by_user_id IS 'ID of the user who created the record';
 COMMENT ON COLUMN moped_proj_component_work_types.created_at IS 'Timestamp when the record was created';
@@ -61,7 +61,7 @@ ALTER TABLE moped_proj_component_tags
 ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 ADD COLUMN created_by_user_id INT4 NULL,
 ADD COLUMN updated_by_user_id INT4 NULL,
-ADD COLUMN updated_at TIMESTAMPTZ NULL;
+ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
 
 COMMENT ON COLUMN moped_proj_component_tags.created_by_user_id IS 'ID of the user who created the record';
 COMMENT ON COLUMN moped_proj_component_tags.created_at IS 'Timestamp when the record was created';


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14946

This PR adds the audit fields and triggers to the `moped_proj_component_tags` and `moped_proj_component_work_types` tables so that their records and the parent component and parent project records get audit column updates when a user adds or updates them.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start up the local stack and find a project.
2. If there isn't already a component, add one to the project.
3. Use the SQL below with your project ID # filled in to monitor the changes that happen through these test steps.
4. Open the component attributes form and add a tag.
5. Use the SQL below to check that:
   - the project, project component, and project component tag `updated_by_user_id` match and are your user table ID
   - the project component tag `created_by_user_id` matches your user table ID
   - the project, project component, and project component tag `updated_at` timestamps match
   - the project component tag `created_at` timestamps matches those update timestamps
6. Now, remove that tag and add another at the same time. One tag should have `is_deleted = TRUE` now. Check that:
   - for the soft-deleted tag row, the `updated_at` timestamps for the project, project component, and project component tag all match and are different from the tag record's `created_at` timestamp
7. Now, repeat the above steps except add and remove work types in the project component attributes form and use the second query below to check the same fields.

```sql
-- Query to see component tags and associated project and project component record changes
SELECT
	mp.project_id,
	mp.updated_by_user_id,
	mp.updated_at,
	mpc.project_component_id,
	mpc.updated_at,
	mpc.updated_by_user_id,
	mpct.id,
	mpct.created_at,
	mpct.updated_at,
	mpct.created_by_user_id,
	mpct.updated_by_user_id,
	mpct.is_deleted
FROM
	moped_project mp
	LEFT JOIN moped_proj_components mpc ON mp.project_id = mpc.project_id
	LEFT JOIN moped_proj_component_tags mpct ON mpc.project_component_id = mpct.project_component_id
WHERE
	mp.project_id = <your project ID>;
```

```sql
-- Query to see component work types and associated project and project component record changes
SELECT
	mp.project_id,
	mp.updated_by_user_id,
	mp.updated_at,
	mpc.project_component_id,
	mpc.updated_at,
	mpc.updated_by_user_id,
	mpcwt.id,
	mpcwt.created_at,
	mpcwt.updated_at,
	mpcwt.created_by_user_id,
	mpcwt.updated_by_user_id,
	mpcwt.is_deleted
FROM
	moped_project mp
	LEFT JOIN moped_proj_components mpc ON mp.project_id = mpc.project_id
	LEFT JOIN moped_proj_component_work_types mpcwt ON mpc.project_component_id = mpcwt.project_component_id
WHERE
	mp.project_id = <your project ID>;
```

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
