### PR TITLE
fixes bug where role update is reflected as notes update

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3439,6 +3439,9 @@
       request_transform:
         body:
           action: transform
+          // this transformation or the schema itself may need to be refactored
+          // as it does not provide a project id or personnel id to associate this
+          // table with moped_proj_personnel in the activity log
           template: |-
             {
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",

--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -3439,9 +3439,6 @@
       request_transform:
         body:
           action: transform
-          // this transformation or the schema itself may need to be refactored
-          // as it does not provide a project id or personnel id to associate this
-          // table with moped_proj_personnel in the activity log
           template: |-
             {
               "query": "mutation InsertActivity($object: moped_activity_log_insert_input!) { insert_moped_activity_log_one(object: $object) { activity_id } }",

--- a/moped-editor/src/utils/activityLogFormatters/mopedPersonnelActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPersonnelActivity.js
@@ -41,12 +41,24 @@ export const formatPersonnelActivity = (change, userList) => {
     };
   }
 
-  // currently 'notes' is the only other editable field on this table
-  return {
+  // update the notes field
+  if (change.description[0].field === "notes")
+    return {
     changeIcon,
     changeText: [
       { text: "Updated team member notes for " },
       { text: userList[changeData.new.user_id], style: "boldText" },
     ],
   };
+
+  // the only other change that would be reflected here is adding or removing roles
+  else {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Updated personnel role for "},
+        { text: userList[changeData.new.user_id], style: "boldText"},
+      ]
+    }
+  }
 };


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/16950

this issue stems from the ``moped_proj_personnel_roles`` table not being associated with a ``project_id`` (rendering that field as ``null``) and therefore not returning records as part of the ``moped_activity_log`` query. investigating this has uncovered some potential tech debt when it comes to the activity log triggers (as noted in this pr), but @mddilley and i decided in the short term to fix the activity log rendering incorrect associations in the ui by assuming that a change made to the ``moped_proj_personnel`` table that is not related to a user or note is related to a role.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1424--atd-moped-main.netlify.app/

**Steps to test:**
- go to a project team and add or edit a team member
- change their role, the change should be reflected in the activity log
- change their notes, the change should also be reflected in the activity log

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
