### PR TITLE
Add empty filters if basic search is populated

### DIFF
--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -143,6 +143,7 @@ export const getDefaultOperator = (filterConfigForField) => {
  * Used to initialize filter state
  * @param {Object} searchParams - The URL search parameters
  * @param {String} advancedSearchFilterParamName
+ * @param {Boolean} isEmptyFilterNeeded - toggle adding an empty filter to add initial row in the Filters component
  * @return {Object}
  */
 export const useMakeFilterState = ({

--- a/moped-editor/src/components/GridTable/helpers.js
+++ b/moped-editor/src/components/GridTable/helpers.js
@@ -155,11 +155,13 @@ export const useMakeFilterState = ({
       const filterSearchParams = searchParams.get(
         advancedSearchFilterParamName
       );
-      if (filterSearchParams === null) return [];
+      if (filterSearchParams === null) {
+        return isEmptyFilterNeeded ? [generateEmptyFilter()] : [];
+      }
       try {
         return JSON.parse(filterSearchParams);
       } catch {
-        return [];
+        return isEmptyFilterNeeded ? [generateEmptyFilter()] : [];
       }
     }
     return isEmptyFilterNeeded ? [generateEmptyFilter()] : [];


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/17277

## Testing
**URL to test:** 

https://deploy-preview-1346--atd-moped-main.netlify.app/moped/projects?search=creator

**Steps to test:**

There is a search already populated in the link above, open the advanced filters and see if a blank filter set is prepopulated

Now try the same here: https://moped.austinmobility.io/moped/projects?search=test. No blank filter!

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
