### PR TITLE
Add sidebar with project details on selection of project components in map

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5204,55 +5204,58 @@
     - role: moped-admin
       permission:
         columns:
-          - is_deleted
-          - original_fk
-          - table
+          - attributes
           - component_archtype_id
           - component_id
-          - feature_id
-          - project_id
-          - attributes
           - component_name
-          - project_name
-          - geography
           - council_districts
+          - feature_id
+          - geography
+          - is_deleted
           - length_feet
+          - line_representation
+          - original_fk
+          - project_id
+          - project_name
+          - table
         filter: {}
         allow_aggregations: true
     - role: moped-editor
       permission:
         columns:
-          - project_id
-          - feature_id
+          - attributes
           - component_archtype_id
           - component_id
+          - component_name
+          - council_districts
+          - feature_id
+          - geography
           - is_deleted
+          - length_feet
+          - line_representation
+          - original_fk
+          - project_id
           - project_name
           - table
-          - original_fk
-          - component_name
-          - attributes
-          - geography
-          - council_districts
-          - length_feet
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
       permission:
         columns:
-          - is_deleted
-          - original_fk
-          - table
+          - attributes
           - component_archtype_id
           - component_id
-          - feature_id
-          - project_id
-          - attributes
           - component_name
-          - project_name
-          - geography
           - council_districts
+          - feature_id
+          - geography
+          - is_deleted
           - length_feet
+          - line_representation
+          - original_fk
+          - project_id
+          - project_name
+          - table
         filter: {}
         allow_aggregations: true
 - table:

--- a/moped-database/migrations/1716843075050_add_line_rep_to_proj_geo_view/down.sql
+++ b/moped-database/migrations/1716843075050_add_line_rep_to_proj_geo_view/down.sql
@@ -1,0 +1,26 @@
+DROP VIEW IF EXISTS project_geography;
+
+CREATE OR REPLACE VIEW project_geography AS SELECT
+    moped_project.project_id,
+    uniform_features.id AS feature_id,
+    moped_components.component_id AS component_archtype_id,
+    moped_proj_components.project_component_id AS component_id,
+    moped_proj_components.is_deleted,
+    moped_project.project_name,
+    feature_layers.internal_table AS "table",
+    feature_layers.reference_layer_primary_key_column AS original_fk,
+    moped_components.component_name,
+    uniform_features.attributes,
+    uniform_features.geography,
+    uniform_features.council_districts,
+    uniform_features.length_feet,
+    uniform_features.created_at AS feature_created_at,
+    uniform_features.updated_at AS feature_updated_at,
+    uniform_features.created_by_user_id AS feature_created_by_user_id,
+    uniform_features.updated_by_user_id AS feature_updated_by_user_id
+FROM moped_project
+INNER JOIN moped_proj_components ON moped_project.project_id = moped_proj_components.project_id
+INNER JOIN moped_components ON moped_proj_components.component_id = moped_components.component_id
+INNER JOIN feature_layers ON moped_components.feature_layer_id = feature_layers.id
+INNER JOIN uniform_features ON moped_proj_components.project_component_id = uniform_features.component_id
+WHERE moped_proj_components.is_deleted IS FALSE;

--- a/moped-database/migrations/1716843075050_add_line_rep_to_proj_geo_view/up.sql
+++ b/moped-database/migrations/1716843075050_add_line_rep_to_proj_geo_view/up.sql
@@ -1,0 +1,31 @@
+DROP VIEW IF EXISTS project_geography;
+
+CREATE OR REPLACE VIEW project_geography AS (
+    SELECT
+        moped_project.project_id,
+        uniform_features.id AS feature_id,
+        moped_components.component_id AS component_archtype_id,
+        moped_components.line_representation AS line_representation,
+        moped_proj_components.project_component_id AS component_id,
+        moped_proj_components.is_deleted,
+        moped_project.project_name,
+        feature_layers.internal_table AS "table",
+        feature_layers.reference_layer_primary_key_column AS original_fk,
+        moped_components.component_name,
+        uniform_features.attributes,
+        uniform_features.geography,
+        uniform_features.council_districts,
+        uniform_features.length_feet,
+        uniform_features.created_at AS feature_created_at,
+        uniform_features.updated_at AS feature_updated_at,
+        uniform_features.created_by_user_id AS feature_created_by_user_id,
+        uniform_features.updated_by_user_id AS feature_updated_by_user_id
+    FROM
+        moped_project
+    INNER JOIN moped_proj_components ON moped_project.project_id = moped_proj_components.project_id
+    INNER JOIN moped_components ON moped_proj_components.component_id = moped_components.component_id
+    INNER JOIN feature_layers ON moped_components.feature_layer_id = feature_layers.id
+    INNER JOIN uniform_features ON moped_proj_components.project_component_id = uniform_features.component_id
+    WHERE
+        moped_proj_components.is_deleted IS FALSE
+);

--- a/moped-database/views/project_geography.sql
+++ b/moped-database/views/project_geography.sql
@@ -1,9 +1,10 @@
--- Most recent migration: moped-database/migrations/1707416196012_add_check_for_deleted_components/up.sql
+-- Most recent migration: moped-database/migrations/1716843075050_add_line_rep_to_proj_geo_view/up.sql
 
 CREATE OR REPLACE VIEW project_geography AS SELECT
     moped_project.project_id,
     uniform_features.id AS feature_id,
     moped_components.component_id AS component_archtype_id,
