### PR TITLE
replaces react-quill with react-quill-new

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -94,7 +94,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.49.3",
     "react-map-gl": "^7.1.7",
-    "react-quill": "^2.0.0",
+    "react-quill-new": "^3.2.0",
     "react-router": "^6.3.0",
     "react-router-dom": "^6.21.2",
     "react-scripts": "^5.0.1",

--- a/moped-editor/src/views/projects/projectView/NoteInputQuill.js
+++ b/moped-editor/src/views/projects/projectView/NoteInputQuill.js
@@ -9,8 +9,8 @@ import {
   RadioGroup,
   FormControlLabel,
 } from "@mui/material";
-import ReactQuill from "react-quill";
-import "react-quill/dist/quill.snow.css";
+import ReactQuill from "react-quill-new";
+import "react-quill-new/dist/quill.snow.css";
 import makeStyles from "@mui/styles/makeStyles";
 import ProjectSaveButton from "../newProjectView/ProjectSaveButton";
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/17450

this is a holdover to replace the react-quill library with a patched version that is compatible with upcoming Chrome updates

we will remove this library once we have [lexical-react](https://www.npmjs.com/package/@lexical/react) in place as our new rich text editor

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1375--atd-moped-main.netlify.app/

**Steps to test:**
- open a project notes tab and ensure that the rich text editor is working

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
