### PR TITLE
adds moped_proj_partners audit triggers

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3031,8 +3031,8 @@
       permission:
         check: {}
         set:
-          created_by_user_id: x-hasura-x-hasura-user-db-id
-          updated_by_user_id: x-hasura-x-hasura-user-db-id
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - entity_id
           - is_deleted
@@ -3041,8 +3041,8 @@
       permission:
         check: {}
         set:
-          created_by_user_id: x-hasura-x-hasura-user-db-id
-          updated_by_user_id: x-hasura-x-hasura-user-db-id
+          created_by_user_id: x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
         columns:
           - entity_id
           - is_deleted
@@ -3094,7 +3094,7 @@
         filter: {}
         check: {}
         set:
-          updated_by_user_id: x-hasura-x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
     - role: moped-editor
       permission:
         columns:
@@ -3104,7 +3104,7 @@
         filter: {}
         check: {}
         set:
-          updated_by_user_id: x-hasura-x-hasura-user-db-id
+          updated_by_user_id: x-hasura-user-db-id
   event_triggers:
     - name: activity_log_moped_proj_partners
       definition:

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3031,8 +3031,6 @@
       permission:
         check: {}
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - project_id
@@ -3040,8 +3038,6 @@
       permission:
         check: {}
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - project_id
@@ -3049,8 +3045,6 @@
     - role: moped-admin
       permission:
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - proj_partner_id
@@ -3059,8 +3053,6 @@
     - role: moped-editor
       permission:
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - proj_partner_id
@@ -3069,8 +3061,6 @@
     - role: moped-viewer
       permission:
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - proj_partner_id
@@ -3080,8 +3070,6 @@
     - role: moped-admin
       permission:
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - project_id
@@ -3090,8 +3078,6 @@
     - role: moped-editor
       permission:
         columns:
-          - added_by
-          - date_added
           - entity_id
           - is_deleted
           - project_id
@@ -3118,7 +3104,7 @@
           action: transform
           template: |-
             {
-              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!, $project_id:Int!, $updated_at:timestamptz ) { insert_moped_activity_log_one(object: $object) { activity_id } update_moped_project_by_pk(pk_columns: {project_id: $project_id}, _set: {updated_at: $updated_at}) { updated_at }}",
+              "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",
               "variables": {
                 "object": {
                   "record_id": {{ $body.event.data.new.proj_partner_id }},
@@ -3129,9 +3115,7 @@
                   "description": [{"newSchema": "true"}],
                   "operation_type": {{ $body.event.op }},
                   "updated_by_user_id": {{ $session_variables?['x-hasura-user-db-id'] ?? 1}}
-                },
-                "updated_at": {{$body.created_at}},
-                "project_id": {{$body.event.data.new.project_id}}
+                }
               }
             }
         method: POST

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3030,6 +3030,9 @@
     - role: moped-admin
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-x-hasura-user-db-id
+          updated_by_user_id: x-hasura-x-hasura-user-db-id
         columns:
           - entity_id
           - is_deleted
@@ -3037,6 +3040,9 @@
     - role: moped-editor
       permission:
         check: {}
+        set:
+          created_by_user_id: x-hasura-x-hasura-user-db-id
+          updated_by_user_id: x-hasura-x-hasura-user-db-id
         columns:
           - entity_id
           - is_deleted
@@ -3045,26 +3051,38 @@
     - role: moped-admin
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - entity_id
           - is_deleted
           - proj_partner_id
           - project_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
     - role: moped-editor
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - entity_id
           - is_deleted
           - proj_partner_id
           - project_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
     - role: moped-viewer
       permission:
         columns:
+          - created_at
+          - created_by_user_id
           - entity_id
           - is_deleted
           - proj_partner_id
           - project_id
+          - updated_at
+          - updated_by_user_id
         filter: {}
   update_permissions:
     - role: moped-admin
@@ -3075,6 +3093,8 @@
           - project_id
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-x-hasura-user-db-id
     - role: moped-editor
       permission:
         columns:
@@ -3083,6 +3103,8 @@
           - project_id
         filter: {}
         check: {}
+        set:
+          updated_by_user_id: x-hasura-x-hasura-user-db-id
   event_triggers:
     - name: activity_log_moped_proj_partners
       definition:

