### PR TITLE
[Bug] User password requirement error is not translating correctly

### DIFF
--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -118,6 +118,7 @@ const StaffForm = ({
   } = useQuery(WORKGROUPS_QUERY);
 
   console.log("errors ", errors)
+  console.log("user api errors ", userApiErrors)
 
   /**
    * Closes the modal

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -117,7 +117,6 @@ const StaffForm = ({
     data: workgroups,
   } = useQuery(WORKGROUPS_QUERY);
 
-  console.log("errors ", errors)
   console.log("user api errors ", userApiErrors)
 
   /**

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -117,8 +117,6 @@ const StaffForm = ({
     data: workgroups,
   } = useQuery(WORKGROUPS_QUERY);
 
-  console.log("user api errors ", userApiErrors)
-
   /**
    * Closes the modal
    */
@@ -226,7 +224,7 @@ const StaffForm = ({
               {...register("password")}
               error={!!errors.password || !!userApiErrors?.password}
               helperText={
-                errors.password?.message || // what is this message
+                errors.password?.message ||
                 formatApiErrors(userApiErrors?.password)
               }
             />

--- a/moped-editor/src/views/staff/StaffForm.js
+++ b/moped-editor/src/views/staff/StaffForm.js
@@ -117,6 +117,8 @@ const StaffForm = ({
     data: workgroups,
   } = useQuery(WORKGROUPS_QUERY);
 
+  console.log("errors ", errors)
+
   /**
    * Closes the modal
    */
@@ -224,7 +226,7 @@ const StaffForm = ({
               {...register("password")}
               error={!!errors.password || !!userApiErrors?.password}
               helperText={
-                errors.password?.message ||
+                errors.password?.message || // what is this message
                 formatApiErrors(userApiErrors?.password)
               }
             />

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -68,8 +68,6 @@ export function useUserApi() {
 const errorsToTranslate = {
   "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'":
     "not a valid email format",
-  "value does not match regex '^[a-zA-Z0-9_-!@%^*~?.:&*()[]$]*$'":
-    "password must be at least 12 characters long, it must include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
   "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'":
     "password must be at least 12 characters long, include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
 };

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -84,7 +84,7 @@ export const formatApiErrors = (errorsArray) =>
  */
 export const passwordLooksGood = (password) =>
   new RegExp(
-    "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'"
+    "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$"
   ).test(password);
 
 /**

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -70,6 +70,7 @@ const errorsToTranslate = {
     "not a valid email format",
   "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'":
     "password must be at least 12 characters long, include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
+  "min length is 8": "",
 };
 
 export const formatApiErrors = (errorsArray) =>
@@ -83,7 +84,7 @@ export const formatApiErrors = (errorsArray) =>
  */
 export const passwordLooksGood = (password) =>
   new RegExp(
-    "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$"
+    "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'"
   ).test(password);
 
 /**

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -70,7 +70,7 @@ const errorsToTranslate = {
     "not a valid email format",
   "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'":
     "password must be at least 12 characters long, include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
-  "min length is 8": "",
+  "min length is 8": "password is too short",
 };
 
 export const formatApiErrors = (errorsArray) =>

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -70,6 +70,8 @@ const errorsToTranslate = {
     "not a valid email format",
   "value does not match regex '^[a-zA-Z0-9_-!@%^*~?.:&*()[]$]*$'":
     "password must be at least 12 characters long, it must include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
+  "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$":
+    "password must be at least 12 characters long, include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
 };
 
 export const formatApiErrors = (errorsArray) =>

--- a/moped-editor/src/views/staff/helpers.js
+++ b/moped-editor/src/views/staff/helpers.js
@@ -70,7 +70,7 @@ const errorsToTranslate = {
     "not a valid email format",
   "value does not match regex '^[a-zA-Z0-9_-!@%^*~?.:&*()[]$]*$'":
     "password must be at least 12 characters long, it must include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
-  "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$":
+  "value does not match regex '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$'":
     "password must be at least 12 characters long, include at least one lowercase letter, one uppercase letter, one number, and one special character: _-!@%^~?.:&()[]$",
 };
 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/17285

## Testing
**URL to test:** 

https://deploy-preview-1358--atd-moped-main.netlify.app/moped/staff/new

**Steps to test:**

Fill out the new user form, every required field. Try a one letter password, you will see both error messages. 
Now try one that is longer than 8, but still not correct. 

<img width="1040" alt="Screenshot 2024-06-10 at 11 32 37 AM" src="https://github.com/cityofaustin/atd-moped/assets/12474808/7ebd84d2-7450-4e3a-a741-0239597b4e62">




---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
