### PR TITLE
Order the component tags alphabetically

### DIFF
--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -39,7 +39,10 @@ export const GET_COMPONENTS_FORM_OPTIONS = gql`
         subphase_name
       }
     }
-    moped_component_tags(where: { is_deleted: { _eq: false } }) {
+    moped_component_tags(
+      order_by: { type: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
       name
       slug
       type


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/16367

## Testing
**URL to test:** 
https://deploy-preview-1309--atd-moped-main.netlify.app/moped/projects/1936?tab=map&project_component_id=2470

**Steps to test:**

Open the dropdown for the component tags, they should now be in alphabetical order, the Bikeways for example should all be up at the top. 

![Screenshot 2024-03-29 at 2 30 01 PM](https://github.com/cityofaustin/atd-moped/assets/12474808/c53fa60c-913f-4ffc-9b2b-c1b848bca7f2)



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
