### PR TITLE
Fix status update advanced search

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -262,7 +262,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       ],
     },
     {
-      name: "project_note",
+      name: "project_status_update",
       label: "Status update",
       placeholder: "Status update",
       type: "string",


### PR DESCRIPTION
## Associated issues
n/a

Fixes a mismatch between the column name in the app config for advanced searching status updates and the column in the database view that is queried.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1315--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Try an advanced search with `Status update contains potential` on staging or visit https://moped.austinmobility.io/moped/projects?filters=%5B%7B%22field%22%3A%22project_note%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22potential%22%7D%5D&isOr=false. See error.
2. Try the same search on the deploy preview or visit https://deploy-preview-1315--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22project_status_update%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22potential%22%7D%5D&isOr=false

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
