### PR TITLE
Close delete confirmation modal only after mutation is complete

### DIFF
--- a/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
+++ b/moped-editor/src/views/projects/projectView/DeleteConfirmationModal.js
@@ -43,7 +43,7 @@ const DeleteConfirmationModal = ({
             startIcon={<DeleteIcon />}
             onClick={() => {
               submitDelete();
-              handleDeleteClose();
+              // closing the confirmation modal should happen after the delete mutation completes
             }}
           >
             <span>Delete</span>

--- a/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFundingTable.js
@@ -408,6 +408,7 @@ const ProjectFundingTable = () => {
         },
       })
         .then(() => refetch())
+        .then(() => setIsDeleteConfirmationOpen(false))
         .catch((error) => {
           setSnackbarState({
             open: true,

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -235,7 +235,9 @@ const ProjectNotes = (props) => {
         projectId: Number(projectId),
         projectNoteId: project_note_id,
       },
-    });
+    })
+      .then(() => setIsDeleteConfirmationOpen(false))
+      .catch((error) => console.error(error));
   };
 
   /**

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/TagsSection.js
@@ -111,6 +111,7 @@ const TagsSection = ({ projectId }) => {
       },
     })
       .then(() => refetch())
+      .then(() => setIsDeleteConfirmationOpen(false))
       .catch((error) => {
         console.error(error);
       });

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -184,10 +184,11 @@ const ProjectWorkActivitiesTable = () => {
 
   const handleDeleteConfirmed = useCallback(() => {
     if (activityToDelete) {
-      deleteContract({ variables: { id: activityToDelete } }).then(() => {
-        refetch();
-        setActivityToDelete(null);
-      });
+      deleteContract({ variables: { id: activityToDelete } })
+        .then(() => refetch())
+        .then((resp) => {
+          console.log(resp)
+          setActivityToDelete(null)});
     }
   }, [activityToDelete, deleteContract, refetch]);
 

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -186,9 +186,10 @@ const ProjectWorkActivitiesTable = () => {
     if (activityToDelete) {
       deleteContract({ variables: { id: activityToDelete } })
         .then(() => refetch())
-        .then((resp) => {
-          console.log(resp)
-          setActivityToDelete(null)});
+        .then(() => {
+          setActivityToDelete(null);
+          setIsDeleteConfirmationOpen(false);
+        });
     }
   }, [activityToDelete, deleteContract, refetch]);
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/18639

## Testing
**URL to test:** 

https://deploy-preview-1399--atd-moped-main.netlify.app/moped/projects


**Steps to test:**

The delete confirmation modal is used in the 
Funding Table
Work Activity table
Notes
Tags (on project summary page)

Add records on each type, test deleting the record and check that the modal closes. 
Also test cancelling the delete and confirm the modal still closes. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
