### PR TITLE
Update tag styles to display inline

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -18,8 +18,8 @@ import AddCircle from "@mui/icons-material/AddCircle";
 import Autocomplete from "@mui/material/Autocomplete";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 import DeleteConfirmationModal from "../DeleteConfirmationModal";
-
 import Grid from "@mui/material/Grid";
+import theme from "src/theme";
 
 import {
   TAGS_QUERY,
@@ -164,11 +164,19 @@ const TagsSection = ({ projectId }) => {
           >
             <Grid container spacing={1}>
               {data.moped_proj_tags.map((tag) => (
-                <Grid item spacing={0.5}>
+                <Grid item>
                   <Chip
                     key={tag.id}
                     label={tag.moped_tag.name}
                     onDelete={() => handleDeleteOpen(tag)}
+                    sx={{
+                      height: "auto",
+                      minHeight: theme.spacing(4),
+                      "& .MuiChip-label": {
+                        display: "block",
+                        whiteSpace: "normal",
+                      },
+                    }}
                   />
                 </Grid>
               ))}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -19,6 +19,8 @@ import Autocomplete from "@mui/material/Autocomplete";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 import DeleteConfirmationModal from "../DeleteConfirmationModal";
 
+import Grid from "@mui/material/Grid";
+
 import {
   TAGS_QUERY,
   DELETE_PROJECT_TAG,
@@ -29,20 +31,17 @@ const useStyles = makeStyles((theme) => ({
   paperTags: {
     padding: "8px",
   },
-  chip: {
-    margin: theme.spacing(0.5),
-  },
   chipContainer: {
     display: "flex",
     justifyContent: "left",
     flexWrap: "wrap",
     listStyle: "none",
-    padding: "1rem 0",
-    paddingLeft: "16px",
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+    paddingRight: 0,
     margin: 0,
   },
   chipAddContainer: {
-    paddingLeft: "8px",
+    padding: theme.spacing(1),
   },
   tagAutocomplete: {
     minWidth: "250px",
@@ -163,14 +162,17 @@ const TagsSection = ({ projectId }) => {
             isDeleteConfirmationOpen={isDeleteConfirmationOpen}
             setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
           >
-            {data.moped_proj_tags.map((tag) => (
-              <Chip
-                key={tag.id}
-                label={tag.moped_tag.name}
-                onDelete={() => handleDeleteOpen(tag)}
-                className={classes.chip}
-              />
-            ))}
+            <Grid container spacing={1}>
+              {data.moped_proj_tags.map((tag) => (
+                <Grid item spacing={0.5}>
+                  <Chip
+                    key={tag.id}
+                    label={tag.moped_tag.name}
+                    onDelete={() => handleDeleteOpen(tag)}
+                  />
+                </Grid>
+              ))}
+            </Grid>
           </DeleteConfirmationModal>
           {addTagMode && (
             <Box

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -13,9 +13,9 @@ import {
   Toolbar,
   Typography,
 } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import AddCircle from "@mui/icons-material/AddCircle";
-import Autocomplete from '@mui/material/Autocomplete';
+import Autocomplete from "@mui/material/Autocomplete";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 import DeleteConfirmationModal from "../DeleteConfirmationModal";
 
@@ -156,7 +156,7 @@ const TagsSection = ({ projectId }) => {
             Add tag
           </Button>
         </Toolbar>
-        <Box component={"ul"} className={classes.chipContainer}>
+        <Box className={classes.chipContainer}>
           <DeleteConfirmationModal
             type="tag"
             submitDelete={() => handleTagDelete(deleteConfirmationId)}
@@ -164,13 +164,12 @@ const TagsSection = ({ projectId }) => {
             setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
           >
             {data.moped_proj_tags.map((tag) => (
-              <li key={tag.id}>
-                <Chip
-                  label={tag.moped_tag.name}
-                  onDelete={() => handleDeleteOpen(tag)}
-                  className={classes.chip}
-                />
-              </li>
+              <Chip
+                key={tag.id}
+                label={tag.moped_tag.name}
+                onDelete={() => handleDeleteOpen(tag)}
+                className={classes.chip}
+              />
             ))}
           </DeleteConfirmationModal>
           {addTagMode && (
@@ -201,14 +200,16 @@ const TagsSection = ({ projectId }) => {
                   className={classes.editIconButton}
                   aria-label="Add"
                   onClick={handleTagAdd}
-                  size="large">
+                  size="large"
+                >
                   <Icon fontSize={"small"}>check</Icon>
                 </IconButton>
                 <IconButton
                   className={classes.editIconButton}
                   aria-label="Cancel"
                   onClick={handleNewTagCancel}
-                  size="large">
+                  size="large"
+                >
                   <Icon fontSize={"small"}>close</Icon>
                 </IconButton>
               </div>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16778

This PR updates the project tags in the summary view to show inline and wrap instead of as a single column list. I used the [MUI multiline chip example](https://mui.com/material-ui/react-chip/#multiline-chip) for chips with long text on smaller screens.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1323--atd-moped-main.netlify.app/moped/projects/1909

**Steps to test:**
1. Go to the link above
2. Scroll down to the **Tags** section and:
   - See that the many tags are now displayed inline and not in a single column
   - Click the X icon to remove a tag in the middle of the list and see they adjust to fill the empty space
   - Add a tag and see that it adds to the list at the end
   - **Question**: Should we update the order that the tag chips are displayed? Alphabetical? We order the dropdown ascending by name.
   - Make the screen mobile size (somewhere around 400px width) and see that the text within the chips wraps to multiline if needed

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
