### PR TITLE
Use project full name instead of primary name

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -4141,6 +4141,7 @@
           - project_id
           - project_lead_id
           - project_name
+          - project_name_full
           - project_name_secondary
           - project_sponsor
           - project_website
@@ -4162,6 +4163,7 @@
           - project_id
           - project_lead_id
           - project_name
+          - project_name_full
           - project_name_secondary
           - project_sponsor
           - project_website
@@ -4183,6 +4185,7 @@
           - project_id
           - project_lead_id
           - project_name
+          - project_name_full
           - project_name_secondary
           - project_sponsor
           - project_website

--- a/moped-database/migrations/1713896796482_add_full_name_to_list_view/down.sql
+++ b/moped-database/migrations/1713896796482_add_full_name_to_list_view/down.sql
@@ -1,0 +1,423 @@
+DROP VIEW project_list_view CASCADE;
+
+CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
+    SELECT
+        mpp.project_id,
+        string_agg(DISTINCT concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members
+    FROM moped_proj_personnel mpp
+    JOIN moped_users mu ON mpp.user_id = mu.user_id
+    JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+    JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+    WHERE mpp.is_deleted = false AND mppr.is_deleted = false
+    GROUP BY mpp.project_id
+),
+
+funding_sources_lookup AS (
+    SELECT
+        mpf_1.project_id,
+        string_agg(mfs.funding_source_name, ', '::text) AS funding_source_name
+    FROM moped_proj_funding mpf_1
+    LEFT JOIN moped_fund_sources mfs ON mpf_1.funding_source_id = mfs.funding_source_id
+    WHERE mpf_1.is_deleted = false
+    GROUP BY mpf_1.project_id
+),
+
+project_type_lookup AS (
+    SELECT
+        mpt.project_id,
+        string_agg(mt.type_name, ', '::text) AS type_name
+    FROM moped_project_types mpt
+    LEFT JOIN moped_types mt ON mpt.project_type_id = mt.type_id AND mpt.is_deleted = false
+    GROUP BY mpt.project_id
+),
+
+child_project_lookup AS (
+    SELECT
+        jsonb_agg(children.project_id) AS children_project_ids,
+        children.parent_project_id AS parent_id
+    FROM moped_project children
+    JOIN moped_project parent ON children.parent_project_id = parent.project_id
+    WHERE children.is_deleted = false
+    GROUP BY children.parent_project_id
+),
+
+work_activities AS (
+    SELECT
+        mpwa.project_id,
+        string_agg(task_order_objects.task_order_object ->> 'display_name'::text, ', '::text) AS task_order_names,
+        string_agg(task_order_objects.task_order_object ->> 'task_order'::text, ', '::text) AS task_order_names_short,
+        jsonb_agg(DISTINCT task_order_objects.task_order_object) FILTER (WHERE task_order_objects.task_order_object IS NOT null) AS task_orders,
+        string_agg(DISTINCT mpwa.workgroup_contractor, ', '::text) AS workgroup_contractors,
+        string_agg(mpwa.contract_number, ', '::text) AS contract_numbers
+    FROM moped_proj_work_activity mpwa
+    LEFT JOIN LATERAL jsonb_array_elements(mpwa.task_orders) task_order_objects (task_order_object) ON true
+    WHERE 1 = 1 AND mpwa.is_deleted = false
+    GROUP BY mpwa.project_id
+),
+
+moped_proj_components_subtypes AS (
+    SELECT
+        mpc.project_id,
+        string_agg(DISTINCT mc.component_name_full, ', '::text) AS components
+    FROM moped_proj_components mpc
+    LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id
+    WHERE mpc.is_deleted = false
+    GROUP BY mpc.project_id
+),
+
+project_district_association AS (
+    WITH project_council_district_map AS (
+        SELECT DISTINCT
+            moped_project.project_id,
+            features_council_districts.council_district_id
+        FROM moped_project
+        LEFT JOIN moped_proj_components ON moped_project.project_id = moped_proj_components.project_id
+        LEFT JOIN features ON moped_proj_components.project_component_id = features.component_id
+        LEFT JOIN features_council_districts ON features.id = features_council_districts.feature_id
+        WHERE features.is_deleted IS false AND moped_proj_components.is_deleted IS false
+    ),
+
+parent_child_project_map AS (
+        SELECT
+            parent_projects.project_id,
+            unnest(ARRAY[parent_projects.project_id] || array_agg(child_projects.project_id)) AS self_and_children_project_ids
+        FROM moped_project parent_projects
+        LEFT JOIN moped_project child_projects ON parent_projects.project_id = child_projects.parent_project_id
+        GROUP BY parent_projects.project_id
+        ORDER BY parent_projects.project_id
+    )
+
+    SELECT
+        projects.project_id,
+        array_agg(DISTINCT project_districts.council_district_id) FILTER (WHERE project_districts.council_district_id IS NOT null) AS project_council_districts,
+        array_agg(DISTINCT project_and_children_districts.council_district_id) FILTER (WHERE project_and_children_districts.council_district_id IS NOT null) AS project_and_child_project_council_districts
+    FROM parent_child_project_map projects
+    LEFT JOIN project_council_district_map project_and_children_districts ON projects.self_and_children_project_ids = project_and_children_districts.project_id
+    LEFT JOIN project_council_district_map project_districts ON projects.project_id = project_districts.project_id
+    GROUP BY projects.project_id
+)
+
+SELECT
+    mp.project_id,
+    mp.project_name_full,
+    mp.project_name,
+    mp.project_name_secondary,
+    mp.project_description,
+    mp.ecapris_subproject_id,
+    mp.project_website,
+    mp.date_added,
+    mp.is_deleted,
+    mp.updated_at,
+    current_phase.phase_name AS current_phase,
+    current_phase.phase_key AS current_phase_key,
+    current_phase.phase_name_simple AS current_phase_simple,
+    ppll.project_team_members,
+    me.entity_name AS project_sponsor,
+    mel.entity_name AS project_lead,
+    mpps.name AS public_process_status,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    'https://mobility.austin.gov/moped/projects/'::text || mp.project_id::text AS project_url,
+    'https://mobility.austin.gov/moped/projects/'::text || mp.parent_project_id::text AS parent_project_url,
+    proj_status_update.project_note AS project_status_update,
+    proj_status_update.date_created AS project_status_update_date_created,
+    work_activities.workgroup_contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders,
+    'placeholder text'::text AS project_development_status,
+    '2024-01-01T00:00:00-06:00'::text AS project_development_status_date,
+    9999 AS project_development_status_date_calendar_year,
+    'placeholder text'::text AS project_development_status_date_calendar_year_month,
+    'placeholder text'::text AS project_development_status_date_calendar_year_month_numeric,
+    'placeholder text'::text AS project_development_status_date_calendar_year_quarter,
+    999 AS project_development_status_date_fiscal_year,
+    'placeholder text'::text AS project_development_status_date_fiscal_year_quarter,
+    (
+        SELECT moped_project.project_name
+        FROM moped_project
+        WHERE moped_project.project_id = mp.parent_project_id
+    ) AS parent_project_name,
+    cpl.children_project_ids,
+    string_agg(DISTINCT me2.entity_name, ', '::text) AS project_partners,
+    (
+        SELECT json_agg(json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type, 'id', feature_signals.id)) AS json_agg
+        FROM moped_proj_components components
+        LEFT JOIN feature_signals ON components.project_component_id = feature_signals.component_id
+        WHERE true AND components.is_deleted = false AND components.project_id = mp.project_id AND feature_signals.signal_id IS NOT null AND feature_signals.is_deleted = false
+    ) AS project_feature,
+    fsl.funding_source_name,
+    ptl.type_name,
+    (
+        SELECT min(phases.phase_start) AS min
+        FROM moped_proj_phases phases
+        WHERE true AND phases.project_id = mp.project_id AND phases.phase_id = 9 AND phases.is_deleted = false
+    ) AS construction_start_date,
+    (
+        SELECT max(phases.phase_end) AS max
+        FROM moped_proj_phases phases
+        WHERE true AND phases.project_id = mp.project_id AND phases.phase_id = 11 AND phases.is_deleted = false
+    ) AS completion_end_date,
+    (
+        SELECT min(min_confirmed_dates.min_confirmed_date) AS min
+        FROM (
+            SELECT min(phases.phase_start) AS min_confirmed_date
+            FROM moped_proj_phases phases
+            LEFT JOIN moped_phases ON phases.phase_id = moped_phases.phase_id
+            WHERE true AND phases.phase_start IS NOT null AND phases.is_phase_start_confirmed = true AND phases.project_id = mp.project_id AND moped_phases.phase_name_simple = 'Complete'::text AND phases.is_deleted = false
+            UNION ALL
+            SELECT min(phases.phase_end) AS min_confirmed_date
+            FROM moped_proj_phases phases
+            LEFT JOIN moped_phases ON phases.phase_id = moped_phases.phase_id
+            WHERE true AND phases.phase_end IS NOT null AND phases.is_phase_end_confirmed = true AND phases.project_id = mp.project_id AND moped_phases.phase_name_simple = 'Complete'::text AND phases.is_deleted = false
+        ) min_confirmed_dates
+    ) AS substantial_completion_date,
+    (
+        SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+        FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+        WHERE 1 = 1 AND mpr.project_role_name = 'Inspector'::text AND mpp.is_deleted = false AND mppr.is_deleted = false AND mpp.project_id = mp.project_id
+        GROUP BY mpp.project_id
+    ) AS project_inspector,
+    (
+        SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+        FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+        WHERE 1 = 1 AND mpr.project_role_name = 'Designer'::text AND mpp.is_deleted = false AND mppr.is_deleted = false AND mpp.project_id = mp.project_id
+        GROUP BY mpp.project_id
+    ) AS project_designer,
+    (
+        SELECT string_agg(tags.name, ', '::text) AS string_agg
+        FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+        WHERE 1 = 1 AND ptags.is_deleted = false AND ptags.project_id = mp.project_id
+        GROUP BY ptags.project_id
+    ) AS project_tags,
+    concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by,
+    mpcs.components,
+    districts.project_council_districts,
+    districts.project_and_child_project_council_districts
+FROM moped_project mp
+LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
+LEFT JOIN funding_sources_lookup fsl ON mp.project_id = fsl.project_id
+LEFT JOIN project_type_lookup ptl ON mp.project_id = ptl.project_id
+LEFT JOIN moped_entity me ON mp.project_sponsor = me.entity_id
+LEFT JOIN moped_entity mel ON mp.project_lead_id = mel.entity_id
+LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
+LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
+LEFT JOIN work_activities ON mp.project_id = work_activities.project_id
+LEFT JOIN moped_users added_by_user ON mp.added_by = added_by_user.user_id
+LEFT JOIN current_phase_view current_phase ON mp.project_id = current_phase.project_id
+LEFT JOIN moped_public_process_statuses mpps ON mp.public_process_status_id = mpps.id
+LEFT JOIN child_project_lookup cpl ON mp.project_id = cpl.parent_id
+LEFT JOIN moped_proj_components_subtypes mpcs ON mp.project_id = mpcs.project_id
+LEFT JOIN project_district_association districts ON mp.project_id = districts.project_id
+LEFT JOIN LATERAL (
+    SELECT
+        mpn.project_note,
+        mpn.created_at AS date_created
+    FROM moped_proj_notes mpn
+    WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
+    ORDER BY mpn.created_at DESC
+    LIMIT 1
+) proj_status_update ON true
+WHERE mp.is_deleted = false
+GROUP BY mp.project_id, mp.project_name, mp.project_description, ppll.project_team_members, mp.ecapris_subproject_id, mp.date_added, mp.is_deleted, me.entity_name, mel.entity_name, mp.updated_at, mp.interim_project_id, mp.parent_project_id, mp.knack_project_id, current_phase.phase_name, current_phase.phase_key, current_phase.phase_name_simple, ptl.type_name, mpcs.components, fsl.funding_source_name, added_by_user.first_name, added_by_user.last_name, mpps.name, cpl.children_project_ids, proj_status_update.project_note, proj_status_update.date_created, work_activities.workgroup_contractors, work_activities.contract_numbers, work_activities.task_order_names, work_activities.task_order_names_short, work_activities.task_orders, districts.project_council_districts, districts.project_and_child_project_council_districts;
+
+CREATE OR REPLACE VIEW component_arcgis_online_view AS WITH work_types AS (
+    SELECT
+        mpcwt.project_component_id,
+        string_agg(mwt.name, ', '::text) AS work_types
+    FROM moped_proj_component_work_types mpcwt
+    LEFT JOIN moped_work_types mwt ON mpcwt.work_type_id = mwt.id
+    WHERE mpcwt.is_deleted = false
+    GROUP BY mpcwt.project_component_id
+),
+
+council_districts AS (
+    SELECT
+        features.component_id AS project_component_id,
+        string_agg(DISTINCT features_council_districts.council_district_id::text, ', '::text) AS council_districts
+    FROM features_council_districts
+    LEFT JOIN features ON features_council_districts.feature_id = features.id
+    WHERE features.is_deleted = false
+    GROUP BY features.component_id
+),
+
+comp_geography AS (
+    SELECT
+        feature_union.component_id AS project_component_id,
+        string_agg(DISTINCT feature_union.id::text, ', '::text) AS feature_ids,
+        st_asgeojson(st_union(array_agg(feature_union.geography)))::json AS geometry,
+        st_asgeojson(st_union(array_agg(feature_union.line_geography)))::json AS line_geometry,
+        string_agg(DISTINCT feature_union.signal_id::text, ', '::text) AS signal_ids,
+        sum(feature_union.length_feet) AS length_feet_total
+    FROM (
+        SELECT
+            feature_signals.id,
+            feature_signals.component_id,
+            feature_signals.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_signals.geography, 7::double precision)::geometry) AS line_geography,
+            feature_signals.signal_id,
+            null::integer AS length_feet
+        FROM feature_signals
+        WHERE feature_signals.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_street_segments.id,
+            feature_street_segments.component_id,
+            feature_street_segments.geography::geometry AS geography,
+            feature_street_segments.geography::geometry AS line_geography,
+            null::integer AS signal_id,
+            feature_street_segments.length_feet
+        FROM feature_street_segments
+        WHERE feature_street_segments.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_intersections.id,
+            feature_intersections.component_id,
+            feature_intersections.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_intersections.geography, 7::double precision)::geometry) AS line_geography,
+            null::integer AS signal_id,
+            null::integer AS length_feet
+        FROM feature_intersections
+        WHERE feature_intersections.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_drawn_points.id,
+            feature_drawn_points.component_id,
+            feature_drawn_points.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_drawn_points.geography, 7::double precision)::geometry) AS line_geography,
+            null::integer AS signal_id,
+            null::integer AS length_feet
+        FROM feature_drawn_points
+        WHERE feature_drawn_points.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_drawn_lines.id,
+            feature_drawn_lines.component_id,
+            feature_drawn_lines.geography::geometry AS geography,
+            feature_drawn_lines.geography::geometry AS line_geography,
+            null::integer AS signal_id,
+            feature_drawn_lines.length_feet
+        FROM feature_drawn_lines
+        WHERE feature_drawn_lines.is_deleted = false
+    ) feature_union
+    GROUP BY feature_union.component_id
+),
+
+subcomponents AS (
+    SELECT
+        mpcs.project_component_id,
+        string_agg(ms.subcomponent_name, ', '::text) AS subcomponents
+    FROM moped_proj_components_subcomponents mpcs
+    LEFT JOIN moped_subcomponents ms ON mpcs.subcomponent_id = ms.subcomponent_id
+    WHERE mpcs.is_deleted = false
+    GROUP BY mpcs.project_component_id
+),
+
+component_tags AS (
+    SELECT
+        mpct.project_component_id,
+        string_agg((mct.type || ' - '::text) || mct.name, ', '::text) AS component_tags
+    FROM moped_proj_component_tags mpct
+    LEFT JOIN moped_component_tags mct ON mpct.component_tag_id = mct.id
+    WHERE mpct.is_deleted = false
+    GROUP BY mpct.project_component_id
+)
+
+SELECT
+    mpc.project_id,
+    comp_geography.project_component_id,
+    comp_geography.feature_ids,
+    mpc.component_id,
+    comp_geography.geometry,
+    comp_geography.line_geometry,
+    comp_geography.signal_ids,
+    council_districts.council_districts,
+    'placeholder text'::text AS council_districts_searchable,
+    NOT coalesce(council_districts.council_districts IS null OR council_districts.council_districts = ''::text, false) AS is_within_city_limits,
+    comp_geography.length_feet_total,
+    round(comp_geography.length_feet_total::numeric / 5280::numeric, 2) AS length_miles_total,
+    mc.component_name,
+    mc.component_subtype,
+    mc.component_name_full,
+    'placeholder text'::text AS component_categories,
+    subcomponents.subcomponents AS component_subcomponents,
+    work_types.work_types AS component_work_types,
+    component_tags.component_tags,
+    mpc.description AS component_description,
+    mpc.interim_project_component_id,
+    mpc.completion_date,
+    coalesce(mpc.completion_date, plv.substantial_completion_date) AS substantial_completion_date,
+    '2024-01-01T00:00:00-06:00'::text AS substantial_completion_date_estimated,
+    mpc.srts_id,
+    mpc.location_description AS component_location_description,
+    plv.project_name,
+    'placeholder text'::text AS project_name_descriptor,
+    'placeholder text'::text AS project_name_with_descriptor,
+    plv.project_description,
+    plv.ecapris_subproject_id,
+    plv.project_website,
+    plv.updated_at AS project_updated_at,
+    mpc.phase_id AS component_phase_id,
+    mph.phase_name AS component_phase_name,
+    mph.phase_name_simple AS component_phase_name_simple,
+    current_phase.phase_id AS project_phase_id,
+    current_phase.phase_name AS project_phase_name,
+    current_phase.phase_name_simple AS project_phase_name_simple,
+    coalesce(mph.phase_name, current_phase.phase_name) AS current_phase_name,
+    coalesce(mph.phase_name_simple, current_phase.phase_name_simple) AS current_phase_name_simple,
+    plv.project_team_members,
+    plv.project_sponsor,
+    plv.project_lead,
+    plv.public_process_status,
+    plv.interim_project_id,
+    plv.project_partners,
+    plv.task_order_names,
+    plv.funding_source_name,
+    plv.type_name,
+    plv.project_status_update,
+    plv.project_status_update_date_created,
+    plv.construction_start_date,
+    plv.completion_end_date,
+    plv.project_inspector,
+    plv.project_designer,
+    plv.project_tags,
+    plv.workgroup_contractors,
+    plv.contract_numbers,
+    plv.parent_project_id,
+    plv.parent_project_name,
+    plv.parent_project_url,
+    'placeholder text'::text AS parent_project_name_with_descriptor,
+    'placeholder text'::text AS related_project_ids,
+    'placeholder text'::text AS related_project_ids_searchable,
+    plv.knack_project_id AS knack_data_tracker_project_record_id,
+    plv.project_url,
+    (plv.project_url || '?tab=map&project_component_id='::text) || mpc.project_component_id::text AS component_url,
+    plv.project_development_status,
+    plv.project_development_status_date,
+    plv.project_development_status_date_calendar_year,
+    plv.project_development_status_date_calendar_year_month,
+    plv.project_development_status_date_calendar_year_month_numeric,
+    plv.project_development_status_date_calendar_year_quarter,
+    plv.project_development_status_date_fiscal_year,
+    plv.project_development_status_date_fiscal_year_quarter,
+    plv.added_by AS project_added_by
+FROM moped_proj_components mpc
+LEFT JOIN comp_geography ON mpc.project_component_id = comp_geography.project_component_id
+LEFT JOIN council_districts ON mpc.project_component_id = council_districts.project_component_id
+LEFT JOIN subcomponents ON mpc.project_component_id = subcomponents.project_component_id
+LEFT JOIN work_types ON mpc.project_component_id = work_types.project_component_id
+LEFT JOIN component_tags ON mpc.project_component_id = component_tags.project_component_id
+LEFT JOIN project_list_view plv ON mpc.project_id = plv.project_id
+LEFT JOIN current_phase_view current_phase ON mpc.project_id = current_phase.project_id
+LEFT JOIN moped_phases mph ON mpc.phase_id = mph.phase_id
+LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id
+WHERE mpc.is_deleted = false AND plv.is_deleted = false;

