### PR TITLE
[Bug] Alert that a moved component cannot be found in original project is missing

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/TheMap.js
@@ -103,10 +103,14 @@ export default function TheMap({
     if (shouldShowZoomAlert) {
       errorMessageDispatch({
         type: "show_error",
-        payload: { message: "Zoom in to select features", severity: "error" },
+        payload: {
+          message: "Zoom in to select features",
+          severity: "error",
+          messageType: "componentZoomError",
+        },
       });
     } else {
-      errorMessageDispatch({ type: "hide_error" });
+      errorMessageDispatch({ type: "hide_zoom_error" });
     }
   }, [
     currentZoom,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
@@ -63,7 +63,7 @@ export const useComponentLinkParams = ({
     }
 
     // Set clicked component from search parameter once projectComponents data loads
-    if (projectComponents.length > 0) {
+    if (projectComponents.length > 0 || allRelatedComponents.length > 0) {
       const componentFromParams =
         projectComponents.find(
           (component) => component.project_component_id === componentParamId

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useComponentLinkParams.js
@@ -105,9 +105,10 @@ export const useComponentLinkParams = ({
             Please check this project's activity log for more details.`,
             severity: "error",
             onClose: () => {
-              errorMessageDispatch({ type: "hide_error" });
+              errorMessageDispatch({ type: "hide_component_error" });
               updateParamsWithoutRender("project_component_id", null);
             },
+            messageType: "componentLinkError"
           },
         });
       }

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useToolbarErrorMessage.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useToolbarErrorMessage.js
@@ -5,13 +5,6 @@ const errorMessageReducer = (state, action) => {
     case "show_error":
       const { message, severity, onClose, messageType } = action.payload;
       return { ...state, isOpen: true, message, severity, onClose, messageType };
-    case "hide_error":
-      return {
-        isOpen: false,
-        message: null,
-        severity: null,
-        onClose: null,
-      };
     case "hide_component_error":
       if (state.messageType !== "componentLinkError") {
         return {...state}
@@ -25,6 +18,7 @@ const errorMessageReducer = (state, action) => {
         };
     case "hide_zoom_error":
       if (state.messageType !== "componentZoomError") {
+        // if zoom error not visible, do nothing
         return {...state}
       }
       return {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useToolbarErrorMessage.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/useToolbarErrorMessage.js
@@ -3,14 +3,36 @@ import { useReducer } from "react";
 const errorMessageReducer = (state, action) => {
   switch (action.type) {
     case "show_error":
-      const { message, severity, onClose } = action.payload;
-      return { ...state, isOpen: true, message, severity, onClose };
+      const { message, severity, onClose, messageType } = action.payload;
+      return { ...state, isOpen: true, message, severity, onClose, messageType };
     case "hide_error":
       return {
         isOpen: false,
         message: null,
         severity: null,
         onClose: null,
+      };
+    case "hide_component_error":
+      if (state.messageType !== "componentLinkError") {
+        return {...state}
+      }
+        return {
+          isOpen: false,
+          message: null,
+          severity: null,
+          onClose: null,
+          messageType: null,
+        };
+    case "hide_zoom_error":
+      if (state.messageType !== "componentZoomError") {
+        return {...state}
+      }
+      return {
+        isOpen: false,
+        message: null,
+        severity: null,
+        onClose: null,
+        messageType: null,
       };
     default:
       throw Error(`Unknown action. ${action.type}`);
@@ -24,6 +46,7 @@ export const useToolbarErrorMessage = () => {
       message: null,
       severity: null,
       onClose: null,
+      messageType: null,
     }
   );
 


### PR DESCRIPTION
## Associated issues

Closes https://github.com/cityofaustin/atd-data-tech/issues/17518

## Testing
**URL to test:** 
https://deploy-preview-1355--atd-moped-main.netlify.app/moped/projects/

**Steps to test:**
1. Visit a project (for example
https://deploy-preview-1355--atd-moped-main.netlify.app/moped/projects/2022?tab=map&project_component_id=2627)
2. Move a component from your project to another project, and then try to visit the previous link. Alternately, make up a component id that doesnt exist: (https://deploy-preview-1355--atd-moped-main.netlify.app/moped/projects/2022?tab=map&project_component_id=262300) Make sure you can see the alert. 
3. Test adding a component, but be zoomed out -- verify the "zoom in to select features" alert appears. And disappears when you zoom in. 
4. This project has related project components, but no mapped components of its own. Verify that if you try this link for a non existent project component id, you still see the alert (https://deploy-preview-1355--atd-moped-main.netlify.app/moped/projects/1940?tab=map&project_component_id=236200)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
