### PR TITLE
Add additional project tag and component tags

### DIFF
--- a/moped-database/migrations/1713206648608_add_2025_component_tag/down.sql
+++ b/moped-database/migrations/1713206648608_add_2025_component_tag/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM public.moped_component_tags WHERE slug = 'map_bikeways_2025'

--- a/moped-database/migrations/1713206648608_add_2025_component_tag/down.sql
+++ b/moped-database/migrations/1713206648608_add_2025_component_tag/down.sql
@@ -1,1 +1,2 @@
-DELETE FROM public.moped_component_tags WHERE slug = 'map_bikeways_2025'
+DELETE FROM public.moped_component_tags WHERE slug IN ('map_bikeways_2025', 'map_ped_crossing');
+DELETE FROM public.moped_tags WHERE slug = 'map_ped_crossing';

--- a/moped-database/migrations/1713206648608_add_2025_component_tag/up.sql
+++ b/moped-database/migrations/1713206648608_add_2025_component_tag/up.sql
@@ -1,2 +1,6 @@
 INSERT INTO public.moped_component_tags ("type", name, slug) VALUES
-('MAP Bikeways', '2025', 'map_bikeways_2025');
+('MAP Bikeways', '2025', 'map_bikeways_2025'),
+('MAP Ped Crossing', '', 'map_ped_crossing');
+
+INSERT INTO moped_tags (name, type, slug, is_deleted) VALUES
+('Map Ped Crossing', 'Other', 'map_ped_crossing', FALSE);

--- a/moped-database/migrations/1713206648608_add_2025_component_tag/up.sql
+++ b/moped-database/migrations/1713206648608_add_2025_component_tag/up.sql
@@ -1,0 +1,2 @@
+INSERT INTO public.moped_component_tags ("type", name, slug) VALUES
+('MAP Bikeways', '2025', 'map_bikeways_2025');

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -40,7 +40,7 @@ export const GET_COMPONENTS_FORM_OPTIONS = gql`
       }
     }
     moped_component_tags(
-      order_by: { type: asc }
+      order_by: [{ type: asc }, {name: asc}]
       where: { is_deleted: { _eq: false } }
     ) {
       name


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/16673
https://github.com/cityofaustin/atd-data-tech/issues/16811

I forgot the Map Bikeways 2025 tag in this PR https://github.com/cityofaustin/atd-moped/pull/1313.

edited to add: And Nathan forgot two tags off the list, adding them here too. 

Also when testing this PR, I noticed that the tags were only being alphabetically sorted by the Type, which meant that 2024 was showing up ahead of 2019. I am further sorting them by name. 

## Testing

run locally, check for the missing tag in the component tag drop down, and for the missing tag in the project tags


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~~
