### PR TITLE
Update status filter to show all phase options

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -974,12 +974,9 @@ export const LOOKUP_TABLES_QUERY = gql`
       last_name
       user_id
     }
-    moped_phases(
-      order_by: { phase_name_simple: asc }
-      distinct_on: phase_name_simple
-    ) {
+    moped_phases(order_by: { phase_name: asc }) {
       phase_id
-      phase_name_simple
+      phase_name
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -142,7 +142,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       type: "string",
       lookup: {
         table_name: "moped_phases",
-        getOptionLabel: (option) => option.phase_name_simple,
+        getOptionLabel: (option) => option.phase_name,
         operators: ["string_equals_case_insensitive"],
       },
       operators: [


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/18451

During Chia's demo in dev sync the other day, she showed this bug and then it clicked for me today. All 14 phases should be available for search on this status field. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1386--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Go to the projects list view and advanced search on **Status**
2. Notice that **all phases** show in the status badges in the table are now available and not just the simple names.
3. Make sure the search still works.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] ~Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
