### PR TITLE
Update and add audit fields to moped proj tags

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3612,6 +3612,9 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - project_id
           - tag_id
@@ -3619,6 +3622,9 @@
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - project_id
           - tag_id
@@ -3627,26 +3633,38 @@
     - role: moped-admin
       permission:
         columns:
+          - is_deleted
           - id
           - project_id
           - tag_id
-          - is_deleted
+          - created_by_user_id
+          - updated_by_user_id
+          - created_at
+          - updated_at
         filter: {}
     - role: moped-editor
       permission:
         columns:
+          - is_deleted
           - id
           - project_id
           - tag_id
-          - is_deleted
+          - created_by_user_id
+          - updated_by_user_id
+          - created_at
+          - updated_at
         filter: {}
     - role: moped-viewer
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - id
+          - is_deleted
           - project_id
           - tag_id
-          - is_deleted
+          - updated_at
+          - updated_by_user_id
         filter: {}
   update_permissions:
     - role: moped-admin
@@ -3657,6 +3675,8 @@
           - is_deleted
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
         columns:
@@ -3665,6 +3685,8 @@
           - is_deleted
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_moped_project_tags
       definition:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3608,6 +3608,12 @@
     - name: moped_tag
       using:
         foreign_key_constraint_on: tag_id
+    - name: moped_user_created_by
+      using:
+        foreign_key_constraint_on: created_by_user_id
+    - name: moped_user_updated_by
+      using:
+        foreign_key_constraint_on: updated_by_user_id
   insert_permissions:
     - role: moped-admin
       permission:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3712,7 +3712,7 @@
           action: transform
           template: |-
             {
-              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input! ) { insert_moped_activity_log_one(object: $object) { activity_id } }",
               "variables": {
                 "object": {
                   "record_id": {{ $body.event.data.new.id }},
@@ -3723,9 +3723,7 @@
                   "description": [{"newSchema": "true"}],
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
-                },
-                  "updated_at": {{$body.created_at}},
-                  "project_id": {{$body.event.data.new.project_id}}
+                }
             }
                                     }
         method: POST

--- a/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/down.sql
+++ b/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/down.sql
@@ -1,7 +1,3 @@
-ALTER TABLE moped_proj_tags 
-DROP COLUMN created_at,
-DROP COLUMN created_by
-DROP COLUMN updated_at
-DROP COLUMN updated_by_user_id;
+ALTER TABLE moped_proj_tags DROP COLUMN created_at, DROP COLUMN created_by_user_id, DROP COLUMN updated_at, DROP COLUMN updated_by_user_id;
 
 DROP TRIGGER update_moped_proj_tags_and_project_audit_fields ON moped_proj_tags;

--- a/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/down.sql
+++ b/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE moped_proj_tags 
+DROP COLUMN created_at,
+DROP COLUMN created_by
+DROP COLUMN updated_at
+DROP COLUMN updated_by_user_id;
+
+DROP TRIGGER update_moped_proj_tags_and_project_audit_fields ON moped_proj_tags;

--- a/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
@@ -1,0 +1,23 @@
+ALTER TABLE moped_proj_tags
+ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+ADD COLUMN created_by_user_id INT4 NULL,
+ADD COLUMN updated_by_user_id INT4 NULL,
+ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+COMMENT ON COLUMN moped_proj_tags.created_by_user_id IS 'ID of the user who created the record';
+COMMENT ON COLUMN moped_proj_tags.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN moped_proj_tags.updated_by_user_id IS 'ID of the user who last updated the record';
+COMMENT ON COLUMN moped_proj_tags.updated_at IS 'Timestamp when the record was last updated';
+
+-- Add fk constraints on user audit fields
+ALTER TABLE moped_proj_tags
+ADD CONSTRAINT project_tags_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
+ADD CONSTRAINT project_tags_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users (user_id);
+
+CREATE TRIGGER update_moped_proj_tags_and_project_audit_fields
+BEFORE INSERT
+OR UPDATE ON moped_proj_tags
+FOR EACH ROW
+EXECUTE FUNCTION public.update_self_and_project_updated_audit_fields();
+
+COMMENT ON TRIGGER update_moped_proj_tags_and_project_audit_fields ON moped_proj_tags IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_tags table.';

--- a/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
@@ -1,8 +1,8 @@
 -- Adds audit columns and trigger to moped_proj_tags
 ALTER TABLE moped_proj_tags
 ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-ADD COLUMN created_by_user_id INT4 NULL,
-ADD COLUMN updated_by_user_id INT4 NULL,
+ADD COLUMN created_by_user_id INTEGER NULL,
+ADD COLUMN updated_by_user_id INTEGER NULL,
 ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
 
 COMMENT ON COLUMN moped_proj_tags.created_by_user_id IS 'ID of the user who created the record';

--- a/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
+++ b/moped-database/migrations/1713466319581_moped_proj_tags_audit_fields/up.sql
@@ -1,3 +1,4 @@
+-- Adds audit columns and trigger to moped_proj_tags
 ALTER TABLE moped_proj_tags
 ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 ADD COLUMN created_by_user_id INT4 NULL,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16180

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Add some project tags to a project. 
2. Check the `moped_proj_tags` table and see that the new columns have been updated - `updated_at`, `created_at`, `updated_by_user_id`, `created_by_user_id`. 
3. Now check the `moped_project` table, you should see the same values in the audit fields for the project you just added tags to.
4. I dont think there is a way to edit tags right? You can just add or delete them?
5. Test the down migration

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