--- a/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/down.sql
+++ b/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/down.sql
@@ -1,0 +1,21 @@
+-- Drop triggers to update audit fields on moped_proj_partners and parent project on insert or update of moped_proj_partners
+DROP TRIGGER IF EXISTS update_moped_proj_partners_and_project_audit_fields ON moped_proj_partners;
+
+-- Drop fk constraints on user audit fields on moped_proj_partners
+ALTER TABLE moped_proj_partners
+DROP CONSTRAINT project_types_created_by_fkey,
+DROP CONSTRAINT project_types_updated_by_fkey;
+
+-- Revert and remove audit columns to moped_proj_partners
+ALTER TABLE moped_proj_partners
+DROP COLUMN updated_at,
+DROP COLUMN updated_by_user_id;
+
+ALTER TABLE moped_proj_partners
+RENAME COLUMN created_at TO date_added;
+
+ALTER TABLE moped_proj_partners
+ALTER COLUMN date_added SET DEFAULT clock_timestamp();
+
+ALTER TABLE moped_proj_partners
+RENAME COLUMN created_by_user_id TO added_by;

--- a/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/down.sql
+++ b/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/down.sql
@@ -3,8 +3,8 @@ DROP TRIGGER IF EXISTS update_moped_proj_partners_and_project_audit_fields ON mo
 
 -- Drop fk constraints on user audit fields on moped_proj_partners
 ALTER TABLE moped_proj_partners
-DROP CONSTRAINT project_types_created_by_fkey,
-DROP CONSTRAINT project_types_updated_by_fkey;
+DROP CONSTRAINT moped_proj_partners_created_by_fkey,
+DROP CONSTRAINT moped_proj_partners_updated_by_fkey;
 
 -- Revert and remove audit columns to moped_proj_partners
 ALTER TABLE moped_proj_partners

--- a/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/up.sql
+++ b/moped-database/migrations/1715277419652_add_moped_proj_partners_audit_triggers/up.sql
@@ -1,0 +1,28 @@
+-- Audit updates to moped_proj_partners
+
+-- Update and add audit columns to moped_proj_partners
+ALTER TABLE moped_proj_partners RENAME COLUMN date_added TO created_at;
+ALTER TABLE moped_proj_partners ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE moped_proj_partners RENAME COLUMN added_by TO created_by_user_id;
+ALTER TABLE moped_proj_partners ADD COLUMN updated_at TIMESTAMPTZ
+NOT NULL DEFAULT now();
+ALTER TABLE moped_proj_partners ADD COLUMN updated_by_user_id INTEGER
+NULL;
+
+COMMENT ON COLUMN moped_proj_partners.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN moped_proj_partners.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN moped_proj_partners.created_by_user_id IS 'ID of the user who created the record';
+COMMENT ON COLUMN moped_proj_partners.updated_by_user_id IS 'ID of the user who last updated the record';
+
+-- Add fk constraints on user audit fields on moped_proj_partners
+ALTER TABLE moped_proj_partners
+ADD CONSTRAINT moped_proj_partners_created_by_fkey FOREIGN KEY (created_by_user_id) REFERENCES moped_users (user_id),
+ADD CONSTRAINT moped_proj_partners_updated_by_fkey FOREIGN KEY (updated_by_user_id) REFERENCES moped_users (user_id);
+
+-- Add triggers to update audit fields on moped_proj_partners and parent project on insert or update of moped_proj_partners
+CREATE TRIGGER update_moped_proj_partners_and_project_audit_fields
+BEFORE INSERT OR UPDATE ON moped_proj_partners
+FOR EACH ROW
+EXECUTE FUNCTION update_self_and_project_updated_audit_fields();
+
+COMMENT ON TRIGGER update_moped_proj_partners_and_project_audit_fields ON moped_proj_partners IS 'Trigger to execute the update_self_and_project_updated_audit_fields function before each update operation on the moped_proj_partners table.';

