### PR TITLE
Show inactive rows for Dept-unit in Funding table

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/views/projects/projectView/FundingDeptUnitAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/FundingDeptUnitAutocomplete.js
@@ -10,7 +10,7 @@ import theme from "src/theme";
  * Transportation Project Financial Codes
  */
 const SOCRATA_ENDPOINT =
-  "https://data.austintexas.gov/resource/bgrt-2m2z.json?dept_unit_status=Active&$limit=9999";
+  "https://data.austintexas.gov/resource/bgrt-2m2z.json?$limit=9999";
 
 const DeptUnitInput = (params, error = false, variant, ref) => {
   return (


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/18340

This PR removes the inactive status filter on the Socrata query that we use to populate the **Dept-unit** dropdown options in the Funding sources table. This will allow Moped users to track spent money (closed or "inactive" Dept-unit numbers).

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1380--atd-moped-main.netlify.app/

**Steps to test:**
1. Visit [this filtered financial codes dataset](https://data.austintexas.gov/Transportation-and-Mobility/Transportation-Department-Financial-Codes/bgrt-2m2z/explore/query/SELECT%0A%20%20%60dept_unit_id%60%2C%0A%20%20%60dept_id%60%2C%0A%20%20%60dept%60%2C%0A%20%20%60unit%60%2C%0A%20%20%60unit_long_name%60%2C%0A%20%20%60unit_short_name%60%2C%0A%20%20%60dept_unit_status%60%0AWHERE%20caseless_eq%28%60unit%60%2C%20%22L117%22%29/page/filter), and you should see two rows. Notice that one row has the value **Active** for `DEPT_UNIT_STATUS` while the other row has **Inactive**.
2. Now, go to a project's funding table and add a new or edit an existing funding source row.
3. In the **Dept-unit** dropdown, enter **L117** and you should see two options show (both inactive and active status).
4. Go to [staging Moped](https://moped.austinmobility.io/moped/projects/1909?tab=funding) and try the same. You should only see the record with active status that has **E 12th** in its name.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] ~Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
