### PR TITLE
adds description column to projects list table

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -27,6 +27,9 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
   current_phase: {
     label: "Status",
   },
+  project_description: {
+    label: "Description"
+  },
   project_team_members: {
     label: "Team",
     filter: filterProjectTeamMembers,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -27,9 +27,6 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
   current_phase: {
     label: "Status",
   },
-  project_description: {
-    label: "Description"
-  },
   project_team_members: {
     label: "Team",
     filter: filterProjectTeamMembers,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -69,8 +69,8 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
       searchable: true,
       sortable: true,
       label: "Project description",
-      showInTable: true,
       defaultHidden: true,
+      showInTable: true,
       search: {
         label: "Search by project description",
         operator: "_ilike",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -69,7 +69,8 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
       searchable: true,
       sortable: true,
       label: "Project description",
-      showInTable: false,
+      showInTable: true,
+      defaultHidden: true,
       search: {
         label: "Search by project description",
         operator: "_ilike",

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -182,6 +182,12 @@ export const useColumns = ({ hiddenColumns }) => {
         },
       },
       {
+        headerName: "Description",
+        field: "project_description",
+        flex: 2,
+        minWidth: COLUMN_WIDTHS.xlarge,
+      },
+      {
         headerName: "Team",
         field: "project_team_members",
         flex: 1,


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/16159

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1304--atd-moped-main.netlify.app/

**Steps to test:**
- go to the project list view and toggle on the description column (it should be off by default) located between 'status' and 'team'
- confirm the descriptions are displayed in the table
- export the table to csv and confirm the description column is included
- I would also recommend pasting a long description into one of the columns to see how it fits into the overall layout (I believe it's out of the scope of this issue but we discussed whether it would be worth truncating longer descriptions)
- toggle off the description column to remove it from the table

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