+    moped_components.line_representation,
     moped_proj_components.project_component_id AS component_id,
     moped_proj_components.is_deleted,
     moped_project.project_name,

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -21,11 +21,10 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   downloadButtonGrid: {
-    padding: theme.spacing(1),
+    // match the existing padding set in gridSearchPadding
+    padding: "12px",
     [theme.breakpoints.down("md")]: {
       paddingTop: 0,
-      // match the existing padding set in gridSearchPadding
-      paddingLeft: "12px",
     },
     alignContent: "top",
   },

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -28,15 +28,18 @@ const useStyles = makeStyles((theme) => ({
   tabStyle: {
     margin: ".5rem",
   },
-  advancedSearchRoot: {
-    width: `calc(100% - ${theme.spacing(2)})`,
-    zIndex: "3",
-    paddingLeft: "16px",
-    paddingRight: "16px",
-    [theme.breakpoints.down("md")]: {
-      paddingLeft: "23px",
-      paddingRight: "14px",
+  searchBarContainer: {
+    padding: "2px",
+    [theme.breakpoints.down("sm")]: {
+      paddingBottom: "12px",
     },
+  },
+  advancedSearchRoot: {
+    width: `calc(100% - ${theme.spacing(6)})`,
+    [theme.breakpoints.down("sm")]: {
+      width: `calc(100% - ${theme.spacing(4)})`,
+    },
+    zIndex: "3",
   },
   advancedSearchPaper: {
     paddingTop: theme.spacing(1),
@@ -47,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
       "rgb(0 0 0 / 31%) 0px 0px 1px 0px, rgb(0 0 0 / 25%) 0px 3px 4px -2px",
   },
   gridSearchPadding: {
-    padding: theme.spacing(1),
+    padding: "12px",
   },
 }));
 

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -22,7 +22,11 @@ const useStyles = makeStyles((theme) => ({
   },
   downloadButtonGrid: {
     padding: theme.spacing(1),
-    [theme.breakpoints.down("md")]: { paddingTop: 0 },
+    [theme.breakpoints.down("md")]: {
+      paddingTop: 0,
+      // match the existing padding set in gridSearchPadding
+      paddingLeft: "12px",
+    },
     alignContent: "top",
   },
   tabStyle: {

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -42,7 +42,8 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("sm")]: {
       width: `calc(100% - ${theme.spacing(4)})`,
     },
-    zIndex: "3",
+    // zIndex must be higher than the MUI Drawer used in MapDrawer
+    zIndex: "1201",
   },
   advancedSearchPaper: {
     paddingTop: theme.spacing(1),

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -23,13 +23,13 @@ const useStyles = makeStyles((theme) => ({
   downloadButtonGrid: {
     padding: theme.spacing(1),
     [theme.breakpoints.down("md")]: { paddingTop: 0 },
-    alignContent: "center",
+    alignContent: "top",
   },
   tabStyle: {
     margin: ".5rem",
   },
   advancedSearchRoot: {
-    width: "calc(100% - 32px)",
+    width: `calc(100% - ${theme.spacing(2)})`,
     zIndex: "3",
     paddingLeft: "16px",
     paddingRight: "16px",
@@ -170,7 +170,7 @@ const Search = ({
                         color="primary"
                         startIcon={<Icon>search</Icon>}
                         onClick={handleSearchSubmission}
-                        sx={{ marginRight: "12px" }}
+                        sx={{ marginRight: theme.spacing(2) }}
                       >
                         Search
                       </Button>

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -996,6 +996,7 @@ export const GET_PROJECTS_GEOGRAPHIES = gql`
       geography
       attributes
       component_name
+      line_representation
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/utils/useProjectGeographies.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/utils/useProjectGeographies.js
@@ -1,0 +1,174 @@
+import React from "react";
+import { styleMapping } from "../../ProjectStatusBadge";
+
+/* Build feature collection to pass to the map, add project_geography attributes to feature properties along with status color */
+export const useProjectGeographies = ({
+  projectsGeographies,
+  projectDataById,
+  featuredProjectIds,
+}) =>
+  React.useMemo(() => {
+    const projectGeographiesFeatureCollectionLines =
+      projectsGeographies?.project_geography
+        ? projectsGeographies?.project_geography.reduce(
+            (acc, projectGeography) => {
+              const lineRepresentation = projectGeography?.line_representation;
+
+              const phaseKey =
+                projectDataById[projectGeography.project_id]?.current_phase_key;
+
+              // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+              const statusBadgeColor = phaseKey
+                ? styleMapping[phaseKey]?.background
+                : styleMapping.default.background;
+
+              const projectGeographyFeature = {
+                id: projectGeography.project_id,
+                type: "Feature",
+                geometry: projectGeography.geography,
+                properties: {
+                  ...(projectGeography.attributes
+                    ? projectGeography.attributes
+                    : {}),
+                  color: statusBadgeColor,
+                },
+              };
+
+              return lineRepresentation
+                ? {
+                    ...acc,
+                    features: [...acc.features, projectGeographyFeature],
+                  }
+                : acc;
+            },
+            { type: "FeatureCollection", features: [] }
+          )
+        : { type: "FeatureCollection", features: [] };
+
+    const projectGeographiesFeatureCollectionPoints =
+      projectsGeographies?.project_geography
+        ? projectsGeographies?.project_geography.reduce(
+            (acc, projectGeography) => {
+              const lineRepresentation = projectGeography?.line_representation;
+              const phaseKey =
+                projectDataById[projectGeography.project_id]?.current_phase_key;
+
+              // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+              const statusBadgeColor = phaseKey
+                ? styleMapping[phaseKey]?.background
+                : styleMapping.default.background;
+
+              const projectGeographyFeature = {
+                id: projectGeography.project_id,
+                type: "Feature",
+                geometry: projectGeography.geography,
+                properties: {
+                  ...(projectGeography.attributes
+                    ? projectGeography.attributes
+                    : {}),
+                  color: statusBadgeColor,
+                },
+              };
+
+              return !lineRepresentation
+                ? {
+                    ...acc,
+                    features: [...acc.features, projectGeographyFeature],
+                  }
+                : acc;
+            },
+            { type: "FeatureCollection", features: [] }
+          )
+        : { type: "FeatureCollection", features: [] };
+
+    const featuredProjectsFeatureCollectionLines =
+      projectsGeographies?.project_geography
+        ? projectsGeographies?.project_geography.reduce(
+            (acc, projectGeography) => {
+              const phaseKey =
+                projectDataById[projectGeography.project_id]?.current_phase_key;
+
+              const isInSelectedProjects = featuredProjectIds.includes(
+                projectGeography.project_id
+              );
+              const lineRepresentation = projectGeography?.line_representation;
+
+              if (!isInSelectedProjects || !lineRepresentation) {
+                return acc;
+              }
+
+              // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+              const statusBadgeColor = phaseKey
+                ? styleMapping[phaseKey]?.background
+                : styleMapping.default.background;
+
+              const projectGeographyFeature = {
+                id: projectGeography.project_id,
+                type: "Feature",
+                geometry: projectGeography.geography,
+                properties: {
+                  ...(projectGeography.attributes
+                    ? projectGeography.attributes
+                    : {}),
+                  color: statusBadgeColor,
+                },
+              };
+
+              return {
+                ...acc,
+                features: [...acc.features, projectGeographyFeature],
+              };
+            },
+            { type: "FeatureCollection", features: [] }
+          )
+        : { type: "FeatureCollection", features: [] };
+
+    const featuredProjectsFeatureCollectionPoints =
+      projectsGeographies?.project_geography
+        ? projectsGeographies?.project_geography.reduce(
+            (acc, projectGeography) => {
+              const phaseKey =
+                projectDataById[projectGeography.project_id]?.current_phase_key;
+
+              const isInSelectedProjects = featuredProjectIds.includes(
+                projectGeography.project_id
+              );
+              const lineRepresentation = projectGeography?.line_representation;
+
+              if (!isInSelectedProjects || lineRepresentation) {
+                return acc;
+              }
+
+              // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+              const statusBadgeColor = phaseKey
+                ? styleMapping[phaseKey]?.background
+                : styleMapping.default.background;
+
+              const projectGeographyFeature = {
+                id: projectGeography.project_id,
+                type: "Feature",
+                geometry: projectGeography.geography,
+                properties: {
+                  ...(projectGeography.attributes
+                    ? projectGeography.attributes
+                    : {}),
+                  color: statusBadgeColor,
+                },
+              };
+
+              return {
+                ...acc,
+                features: [...acc.features, projectGeographyFeature],
+              };
+            },
+            { type: "FeatureCollection", features: [] }
+          )
+        : { type: "FeatureCollection", features: [] };
+
+    return {
+      projectGeographiesFeatureCollectionLines,
+      projectGeographiesFeatureCollectionPoints,
+      featuredProjectsFeatureCollectionLines,
+      featuredProjectsFeatureCollectionPoints,
+    };
+  }, [featuredProjectIds, projectsGeographies, projectDataById]);

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -22,6 +22,8 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+// TODO: Split into points and lines using line_representation columns
+
 const ProjectsListViewMap = ({
   mapQuery,
   fetchPolicy,
@@ -210,7 +212,6 @@ const ProjectsListViewMap = ({
         ref={mapRef}
         projectsFeatureCollection={projectGeographiesFeatureCollection}
         featuredProjectsFeatureCollection={featuredProjectsFeatureCollection}
-        loading={loading}
         setFeaturedProjectIds={setFeaturedProjectIds}
         shouldShowFeaturedProjects={shouldShowFeaturedProjects}
       />

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import { useLocation } from "react-router-dom";
 import { NavLink as RouterLink } from "react-router-dom";
 import MapDrawer from "./components/MapDrawer";
 import ProjectsMap from "./components/ProjectsMap";
@@ -13,10 +14,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 import { styleMapping } from "../projectView/ProjectStatusBadge";
 
-// TODO: Show projects in list with links to project summary view
-// TODO: Open project in new tab
-
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   content: {
     display: "flex",
     height: "100%",
@@ -30,6 +28,10 @@ const ProjectsListViewMap = ({
   setIsMapDataLoading,
 }) => {
   const classes = useStyles();
+
+  /* Get search params to pass in project links for back button in Project Summary view */
+  const location = useLocation();
+  const queryString = location.search;
 
   /* Store map instance to call Mapbox GL methods where needed */
   const mapRef = React.useRef();
@@ -65,7 +67,7 @@ const ProjectsListViewMap = ({
     [projectMapViewData]
   );
 
-  /* Bulid array of project data needed to show in MapDrawer */
+  /* Build array of project data needed to show in MapDrawer */
   const featuredProjectsData = React.useMemo(
     () => featuredProjectIds.map((projectId) => projectDataById[projectId]),
     [featuredProjectIds, projectDataById]
@@ -137,6 +139,7 @@ const ProjectsListViewMap = ({
                       component={RouterLink}
                       to={`/moped/projects/${projectData.project_id}`}
                       target="_blank"
+                      state={{ queryString }}
                     >
                       {projectData.project_name_full}
                     </Link>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -3,9 +3,10 @@ import { useQuery } from "@apollo/client";
 import MapDrawer from "./components/MapDrawer";
 import ProjectsMap from "./components/ProjectsMap";
 import Alert from "@mui/material/Alert";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
 import Paper from "@mui/material/Paper";
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 import { styleMapping } from "../projectView/ProjectStatusBadge";
@@ -124,17 +125,22 @@ const ProjectsListViewMap = ({
   return (
     <Paper component="main" className={classes.content}>
       <MapDrawer title={"Projects"} ref={mapRef} open={open} setOpen={setOpen}>
-        <Stack spacing={1}>
+        <List>
           {featuredProjectsData.length > 0 ? (
             featuredProjectsData.map((projectData) => (
-              <Typography
-                key={projectData.project_id}
-              >{`#${projectData.project_id} - ${projectData.project_name_full}`}</Typography>
+              <ListItem disablePadding>
+                <ListItemText
+                  primary={projectData.project_name_full}
+                  secondary={`#${projectData.project_id}`}
+                />
+              </ListItem>
             ))
           ) : (
-            <Typography>No projects selected</Typography>
+            <ListItem disablePadding>
+              <ListItemText primary="No projects selected" />
+            </ListItem>
           )}
-        </Stack>
+        </List>
       </MapDrawer>
       {error && <Alert severity="error">{`Unable to load project data`}</Alert>}
       <ProjectsMap

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -35,6 +35,7 @@ const ProjectsListViewMap = ({
   /* MapDrawer state and handlers */
   const [open, setOpen] = React.useState(false);
 
+  /* Toggle drawer based on whether components are captured in map click or not */
   useEffect(() => {
     if (featuredProjectIds.length > 0) {
       setOpen(true);
@@ -59,6 +60,12 @@ const ProjectsListViewMap = ({
           }, {})
         : {},
     [projectMapViewData]
+  );
+
+  /* Bulid array of project data needed to show in MapDrawer */
+  const featuredProjectsData = React.useMemo(
+    () => featuredProjectIds.map((projectId) => projectDataById[projectId]),
+    [featuredProjectIds, projectDataById]
   );
 
   /* Build array of project ids to request project geography */
@@ -116,16 +123,17 @@ const ProjectsListViewMap = ({
 
   return (
     <Paper component="main" className={classes.content}>
-      <MapDrawer
-        title={"Filter title"}
-        ref={mapRef}
-        open={open}
-        setOpen={setOpen}
-      >
+      <MapDrawer title={"Projects"} ref={mapRef} open={open} setOpen={setOpen}>
         <Stack spacing={1}>
-          {featuredProjectIds.map((projectId) => (
-            <Typography key={projectId}>{projectId}</Typography>
-          ))}
+          {featuredProjectsData.length > 0 ? (
+            featuredProjectsData.map((projectData) => (
+              <Typography
+                key={projectData.project_id}
+              >{`#${projectData.project_id} - ${projectData.project_name_full}`}</Typography>
+            ))
+          ) : (
+            <Typography>No projects selected</Typography>
+          )}
         </Stack>
       </MapDrawer>
       {error && <Alert severity="error">{`Unable to load project data`}</Alert>}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -122,7 +122,6 @@ const ProjectsListViewMap = ({
                     <Link
                       component={RouterLink}
                       to={`/moped/projects/${projectData?.project_id}`}
-                      target="_blank"
                       state={{ queryString }}
                     >
                       {projectData?.project_name_full}

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -5,6 +5,11 @@ import Alert from "@mui/material/Alert";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 import { styleMapping } from "../projectView/ProjectStatusBadge";
 
+// TODO: Update cursor on hover
+// TODO: Get MapDrawer to fit into this map
+// TODO: Show projects in list with links to project summary view
+// TODO: Open project in new tab
+
 const ProjectsListViewMap = ({
   mapQuery,
   fetchPolicy,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -61,6 +61,7 @@ const ProjectsListViewMap = ({
                 : styleMapping.default.background;
 
               const projectGeographyFeature = {
+                id: projectGeography.project_id,
                 type: "Feature",
                 geometry: projectGeography.geography,
                 properties: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -22,12 +22,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-// TODO: Clear featured IDs when filters are reset
-
 const ProjectsListViewMap = ({
   mapQuery,
   fetchPolicy,
   setIsMapDataLoading,
+  searchWhereString,
+  advancedSearchWhereString,
 }) => {
   const classes = useStyles();
 
@@ -49,10 +49,13 @@ const ProjectsListViewMap = ({
   useEffect(() => {
     if (featuredProjectIds.length > 0) {
       setOpen(true);
-    } else {
-      setOpen(false);
     }
   }, [featuredProjectIds, setOpen]);
+
+  /* Clear featured project IDs when search filters are changed or reset */
+  useEffect(() => {
+    setFeaturedProjectIds([]);
+  }, [searchWhereString, advancedSearchWhereString]);
 
   const { data: projectMapViewData } = useQuery(mapQuery, {
     fetchPolicy,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -12,6 +12,8 @@ const ProjectsListViewMap = ({
 }) => {
   /* Store map instance to call Mapbox GL methods where needed */
   const mapRef = React.useRef();
+  const [featuredProjectIds, setFeaturedProjectIds] = React.useState([]);
+  console.log(featuredProjectIds);
 
   const { data: projectMapViewData } = useQuery(mapQuery, {
     fetchPolicy,
@@ -91,6 +93,7 @@ const ProjectsListViewMap = ({
         ref={mapRef}
         projectsFeatureCollection={projectsFeatureCollection}
         loading={loading}
+        setFeaturedProjectIds={setFeaturedProjectIds}
       />
     </>
   );

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -17,6 +17,7 @@ const ProjectsListViewMap = ({
     fetchPolicy,
   });
 
+  /* Build object to get project data needed for projectsFeatureCollection by project id  */
   const projectDataById = React.useMemo(
     () =>
       projectMapViewData
@@ -30,6 +31,7 @@ const ProjectsListViewMap = ({
     [projectMapViewData]
   );
 
+  /* Build array of project ids to request project geography */
   const projectIds = React.useMemo(
     () => Object.keys(projectDataById),
     [projectDataById]
@@ -41,10 +43,12 @@ const ProjectsListViewMap = ({
     data: projectsGeographies,
   } = useQuery(GET_PROJECTS_GEOGRAPHIES, { variables: { projectIds } });
 
+  /* Update state tied to loading spinner in SearchBar component */
   useEffect(() => {
     setIsMapDataLoading(loading);
   }, [loading, setIsMapDataLoading]);
 
+  /* Build feature collection to pass to the map, add project_geography attributes to feature properties along with status color */
   const projectsFeatureCollection = React.useMemo(() => {
     const projectGeographiesFeatureCollection =
       projectsGeographies?.project_geography

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -5,7 +5,6 @@ import Alert from "@mui/material/Alert";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 import { styleMapping } from "../projectView/ProjectStatusBadge";
 
-// TODO: Update cursor on hover
 // TODO: Get MapDrawer to fit into this map
 // TODO: Show projects in list with links to project summary view
 // TODO: Open project in new tab

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -38,23 +38,23 @@ const ProjectsListViewMap = ({
   /* Store map instance to call Mapbox GL methods where needed */
   const mapRef = React.useRef();
 
-  /* Store featured project IDs for sidebar items */
-  const [featuredProjectIds, setFeaturedProjectIds] = React.useState([]);
-  const shouldShowFeaturedProjects = featuredProjectIds.length > 0;
+  /* Store selected project IDs for sidebar items */
+  const [selectedProjectIds, setSelectedProjectIds] = React.useState([]);
+  const shouldShowSelectedProjects = selectedProjectIds.length > 0;
 
   /* MapDrawer state and handlers */
   const [open, setOpen] = React.useState(false);
 
   /* Toggle drawer based on whether components are captured in map click or not */
   useEffect(() => {
-    if (featuredProjectIds.length > 0) {
+    if (selectedProjectIds.length > 0) {
       setOpen(true);
     }
-  }, [featuredProjectIds, setOpen]);
+  }, [selectedProjectIds, setOpen]);
 
-  /* Clear featured project IDs when search filters are changed or reset */
+  /* Clear selected project IDs when search filters are changed or reset */
   useEffect(() => {
-    setFeaturedProjectIds([]);
+    setSelectedProjectIds([]);
   }, [searchWhereString, advancedSearchWhereString]);
 
   const { data: projectMapViewData } = useQuery(mapQuery, {
@@ -76,9 +76,9 @@ const ProjectsListViewMap = ({
   );
 
   /* Build array of project data needed to show in MapDrawer */
-  const featuredProjectsData = React.useMemo(
-    () => featuredProjectIds.map((projectId) => projectDataById[projectId]),
-    [featuredProjectIds, projectDataById]
+  const selectedProjectsData = React.useMemo(
+    () => selectedProjectIds.map((projectId) => projectDataById[projectId]),
+    [selectedProjectIds, projectDataById]
   );
 
   /* Build array of project ids to request project geography */
@@ -102,10 +102,10 @@ const ProjectsListViewMap = ({
   const {
     projectGeographiesFeatureCollectionLines,
     projectGeographiesFeatureCollectionPoints,
-    featuredProjectsFeatureCollectionLines,
-    featuredProjectsFeatureCollectionPoints,
+    selectedProjectsFeatureCollectionLines,
+    selectedProjectsFeatureCollectionPoints,
   } = useProjectGeographies({
-    featuredProjectIds,
+    selectedProjectIds,
     projectsGeographies,
     projectDataById,
   });
@@ -114,8 +114,8 @@ const ProjectsListViewMap = ({
     <Paper component="main" className={classes.content}>
       <MapDrawer title={"Projects"} ref={mapRef} open={open} setOpen={setOpen}>
         <List>
-          {featuredProjectsData.length > 0 ? (
-            featuredProjectsData.map((projectData) => (
+          {selectedProjectsData.length > 0 ? (
+            selectedProjectsData.map((projectData) => (
               <ListItem key={projectData?.project_id} disablePadding>
                 <ListItemText
                   primary={
@@ -133,7 +133,7 @@ const ProjectsListViewMap = ({
             ))
           ) : (
             <ListItem disablePadding>
-              <ListItemText primary="No projects selected" />
+              <ListItemText primary="Select components on map to list projects" />
             </ListItem>
           )}
         </List>
@@ -147,14 +147,14 @@ const ProjectsListViewMap = ({
         projectsFeatureCollectionPoints={
           projectGeographiesFeatureCollectionPoints
         }
-        featuredProjectsFeatureCollectionLines={
-          featuredProjectsFeatureCollectionLines
+        selectedProjectsFeatureCollectionLines={
+          selectedProjectsFeatureCollectionLines
         }
-        featuredProjectsFeatureCollectionPoints={
-          featuredProjectsFeatureCollectionPoints
+        selectedProjectsFeatureCollectionPoints={
+          selectedProjectsFeatureCollectionPoints
         }
-        setFeaturedProjectIds={setFeaturedProjectIds}
-        shouldShowFeaturedProjects={shouldShowFeaturedProjects}
+        setSelectedProjectIds={setSelectedProjectIds}
+        shouldShowSelectedProjects={shouldShowSelectedProjects}
       />
     </Paper>
   );

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -1,23 +1,39 @@
 import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import MapDrawer from "./components/MapDrawer";
 import ProjectsMap from "./components/ProjectsMap";
 import Alert from "@mui/material/Alert";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import makeStyles from "@mui/styles/makeStyles";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 import { styleMapping } from "../projectView/ProjectStatusBadge";
 
-// TODO: Get MapDrawer to fit into this map
 // TODO: Show projects in list with links to project summary view
 // TODO: Open project in new tab
+
+const useStyles = makeStyles((theme) => ({
+  content: {
+    display: "flex",
+    height: "100%",
+    width: "100%",
+  },
+}));
 
 const ProjectsListViewMap = ({
   mapQuery,
   fetchPolicy,
   setIsMapDataLoading,
 }) => {
+  const classes = useStyles();
+
   /* Store map instance to call Mapbox GL methods where needed */
   const mapRef = React.useRef();
   const [featuredProjectIds, setFeaturedProjectIds] = React.useState([]);
-  console.log(featuredProjectIds);
+
+  /* MapDrawer state and handlers */
+  const [open, setOpen] = React.useState(false);
 
   const { data: projectMapViewData } = useQuery(mapQuery, {
     fetchPolicy,
@@ -91,7 +107,19 @@ const ProjectsListViewMap = ({
   }, [projectsGeographies, projectDataById]);
 
   return (
-    <>
+    <Paper component="main" className={classes.content}>
+      <MapDrawer
+        title={"Filter title"}
+        ref={mapRef}
+        open={open}
+        setOpen={setOpen}
+      >
+        <Stack spacing={1}>
+          {featuredProjectIds.map((projectId) => (
+            <Typography key={projectId}>{projectId}</Typography>
+          ))}
+        </Stack>
+      </MapDrawer>
       {error && <Alert severity="error">{`Unable to load project data`}</Alert>}
       <ProjectsMap
         ref={mapRef}
@@ -99,7 +127,7 @@ const ProjectsListViewMap = ({
         loading={loading}
         setFeaturedProjectIds={setFeaturedProjectIds}
       />
-    </>
+    </Paper>
   );
 };
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -98,9 +98,25 @@ const ProjectsListViewMap = ({
             (acc, projectGeography) => {
               const phaseKey =
                 projectDataById[projectGeography.project_id]?.current_phase_key;
-              const statusBadgeColor = phaseKey
-                ? styleMapping[phaseKey]?.background
-                : styleMapping.default.background;
+
+              const shouldMuteUnselectedProjects =
+                featuredProjectIds.length > 0;
+              const isInSelectedProjects = featuredProjectIds.includes(
+                projectGeography.project_id
+              );
+
+              // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+              let statusBadgeColor;
+
+              if (shouldMuteUnselectedProjects) {
+                statusBadgeColor = isInSelectedProjects
+                  ? styleMapping[phaseKey]?.background
+                  : styleMapping.default.background;
+              } else {
+                statusBadgeColor = phaseKey
+                  ? styleMapping[phaseKey]?.background
+                  : styleMapping.default.background;
+              }
 
               const projectGeographyFeature = {
                 id: projectGeography.project_id,
@@ -124,7 +140,7 @@ const ProjectsListViewMap = ({
         : { type: "FeatureCollection", features: [] };
 
     return projectGeographiesFeatureCollection;
-  }, [projectsGeographies, projectDataById]);
+  }, [featuredProjectIds, projectsGeographies, projectDataById]);
 
   return (
     <Paper component="main" className={classes.content}>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -1,8 +1,10 @@
 import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import { NavLink as RouterLink } from "react-router-dom";
 import MapDrawer from "./components/MapDrawer";
 import ProjectsMap from "./components/ProjectsMap";
 import Alert from "@mui/material/Alert";
+import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
@@ -128,9 +130,17 @@ const ProjectsListViewMap = ({
         <List>
           {featuredProjectsData.length > 0 ? (
             featuredProjectsData.map((projectData) => (
-              <ListItem disablePadding>
+              <ListItem key={projectData.project_id} disablePadding>
                 <ListItemText
-                  primary={projectData.project_name_full}
+                  primary={
+                    <Link
+                      component={RouterLink}
+                      to={`/moped/projects/${projectData.project_id}`}
+                      target="_blank"
+                    >
+                      {projectData.project_name_full}
+                    </Link>
+                  }
                   secondary={`#${projectData.project_id}`}
                 />
               </ListItem>

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -11,7 +11,7 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Paper from "@mui/material/Paper";
 import makeStyles from "@mui/styles/makeStyles";
-import { useProjectGeographies } from "../projectView/ProjectSummary/utils/useProjectGeographies";
+import { useProjectGeographies } from "./useProjectGeographies/useProjectGeographies";
 import { GET_PROJECTS_GEOGRAPHIES } from "src/queries/project";
 
 const useStyles = makeStyles(() => ({
@@ -21,6 +21,8 @@ const useStyles = makeStyles(() => ({
     width: "100%",
   },
 }));
+
+// TODO: Clear featured IDs when filters are reset
 
 const ProjectsListViewMap = ({
   mapQuery,

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewMap.js
@@ -35,6 +35,14 @@ const ProjectsListViewMap = ({
   /* MapDrawer state and handlers */
   const [open, setOpen] = React.useState(false);
 
+  useEffect(() => {
+    if (featuredProjectIds.length > 0) {
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  }, [featuredProjectIds, setOpen]);
+
   const { data: projectMapViewData } = useQuery(mapQuery, {
     fetchPolicy,
   });

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -119,7 +119,7 @@ const ProjectsListViewTable = () => {
   });
 
   const { query: mapQuery } = useGetProjectListView({
-    columnsToReturn: ["project_id", "current_phase_key"],
+    columnsToReturn: ["project_id", "current_phase_key", "project_name_full"],
     searchWhereString: searchWhereString,
     advancedSearchWhereString: advancedSearchWhereString,
     queryName: "ProjectListViewMap",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -278,6 +278,8 @@ const ProjectsListViewTable = () => {
                   PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy
                 }
                 setIsMapDataLoading={setIsMapDataLoading}
+                searchWhereString={searchWhereString}
+                advancedSearchWhereString={advancedSearchWhereString}
               />
             )}
           </Box>

--- a/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
+++ b/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
@@ -1,6 +1,5 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import MuiDrawer from "@mui/material/Drawer";

--- a/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
+++ b/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
 import MuiDrawer from "@mui/material/Drawer";
@@ -74,7 +75,11 @@ function DrawerContent({
             flexGrow={1}
             display={showDrawerContent && open ? "flex" : "none"}
           >
-            <Typography variant="h2" color={theme.palette.text.primary}>
+            <Typography
+              variant="h2"
+              color={theme.palette.text.primary}
+              paddingLeft={theme.spacing(1)}
+            >
               {title}
             </Typography>
           </Grid>
@@ -90,6 +95,7 @@ function DrawerContent({
         display={showDrawerContent && open ? "flex" : "none"}
         overflow="scroll"
         padding={theme.spacing(1)}
+        paddingLeft={theme.spacing(2)}
       >
         {children}
       </Box>

--- a/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
+++ b/moped-editor/src/views/projects/projectsListView/components/MapDrawer.js
@@ -102,9 +102,11 @@ function DrawerContent({
  * See https://mui.com/material-ui/react-drawer/#responsive-drawer
  * See https://mui.com/material-ui/react-drawer/#mini-variant-drawer
  */
-export default React.forwardRef(function MapDrawer({ children, title }, ref) {
+export default React.forwardRef(function MapDrawer(
+  { children, title, open, setOpen },
+  ref
+) {
   /* Control desktop drawer and content visibility */
-  const [open, setOpen] = React.useState(true);
   const [showDrawerContent, setShowDrawerContent] = React.useState(true);
 
   const toggleDrawer = () => {

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -12,11 +12,19 @@ import { MAP_STYLES } from "./mapStyleSettings";
 import "mapbox-gl/dist/mapbox-gl.css";
 import theme from "src/theme";
 
+const interactiveLayerIds = Object.keys(MAP_STYLES);
+
 export default React.forwardRef(function ProjectsMap(
   { projectsFeatureCollection, loading },
   ref
 ) {
   const [basemapKey, setBasemapKey] = useState("streets");
+
+  const handleLayerClick = (event) => {
+    const clickedFeatures = event.features.length ? event.features : [];
+    const clickedFeaturesIds = clickedFeatures.map((feature) => feature.id);
+    console.log(clickedFeaturesIds);
+  };
 
   return (
     <MapGL
@@ -30,6 +38,8 @@ export default React.forwardRef(function ProjectsMap(
         // set MUI style border radius to match the map's container
         borderRadius: theme.spacing(0.5),
       }}
+      interactiveLayerIds={interactiveLayerIds}
+      onClick={handleLayerClick}
     >
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
       <NavigationControl position="bottom-left" showCompass={false} />

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -11,11 +11,18 @@ import {
 import { MAP_STYLES } from "./mapStyleSettings";
 import "mapbox-gl/dist/mapbox-gl.css";
 import theme from "src/theme";
+import { styleMapping } from "../../projectView/ProjectStatusBadge";
 
 const interactiveLayerIds = Object.keys(MAP_STYLES);
 
 export default React.forwardRef(function ProjectsMap(
-  { projectsFeatureCollection, loading, setFeaturedProjectIds },
+  {
+    projectsFeatureCollection,
+    featuredProjectsFeatureCollection,
+    shouldShowFeaturedProjects,
+    loading,
+    setFeaturedProjectIds,
+  },
   ref
 ) {
   const [basemapKey, setBasemapKey] = useState("streets");
@@ -73,11 +80,50 @@ export default React.forwardRef(function ProjectsMap(
         />
         <Layer
           {...MAP_STYLES["project-lines"].layerProps}
+          paint={{
+            ...MAP_STYLES["project-lines"].layerProps.paint,
+            "line-color": !shouldShowFeaturedProjects
+              ? ["get", "color"]
+              : styleMapping.default.background,
+          }}
           layout={{ visibility: !loading ? "visible" : "none" }}
         />
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
+          paint={{
+            ...MAP_STYLES["project-points"].layerProps.paint,
+            "circle-color": !shouldShowFeaturedProjects
+              ? ["get", "color"]
+              : styleMapping.default.background,
+          }}
           layout={{ visibility: !loading ? "visible" : "none" }}
+        />
+      </Source>
+      <Source
+        id="projects-featured-geographies"
+        type="geojson"
+        data={featuredProjectsFeatureCollection}
+      >
+        <Layer
+          {...MAP_STYLES["project-lines-outline"].layerProps}
+          layout={{
+            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+          }}
+          id="project-lines-outline-featured"
+        />
+        <Layer
+          {...MAP_STYLES["project-lines"].layerProps}
+          layout={{
+            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+          }}
+          id="project-lines-featured"
+        />
+        <Layer
+          {...MAP_STYLES["project-points"].layerProps}
+          layout={{
+            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+          }}
+          id="project-points-featured"
         />
       </Source>
     </MapGL>

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -13,12 +13,12 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import theme from "src/theme";
 import { styleMapping } from "../../projectView/ProjectStatusBadge";
 
-const interactiveLayerIds = Object.keys(MAP_STYLES);
-
 export default React.forwardRef(function ProjectsMap(
   {
-    projectsFeatureCollection,
-    featuredProjectsFeatureCollection,
+    projectsFeatureCollectionLines,
+    projectsFeatureCollectionPoints,
+    featuredProjectsFeatureCollectionLines,
+    featuredProjectsFeatureCollectionPoints,
     shouldShowFeaturedProjects,
     setFeaturedProjectIds,
   },
@@ -57,7 +57,15 @@ export default React.forwardRef(function ProjectsMap(
         // set MUI style border radius to match the map's container
         borderRadius: theme.spacing(0.5),
       }}
-      interactiveLayerIds={interactiveLayerIds}
+      interactiveLayerIds={[
+        "project-lines-outline",
+        "project-lines",
+        "project-points",
+        "project-lines-muted",
+        "project-points-muted",
+        "project-lines-featured",
+        "project-points-featured",
+      ]}
       onClick={handleLayerClick}
       cursor={cursor}
       onMouseEnter={handleMouseEnter}
@@ -68,17 +76,18 @@ export default React.forwardRef(function ProjectsMap(
       <GeocoderControl position="top-left" marker={false} />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
 
-      {/* Project features with status badge color */}
+      {/* Project line features with status badge color */}
       <Source
-        id="projects-geographies"
+        id="projects-geographies-lines"
         type="geojson"
-        data={projectsFeatureCollection}
+        data={projectsFeatureCollectionLines}
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
           layout={{
             visibility: !shouldShowFeaturedProjects ? "visible" : "none",
           }}
+          id="project-lines-outline"
         />
         <Layer
           {...MAP_STYLES["project-lines"].layerProps}
@@ -91,7 +100,16 @@ export default React.forwardRef(function ProjectsMap(
           layout={{
             visibility: !shouldShowFeaturedProjects ? "visible" : "none",
           }}
+          id="project-lines"
         />
+      </Source>
+
+      {/* Project point features with status badge color */}
+      <Source
+        id="projects-geographies-points"
+        type="geojson"
+        data={projectsFeatureCollectionPoints}
+      >
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
           paint={{
@@ -103,14 +121,15 @@ export default React.forwardRef(function ProjectsMap(
           layout={{
             visibility: !shouldShowFeaturedProjects ? "visible" : "none",
           }}
+          id="project-points"
         />
       </Source>
 
-      {/* Muted project features */}
+      {/* Muted line project features */}
       <Source
-        id="projects-geographies-muted"
+        id="projects-geographies-lines-muted"
         type="geojson"
-        data={projectsFeatureCollection}
+        data={projectsFeatureCollectionLines}
       >
         <Layer
           {...MAP_STYLES["project-lines-muted"].layerProps}
@@ -119,6 +138,14 @@ export default React.forwardRef(function ProjectsMap(
           }}
           id="project-lines-muted"
         />
+      </Source>
+
+      {/* Muted point project features */}
+      <Source
+        id="projects-geographies-points-muted"
+        type="geojson"
+        data={projectsFeatureCollectionPoints}
+      >
         <Layer
           {...MAP_STYLES["project-points-muted"].layerProps}
           layout={{
@@ -128,11 +155,11 @@ export default React.forwardRef(function ProjectsMap(
         />
       </Source>
 
-      {/* Featured project features */}
+      {/* Featured line project features */}
       <Source
-        id="projects-featured-geographies"
+        id="projects-featured-lines-geographies"
         type="geojson"
-        data={featuredProjectsFeatureCollection}
+        data={featuredProjectsFeatureCollectionLines}
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
@@ -148,6 +175,13 @@ export default React.forwardRef(function ProjectsMap(
           }}
           id="project-lines-featured"
         />
+      </Source>
+      {/* Featured line project features */}
+      <Source
+        id="projects-featured-points-geographies"
+        type="geojson"
+        data={featuredProjectsFeatureCollectionPoints}
+      >
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
           layout={{

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -20,7 +20,6 @@ export default React.forwardRef(function ProjectsMap(
     projectsFeatureCollection,
     featuredProjectsFeatureCollection,
     shouldShowFeaturedProjects,
-    loading,
     setFeaturedProjectIds,
   },
   ref

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -20,6 +20,17 @@ export default React.forwardRef(function ProjectsMap(
 ) {
   const [basemapKey, setBasemapKey] = useState("streets");
 
+  /* Handle cursor update on  */
+  const [cursor, setCursor] = useState("grab");
+
+  const onMouseEnter = () => {
+    setCursor("pointer");
+  };
+
+  const onMouseLeave = () => {
+    setCursor("grab");
+  };
+
   const handleLayerClick = (event) => {
     const clickedFeatures = event.features.length ? event.features : [];
     const clickedFeaturesIds = clickedFeatures.map((feature) => feature.id);
@@ -42,6 +53,9 @@ export default React.forwardRef(function ProjectsMap(
       }}
       interactiveLayerIds={interactiveLayerIds}
       onClick={handleLayerClick}
+      cursor={cursor}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
       <NavigationControl position="bottom-left" showCompass={false} />

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -15,7 +15,7 @@ import theme from "src/theme";
 const interactiveLayerIds = Object.keys(MAP_STYLES);
 
 export default React.forwardRef(function ProjectsMap(
-  { projectsFeatureCollection, loading },
+  { projectsFeatureCollection, loading, setFeaturedProjectIds },
   ref
 ) {
   const [basemapKey, setBasemapKey] = useState("streets");
@@ -23,7 +23,9 @@ export default React.forwardRef(function ProjectsMap(
   const handleLayerClick = (event) => {
     const clickedFeatures = event.features.length ? event.features : [];
     const clickedFeaturesIds = clickedFeatures.map((feature) => feature.id);
-    console.log(clickedFeaturesIds);
+
+    const uniqueClickedFeaturesIds = [...new Set(clickedFeaturesIds)];
+    setFeaturedProjectIds(uniqueClickedFeaturesIds);
   };
 
   return (

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -77,7 +77,9 @@ export default React.forwardRef(function ProjectsMap(
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
-          // layout={{ visibility: !loading ? "visible" : "none" }}
+          layout={{
+            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
+          }}
         />
         <Layer
           {...MAP_STYLES["project-lines"].layerProps}
@@ -87,7 +89,9 @@ export default React.forwardRef(function ProjectsMap(
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
-          // layout={{ visibility: !loading ? "visible" : "none" }}
+          layout={{
+            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
+          }}
         />
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
@@ -97,7 +101,9 @@ export default React.forwardRef(function ProjectsMap(
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
-          // layout={{ visibility: !loading ? "visible" : "none" }}
+          layout={{
+            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
+          }}
         />
       </Source>
 
@@ -112,12 +118,14 @@ export default React.forwardRef(function ProjectsMap(
           layout={{
             visibility: shouldShowFeaturedProjects ? "visible" : "none",
           }}
+          id="project-lines-muted"
         />
         <Layer
           {...MAP_STYLES["project-points-muted"].layerProps}
           layout={{
             visibility: shouldShowFeaturedProjects ? "visible" : "none",
           }}
+          id="project-points-muted"
         />
       </Source>
 

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -24,9 +24,10 @@ export default React.forwardRef(function ProjectsMap(
   },
   ref
 ) {
+  /* Store basemap key */
   const [basemapKey, setBasemapKey] = useState("streets");
 
-  /* Handle cursor update on  */
+  /* Store cursor */
   const [cursor, setCursor] = useState("grab");
 
   const handleMouseEnter = () => {
@@ -84,9 +85,6 @@ export default React.forwardRef(function ProjectsMap(
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
-          layout={{
-            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
-          }}
           id="project-lines-outline"
         />
         <Layer
@@ -96,9 +94,6 @@ export default React.forwardRef(function ProjectsMap(
             "line-color": !shouldShowFeaturedProjects
               ? ["get", "color"]
               : styleMapping.default.background,
-          }}
-          layout={{
-            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
           }}
           id="project-lines"
         />
@@ -117,9 +112,6 @@ export default React.forwardRef(function ProjectsMap(
             "circle-color": !shouldShowFeaturedProjects
               ? ["get", "color"]
               : styleMapping.default.background,
-          }}
-          layout={{
-            visibility: !shouldShowFeaturedProjects ? "visible" : "none",
           }}
           id="project-points"
         />
@@ -176,6 +168,7 @@ export default React.forwardRef(function ProjectsMap(
           id="project-lines-featured"
         />
       </Source>
+
       {/* Featured line project features */}
       <Source
         id="projects-featured-points-geographies"

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -23,11 +23,11 @@ export default React.forwardRef(function ProjectsMap(
   /* Handle cursor update on  */
   const [cursor, setCursor] = useState("grab");
 
-  const onMouseEnter = () => {
+  const handleMouseEnter = () => {
     setCursor("pointer");
   };
 
-  const onMouseLeave = () => {
+  const handleMouseLeave = () => {
     setCursor("grab");
   };
 
@@ -54,8 +54,8 @@ export default React.forwardRef(function ProjectsMap(
       interactiveLayerIds={interactiveLayerIds}
       onClick={handleLayerClick}
       cursor={cursor}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <BasemapSpeedDial basemapKey={basemapKey} setBasemapKey={setBasemapKey} />
       <NavigationControl position="bottom-left" showCompass={false} />

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -69,6 +69,7 @@ export default React.forwardRef(function ProjectsMap(
       <GeocoderControl position="top-left" marker={false} />
       <BaseMapSourceAndLayers basemapKey={basemapKey} />
 
+      {/* Project features with status badge color */}
       <Source
         id="projects-geographies"
         type="geojson"
@@ -76,7 +77,7 @@ export default React.forwardRef(function ProjectsMap(
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
-          layout={{ visibility: !loading ? "visible" : "none" }}
+          // layout={{ visibility: !loading ? "visible" : "none" }}
         />
         <Layer
           {...MAP_STYLES["project-lines"].layerProps}
@@ -86,7 +87,7 @@ export default React.forwardRef(function ProjectsMap(
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
-          layout={{ visibility: !loading ? "visible" : "none" }}
+          // layout={{ visibility: !loading ? "visible" : "none" }}
         />
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
@@ -96,9 +97,31 @@ export default React.forwardRef(function ProjectsMap(
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
-          layout={{ visibility: !loading ? "visible" : "none" }}
+          // layout={{ visibility: !loading ? "visible" : "none" }}
         />
       </Source>
+
+      {/* Muted project features */}
+      <Source
+        id="projects-geographies-muted"
+        type="geojson"
+        data={projectsFeatureCollection}
+      >
+        <Layer
+          {...MAP_STYLES["project-lines-muted"].layerProps}
+          layout={{
+            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+          }}
+        />
+        <Layer
+          {...MAP_STYLES["project-points-muted"].layerProps}
+          layout={{
+            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+          }}
+        />
+      </Source>
+
+      {/* Featured project features */}
       <Source
         id="projects-featured-geographies"
         type="geojson"

--- a/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
+++ b/moped-editor/src/views/projects/projectsListView/components/ProjectsMap.js
@@ -17,10 +17,10 @@ export default React.forwardRef(function ProjectsMap(
   {
     projectsFeatureCollectionLines,
     projectsFeatureCollectionPoints,
-    featuredProjectsFeatureCollectionLines,
-    featuredProjectsFeatureCollectionPoints,
-    shouldShowFeaturedProjects,
-    setFeaturedProjectIds,
+    selectedProjectsFeatureCollectionLines,
+    selectedProjectsFeatureCollectionPoints,
+    shouldShowSelectedProjects,
+    setSelectedProjectIds,
   },
   ref
 ) {
@@ -43,7 +43,7 @@ export default React.forwardRef(function ProjectsMap(
     const clickedFeaturesIds = clickedFeatures.map((feature) => feature.id);
 
     const uniqueClickedFeaturesIds = [...new Set(clickedFeaturesIds)];
-    setFeaturedProjectIds(uniqueClickedFeaturesIds);
+    setSelectedProjectIds(uniqueClickedFeaturesIds);
   };
 
   return (
@@ -64,8 +64,8 @@ export default React.forwardRef(function ProjectsMap(
         "project-points",
         "project-lines-muted",
         "project-points-muted",
-        "project-lines-featured",
-        "project-points-featured",
+        "project-lines-selected",
+        "project-points-selected",
       ]}
       onClick={handleLayerClick}
       cursor={cursor}
@@ -91,7 +91,7 @@ export default React.forwardRef(function ProjectsMap(
           {...MAP_STYLES["project-lines"].layerProps}
           paint={{
             ...MAP_STYLES["project-lines"].layerProps.paint,
-            "line-color": !shouldShowFeaturedProjects
+            "line-color": !shouldShowSelectedProjects
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
@@ -109,7 +109,7 @@ export default React.forwardRef(function ProjectsMap(
           {...MAP_STYLES["project-points"].layerProps}
           paint={{
             ...MAP_STYLES["project-points"].layerProps.paint,
-            "circle-color": !shouldShowFeaturedProjects
+            "circle-color": !shouldShowSelectedProjects
               ? ["get", "color"]
               : styleMapping.default.background,
           }}
@@ -126,7 +126,7 @@ export default React.forwardRef(function ProjectsMap(
         <Layer
           {...MAP_STYLES["project-lines-muted"].layerProps}
           layout={{
-            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+            visibility: shouldShowSelectedProjects ? "visible" : "none",
           }}
           id="project-lines-muted"
         />
@@ -141,46 +141,46 @@ export default React.forwardRef(function ProjectsMap(
         <Layer
           {...MAP_STYLES["project-points-muted"].layerProps}
           layout={{
-            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+            visibility: shouldShowSelectedProjects ? "visible" : "none",
           }}
           id="project-points-muted"
         />
       </Source>
 
-      {/* Featured line project features */}
+      {/* Selected line project features */}
       <Source
-        id="projects-featured-lines-geographies"
+        id="projects-selected-lines-geographies"
         type="geojson"
-        data={featuredProjectsFeatureCollectionLines}
+        data={selectedProjectsFeatureCollectionLines}
       >
         <Layer
           {...MAP_STYLES["project-lines-outline"].layerProps}
           layout={{
-            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+            visibility: shouldShowSelectedProjects ? "visible" : "none",
           }}
-          id="project-lines-outline-featured"
+          id="project-lines-outline-selected"
         />
         <Layer
           {...MAP_STYLES["project-lines"].layerProps}
           layout={{
-            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+            visibility: shouldShowSelectedProjects ? "visible" : "none",
           }}
-          id="project-lines-featured"
+          id="project-lines-selected"
         />
       </Source>
 
-      {/* Featured line project features */}
+      {/* Selected line project features */}
       <Source
-        id="projects-featured-points-geographies"
+        id="projects-selected-points-geographies"
         type="geojson"
-        data={featuredProjectsFeatureCollectionPoints}
+        data={selectedProjectsFeatureCollectionPoints}
       >
         <Layer
           {...MAP_STYLES["project-points"].layerProps}
           layout={{
-            visibility: shouldShowFeaturedProjects ? "visible" : "none",
+            visibility: shouldShowSelectedProjects ? "visible" : "none",
           }}
-          id="project-points-featured"
+          id="project-points-selected"
         />
       </Source>
     </MapGL>

--- a/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
@@ -56,7 +56,7 @@ export const MAP_STYLES = {
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
-        "circle-stroke-color": COLORS.mutedGray,
+        "circle-stroke-color": COLORS.black,
         "circle-stroke-width": 1,
         "circle-stroke-opacity": 0.9,
         "circle-color": COLORS.mutedGray,

--- a/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
@@ -15,8 +15,6 @@ export const lineWidthStops = {
 export const MAP_STYLES = {
   "project-points": {
     layerProps: {
-      id: "project-points",
-      _featureIdProp: "INTERSECTIONID",
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
@@ -30,8 +28,6 @@ export const MAP_STYLES = {
   },
   "project-lines": {
     layerProps: {
-      id: "project-lines",
-      _featureIdProp: "CTN_SEGMENT_ID",
       type: "line",
       paint: {
         "line-width": lineWidthStops,
@@ -45,8 +41,6 @@ export const MAP_STYLES = {
   },
   "project-lines-outline": {
     layerProps: {
-      id: "project-lines-outline",
-      _featureIdProp: "CTN_SEGMENT_ID",
       type: "line",
       paint: {
         "line-width": lineOutlineWidthStops,
@@ -59,8 +53,6 @@ export const MAP_STYLES = {
   },
   "project-points-muted": {
     layerProps: {
-      id: "project-points",
-      _featureIdProp: "INTERSECTIONID",
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
@@ -74,8 +66,6 @@ export const MAP_STYLES = {
   },
   "project-lines-muted": {
     layerProps: {
-      id: "project-lines",
-      _featureIdProp: "CTN_SEGMENT_ID",
       type: "line",
       paint: {
         "line-width": lineWidthStops,

--- a/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
@@ -18,7 +18,7 @@ export const MAP_STYLES = {
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
-        "circle-stroke-color": COLORS.black,
+        "circle-stroke-color": COLORS.white,
         "circle-stroke-width": 1,
         "circle-stroke-opacity": 0.9,
         "circle-color": ["get", "color"],
@@ -44,7 +44,7 @@ export const MAP_STYLES = {
       type: "line",
       paint: {
         "line-width": lineOutlineWidthStops,
-        "line-color": COLORS.black,
+        "line-color": COLORS.white,
       },
       layout: {
         "line-cap": "round",
@@ -56,7 +56,7 @@ export const MAP_STYLES = {
       type: "circle",
       paint: {
         "circle-radius": pointsCircleRadiusStops,
-        "circle-stroke-color": COLORS.black,
+        "circle-stroke-color": COLORS.white,
         "circle-stroke-width": 1,
         "circle-stroke-opacity": 0.9,
         "circle-color": COLORS.mutedGray,

--- a/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
+++ b/moped-editor/src/views/projects/projectsListView/components/mapStyleSettings.js
@@ -57,4 +57,34 @@ export const MAP_STYLES = {
       },
     },
   },
+  "project-points-muted": {
+    layerProps: {
+      id: "project-points",
+      _featureIdProp: "INTERSECTIONID",
+      type: "circle",
+      paint: {
+        "circle-radius": pointsCircleRadiusStops,
+        "circle-stroke-color": COLORS.mutedGray,
+        "circle-stroke-width": 1,
+        "circle-stroke-opacity": 0.9,
+        "circle-color": COLORS.mutedGray,
+        "circle-opacity": 0.9,
+      },
+    },
+  },
+  "project-lines-muted": {
+    layerProps: {
+      id: "project-lines",
+      _featureIdProp: "CTN_SEGMENT_ID",
+      type: "line",
+      paint: {
+        "line-width": lineWidthStops,
+        "line-color": COLORS.mutedGray,
+        "line-opacity": 0.9,
+      },
+      layout: {
+        "line-cap": "round",
+      },
+    },
+  },
 };

--- a/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
@@ -38,12 +38,11 @@ export const useProjectGeographies = ({
 
     const projectGeographiesMap = projectGeographiesArr.reduce(
       (acc, projectGeography) => {
-        console.log(projectGeography);
         const lineRepresentation = projectGeography?.line_representation;
         const phaseKey =
           projectDataById[projectGeography.project_id]?.current_phase_key;
 
-        // Set color based on phase key or default and mute if not in selected projects (if there are any selected)
+        // Set color based on phase key or default if not defined
         const statusBadgeColor = phaseKey
           ? styleMapping[phaseKey]?.background
           : styleMapping.default.background;
@@ -58,13 +57,14 @@ export const useProjectGeographies = ({
           },
         };
 
-        // Check if project is featured and add to line or point feature collections
+        // Check if project is featured and if it is a line or point feature
         const isFeatured = featuredProjectIds.includes(
           projectGeography.project_id
         );
         const isFeaturedLine = lineRepresentation && isFeatured;
         const isFeaturePoint = !lineRepresentation && isFeatured;
 
+        // Sort into featured or non-featured project and line and point geographies for map layers
         if (isFeaturedLine) {
           return {
             ...acc,

--- a/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { styleMapping } from "../../ProjectStatusBadge";
+import { styleMapping } from "../../projectView/ProjectStatusBadge";
 
+/* Initial feature collections to pass to the map when data has not yet loaded */
 const initialProjectGeographiesMap = {
   projectGeographiesFeatureCollectionLines: {
     type: "FeatureCollection",
@@ -20,7 +21,11 @@ const initialProjectGeographiesMap = {
   },
 };
 
-/* Build feature collection to pass to the map, add project_geography attributes to feature properties along with status color */
+/**  Build feature collection to pass to the map, add project_geography attributes to feature properties along with status color
+ * @param {Object} projectsGeographies - Object with project geographies data
+ * @param {Object} projectDataById - Object with project data by project id to add to feature properties
+ * @param {Array} featuredProjectIds - Array of project ids that are featured (clicked on map)
+ */
 export const useProjectGeographies = ({
   projectsGeographies,
   projectDataById,

--- a/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectGeographies/useProjectGeographies.js
@@ -11,11 +11,11 @@ const initialProjectGeographiesMap = {
     type: "FeatureCollection",
     features: [],
   },
-  featuredProjectsFeatureCollectionLines: {
+  selectedProjectsFeatureCollectionLines: {
     type: "FeatureCollection",
     features: [],
   },
-  featuredProjectsFeatureCollectionPoints: {
+  selectedProjectsFeatureCollectionPoints: {
     type: "FeatureCollection",
     features: [],
   },
@@ -24,12 +24,12 @@ const initialProjectGeographiesMap = {
 /**  Build feature collection to pass to the map, add project_geography attributes to feature properties along with status color
  * @param {Object} projectsGeographies - Object with project geographies data
  * @param {Object} projectDataById - Object with project data by project id to add to feature properties
- * @param {Array} featuredProjectIds - Array of project ids that are featured (clicked on map)
+ * @param {Array} selectedProjectIds - Array of project ids that are selected (clicked on map)
  */
 export const useProjectGeographies = ({
   projectsGeographies,
   projectDataById,
-  featuredProjectIds,
+  selectedProjectIds,
 }) =>
   React.useMemo(() => {
     const projectGeographiesArr = projectsGeographies?.project_geography;
@@ -57,32 +57,32 @@ export const useProjectGeographies = ({
           },
         };
 
-        // Check if project is featured and if it is a line or point feature
-        const isFeatured = featuredProjectIds.includes(
+        // Check if project is selected and if it is a line or point feature
+        const isSelected = selectedProjectIds.includes(
           projectGeography.project_id
         );
-        const isFeaturedLine = lineRepresentation && isFeatured;
-        const isFeaturePoint = !lineRepresentation && isFeatured;
+        const isSelectedLine = lineRepresentation && isSelected;
+        const isSelectedPoint = !lineRepresentation && isSelected;
 
-        // Sort into featured or non-featured project and line and point geographies for map layers
-        if (isFeaturedLine) {
+        // Sort into selected or non-selected project and line and point geographies for map layers
+        if (isSelectedLine) {
           return {
             ...acc,
-            featuredProjectsFeatureCollectionLines: {
+            selectedProjectsFeatureCollectionLines: {
               type: "FeatureCollection",
               features: [
-                ...acc.featuredProjectsFeatureCollectionLines.features,
+                ...acc.selectedProjectsFeatureCollectionLines.features,
                 projectGeographyFeature,
               ],
             },
           };
-        } else if (isFeaturePoint) {
+        } else if (isSelectedPoint) {
           return {
             ...acc,
-            featuredProjectsFeatureCollectionPoints: {
+            selectedProjectsFeatureCollectionPoints: {
               type: "FeatureCollection",
               features: [
-                ...acc.featuredProjectsFeatureCollectionPoints.features,
+                ...acc.selectedProjectsFeatureCollectionPoints.features,
                 projectGeographyFeature,
               ],
             },
@@ -117,4 +117,4 @@ export const useProjectGeographies = ({
     );
 
     return projectGeographiesMap;
-  }, [featuredProjectIds, projectsGeographies, projectDataById]);
+  }, [selectedProjectIds, projectsGeographies, projectDataById]);


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/9918

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Go to the project list view and toggle the Map switch
2. You should see all project components load in the map and a collapsed sidebar on the left of the map
3. Expand the sidebar, see that there is a message that no components are selected, and then collapse it again
4. Hover components on the map and find a place where multiple of them overlap
5. Click and see that the sidebar opens and show a list of unique projects that have components overlapping in the place you clicked
6. You should see that all components associated with the projects in the list remain their status color and the rest are a muted gray
7. If you click a spot on the map where there are not components, the muted colors will regain their status colors
8. Try using advanced filters and click different areas of the map
9. Try a clicking links in the sidebar and you should be redirected to the project summary page of the project
10. Last, from a project summary page, click the link in the top left that says `< ALL PROJECTS`. You should be navigated back to the project list view with your previous filter. I created [another issue to capture the projects map toggle state in the search params](https://github.com/cityofaustin/atd-data-tech/issues/17601) so that it will navigate back to the map with the previous filters applied. Do y'all think that makes sense?

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