--- a/moped-database/seeds/1602292389297_initial_seed_staging.sql
+++ b/moped-database/seeds/1602292389297_initial_seed_staging.sql
@@ -108,16 +108,16 @@ INSERT INTO public.moped_proj_notes (project_note_id, project_note, created_at, 
 -- Data for Name: moped_proj_partners; Type: TABLE DATA; Schema: public; Owner: moped
 --
 
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (1, 2, 227, '2022-11-12 18:09:10.83628+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (2, 3, 227, '2022-11-12 18:09:10.836658+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (6, 4, 227, '2022-11-12 18:09:10.836667+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (12, 5, 227, '2022-11-12 18:09:10.836672+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (14, 6, 227, '2022-11-12 18:09:10.836677+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (4, 7, 229, '2022-11-15 16:47:43.293093+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (7, 8, 229, '2022-11-15 16:47:43.293178+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (8, 9, 229, '2022-11-15 16:47:43.293185+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (12, 10, 229, '2022-11-15 16:47:43.29319+00', NULL, false);
-INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, date_added, added_by, is_deleted) VALUES (21, 11, 229, '2022-11-15 16:47:43.293194+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (1, 2, 227, '2022-11-12 18:09:10.83628+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (2, 3, 227, '2022-11-12 18:09:10.836658+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (6, 4, 227, '2022-11-12 18:09:10.836667+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (12, 5, 227, '2022-11-12 18:09:10.836672+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (14, 6, 227, '2022-11-12 18:09:10.836677+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (4, 7, 229, '2022-11-15 16:47:43.293093+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (7, 8, 229, '2022-11-15 16:47:43.293178+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (8, 9, 229, '2022-11-15 16:47:43.293185+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (12, 10, 229, '2022-11-15 16:47:43.29319+00', NULL, false);
+INSERT INTO public.moped_proj_partners (entity_id, proj_partner_id, project_id, created_at, created_by_user_id, is_deleted) VALUES (21, 11, 229, '2022-11-15 16:47:43.293194+00', NULL, false);
 
 
 --

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -219,7 +219,7 @@ export const ProjectActivityLogTableMaps = {
       added_by_user_id: {
         icon: "",
         label: "added by user",
-        data_type: "int4",
+        type: "int4",
       },
       proj_partner_id: {
         icon: "",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -201,12 +201,12 @@ export const ProjectActivityLogTableMaps = {
   moped_proj_partners: {
     label: "Partner",
     fields: {
-      added_by: {
+      created_by_user_id: {
         icon: "",
         label: "added By",
         type: "int4",
       },
-      date_added: {
+      created_at: {
         icon: "",
         label: "date added",
         type: "timestamptz",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -201,15 +201,25 @@ export const ProjectActivityLogTableMaps = {
   moped_proj_partners: {
     label: "Partner",
     fields: {
-      created_by_user_id: {
+      date_added: {
         icon: "",
-        label: "added By",
-        type: "int4",
+        label: "date added",
+        data_type: "timestamptz",
       },
       created_at: {
         icon: "",
-        label: "date added",
-        type: "timestamptz",
+        label: "created at",
+        data_type: "timestamptz",
+      },
+      added_by: {
+        icon: "",
+        label: "added by",
+        data_type: "integer",
+      },
+      added_by_user_id: {
+        icon: "",
+        label: "added by user",
+        data_type: "integer",
       },
       proj_partner_id: {
         icon: "",

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -204,22 +204,22 @@ export const ProjectActivityLogTableMaps = {
       date_added: {
         icon: "",
         label: "date added",
-        data_type: "timestamptz",
+        type: "timestamptz",
       },
       created_at: {
         icon: "",
         label: "created at",
-        data_type: "timestamptz",
+        type: "timestamptz",
       },
       added_by: {
         icon: "",
         label: "added by",
-        data_type: "integer",
+        type: "int4",
       },
       added_by_user_id: {
         icon: "",
         label: "added by user",
-        data_type: "integer",
+        data_type: "int4",
       },
       proj_partner_id: {
         icon: "",


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/17017

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local

**Steps to test:**

- run the sql command below and note the values for the audit fields (created_by_user_id, created_at, updated_by_user_id, and updated_at) for the moped_project and moped_proj_partners tables
- add and/or remove a project partner to a project
- updated_by_user_id and updated_at should have updated for all records on the project table, and all audit fields should have updated for the record you created/edited on the moped_proj_partners table

```sql
SELECT
	mp.project_id,
	mp.updated_by_user_id,
	mp.updated_at,
	mpp.proj_partner_id,
	mpp.created_at,
	mpp.updated_at,
	mpp.created_by_user_id,
	mpp.updated_by_user_id,
	mpp.is_deleted
FROM
	moped_project mp
	LEFT JOIN moped_proj_partners mpp ON mp.project_id = mpp.project_id
WHERE
	mp.project_id = <id>;
```
---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
