### PR TITLE
Fix work types not showing as options with Project Extent - Generic

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -99,7 +99,7 @@ export const useComponentOptionsWithoutSignals = (options) =>
  */
 export const useSubcomponentOptions = (componentId, optionsData) =>
   useMemo(() => {
-    if (!componentId || !optionsData) return [];
+    if ((!componentId && componentId !== 0) || !optionsData) return [];
 
     const subcomponents = optionsData.find(
       (option) => option.component_id === componentId
@@ -124,7 +124,7 @@ export const useSubcomponentOptions = (componentId, optionsData) =>
  */
 export const useWorkTypeOptions = (componentId, optionsData) =>
   useMemo(() => {
-    if (!componentId || !optionsData) return [];
+    if ((!componentId && componentId !== 0) || !optionsData) return [];
 
     const workTypes = optionsData.find(
       (option) => option.component_id === componentId


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/19133

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Deploy preview

**Steps to test:**
1. Create a new component and choose the **Project Extent - Generic** component type
2. Try to select a work type and you should see three options - New, Maintenance / Repair, and Modification
3. Try the same in staging and you should see that no options show up in the work type dropdown
4. Check that subcomponents still work too since I updated that line to avoid this same type of bug

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
