### PR TITLE
 [Bug] Error happens when not completely removing an advanced search filter

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -115,6 +115,8 @@ const Filters = ({
   resetSimpleSearch,
   isOr,
   setIsOr,
+  searchParams,
+  setSearchParams,
 }) => {
   /**
    * The styling of the search bar
@@ -122,7 +124,6 @@ const Filters = ({
    * @default
    */
   const classes = useStyles();
-  let [, setSearchParams] = useSearchParams();
 
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 
@@ -283,10 +284,8 @@ const Filters = ({
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete(advancedSearchFilterParamName);
       prevSearchParams.delete(advancedSearchIsOrParamName);
-
       return prevSearchParams;
     });
-
     resetSimpleSearch();
   };
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -129,15 +129,14 @@ const Filters = ({
 
   if (error) console.error(error);
 
+  const isEmptyFilterNeeded = true;
+
   /* Consume existing URL search params or start with an empty filter if none exist */
   let initialFilterParameters = useMakeFilterState(
     searchParams,
-    advancedSearchFilterParamName
+    advancedSearchFilterParamName,
+    isEmptyFilterNeeded
   );
-  initialFilterParameters =
-    initialFilterParameters.length > 0
-      ? initialFilterParameters
-      : [generateEmptyFilter()];
 
   /**
    * The current local filter parameters so that we can store updated filters and

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -130,10 +130,14 @@ const Filters = ({
   if (error) console.error(error);
 
   /* Consume existing URL search params or start with an empty filter if none exist */
-  const initialFilterParameters = useMakeFilterState(
+  let initialFilterParameters = useMakeFilterState(
     searchParams,
     advancedSearchFilterParamName
   );
+  initialFilterParameters =
+    initialFilterParameters.length > 0
+      ? initialFilterParameters
+      : [generateEmptyFilter()];
 
   /**
    * The current local filter parameters so that we can store updated filters and

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -114,6 +114,7 @@ const Filters = ({
   resetSimpleSearch,
   isOr,
   setIsOr,
+  setSearchParams,
 }) => {
   /**
    * The styling of the search bar
@@ -121,7 +122,7 @@ const Filters = ({
    * @default
    */
   const classes = useStyles();
-  let [searchParams, setSearchParams] = useSearchParams();
+  let [searchParams] = useSearchParams();
 
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -147,6 +147,7 @@ const Filters = ({
   const [filterParameters, setFilterParameters] = useState(
     initialFilterParameters
   );
+  const [searchParameters, setSearchParameters] = useState();
 
   /* Track toggle value so we update the query value in handleApplyButtonClick */
   const [isOrToggleValue, setIsOrToggleValue] = useState(isOr);
@@ -235,25 +236,26 @@ const Filters = ({
 
     const remainingFiltersCount = filtersNewState.length;
 
-    if (remainingFiltersCount === 0) {
-      /* Clear search params since we have no advanced filters */
-      setSearchParams((prevSearchParams) => {
-        prevSearchParams.delete(advancedSearchFilterParamName);
-        prevSearchParams.delete(advancedSearchIsOrParamName);
+    // if (remainingFiltersCount === 0) {
+    //   /* Clear search params since we have no advanced filters */
+    //   setSearchParams((prevSearchParams) => {
+    //     prevSearchParams.delete(advancedSearchFilterParamName);
+    //     prevSearchParams.delete(advancedSearchIsOrParamName);
 
-        return prevSearchParams;
-      });
-    } else if (remainingFiltersCount === 1) {
+    //     return prevSearchParams;
+    //   });
+    // } else
+    if (remainingFiltersCount === 1) {
       /* Reset isOr to false (all/and) if there is only one filter left */
       setIsOrToggleValue(false);
-    } else {
-      /* Remove the details of the removed filter from search params */
-      const jsonParamString = JSON.stringify(filtersNewState);
-      setSearchParams((prevSearchParams) => {
-        prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
+      // } else {
+      //   /* Remove the details of the removed filter from search params */
+      //   const jsonParamString = JSON.stringify(filtersNewState);
+      //   setSearchParams((prevSearchParams) => {
+      //     prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
 
-        return prevSearchParams;
-      });
+      //     return prevSearchParams;
+      //   });
     }
   };
 
@@ -274,7 +276,7 @@ const Filters = ({
   /**
    * Reset search box and advanced filters
    */
-  const handleResetFilters = useCallback(() => {
+  const handleResetFilters = () => {
     setFilterParameters([generateEmptyFilter()]);
     setFilters([]);
     setIsOr(false);
@@ -286,7 +288,7 @@ const Filters = ({
     });
 
     resetSimpleSearch();
-  }, [setSearchParams, setFilters, setIsOr, resetSimpleSearch]);
+  };
 
   /**
    * Applies the current local state and updates the parent's state
@@ -306,6 +308,14 @@ const Filters = ({
       setFilters(filterParameters);
     } else {
       /* If we have no advanced filters, reset query state */
+
+      /* Clear search params since we have no advanced filters */
+      setSearchParams((prevSearchParams) => {
+        prevSearchParams.delete(advancedSearchFilterParamName);
+        prevSearchParams.delete(advancedSearchIsOrParamName);
+
+        return prevSearchParams;
+      });
       setFilters([]);
       setIsOr(false);
     }

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
+import { useMakeFilterState } from "./helpers";
 
 import {
   Button,
@@ -130,21 +131,10 @@ const Filters = ({
   let [searchParams] = useSearchParams();
 
   /* Consume existing filters or start with an empty filter if none exist */
-  const initialFilterParameters = useMemo(() => {
-    if (Array.from(searchParams).length > 0) {
-      const filterSearchParams = searchParams.get(
-        advancedSearchFilterParamName
-      );
-      if (filterSearchParams === null) return [];
-
-      try {
-        return JSON.parse(filterSearchParams);
-      } catch {
-        return [];
-      }
-    }
-    return [];
-  }, [searchParams]);
+  const initialFilterParameters = useMakeFilterState(
+    searchParams,
+    advancedSearchFilterParamName
+  );
 
   /**
    * The current local filter parameters so that we can store updated filters and

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -103,6 +103,8 @@ const useStyles = makeStyles((theme) => ({
  * @param {Function} handleAdvancedSearchClose - Used to close the advanced search
  * @param {Object} filtersConfig - The configuration object for the filters
  * @param {Function} resetSimpleSearch - Function to reset the simple search
+ * @param {Object} searchParams - The URL search params
+ * @param {Function} setSearchParams - Function to set the URL search params
  * @return {JSX.Element}
  * @constructor
  */

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -129,14 +129,12 @@ const Filters = ({
 
   if (error) console.error(error);
 
-  const isEmptyFilterNeeded = true;
-
   /* Consume existing URL search params or start with an empty filter if none exist */
-  let initialFilterParameters = useMakeFilterState(
+  const initialFilterParameters = useMakeFilterState({
     searchParams,
     advancedSearchFilterParamName,
-    isEmptyFilterNeeded
-  );
+    isEmptyFilterNeeded: true,
+  });
 
   /**
    * The current local filter parameters so that we can store updated filters and

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -100,7 +100,6 @@ const useStyles = makeStyles((theme) => ({
 
 /**
  * Filter Search Component aka Advanced Search
- * @param {Object} filters - The current filters from useAdvancedSearch hook
  * @param {Function} setFilters - Set the current filters from useAdvancedSearch hook
  * @param {Function} handleAdvancedSearchClose - Used to close the advanced search
  * @param {Object} filtersConfig - The configuration object for the filters
@@ -128,7 +127,7 @@ const Filters = ({
 
   if (error) console.error(error);
 
-  /* Consume existing filters or start with an empty filter if none exist */
+  /* Consume existing URL search params or start with an empty filter if none exist */
   const initialFilterParameters = useMakeFilterState(
     searchParams,
     advancedSearchFilterParamName
@@ -136,7 +135,7 @@ const Filters = ({
 
   /**
    * The current local filter parameters so that we can store updated filters and
-   * then apply them to the query when the search button is clicked.
+   * then apply them to the query when the apply button is clicked.
    * @type {Object} filterParameters - Contains all the current filters
    * @function setFilterParameters - Update the state of filterParameters
    * @default {filters}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useSearchParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
 import { useMakeFilterState } from "./helpers";
@@ -284,8 +283,6 @@ const Filters = ({
       setIsOr(isOrToggleValue);
       setFilters(filterParameters);
     } else {
-      /* If we have no advanced filters, reset query state */
-
       /* Clear search params since we have no advanced filters */
       setSearchParams((prevSearchParams) => {
         prevSearchParams.delete(advancedSearchFilterParamName);
@@ -293,6 +290,7 @@ const Filters = ({
 
         return prevSearchParams;
       });
+      /* If we have no advanced filters, reset query state */
       setFilters([]);
       setIsOr(false);
     }

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -115,7 +115,6 @@ const Filters = ({
   resetSimpleSearch,
   isOr,
   setIsOr,
-  setSearchParams,
 }) => {
   /**
    * The styling of the search bar
@@ -123,12 +122,11 @@ const Filters = ({
    * @default
    */
   const classes = useStyles();
+  let [searchParams, setSearchParams] = useSearchParams();
 
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 
   if (error) console.error(error);
-
-  let [searchParams] = useSearchParams();
 
   /* Consume existing filters or start with an empty filter if none exist */
   const initialFilterParameters = useMakeFilterState(

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -114,6 +114,7 @@ const Filters = ({
   resetSimpleSearch,
   isOr,
   setIsOr,
+  searchParams,
   setSearchParams,
 }) => {
   /**
@@ -122,7 +123,6 @@ const Filters = ({
    * @default
    */
   const classes = useStyles();
-  let [searchParams] = useSearchParams();
 
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -185,6 +185,7 @@ const Search = ({
             resetSimpleSearch={resetSimpleSearch}
             isOr={isOr}
             setIsOr={setIsOr}
+            setSearchParams={setSearchParams}
           />
         </Paper>
       </Popper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -85,7 +85,7 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
-  let [searchParams, setSearchParams] = useSearchParams();
+  let [, setSearchParams] = useSearchParams();
 
   /**
    * The contents of the search box in SearchBar
@@ -186,7 +186,6 @@ const Search = ({
             resetSimpleSearch={resetSimpleSearch}
             isOr={isOr}
             setIsOr={setIsOr}
-            searchParams={searchParams}
             setSearchParams={setSearchParams}
           />
         </Paper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -85,7 +85,7 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
-  let [, setSearchParams] = useSearchParams();
+  let [searchParams, setSearchParams] = useSearchParams();
 
   /**
    * The contents of the search box in SearchBar
@@ -112,7 +112,6 @@ const Search = ({
 
     setSearchParams((prevSearchParams) => {
       prevSearchParams.delete(simpleSearchParamName);
-
       return prevSearchParams;
     });
   };
@@ -187,6 +186,8 @@ const Search = ({
             resetSimpleSearch={resetSimpleSearch}
             isOr={isOr}
             setIsOr={setIsOr}
+            searchParams={searchParams}
+            setSearchParams={setSearchParams}
           />
         </Paper>
       </Popper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -85,7 +85,7 @@ const Search = ({
   const classes = useStyles();
   const divRef = React.useRef();
 
-  let [, setSearchParams] = useSearchParams();
+  let [searchParams, setSearchParams] = useSearchParams();
 
   /**
    * The contents of the search box in SearchBar
@@ -186,6 +186,7 @@ const Search = ({
             isOr={isOr}
             setIsOr={setIsOr}
             setSearchParams={setSearchParams}
+            searchParams={searchParams}
           />
         </Paper>
       </Popper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -185,7 +185,6 @@ const Search = ({
             resetSimpleSearch={resetSimpleSearch}
             isOr={isOr}
             setIsOr={setIsOr}
-            setSearchParams={setSearchParams}
           />
         </Paper>
       </Popper>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -179,7 +179,6 @@ const Search = ({
       >
         <Paper className={classes.advancedSearchPaper}>
           <Filters
-            filters={filters}
             setFilters={setFilters}
             handleAdvancedSearchClose={handleAdvancedSearchClose}
             filtersConfig={filtersConfig}

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -182,7 +182,7 @@ const SearchBar = ({
       const fieldFilterConfig = filtersConfig.fields.find(
         (fieldConfig) => fieldConfig.name === filter.field
       );
-      return fieldFilterConfig.label;
+      return fieldFilterConfig?.label;
     });
 
   return (

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -139,9 +139,11 @@ export const getDefaultOperator = (filterConfigForField) => {
 };
 
 /**
- * if filter exists in url, get the values and try to parse them
+ * If filter exists in url, get the values and try to parse them
  * Used to initialize filter state
- * @return Object
+ * @param {Object} searchParams - The URL search parameters
+ * @param {String} advancedSearchFilterParamName
+ * @return {Object}
  */
 export const useMakeFilterState = (
   searchParams,
@@ -153,7 +155,6 @@ export const useMakeFilterState = (
         advancedSearchFilterParamName
       );
       if (filterSearchParams === null) return [];
-
       try {
         return JSON.parse(filterSearchParams);
       } catch {

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -1,5 +1,6 @@
 import { OPERATORS_WITHOUT_SEARCH_VALUES } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
 import { AUTOCOMPLETE_OPERATORS } from "src/views/projects/projectsListView/ProjectsListViewFiltersConf";
+import { useMemo } from "react";
 
 /**
  * Generates a copy of an empty filter
@@ -136,3 +137,28 @@ export const getDefaultOperator = (filterConfigForField) => {
 
   return isDefaultOperator ? defaultOperator : fallbackOperator;
 };
+
+/**
+ * if filter exists in url, get the values and try to parse them
+ * Used to initialize filter state
+ * @return Object
+ */
+export const useMakeFilterState = (
+  searchParams,
+  advancedSearchFilterParamName
+) =>
+  useMemo(() => {
+    if (Array.from(searchParams).length > 0) {
+      const filterSearchParams = searchParams.get(
+        advancedSearchFilterParamName
+      );
+      if (filterSearchParams === null) return [];
+
+      try {
+        return JSON.parse(filterSearchParams);
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }, [searchParams, advancedSearchFilterParamName]);

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -147,7 +147,8 @@ export const getDefaultOperator = (filterConfigForField) => {
  */
 export const useMakeFilterState = (
   searchParams,
-  advancedSearchFilterParamName
+  advancedSearchFilterParamName,
+  isEmptyFilterNeeded
 ) =>
   useMemo(() => {
     if (Array.from(searchParams).length > 0) {
@@ -161,5 +162,5 @@ export const useMakeFilterState = (
         return [];
       }
     }
-    return [];
-  }, [searchParams, advancedSearchFilterParamName]);
+    return isEmptyFilterNeeded ? [generateEmptyFilter()] : [];
+  }, [searchParams, advancedSearchFilterParamName, isEmptyFilterNeeded]);

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -145,11 +145,11 @@ export const getDefaultOperator = (filterConfigForField) => {
  * @param {String} advancedSearchFilterParamName
  * @return {Object}
  */
-export const useMakeFilterState = (
+export const useMakeFilterState = ({
   searchParams,
   advancedSearchFilterParamName,
-  isEmptyFilterNeeded
-) =>
+  isEmptyFilterNeeded = false,
+}) =>
   useMemo(() => {
     if (Array.from(searchParams).length > 0) {
       const filterSearchParams = searchParams.get(

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -88,10 +88,10 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 export const useAdvancedSearch = () => {
   /* Get advanced filters settings from search params if they exist */
   let [searchParams] = useSearchParams();
-  const initialFilterState = useMakeFilterState(
+  const initialFilterState = useMakeFilterState({
     searchParams,
-    advancedSearchFilterParamName
-  );
+    advancedSearchFilterParamName,
+  });
 
   /* Determine or/any from search params if it exists */
   const isOrFromSearchParams = searchParams.get(advancedSearchIsOrParamName);

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -4,32 +4,11 @@ import { PROJECT_LIST_VIEW_FILTERS_CONFIG } from "../ProjectsListViewFiltersConf
 import { FiltersCommonOperators } from "src/components/GridTable/FiltersCommonOperators";
 import { parseGqlString } from "src/utils/gridTableHelpers";
 import { addDays, parseISO, format } from "date-fns";
+import { useMakeFilterState } from "src/components/GridTable/helpers";
 
 /* Names of advanced search URL parameters */
 export const advancedSearchFilterParamName = "filters";
 export const advancedSearchIsOrParamName = "isOr";
-
-/**
- * if filter exists in url, get the values and try to parse them
- * Used to initialize filter state
- * @return Object
- */
-const useMakeFilterState = (searchParams) =>
-  useMemo(() => {
-    if (Array.from(searchParams).length > 0) {
-      const filterSearchParams = searchParams.get(
-        advancedSearchFilterParamName
-      );
-      if (filterSearchParams === null) return [];
-
-      try {
-        return JSON.parse(filterSearchParams);
-      } catch {
-        return [];
-      }
-    }
-    return [];
-  }, [searchParams]);
 
 /**
  * Build an array of filter strings to be used in generating the advanced search where string
@@ -109,7 +88,10 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 export const useAdvancedSearch = () => {
   /* Get advanced filters settings from search params if they exist */
   let [searchParams] = useSearchParams();
-  const initialFilterState = useMakeFilterState(searchParams);
+  const initialFilterState = useMakeFilterState(
+    searchParams,
+    advancedSearchFilterParamName
+  );
 
   /* Determine or/any from search params if it exists */
   const isOrFromSearchParams = searchParams.get(advancedSearchIsOrParamName);


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/16889

I addressed the bug and also added a few other improvements. Previously when you deleted a filter it would update the URL search params before you hit apply. Now the URL search params are only updated once you click apply. I also made it so that when you edit filters and dont apply your changes, close out of advanced search, and open again, ur unsaved changes are not persisted which is what users said they would expect. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1335--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Open the advanced search. See that the Search button now says Apply.
2. Create a filter, add an operator and value and hit apply. Open up advanced search again. Clear out the Field part of the filter and exit out of the advanced search without clicking Apply. You should not get an error anymore and when you open it again your unapplied change should not persist. Also the URL search params should not change until you click Apply.
3. Test changing the value of the filter and exiting out without applying, open up advanced search, the unapplied changes should not persist.
4. Test adding multiple filters, deleting some, exiting out without applying, other times with applying.
5. Now when you click the Reset button it will clear the URL search params as well. Before it would delete all the filters/search and update the search results, but the URL would still have the old search params.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
