### PR TITLE
Update filter dropdown responsive widths

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -30,14 +30,11 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   advancedSearchRoot: {
-    width: "calc(100% - 32px)",
-    zIndex: "3",
-    paddingLeft: "16px",
-    paddingRight: "16px",
-    [theme.breakpoints.down("md")]: {
-      paddingLeft: "23px",
-      paddingRight: "14px",
+    width: `calc(100% - ${theme.spacing(6)})`,
+    [theme.breakpoints.down("sm")]: {
+      width: `calc(100% - ${theme.spacing(4)})`,
     },
+    zIndex: "3",
   },
   advancedSearchPaper: {
     paddingTop: theme.spacing(1),


### PR DESCRIPTION
## Associated issues
n/a

Small change brought over from the in-progress projects map MVP. h/t to @chiaberry for suggesting to pull this change in and not wait on the map. Targeting for this to release this week.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1348--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
1. Go to the project list view
2. Open the advanced filter dropdown, try out different widths from desktop down to mobile and make sure the dropdown's width stays the same as the search box above it

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
