### PR TITLE
Patch v2.15.1

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useMutation } from "@apollo/client";
+import isEqual from "lodash/isEqual";
 
 // Material
 import {
@@ -491,27 +492,35 @@ const ProjectFundingTable = () => {
           })
       );
     } else {
-      return (
-        updateProjectFunding({
-          variables: updateProjectFundingData,
-        })
-          .then(() => refetch())
-          // from the data grid docs:
-          // Please note that the processRowUpdate must return the row object to update the Data Grid internal state.
-          .then(() => updatedRow)
-          .catch((error) => {
-            setSnackbarState({
-              open: true,
-              message: (
-                <span>
-                  There was a problem updating funding. Error message:{" "}
-                  {error.message}
-                </span>
-              ),
-              severity: "error",
-            });
+      // Remove __typename since we cleaned it up in the updateProjectFundingData and check if the row has changed
+      delete originalRow.__typename;
+      const hasRowChanged = !isEqual(updatedRow, originalRow);
+
+      if (!hasRowChanged) {
+        return Promise.resolve(updatedRow);
+      } else {
+        return (
+          updateProjectFunding({
+            variables: updateProjectFundingData,
           })
-      );
+            .then(() => refetch())
+            // from the data grid docs:
+            // Please note that the processRowUpdate must return the row object to update the Data Grid internal state.
+            .then(() => updatedRow)
+            .catch((error) => {
+              setSnackbarState({
+                open: true,
+                message: (
+                  <span>
+                    There was a problem updating funding. Error message:{" "}
+                    {error.message}
+                  </span>
+                ),
+                severity: "error",
+              });
+            })
+        );
+      }
     }
   };
 


### PR DESCRIPTION
## Associated issues
n/a

When double-clicking a cell and then clicking away to cancel without actually making a value change, the update mutation is still called and ends up creating an activity log entry with the same before and after values. This adds a check for updated form data before calling the mutation.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->


**Steps to test:**
1. Go to a project funding sources table with a funding row or create a row if there isn't one
2. Open your dev tools to watch for network requests then double-click a cell to edit. Without making a change, click outside the table to cancel. You should not see a network request happen.
3. Now, do the same but make an update. You should see a network request for the mutation.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
