### PR TITLE
disables modal close on backdrop click

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -76,7 +76,9 @@ const CreateComponentModal = ({
     }
   };
 
-  const onClose = () => {
+  const onClose = (reason) => {
+    if (reason && reason === "backdropClick")
+      return;
     setLinkMode(null);
     createDispatch({ type: "cancel_create" });
   };

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/CreateComponentModal.js
@@ -76,7 +76,7 @@ const CreateComponentModal = ({
     }
   };
 
-  const onClose = (reason) => {
+  const onClose = (event, reason) => {
     if (reason && reason === "backdropClick")
       return;
     setLinkMode(null);

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/EditAttributesModal.js
@@ -112,7 +112,9 @@ const EditAttributesModal = ({
       });
   };
 
-  const onClose = () => {
+  const onClose = (event, reason) => {
+    if (reason && reason === "backdropClick")
+      return;
     editDispatch({ type: "cancel_attributes_edit" });
   };
 


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/17095

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1388--atd-moped-main.netlify.app/

**Steps to test:**
- go to a project map page and click 'new component'
- click outside of the new component dialog, nothing should happen
- close out of the component by completing it or clicking the 'x'

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
