### PR TITLE
Update project list view advanced search funding sources

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -950,6 +950,10 @@ export const LOOKUP_TABLES_QUERY = gql`
       funding_source_id
       funding_source_name
     }
+    moped_fund_programs {
+      funding_program_id
+      funding_program_name
+    }
     moped_types(order_by: { type_name: asc }) {
       type_id
       type_name

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -950,10 +950,6 @@ export const LOOKUP_TABLES_QUERY = gql`
       funding_source_id
       funding_source_name
     }
-    moped_fund_programs {
-      funding_program_id
-      funding_program_name
-    }
     moped_types(order_by: { type_name: asc }) {
       type_id
       type_name

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -258,7 +258,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       ],
     },
     {
-      name: "funding_source_name",
+      name: "funding_source_and_program_names",
       label: "Funding source",
       placeholder: "Funding source",
       type: "string",
@@ -274,10 +274,29 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_contains_case_insensitive",
         "string_begins_with_case_insensitive",
         "string_ends_with_case_insensitive",
-        "string_equals_case_insensitive",
-        "string_does_not_equal_case_insensitive",
         "string_is_null",
-        "string_is_not_null",
+        "string_is_not_null"
+      ],
+    },
+    {
+      name: "funding_source_and_program_names",
+      label: "Funding program",
+      placeholder: "Funding program",
+      type: "string",
+      lookup: {
+        table_name: "moped_fund_sources",
+        getOptionLabel: (option) => option.funding_source_name,
+        operators: [
+          "string_equals_case_insensitive",
+          "string_does_not_equal_case_insensitive",
+        ],
+      },
+      operators: [
+        "string_contains_case_insensitive",
+        "string_begins_with_case_insensitive",
+        "string_ends_with_case_insensitive",
+        "string_is_null",
+        "string_is_not_null"
       ],
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -274,22 +274,6 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       ],
     },
     {
-      name: "funding_source_and_program_names",
-      label: "Funding program",
-      placeholder: "Funding program",
-      type: "string",
-      lookup: {
-        table_name: "moped_fund_programs",
-        getOptionLabel: (option) => option.funding_program_name,
-        operators: ["string_contains_case_insensitive"],
-      },
-      operators: [
-        "string_contains_case_insensitive",
-        "string_is_null",
-        "string_is_not_null",
-      ],
-    },
-    {
       name: "project_status_update",
       label: "Status update",
       placeholder: "Status update",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -258,21 +258,19 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       ],
     },
     {
-      name: "funding_source_and_program_names",
+      name: "funding_source_name",
       label: "Funding source",
       placeholder: "Funding source",
       type: "string",
       lookup: {
         table_name: "moped_fund_sources",
         getOptionLabel: (option) => option.funding_source_name,
-        operators: [
-          "string_contains_case_insensitive",
-        ],
+        operators: ["string_contains_case_insensitive"],
       },
       operators: [
         "string_contains_case_insensitive",
         "string_is_null",
-        "string_is_not_null"
+        "string_is_not_null",
       ],
     },
     {
@@ -283,14 +281,12 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       lookup: {
         table_name: "moped_fund_programs",
         getOptionLabel: (option) => option.funding_program_name,
-        operators: [
-          "string_contains_case_insensitive",
-        ],
+        operators: ["string_contains_case_insensitive"],
       },
       operators: [
         "string_contains_case_insensitive",
         "string_is_null",
-        "string_is_not_null"
+        "string_is_not_null",
       ],
     },
     {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -266,14 +266,11 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         table_name: "moped_fund_sources",
         getOptionLabel: (option) => option.funding_source_name,
         operators: [
-          "string_equals_case_insensitive",
-          "string_does_not_equal_case_insensitive",
+          "string_contains_case_insensitive",
         ],
       },
       operators: [
         "string_contains_case_insensitive",
-        "string_begins_with_case_insensitive",
-        "string_ends_with_case_insensitive",
         "string_is_null",
         "string_is_not_null"
       ],
@@ -284,17 +281,14 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       placeholder: "Funding program",
       type: "string",
       lookup: {
-        table_name: "moped_fund_sources",
-        getOptionLabel: (option) => option.funding_source_name,
+        table_name: "moped_fund_programs",
+        getOptionLabel: (option) => option.funding_program_name,
         operators: [
-          "string_equals_case_insensitive",
-          "string_does_not_equal_case_insensitive",
+          "string_contains_case_insensitive",
         ],
       },
       operators: [
         "string_contains_case_insensitive",
-        "string_begins_with_case_insensitive",
-        "string_ends_with_case_insensitive",
         "string_is_null",
         "string_is_not_null"
       ],

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -259,7 +259,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     },
     {
       name: "funding_source_name",
-      label: "Funding source",
+      label: "Funding sources",
       placeholder: "Funding source",
       type: "string",
       lookup: {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/18361

## Update

Going to use this PR to make some small changes to the funding sources filter and come back to the funding program after some more changes. 


To test: 
https://deploy-preview-1394--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22funding_source_name%22%2C%22operator%22%3A%22string_is_null%22%2C%22value%22%3Anull%7D%5D&isOr=false

Confirm the filter options for the funding sources have been pared down. 

---
## old description

The issue description says both funding source and funding program should search on `funding_source_and_program_names`, but I ran into issues with two different entries in the config searching on the same field. Rather than refactor the entire filter config I instead left the funding source searching on the funding_source_name field. 

There is a quirk (or maybe its a bug?) with having the funding program search on the entire source and program name string: if someone searches "is blank", the results are projects that have neither a source nor a program. This project has only a source: https://deploy-preview-1394--atd-moped-main.netlify.app/moped/projects/1802?tab=funding, but will not come up when searching is program blank. 

Also the AND search behavior may be more restrictive than if both options were searching on the same field, but this feels more correct to me. 


## Testing
**URL to test:** 

https://deploy-preview-1394--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22funding_source_and_program_names%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22Bikeways%22%7D%2C%7B%22field%22%3A%22funding_source_name%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%222012+Bond%22%7D%5D&isOr=false

**Steps to test:**

The link above has a search with Funding source and Funding program. 
Test searching with only one or the other. 
Try searching is blank, is not blank. 




---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
