### PR TITLE
Add ability to toggle filters on any or all in the search filters chips

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -95,17 +95,12 @@ const FiltersChips = ({
 
   /**
    * Triggered by Filter Chip any/all click
-   * Gets previous IsOr state and sets the IsOr state and the url params state to be the opposite
+   * Sets the IsOr state and the url params state to be the opposite of current isOr state
    */
   const toggleIsOrOnClick = () => {
-    let newIsOrState = null;
-    setIsOr((prevState) => {
-      newIsOrState = !prevState;
-      return newIsOrState;
-    });
-
+    setIsOr(!isOr);
     setSearchParams((prevSearchParams) => {
-      prevSearchParams.set(advancedSearchIsOrParamName, newIsOrState);
+      prevSearchParams.set(advancedSearchIsOrParamName, !isOr);
       return prevSearchParams;
     });
   };

--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -118,6 +118,7 @@ const FiltersChips = ({
             <Grid item>
               <Chip
                 variant="outlined"
+                color="primary"
                 onClick={toggleIsOrOnClick}
                 label={
                   isOr ? (

--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -93,6 +93,23 @@ const FiltersChips = ({
     }
   };
 
+  /**
+   * Triggered by Filter Chip any/all click
+   * Gets previous IsOr state and sets the IsOr state and the url params state to be the opposite
+   */
+  const toggleIsOrOnClick = () => {
+    let newIsOrState = null;
+    setIsOr((prevState) => {
+      newIsOrState = !prevState;
+      return newIsOrState;
+    });
+
+    setSearchParams((prevSearchParams) => {
+      prevSearchParams.set(advancedSearchIsOrParamName, newIsOrState);
+      return prevSearchParams;
+    });
+  };
+
   return (
     <Box className={classes.filtersList}>
       <Typography className={classes.filtersText} component="span">
@@ -101,7 +118,7 @@ const FiltersChips = ({
             <Grid item>
               <Chip
                 variant="outlined"
-                onClick={() => setIsOr((prevState) => !prevState)}
+                onClick={toggleIsOrOnClick}
                 label={
                   isOr ? (
                     <>

--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -101,6 +101,7 @@ const FiltersChips = ({
             <Grid item>
               <Chip
                 variant="outlined"
+                onClick={() => setIsOr((prevState) => !prevState)}
                 label={
                   isOr ? (
                     <>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/17956

## Testing
**URL to test:** 

[Deploy Preview with filters applied](https://deploy-preview-1400--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22test%22%7D%2C%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22Mike%22%7D%5D&isOr=false)

**Steps to test:**

Add more than one filter to the advanced search filters. Apply filters
Click on the Matching *all* filters chip. 
Confirm that it switches to any filters, the url params update (the end of the params says `isOr=true`) and the search results update. 
Click again! Search goes back to filtering on all, url param updates and search results update. 

![Screenshot 2024-08-29 at 9 34 51 AM](https://github.com/user-attachments/assets/77773977-8969-468b-82d0-786f790cf7b9)


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
