### PR TITLE
Fix regression displaying MUG status on staff page

### DIFF
--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -306,6 +306,7 @@ function __check_export_complete() {
 
 function replicate() {
   source ./env;
+  stop;
   start_only;
   mkdir -p ./snapshots;
 
@@ -315,6 +316,7 @@ function replicate() {
 
   # If use_any_snapshot is true, use the most recent snapshot
   if $use_any_snapshot; then
+    echo "Using most recent snapshot $snapshot_file"
     snapshot_file="./snapshots/$(ls -t ./snapshots | head -n 1)"
   fi
 

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -81,7 +81,7 @@ const staffColumns = [
   {
     headerName: "MUG Member",
     field: "is_user_group_member",
-    valueGetter: (props) => (props.value ? "Yes" : "No"),
+    valueGetter: (value) => (value ? "Yes" : "No"),
   },
   {
     headerName: "Active",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/17287

Regression introduced and now fixed!

## Testing
**URL to test:** 

https://deploy-preview-1345--atd-moped-main.netlify.app/moped/staff

**Steps to test:**

do you see mug staff yes? then yay

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
