### PR TITLE
[Bug] Unable to remove Lead or Sponsor in Project summary view

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -761,7 +761,7 @@ export const PROJECT_SUMMARY_STATUS_UPDATE_INSERT = gql`
 `;
 
 export const PROJECT_UPDATE_SPONSOR = gql`
-  mutation ProjectUpdateSponsor($projectId: Int!, $fieldValueId: Int!) {
+  mutation ProjectUpdateSponsor($projectId: Int!, $fieldValueId: Int) {
     update_moped_project_by_pk(
       pk_columns: { project_id: $projectId }
       _set: { project_sponsor: $fieldValueId }
@@ -772,7 +772,7 @@ export const PROJECT_UPDATE_SPONSOR = gql`
 `;
 
 export const PROJECT_UPDATE_LEAD = gql`
-  mutation ProjectUpdateLead($projectId: Int!, $fieldValueId: Int!) {
+  mutation ProjectUpdateLead($projectId: Int!, $fieldValueId: Int) {
     update_moped_project_by_pk(
       pk_columns: { project_id: $projectId }
       _set: { project_lead_id: $fieldValueId }
@@ -926,10 +926,17 @@ export const UPDATE_PROJECT_TASK_ORDER = gql`
 `;
 
 export const UPDATE_PROJECT_NAMES_QUERY = gql`
-  mutation UpdateProjectName($projectId: Int!, $projectName: String!, $projectNameSecondary: String) {
+  mutation UpdateProjectName(
+    $projectId: Int!
+    $projectName: String!
+    $projectNameSecondary: String
+  ) {
     update_moped_project_by_pk(
       pk_columns: { project_id: $projectId }
-      _set: { project_name: $projectName, project_name_secondary: $projectNameSecondary}
+      _set: {
+        project_name: $projectName
+        project_name_secondary: $projectNameSecondary
+      }
     ) {
       project_name
       project_name_secondary


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/16964

This one updates the project lead and sponsor mutations to accept null when clearing them out in the project summary view.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1327--atd-moped-main.netlify.app/moped/projects/1909

**Steps to test:**
1. Go to staging and try to clear out a project lead or sponsor and see that there is a GraphQL error message shows in a snackbar
2. Go to this deploy preview and try the same, and it should work

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