--- a/moped-database/migrations/1713896796482_add_full_name_to_list_view/up.sql
+++ b/moped-database/migrations/1713896796482_add_full_name_to_list_view/up.sql
@@ -1,0 +1,423 @@
+DROP VIEW project_list_view CASCADE;
+
+CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
+    SELECT
+        mpp.project_id,
+        string_agg(DISTINCT concat(mu.first_name, ' ', mu.last_name, ':', mpr.project_role_name), ','::text) AS project_team_members
+    FROM moped_proj_personnel mpp
+    JOIN moped_users mu ON mpp.user_id = mu.user_id
+    JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+    JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+    WHERE mpp.is_deleted = false AND mppr.is_deleted = false
+    GROUP BY mpp.project_id
+),
+
+funding_sources_lookup AS (
+    SELECT
+        mpf_1.project_id,
+        string_agg(mfs.funding_source_name, ', '::text) AS funding_source_name
+    FROM moped_proj_funding mpf_1
+    LEFT JOIN moped_fund_sources mfs ON mpf_1.funding_source_id = mfs.funding_source_id
+    WHERE mpf_1.is_deleted = false
+    GROUP BY mpf_1.project_id
+),
+
+project_type_lookup AS (
+    SELECT
+        mpt.project_id,
+        string_agg(mt.type_name, ', '::text) AS type_name
+    FROM moped_project_types mpt
+    LEFT JOIN moped_types mt ON mpt.project_type_id = mt.type_id AND mpt.is_deleted = false
+    GROUP BY mpt.project_id
+),
+
+child_project_lookup AS (
+    SELECT
+        jsonb_agg(children.project_id) AS children_project_ids,
+        children.parent_project_id AS parent_id
+    FROM moped_project children
+    JOIN moped_project parent ON children.parent_project_id = parent.project_id
+    WHERE children.is_deleted = false
+    GROUP BY children.parent_project_id
+),
+
+work_activities AS (
+    SELECT
+        mpwa.project_id,
+        string_agg(task_order_objects.task_order_object ->> 'display_name'::text, ', '::text) AS task_order_names,
+        string_agg(task_order_objects.task_order_object ->> 'task_order'::text, ', '::text) AS task_order_names_short,
+        jsonb_agg(DISTINCT task_order_objects.task_order_object) FILTER (WHERE task_order_objects.task_order_object IS NOT null) AS task_orders,
+        string_agg(DISTINCT mpwa.workgroup_contractor, ', '::text) AS workgroup_contractors,
+        string_agg(mpwa.contract_number, ', '::text) AS contract_numbers
+    FROM moped_proj_work_activity mpwa
+    LEFT JOIN LATERAL jsonb_array_elements(mpwa.task_orders) task_order_objects (task_order_object) ON true
+    WHERE 1 = 1 AND mpwa.is_deleted = false
+    GROUP BY mpwa.project_id
+),
+
+moped_proj_components_subtypes AS (
+    SELECT
+        mpc.project_id,
+        string_agg(DISTINCT mc.component_name_full, ', '::text) AS components
+    FROM moped_proj_components mpc
+    LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id
+    WHERE mpc.is_deleted = false
+    GROUP BY mpc.project_id
+),
+
+project_district_association AS (
+    WITH project_council_district_map AS (
+        SELECT DISTINCT
+            moped_project.project_id,
+            features_council_districts.council_district_id
+        FROM moped_project
+        LEFT JOIN moped_proj_components ON moped_project.project_id = moped_proj_components.project_id
+        LEFT JOIN features ON moped_proj_components.project_component_id = features.component_id
+        LEFT JOIN features_council_districts ON features.id = features_council_districts.feature_id
+        WHERE features.is_deleted IS false AND moped_proj_components.is_deleted IS false
+    ),
+
+    parent_child_project_map AS (
+        SELECT
+            parent_projects.project_id,
+            unnest(ARRAY[parent_projects.project_id] || array_agg(child_projects.project_id)) AS self_and_children_project_ids
+        FROM moped_project parent_projects
+        LEFT JOIN moped_project child_projects ON parent_projects.project_id = child_projects.parent_project_id
+        GROUP BY parent_projects.project_id
+        ORDER BY parent_projects.project_id
+    )
+
+    SELECT
+        projects.project_id,
+        array_agg(DISTINCT project_districts.council_district_id) FILTER (WHERE project_districts.council_district_id IS NOT null) AS project_council_districts,
+        array_agg(DISTINCT project_and_children_districts.council_district_id) FILTER (WHERE project_and_children_districts.council_district_id IS NOT null) AS project_and_child_project_council_districts
+    FROM parent_child_project_map projects
+    LEFT JOIN project_council_district_map project_and_children_districts ON projects.self_and_children_project_ids = project_and_children_districts.project_id
+    LEFT JOIN project_council_district_map project_districts ON projects.project_id = project_districts.project_id
+    GROUP BY projects.project_id
+)
+
+SELECT
+    mp.project_id,
+    mp.project_name_full,
+    mp.project_name,
+    mp.project_name_secondary,
+    mp.project_description,
+    mp.ecapris_subproject_id,
+    mp.project_website,
+    mp.date_added,
+    mp.is_deleted,
+    mp.updated_at,
+    current_phase.phase_name AS current_phase,
+    current_phase.phase_key AS current_phase_key,
+    current_phase.phase_name_simple AS current_phase_simple,
+    ppll.project_team_members,
+    me.entity_name AS project_sponsor,
+    mel.entity_name AS project_lead,
+    mpps.name AS public_process_status,
+    mp.interim_project_id,
+    mp.parent_project_id,
+    mp.knack_project_id,
+    'https://mobility.austin.gov/moped/projects/'::text || mp.project_id::text AS project_url,
+    'https://mobility.austin.gov/moped/projects/'::text || mp.parent_project_id::text AS parent_project_url,
+    proj_status_update.project_note AS project_status_update,
+    proj_status_update.date_created AS project_status_update_date_created,
+    work_activities.workgroup_contractors,
+    work_activities.contract_numbers,
+    work_activities.task_order_names,
+    work_activities.task_order_names_short,
+    work_activities.task_orders,
+    'placeholder text'::text AS project_development_status,
+    '2024-01-01T00:00:00-06:00'::text AS project_development_status_date,
+    9999 AS project_development_status_date_calendar_year,
+    'placeholder text'::text AS project_development_status_date_calendar_year_month,
+    'placeholder text'::text AS project_development_status_date_calendar_year_month_numeric,
+    'placeholder text'::text AS project_development_status_date_calendar_year_quarter,
+    999 AS project_development_status_date_fiscal_year,
+    'placeholder text'::text AS project_development_status_date_fiscal_year_quarter,
+    (
+        SELECT moped_project.project_name_full
+        FROM moped_project
+        WHERE moped_project.project_id = mp.parent_project_id
+    ) AS parent_project_name,
+    cpl.children_project_ids,
+    string_agg(DISTINCT me2.entity_name, ', '::text) AS project_partners,
+    (
+        SELECT json_agg(json_build_object('signal_id', feature_signals.signal_id, 'knack_id', feature_signals.knack_id, 'location_name', feature_signals.location_name, 'signal_type', feature_signals.signal_type, 'id', feature_signals.id)) AS json_agg
+        FROM moped_proj_components components
+        LEFT JOIN feature_signals ON components.project_component_id = feature_signals.component_id
+        WHERE true AND components.is_deleted = false AND components.project_id = mp.project_id AND feature_signals.signal_id IS NOT null AND feature_signals.is_deleted = false
+    ) AS project_feature,
+    fsl.funding_source_name,
+    ptl.type_name,
+    (
+        SELECT min(phases.phase_start) AS min
+        FROM moped_proj_phases phases
+        WHERE true AND phases.project_id = mp.project_id AND phases.phase_id = 9 AND phases.is_deleted = false
+    ) AS construction_start_date,
+    (
+        SELECT max(phases.phase_end) AS max
+        FROM moped_proj_phases phases
+        WHERE true AND phases.project_id = mp.project_id AND phases.phase_id = 11 AND phases.is_deleted = false
+    ) AS completion_end_date,
+    (
+        SELECT min(min_confirmed_dates.min_confirmed_date) AS min
+        FROM (
+            SELECT min(phases.phase_start) AS min_confirmed_date
+            FROM moped_proj_phases phases
+            LEFT JOIN moped_phases ON phases.phase_id = moped_phases.phase_id
+            WHERE true AND phases.phase_start IS NOT null AND phases.is_phase_start_confirmed = true AND phases.project_id = mp.project_id AND moped_phases.phase_name_simple = 'Complete'::text AND phases.is_deleted = false
+            UNION ALL
+            SELECT min(phases.phase_end) AS min_confirmed_date
+            FROM moped_proj_phases phases
+            LEFT JOIN moped_phases ON phases.phase_id = moped_phases.phase_id
+            WHERE true AND phases.phase_end IS NOT null AND phases.is_phase_end_confirmed = true AND phases.project_id = mp.project_id AND moped_phases.phase_name_simple = 'Complete'::text AND phases.is_deleted = false
+        ) min_confirmed_dates
+    ) AS substantial_completion_date,
+    (
+        SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+        FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+        WHERE 1 = 1 AND mpr.project_role_name = 'Inspector'::text AND mpp.is_deleted = false AND mppr.is_deleted = false AND mpp.project_id = mp.project_id
+        GROUP BY mpp.project_id
+    ) AS project_inspector,
+    (
+        SELECT string_agg(concat(users.first_name, ' ', users.last_name), ', '::text) AS string_agg
+        FROM moped_proj_personnel mpp
+        JOIN moped_users users ON mpp.user_id = users.user_id
+        JOIN moped_proj_personnel_roles mppr ON mpp.project_personnel_id = mppr.project_personnel_id
+        JOIN moped_project_roles mpr ON mppr.project_role_id = mpr.project_role_id
+        WHERE 1 = 1 AND mpr.project_role_name = 'Designer'::text AND mpp.is_deleted = false AND mppr.is_deleted = false AND mpp.project_id = mp.project_id
+        GROUP BY mpp.project_id
+    ) AS project_designer,
+    (
+        SELECT string_agg(tags.name, ', '::text) AS string_agg
+        FROM moped_proj_tags ptags
+        JOIN moped_tags tags ON ptags.tag_id = tags.id
+        WHERE 1 = 1 AND ptags.is_deleted = false AND ptags.project_id = mp.project_id
+        GROUP BY ptags.project_id
+    ) AS project_tags,
+    concat(added_by_user.first_name, ' ', added_by_user.last_name) AS added_by,
+    mpcs.components,
+    districts.project_council_districts,
+    districts.project_and_child_project_council_districts
+FROM moped_project mp
+LEFT JOIN project_person_list_lookup ppll ON mp.project_id = ppll.project_id
+LEFT JOIN funding_sources_lookup fsl ON mp.project_id = fsl.project_id
+LEFT JOIN project_type_lookup ptl ON mp.project_id = ptl.project_id
+LEFT JOIN moped_entity me ON mp.project_sponsor = me.entity_id
+LEFT JOIN moped_entity mel ON mp.project_lead_id = mel.entity_id
+LEFT JOIN moped_proj_partners mpp2 ON mp.project_id = mpp2.project_id AND mpp2.is_deleted = false
+LEFT JOIN moped_entity me2 ON mpp2.entity_id = me2.entity_id
+LEFT JOIN work_activities ON mp.project_id = work_activities.project_id
+LEFT JOIN moped_users added_by_user ON mp.added_by = added_by_user.user_id
+LEFT JOIN current_phase_view current_phase ON mp.project_id = current_phase.project_id
+LEFT JOIN moped_public_process_statuses mpps ON mp.public_process_status_id = mpps.id
+LEFT JOIN child_project_lookup cpl ON mp.project_id = cpl.parent_id
+LEFT JOIN moped_proj_components_subtypes mpcs ON mp.project_id = mpcs.project_id
+LEFT JOIN project_district_association districts ON mp.project_id = districts.project_id
+LEFT JOIN LATERAL (
+    SELECT
+        mpn.project_note,
+        mpn.created_at AS date_created
+    FROM moped_proj_notes mpn
+    WHERE mpn.project_id = mp.project_id AND mpn.project_note_type = 2 AND mpn.is_deleted = false
+    ORDER BY mpn.created_at DESC
+    LIMIT 1
+) proj_status_update ON true
+WHERE mp.is_deleted = false
+GROUP BY mp.project_id, mp.project_name, mp.project_description, ppll.project_team_members, mp.ecapris_subproject_id, mp.date_added, mp.is_deleted, me.entity_name, mel.entity_name, mp.updated_at, mp.interim_project_id, mp.parent_project_id, mp.knack_project_id, current_phase.phase_name, current_phase.phase_key, current_phase.phase_name_simple, ptl.type_name, mpcs.components, fsl.funding_source_name, added_by_user.first_name, added_by_user.last_name, mpps.name, cpl.children_project_ids, proj_status_update.project_note, proj_status_update.date_created, work_activities.workgroup_contractors, work_activities.contract_numbers, work_activities.task_order_names, work_activities.task_order_names_short, work_activities.task_orders, districts.project_council_districts, districts.project_and_child_project_council_districts;
+
+CREATE OR REPLACE VIEW component_arcgis_online_view AS WITH work_types AS (
+    SELECT
+        mpcwt.project_component_id,
+        string_agg(mwt.name, ', '::text) AS work_types
+    FROM moped_proj_component_work_types mpcwt
+    LEFT JOIN moped_work_types mwt ON mpcwt.work_type_id = mwt.id
+    WHERE mpcwt.is_deleted = false
+    GROUP BY mpcwt.project_component_id
+),
+
+council_districts AS (
+    SELECT
+        features.component_id AS project_component_id,
+        string_agg(DISTINCT features_council_districts.council_district_id::text, ', '::text) AS council_districts
+    FROM features_council_districts
+    LEFT JOIN features ON features_council_districts.feature_id = features.id
+    WHERE features.is_deleted = false
+    GROUP BY features.component_id
+),
+
+comp_geography AS (
+    SELECT
+        feature_union.component_id AS project_component_id,
+        string_agg(DISTINCT feature_union.id::text, ', '::text) AS feature_ids,
+        st_asgeojson(st_union(array_agg(feature_union.geography)))::json AS geometry,
+        st_asgeojson(st_union(array_agg(feature_union.line_geography)))::json AS line_geometry,
+        string_agg(DISTINCT feature_union.signal_id::text, ', '::text) AS signal_ids,
+        sum(feature_union.length_feet) AS length_feet_total
+    FROM (
+        SELECT
+            feature_signals.id,
+            feature_signals.component_id,
+            feature_signals.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_signals.geography, 7::double precision)::geometry) AS line_geography,
+            feature_signals.signal_id,
+            null::integer AS length_feet
+        FROM feature_signals
+        WHERE feature_signals.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_street_segments.id,
+            feature_street_segments.component_id,
+            feature_street_segments.geography::geometry AS geography,
+            feature_street_segments.geography::geometry AS line_geography,
+            null::integer AS signal_id,
+            feature_street_segments.length_feet
+        FROM feature_street_segments
+        WHERE feature_street_segments.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_intersections.id,
+            feature_intersections.component_id,
+            feature_intersections.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_intersections.geography, 7::double precision)::geometry) AS line_geography,
+            null::integer AS signal_id,
+            null::integer AS length_feet
+        FROM feature_intersections
+        WHERE feature_intersections.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_drawn_points.id,
+            feature_drawn_points.component_id,
+            feature_drawn_points.geography::geometry AS geography,
+            st_exteriorring(st_buffer(feature_drawn_points.geography, 7::double precision)::geometry) AS line_geography,
+            null::integer AS signal_id,
+            null::integer AS length_feet
+        FROM feature_drawn_points
+        WHERE feature_drawn_points.is_deleted = false
+        UNION ALL
+        SELECT
+            feature_drawn_lines.id,
+            feature_drawn_lines.component_id,
+            feature_drawn_lines.geography::geometry AS geography,
+            feature_drawn_lines.geography::geometry AS line_geography,
+            null::integer AS signal_id,
+            feature_drawn_lines.length_feet
+        FROM feature_drawn_lines
+        WHERE feature_drawn_lines.is_deleted = false
+    ) feature_union
+    GROUP BY feature_union.component_id
+),
+
+subcomponents AS (
+    SELECT
+        mpcs.project_component_id,
+        string_agg(ms.subcomponent_name, ', '::text) AS subcomponents
+    FROM moped_proj_components_subcomponents mpcs
+    LEFT JOIN moped_subcomponents ms ON mpcs.subcomponent_id = ms.subcomponent_id
+    WHERE mpcs.is_deleted = false
+    GROUP BY mpcs.project_component_id
+),
+
+component_tags AS (
+    SELECT
+        mpct.project_component_id,
+        string_agg((mct.type || ' - '::text) || mct.name, ', '::text) AS component_tags
+    FROM moped_proj_component_tags mpct
+    LEFT JOIN moped_component_tags mct ON mpct.component_tag_id = mct.id
+    WHERE mpct.is_deleted = false
+    GROUP BY mpct.project_component_id
+)
+
+SELECT
+    mpc.project_id,
+    comp_geography.project_component_id,
+    comp_geography.feature_ids,
+    mpc.component_id,
+    comp_geography.geometry,
+    comp_geography.line_geometry,
+    comp_geography.signal_ids,
+    council_districts.council_districts,
+    'placeholder text'::text AS council_districts_searchable,
+    NOT coalesce(council_districts.council_districts IS null OR council_districts.council_districts = ''::text, false) AS is_within_city_limits,
+    comp_geography.length_feet_total,
+    round(comp_geography.length_feet_total::numeric / 5280::numeric, 2) AS length_miles_total,
+    mc.component_name,
+    mc.component_subtype,
+    mc.component_name_full,
+    'placeholder text'::text AS component_categories,
+    subcomponents.subcomponents AS component_subcomponents,
+    work_types.work_types AS component_work_types,
+    component_tags.component_tags,
+    mpc.description AS component_description,
+    mpc.interim_project_component_id,
+    mpc.completion_date,
+    coalesce(mpc.completion_date, plv.substantial_completion_date) AS substantial_completion_date,
+    '2024-01-01T00:00:00-06:00'::text AS substantial_completion_date_estimated,
+    mpc.srts_id,
+    mpc.location_description AS component_location_description,
+    plv.project_name,
+    'placeholder text'::text AS project_name_descriptor,
+    'placeholder text'::text AS project_name_with_descriptor,
+    plv.project_description,
+    plv.ecapris_subproject_id,
+    plv.project_website,
+    plv.updated_at AS project_updated_at,
+    mpc.phase_id AS component_phase_id,
+    mph.phase_name AS component_phase_name,
+    mph.phase_name_simple AS component_phase_name_simple,
+    current_phase.phase_id AS project_phase_id,
+    current_phase.phase_name AS project_phase_name,
+    current_phase.phase_name_simple AS project_phase_name_simple,
+    coalesce(mph.phase_name, current_phase.phase_name) AS current_phase_name,
+    coalesce(mph.phase_name_simple, current_phase.phase_name_simple) AS current_phase_name_simple,
+    plv.project_team_members,
+    plv.project_sponsor,
+    plv.project_lead,
+    plv.public_process_status,
+    plv.interim_project_id,
+    plv.project_partners,
+    plv.task_order_names,
+    plv.funding_source_name,
+    plv.type_name,
+    plv.project_status_update,
+    plv.project_status_update_date_created,
+    plv.construction_start_date,
+    plv.completion_end_date,
+    plv.project_inspector,
+    plv.project_designer,
+    plv.project_tags,
+    plv.workgroup_contractors,
+    plv.contract_numbers,
+    plv.parent_project_id,
+    plv.parent_project_name,
+    plv.parent_project_url,
+    'placeholder text'::text AS parent_project_name_with_descriptor,
+    'placeholder text'::text AS related_project_ids,
+    'placeholder text'::text AS related_project_ids_searchable,
+    plv.knack_project_id AS knack_data_tracker_project_record_id,
+    plv.project_url,
+    (plv.project_url || '?tab=map&project_component_id='::text) || mpc.project_component_id::text AS component_url,
+    plv.project_development_status,
+    plv.project_development_status_date,
+    plv.project_development_status_date_calendar_year,
+    plv.project_development_status_date_calendar_year_month,
+    plv.project_development_status_date_calendar_year_month_numeric,
+    plv.project_development_status_date_calendar_year_quarter,
+    plv.project_development_status_date_fiscal_year,
+    plv.project_development_status_date_fiscal_year_quarter,
+    plv.added_by AS project_added_by
+FROM moped_proj_components mpc
+LEFT JOIN comp_geography ON mpc.project_component_id = comp_geography.project_component_id
+LEFT JOIN council_districts ON mpc.project_component_id = council_districts.project_component_id
+LEFT JOIN subcomponents ON mpc.project_component_id = subcomponents.project_component_id
+LEFT JOIN work_types ON mpc.project_component_id = work_types.project_component_id
+LEFT JOIN component_tags ON mpc.project_component_id = component_tags.project_component_id
+LEFT JOIN project_list_view plv ON mpc.project_id = plv.project_id
+LEFT JOIN current_phase_view current_phase ON mpc.project_id = current_phase.project_id
+LEFT JOIN moped_phases mph ON mpc.phase_id = mph.phase_id
+LEFT JOIN moped_components mc ON mpc.component_id = mc.component_id
+WHERE mpc.is_deleted = false AND plv.is_deleted = false;

