### PR TITLE
Prevent staff list from showing stale data

### DIFF
--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -316,8 +316,8 @@ function replicate() {
 
   # If use_any_snapshot is true, use the most recent snapshot
   if $use_any_snapshot; then
-    echo "Using most recent snapshot $snapshot_file"
     snapshot_file="./snapshots/$(ls -t ./snapshots | head -n 1)"
+    echo "Using most recent snapshot $snapshot_file"
   fi
 
   # Check if the file already exists and the export is complete

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5019,6 +5019,7 @@
           - picture
           - roles
           - title
+          - user_id
           - workgroup_id
   select_permissions:
     - role: moped-admin
@@ -5097,6 +5098,7 @@
           - picture
           - roles
           - title
+          - user_id
           - workgroup_id
         filter: {}
         check: {}

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5019,7 +5019,6 @@
           - picture
           - roles
           - title
-          - user_id
           - workgroup_id
   select_permissions:
     - role: moped-admin
@@ -5098,7 +5097,6 @@
           - picture
           - roles
           - title
-          - user_id
           - workgroup_id
         filter: {}
         check: {}

--- a/moped-editor/src/queries/staff.js
+++ b/moped-editor/src/queries/staff.js
@@ -72,7 +72,6 @@ export const UPDATE_NON_MOPED_USER = gql`
       first_name
       last_name
       title
-      user_id
       moped_workgroup {
         workgroup_id
         workgroup_name

--- a/moped-editor/src/queries/staff.js
+++ b/moped-editor/src/queries/staff.js
@@ -51,7 +51,6 @@ export const ADD_NON_MOPED_USER = gql`
       first_name
       last_name
       title
-      user_id
       moped_workgroup {
         workgroup_id
         workgroup_name

--- a/moped-editor/src/views/staff/EditStaffView.js
+++ b/moped-editor/src/views/staff/EditStaffView.js
@@ -44,6 +44,7 @@ const EditStaffView = () => {
     error: userQueryError,
   } = useQuery(GET_USER, {
     variables: { userId },
+    fetchPolicy: "cache-and-network",
   });
 
   if (userQueryError) {

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -101,7 +101,7 @@ const staffColumns = [
 const StaffListView = () => {
   const classes = useStyles();
 
-  const { data, loading, error } = useQuery(GET_ALL_USERS);
+  const { data, loading, error } = useQuery(GET_ALL_USERS, {fetchPolicy: "cache-and-network"}); // breadcrumb
 
   if (error) {
     console.error(error);

--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -69,7 +69,7 @@ const staffColumns = [
   {
     headerName: "Role",
     field: "roles",
-    valueGetter: value => {
+    valueGetter: (value) => {
       if (!value || !value[0]) {
         return "N/A";
       }
@@ -101,7 +101,9 @@ const staffColumns = [
 const StaffListView = () => {
   const classes = useStyles();
 
-  const { data, loading, error } = useQuery(GET_ALL_USERS, {fetchPolicy: "cache-and-network"}); // breadcrumb
+  const { data, loading, error } = useQuery(GET_ALL_USERS, {
+    fetchPolicy: "cache-and-network",
+  });
 
   if (error) {
     console.error(error);

--- a/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
+++ b/moped-editor/src/views/staff/components/NonLoginUserActivationButtons.js
@@ -60,7 +60,7 @@ const NonLoginUserActivationButtons = ({
   };
 
   const handleUpdateNonLoginUser = async () => {
-    const { password, __typename, ...restOfFormValues } =
+    const { password, __typename, user_id, ...restOfFormValues } =
       transformFormDataIntoDatabaseTypes(formValues);
     updateNonMopedUser({
       variables: {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/17286

## Testing
**URL to test:** 

Test by updating login users here. nonlogin users will not work on the netlify app

https://deploy-preview-1350--atd-moped-main.netlify.app/moped/staff 

1. Change a name or title. 
2. Go back to the page list view
3. see that your updates is there
4. navigate back to the profile you just updated. see that the user details matches your updates

To test updating nonlogin users you will have to test locally
same steps as above, but only for a nonlogin user 



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
