### PR TITLE
Cannot remove secondary project name

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -104,9 +104,11 @@ const ProjectNameForm = ({
     }
   };
 
+  // Update the secondary name state variable when the input changes
   const handleSecondaryNameChange = (e) => {
-    // Update the secondary name state variable when the input changes
-    setSecondaryName(e.target.value);
+    // If user entered an empty string then nullify the value
+    const value = e.target.value.trim() === "" ? null : e.target.value;
+    setSecondaryName(value);
   };
 
   return (


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16810

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1319--atd-moped-main.netlify.app/

**Steps to test:**
1. Go to a project, create a secondary name.
2. Now delete the secondary name and save, instead of an empty string being saved the value should be nullified. Check in the project list view that there is no trailing hyphen. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
