### PR TITLE
Remove user project update from project components activity trigger

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -2305,7 +2305,7 @@
           action: transform
           template: |-
             {
-              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",
               "variables": {
                 "object": {
                   "record_id": {{ $body.event.data.new.project_component_id }},
@@ -2317,8 +2317,6 @@
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
                 },
-                "updated_at": {{$body.created_at}},
-                "project_id": {{$body.event.data.old.project_id}}
               }
             }
         method: POST


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16913

This cleans up the activity trigger for `moped_proj_components`. The update mutation removed from the config is a duplicate of the update already made by a trigger that uses the DB function called `update_self_and_project_updated_audit_fields`.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Use a new or existing project and test adding, updating, and soft-deleting components from the map tab.
2. You can use the SQL below to check that the audit fields on the `moped_project` and `moped_proj_components` tables are still updating as expected. Using different test accounts can help see the updates to the user fields more easily.
3. Check the activity log to see that your creates, updates, and deletes display.

```sql
SELECT
	mp.project_id,
	mp.updated_by_user_id,
	mp.updated_at,
	mpc.project_component_id,
	mpc.created_at,
	mpc.updated_at,
	mpc.created_by_user_id,
	mpc.updated_by_user_id,
	mpc.is_deleted
FROM
	moped_project mp
	LEFT JOIN moped_proj_components mpc ON mp.project_id = mpc.project_id
WHERE
	mp.project_id = <your project ID>;
```

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
