### PR TITLE
Add map user analytics event and save map toggle state in search params

### DIFF
--- a/moped-database/migrations/1717191608945_update_user_events_constraint/down.sql
+++ b/moped-database/migrations/1717191608945_update_user_events_constraint/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
+
+ALTER TABLE moped_user_events
+ADD CONSTRAINT moped_user_events_event_name_check CHECK (event_name IN ('app_load', 'dashboard_load'));

--- a/moped-database/migrations/1717191608945_update_user_events_constraint/down.sql
+++ b/moped-database/migrations/1717191608945_update_user_events_constraint/down.sql
@@ -1,3 +1,5 @@
+DELETE FROM moped_user_events WHERE event_name = 'projects_map_load';
+
 ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
 
 ALTER TABLE moped_user_events

--- a/moped-database/migrations/1717191608945_update_user_events_constraint/up.sql
+++ b/moped-database/migrations/1717191608945_update_user_events_constraint/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE moped_user_events DROP CONSTRAINT moped_user_events_event_name_check;
+
+ALTER TABLE moped_user_events
+ADD CONSTRAINT moped_user_events_event_name_check CHECK (event_name IN ('app_load', 'dashboard_load', 'projects_map_load'));

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -12,6 +12,7 @@ import Filters from "src/components/GridTable/Filters";
 import SearchBar from "./SearchBar";
 import makeStyles from "@mui/styles/makeStyles";
 import { simpleSearchParamName } from "src/views/projects/projectsListView/useProjectListViewQuery/useSearch";
+import { mapSearchParamName } from "src/views/projects/projectsListView/ProjectsListViewTable";
 import theme from "src/theme";
 
 const useStyles = makeStyles((theme) => ({
@@ -146,6 +147,15 @@ const Search = ({
     });
   };
 
+  const handleMapToggle = () => {
+    setShowMapView(!showMapView);
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.set(mapSearchParamName, !showMapView);
+
+      return prevSearchParams;
+    });
+  };
+
   return (
     <div>
       <Box mt={3}>
@@ -186,7 +196,7 @@ const Search = ({
                         control={
                           <Switch
                             checked={showMapView}
-                            onChange={() => setShowMapView(!showMapView)}
+                            onChange={handleMapToggle}
                           />
                         }
                         label="Map"

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext, useCallback } from "react";
 import { Box, Container, Paper } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import Search from "../../../components/GridTable/Search";
 import ApolloErrorHandler from "../../../components/ApolloErrorHandler";
@@ -31,6 +32,8 @@ import ProjectsListViewMap from "./ProjectsListViewMap";
 import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
 import ActivityMetrics from "src/components/ActivityMetrics";
 
+export const mapSearchParamName = "map";
+
 const useStyles = makeStyles((theme) => ({
   paper: {
     width: "100%",
@@ -60,7 +63,11 @@ const ProjectsListViewTable = () => {
   const [downloadingDialogOpen, setDownloadingDialogOpen] = useState(false);
 
   /* Toggle between list and map view */
-  const [showMapView, setShowMapView] = useState(false);
+  const [searchParams] = useSearchParams();
+  const initialShowMapView = searchParams.get(mapSearchParamName)
+    ? searchParams.get(mapSearchParamName) === "true"
+    : false;
+  const [showMapView, setShowMapView] = useState(initialShowMapView);
 
   /* Project list query */
   const { queryLimit, setQueryLimit, queryOffset, setQueryOffset } =

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewTable.js
@@ -29,6 +29,7 @@ import ProjectListToolbar from "./ProjectListToolbar";
 import { useCurrentData } from "./useProjectListViewQuery/useCurrentData";
 import ProjectsListViewMap from "./ProjectsListViewMap";
 import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
+import ActivityMetrics from "src/components/ActivityMetrics";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -272,15 +273,17 @@ const ProjectsListViewTable = () => {
               />
             )}
             {showMapView && (
-              <ProjectsListViewMap
-                mapQuery={mapQuery}
-                fetchPolicy={
-                  PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy
-                }
-                setIsMapDataLoading={setIsMapDataLoading}
-                searchWhereString={searchWhereString}
-                advancedSearchWhereString={advancedSearchWhereString}
-              />
+              <ActivityMetrics eventName="projects_map_load">
+                <ProjectsListViewMap
+                  mapQuery={mapQuery}
+                  fetchPolicy={
+                    PROJECT_LIST_VIEW_QUERY_CONFIG.options.useQuery.fetchPolicy
+                  }
+                  setIsMapDataLoading={setIsMapDataLoading}
+                  searchWhereString={searchWhereString}
+                  advancedSearchWhereString={advancedSearchWhereString}
+                />
+              </ActivityMetrics>
             )}
           </Box>
         </Paper>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/17601
Closes https://github.com/cityofaustin/atd-data-tech/issues/17480

This PR adds a user analytics event so we can track adoption of the projects map, and it also stores the map toggle state in the query params so filtered map view urls can be saved or shared.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start the local stack and explore the `moped_user_events` table in your DB GUI. You should see that the `event_name` column has a new value in its constraint called `projects_map_load`
2. In your local editor, go to the projects list view and toggle the map switch on. You should see a new row in the `moped_user_events` table capturing this event
3. Also, notice that the url query parameters include a new k/v pair for `map` which is either `true` or `false`
4. Test toggling the map on, adding some advanced filters, and then copying your url
5. In a new tab, paste the url and make sure that the projects map loads with your filters applied
6. You can also test clicking on project features and then visiting a linked project in the sidebar. Click the **< All Projects** link in the project summary page, and see that you are linked to the map with your previous filters applied

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
