### PR TITLE
display only active users by default

### DIFF
--- a/moped-editor/src/views/staff/StaffListView.js
+++ b/moped-editor/src/views/staff/StaffListView.js
@@ -128,6 +128,13 @@ const StaffListView = () => {
               getRowId={(row) => row.user_id}
               slots={{ toolbar: GridToolbar }}
               slotProps={{ toolbar: { showQuickFilter: true } }}
+              initialState={{
+                filter: {
+                  filterModel: {
+                    items: [{ field: 'is_deleted', operator: 'equals', value: 'Yes' }],
+                  },
+                },
+              }}
             />
           </Card>
         </Container>


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/16519

sets an initial filter state to show only active users on the staff list view. users can choose to remove this filter to see all users.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1352--atd-moped-main.netlify.app/

**Steps to test:**

- go to the staff list view
- see that only active users are listed and that this initial filter is already applied
- remove the filter and see that the table displays all users
- refresh the page and see that the initial filter has been reapplied

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
