### PR TITLE
Fix filter chips so they don't show a date with "is blank" operator

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -49,7 +49,10 @@ const FiltersChips = ({
     return {
       filterLabel: fieldFilterConfig?.label,
       operatorLabel: fieldOperatorConfig?.label,
-      filterValue: isDateType ? formatDateType(filter.value) : filter.value,
+      filterValue:
+        isDateType && filter.value
+          ? formatDateType(filter.value)
+          : filter.value,
     };
   });
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/18940

## Testing

When I updated the chips to format dates to be more legible, I neglected to check if the date actually existed or was `null`

**Steps to test:**

Compare https://deploy-preview-1410--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22completion_end_date%22%2C%22operator%22%3A%22date_is_null%22%2C%22value%22%3Anull%7D%5D&isOr=false 

to in staging 
https://moped.austinmobility.io/moped/projects?filters=%5B%7B%22field%22%3A%22completion_end_date%22%2C%22operator%22%3A%22date_is_null%22%2C%22value%22%3Anull%7D%5D&isOr=false


---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