--- a/moped-database/views/component_arcgis_online_view.sql
+++ b/moped-database/views/component_arcgis_online_view.sql
@@ -1,4 +1,4 @@
--- Most recent migration: moped-database/migrations/1712697601393_update_project_list_view_w_full_name/up.sql
+-- Most recent migration: moped-database/migrations/1713896796482_add_full_name_to_list_view/up.sql
 
 CREATE OR REPLACE VIEW component_arcgis_online_view AS WITH work_types AS (
     SELECT

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -1,4 +1,4 @@
--- Most recent migration: moped-database/migrations/1712697601393_update_project_list_view_w_full_name/up.sql
+-- Most recent migration: moped-database/migrations/1713896796482_add_full_name_to_list_view/up.sql
 
 CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
     SELECT
@@ -136,7 +136,7 @@ SELECT
     999 AS project_development_status_date_fiscal_year,
     'placeholder text'::text AS project_development_status_date_fiscal_year_quarter,
     (
-        SELECT moped_project.project_name
+        SELECT moped_project.project_name_full
         FROM moped_project
         WHERE moped_project.project_id = mp.parent_project_id
     ) AS parent_project_name,

--- a/moped-editor/src/queries/dashboard.js
+++ b/moped-editor/src/queries/dashboard.js
@@ -14,6 +14,7 @@ export const DASHBOARD_QUERY = gql`
       project {
         project_id
         project_name
+        project_name_full
         moped_proj_phases(where: { is_current_phase: { _eq: true } }) {
           moped_phase {
             phase_name
@@ -47,6 +48,7 @@ export const DASHBOARD_QUERY = gql`
       project {
         project_id
         project_name
+        project_name_full
         moped_proj_phases(where: { is_current_phase: { _eq: true } }) {
           moped_phase {
             phase_name

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -27,6 +27,7 @@ export const SUMMARY_QUERY = gql`
       project_id
       project_name
       project_name_secondary
+      project_name_full
       project_description
       ecapris_subproject_id
       knack_project_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -972,7 +972,7 @@ export const PROJECT_OPTIONS = gql`
       }
     ) {
       project_id
-      project_name
+      project_name_full
     }
   }
 `;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -38,6 +38,7 @@ export const SUMMARY_QUERY = gql`
       is_deleted
       moped_project {
         project_name
+        project_name_full
       }
       moped_proj_components(
         where: {

--- a/moped-editor/src/queries/subprojects.js
+++ b/moped-editor/src/queries/subprojects.js
@@ -6,6 +6,7 @@ export const SUBPROJECT_QUERY = gql`
       where: { parent_project_id: { _eq: $projectId }, is_deleted: { _eq: false } }
     ) {
       project_name
+      project_name_full
       project_id
       moped_proj_phases(where: { is_current_phase: { _eq: true } }) {
         moped_phase {

--- a/moped-editor/src/queries/subprojects.js
+++ b/moped-editor/src/queries/subprojects.js
@@ -27,7 +27,7 @@ export const SUBPROJECT_QUERY = gql`
       }
     ) {
       project_id
-      project_name
+      project_name_full
     }
   }
 `;

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -183,7 +183,7 @@ const DashboardView = () => {
     },
     {
       title: "Full name",
-      field: "project.project_name",
+      field: "project.project_name_full",
       editable: "never",
       cellStyle: { ...typographyStyle },
       render: (entry) => (

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -182,7 +182,7 @@ const DashboardView = () => {
       width: "10%",
     },
     {
-      title: "Name",
+      title: "Full name",
       field: "project.project_name",
       editable: "never",
       cellStyle: { ...typographyStyle },

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -128,7 +128,7 @@ const DashboardView = () => {
      * Build data needed in Dashboard Material Table
      */
     selectedData.forEach((project) => {
-      project["project_name"] = project.project.project_name;
+      project["project_name_full"] = project.project.project_name_full;
       project["project_id"] = project.project.project_id;
       project["phase_name"] =
         project.project.moped_proj_phases?.[0]?.moped_phase.phase_name;
@@ -189,7 +189,7 @@ const DashboardView = () => {
       render: (entry) => (
         <RenderFieldLink
           projectId={entry.project_id}
-          value={entry.project_name}
+          value={entry.project_name_full}
         />
       ),
       width: "20%",

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
@@ -21,7 +21,7 @@ export const useProjectOptions = (data) =>
 
     const options = data.moped_project.map((option) => ({
       value: option.project_id,
-      label: `${option.project_id} - ${option.project_name}`,
+      label: `${option.project_id} - ${option.project_name_full}`,
     }));
 
     return options;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -10,7 +10,6 @@ import { NavLink as RouterLink } from "react-router-dom";
  * @constructor
  */
 const ProjectSummaryParentProjectLink = ({ data, classes }) => {
-  console.log(data.moped_project)
   const parentProjectId = data?.moped_project?.[0]?.parent_project_id;
   const parentProjectName = data?.moped_project[0].moped_project.project_name_full;
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryParentProjectLink.js
@@ -10,8 +10,9 @@ import { NavLink as RouterLink } from "react-router-dom";
  * @constructor
  */
 const ProjectSummaryParentProjectLink = ({ data, classes }) => {
+  console.log(data.moped_project)
   const parentProjectId = data?.moped_project?.[0]?.parent_project_id;
-  const parentProjectName = data?.moped_project[0].moped_project.project_name;
+  const parentProjectName = data?.moped_project[0].moped_project.project_name_full;
 
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -53,7 +53,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
     },
     {
       title: "Full name",
-      field: "project_name",
+      field: "project_name_full",
       width: "40%",
       validate: (entry) => (!!entry.project_name),
       render: (entry) => (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -69,7 +69,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
             name="project_name"
             options={data.subprojectOptions}
             getOptionLabel={(option) =>
-              `${option.project_id} - ${option.project_name}`
+              `${option.project_id} - ${option.project_name_full}`
             }
             value={props.value || null}
             onChange={(event, value) => props.onChange(value)}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -54,8 +54,8 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
     {
       title: "Full name",
       field: "project_name",
-      width: "35%",
-      validate: (entry) => !!entry.project_name_full,
+      width: "40%",
+      validate: (entry) => (!!entry.project_name),
       render: (entry) => (
         <RenderFieldLink
           projectId={entry.project_id}
@@ -85,7 +85,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
       title: "Status",
       field: "status",
       editable: "never",
-      width: "30%",
+      width: "25%",
       customSort: (a, b) =>
         a.moped_proj_phases?.[0]?.moped_phase?.phase_name <
         b.moped_proj_phases?.[0]?.moped_phase?.phase_name

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -52,14 +52,14 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
       width: "15%",
     },
     {
-      title: "Name",
+      title: "Full name",
       field: "project_name",
       width: "35%",
-      validate: (entry) => !!entry.project_name,
+      validate: (entry) => !!entry.project_name_full,
       render: (entry) => (
         <RenderFieldLink
           projectId={entry.project_id}
-          value={entry.project_name}
+          value={entry.project_name_full}
         />
       ),
       editComponent: (props) => (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -55,7 +55,7 @@ const SubprojectsTable = ({ projectId = null, refetchSummaryData }) => {
       title: "Full name",
       field: "project_name_full",
       width: "40%",
-      validate: (entry) => (!!entry.project_name),
+      validate: (entry) => (!!entry.project_name_full),
       render: (entry) => (
         <RenderFieldLink
           projectId={entry.project_id}

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -407,7 +407,7 @@ const ProjectView = () => {
           title={
             loading
               ? "Project Summary Page"
-              : `${data.moped_project[0].project_name} #${data.moped_project[0].project_id}`
+              : `${data.moped_project[0].project_name_full} #${data.moped_project[0].project_id}`
           }
         >
           <Container maxWidth="xl">

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -554,7 +554,7 @@ const ProjectView = () => {
                             data={data}
                             error={error}
                             refetch={refetch}
-                            projectName={data.moped_project[0].project_name}
+                            projectName={data.moped_project[0].project_name_full}
                             phaseKey={currentPhase?.phase_key}
                             phaseName={currentPhase?.phase_name}
                             parentProjectId={


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/16919

## Testing
**URL to test:** 
you will have to run locally to do the full test, since there are changes to the metadata and the project list view. 

I've switched the project name to use the full project name in the following places:

project list page, parent project name column
project summary page, parent project name
project summary page, subprojects list, what is shown and the options that are in the autocomplete
project name on the map tab
move component selector on the map tab
dashboard project names

**Steps to test:**

Besides visually seeing the full project name shown, there are few places where I've updated the autocomplete choices. 
Test finding projects to move the component to in the map tab. 
![Screenshot 2024-04-23 at 4 04 53 PM](https://github.com/cityofaustin/atd-moped/assets/12474808/2caae2d8-89f0-4ada-a712-0cf01df36aac)

Test the subprojects table on the summary page, searching for projects by secondary name too. 
![Screenshot 2024-04-23 at 4 06 59 PM](https://github.com/cityofaustin/atd-moped/assets/12474808/b15a006e-14f4-4a8d-976b-57a8424992cc)


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~~
