### PR TITLE
Update project list view funding source row and export to show source and program

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -60,7 +60,7 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
   type_name: {
     label: "Type",
   },
-  funding_source_name: {
+  funding_source_and_program_names: {
     label: "Funding",
   },
   project_status_update: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -226,7 +226,7 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
       defaultHidden: true,
       showInTable: true,
     },
-    funding_source_name: {
+    funding_source_and_program_names: {
       type: "string",
       sortable: true,
       defaultHidden: true,
@@ -342,7 +342,7 @@ export const SHOW_ALL_COLS = Object.entries(
   PROJECT_LIST_VIEW_QUERY_CONFIG.columns
 ).reduce((acc, [columnName, config]) => {
   if (config.showInTable === true) {
-    acc[columnName] = true
+    acc[columnName] = true;
   }
   return acc;
 }, {});

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -289,10 +289,10 @@ export const useColumns = ({ hiddenColumns }) => {
       },
       {
         headerName: "Funding",
-        field: "funding_source_name",
+        field: "funding_source_and_program_names",
         cellStyle: { whiteSpace: "noWrap" },
         renderCell: ({ row }) =>
-          renderSplitListDisplayBlock(row, "funding_source_name"),
+          renderSplitListDisplayBlock(row, "funding_source_and_program_names"),
         width: COLUMN_WIDTHS.medium,
       },
       {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18270

This PR updates the column used for funding in the project list view from `funding_source_name` to `funding_source_and_program_names`. I also updated the column in the table export while I was in here.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1385--atd-moped-main.netlify.app/

**Steps to test:**
1. Go to the project list view in the deploy preview and search for project ID 1909 or 2031 or any other project with rows in its funding table with both source and program entered
2. You should see both the source and program names separated by a dash. Either source or program if one is present and not the other.
3. Export the table with either the all or only visible option. Check the export to make sure that the same source and name combination show in the **Funding** column of the export.
4. Test that you can still advance search by **Funding source**. Updates to include the program part of the funding record are being scoped in https://github.com/cityofaustin/atd-data-tech/issues/18361.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] ~Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
