### PR TITLE
Format phase date fields exported from the project list view as month/date/year

### DIFF
--- a/moped-editor/src/utils/dateAndTime.js
+++ b/moped-editor/src/utils/dateAndTime.js
@@ -18,6 +18,8 @@ export const formatDateType = (dateString) => {
  * @return {String} Date formatted as MM/DD/YYYY
  */
 export const formatTimeStampTZType = (timeStampTZString) => {
+  if (timeStampTZString === null) return "";
+
   const dateObject = new Date(timeStampTZString);
   return dateObject.toLocaleDateString("en-US");
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -4,6 +4,7 @@ import {
   filterTaskOrderName,
   resolveHasSubprojects,
 } from "./helpers.js";
+import { formatTimeStampTZType } from "src/utils/dateAndTime.js";
 
 /**
  * The ProjectsListView export settings
@@ -68,9 +69,11 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
   },
   construction_start_date: {
     label: "Construction start",
+    filter: formatTimeStampTZType,
   },
   completion_end_date: {
     label: "Completion date",
+    filter: formatTimeStampTZType,
   },
   project_inspector: {
     label: "Inspector",


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/18795

We store these phase dates as timestamps w/ timezone in the DB, and this updates the export to format them as dates only since we don't save the actual hours/minutes/seconds of phase dates.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1398--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Export the project list view and see that **Construction Start** and **Completion Date** are formatted as dates and not timestamps
2. Compare to staging or production exports
3. Check the **Date uploaded** column in the Project files table to make sure it still renders the same. This PR modifies the helper used for it. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
