### PR TITLE
Clean up click event capture in the eCapris and website links in Project Summary view

### DIFF
--- a/moped-editor/src/components/ExternalLink.js
+++ b/moped-editor/src/components/ExternalLink.js
@@ -3,7 +3,7 @@ import Link from "@mui/material/Link";
 import makeStyles from "@mui/styles/makeStyles";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   iconStyle: {
     fontSize: "1rem",
     marginLeft: "2px",
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
- * LinkWithIcon component
+ * ExternalLink component
  * @param {string} url - link url
  * @param {string} text - link text
  * @param {string} linkColor - color of the link

--- a/moped-editor/src/components/ExternalLink.js
+++ b/moped-editor/src/components/ExternalLink.js
@@ -18,14 +18,28 @@ const useStyles = makeStyles(() => ({
  * @param {string} text - link text
  * @param {string} linkColor - color of the link
  * @param {Object} linkProps - Props supported by MUI Link to override defaults or set other options
+ * @param {Boolean} stopPropagation - stop propagation of the click event from link click event or not
  * @returns {JSX.Element}
  * @constructor
  */
-const ExternalLink = ({ url, text, linkColor, iconStyle, linkProps }) => {
+const ExternalLink = ({
+  url,
+  text,
+  linkColor,
+  iconStyle,
+  linkProps,
+  stopPropagation = false,
+}) => {
   const classes = useStyles();
 
   return (
-    <span>
+    <span
+      onClick={(e) => {
+        if (stopPropagation) {
+          e.stopPropagation();
+        }
+      }}
+    >
       {!!text ? (
         <Link
           href={url}

--- a/moped-editor/src/components/ExternalLink.js
+++ b/moped-editor/src/components/ExternalLink.js
@@ -1,18 +1,27 @@
 import React from "react";
 import Link from "@mui/material/Link";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   iconStyle: {
-    fontSize: "14px",
+    fontSize: "1rem",
     marginLeft: "2px",
     position: "relative",
     bottom: "-3px",
   },
 }));
 
-const ExternalLink = ({ url, text, linkColor, underline, iconStyle }) => {
+/**
+ * LinkWithIcon component
+ * @param {string} url - link url
+ * @param {string} text - link text
+ * @param {string} linkColor - color of the link
+ * @param {Object} linkProps - Props supported by MUI Link to override defaults or set other options
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const ExternalLink = ({ url, text, linkColor, iconStyle, linkProps }) => {
   const classes = useStyles();
 
   return (
@@ -23,7 +32,7 @@ const ExternalLink = ({ url, text, linkColor, underline, iconStyle }) => {
           target="_blank"
           rel="noopener noreferrer"
           color={linkColor ?? "primary"}
-          underline={underline ?? "hover"}
+          {...linkProps}
         >
           {text}
           <OpenInNewIcon

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,12 +1,5 @@
 import React, { useEffect, useState } from "react";
-import {
-  Box,
-  Grid,
-  Icon,
-  Link,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
@@ -162,7 +155,8 @@ const ProjectSummaryProjectECapris = ({
               id="moped-project-ecapris"
               label={null}
               onChange={handleProjectECaprisChange}
-              value={eCapris} />
+              value={eCapris}
+            />
             <Icon
               className={classes.editIconConfirm}
               onClick={handleProjectECaprisSave}
@@ -182,14 +176,12 @@ const ProjectSummaryProjectECapris = ({
             text={
               (eCapris && (
                 <>
-                  <Typography variant={"inherit"} color={"primary"}>
-                    {eCapris}{" "}
-                  </Typography>
                   <Link
                     rel="noopener noreferrer"
                     href={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${eCapris}`}
                     target={"_blank"}
                   >
+                    {eCapris}
                     <OpenInNew className={classes.linkIcon} />
                   </Link>
                 </>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -178,6 +178,7 @@ const ProjectSummaryProjectECapris = ({
                 <ExternalLink
                   text={eCapris}
                   url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${eCapris}`}
+                  stopPropagation
                 />
               )) ||
               ""

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
+import { Box, Grid, Icon, TextField, Typography } from "@mui/material";
 
+import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 import {
@@ -8,7 +9,6 @@ import {
   PROJECT_CLEAR_ECAPRIS_SUBPROJECT_ID,
 } from "../../../../queries/project";
 import { useMutation } from "@apollo/client";
-import { OpenInNew } from "@mui/icons-material";
 
 /**
  * Custom wrapper for the eCapris edit field
@@ -175,16 +175,10 @@ const ProjectSummaryProjectECapris = ({
           <ProjectSummaryLabel
             text={
               (eCapris && (
-                <>
-                  <Link
-                    rel="noopener noreferrer"
-                    href={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${eCapris}`}
-                    target={"_blank"}
-                  >
-                    {eCapris}
-                    <OpenInNew className={classes.linkIcon} />
-                  </Link>
-                </>
+                <ExternalLink
+                  text={eCapris}
+                  url={`https://ecapris.austintexas.gov/index.cfm?fuseaction=subprojects.subprojectData&SUBPROJECT_ID=${eCapris}`}
+                />
               )) ||
               ""
             }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { Box, Grid, Icon, Link, TextField, Typography } from "@mui/material";
+import { Box, Grid, Icon, TextField, Typography } from "@mui/material";
 
+import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
 import { PROJECT_UPDATE_WEBSITE } from "../../../../queries/project";
 import { useMutation } from "@apollo/client";
-import { OpenInNew } from "@mui/icons-material";
 import { isValidUrl, makeUrlValid } from "src/utils/urls";
 
 /**
@@ -127,10 +127,7 @@ const ProjectSummaryProjectWebsite = ({
           <ProjectSummaryLabel
             text={
               (website && website.length > 0 && (
-                <Link href={website} target={"_blank"}>
-                  {website}
-                  <OpenInNew className={classes.linkIcon} />
-                </Link>
+                <ExternalLink text={website} url={website} />
               )) ||
               ""
             }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -127,7 +127,7 @@ const ProjectSummaryProjectWebsite = ({
           <ProjectSummaryLabel
             text={
               (website && website.length > 0 && (
-                <ExternalLink text={website} url={website} />
+                <ExternalLink text={website} url={website} stopPropagation />
               )) ||
               ""
             }

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryWorkOrders.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryWorkOrders.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { Box, Grid, Link, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 
-import { OpenInNew } from "@mui/icons-material";
+import ExternalLink from "src/components/ExternalLink";
 
 /**
  * ProjectSummaryWorkOrders Component
@@ -35,13 +35,7 @@ const ProjectSummaryWorkOrders = ({
         <ProjectSummaryLabel
           className={classes.fieldLabelDataTrackerLink}
           text={
-            <Link
-              href={knackProjectURL}
-              target={"_blank"}
-            >
-              {"View in Data Tracker"}
-              <OpenInNew className={classes.linkIcon} />
-            </Link>
+            <ExternalLink text="View in Data Tracker" url={knackProjectURL} />
           }
           classes={classes}
           spanClassName={classes.fieldLabelTextSpanNoBorder}


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/17595

This PR updates the project summary eCapris, website, and work orders links to use the existing external link component so they behave and look the same. It also updates `ExternalLink` with an optional prop to stop the link click event from propagating in order to prevent entering edit mode when navigating to an external link.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

**Steps to test:**
1. Open up the project summary page of project 1846 in both [staging](https://moped.austinmobility.io/moped/projects/1846) and in the [deploy preview](https://deploy-preview-1389--atd-moped-main.netlify.app/moped/projects/1846). This project shows the website, eCapris, and work orders links needed to test this PR.
2. Notice that, in staging:
   - the external link icon in the website field is not aligned with the link text
   - the external link icon in the eCapris field wraps to a second line and you have to click the icon to visit the link (the eCapris text appears to be a link but is not)
   - when you click on either of these links, a new tab opens, and, when you go back to your original page, the edit input is open like you were trying to update the website or eCapris value
   - the external link icon in the works orders field is not aligned with the link text
3. Notice that, in the deploy preview:
   - the external link icon in the website field is now aligned with the link text
   - the external link icon in the eCapris field does not wrap to a second line and is aligned with the eCapris number text, and the icon or eCapris text can be click to visit the link
   - when you click on either of these links, a new tab opens, and, when you go back to your original page, the edit input **is not** open like you were trying to update the website or eCapris value
   - when hovering either the website or eCapris fields, you can click the gray area to switch to edit mode
   - the external link icon in the works orders field is aligned with the link text
4. Click the **View in Data Tracker** link to make sure it still opens the Data Tracker app in a new tab

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
