### PR TITLE
Fix text overflowing outside of the Work Order Link column

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/Footer.js
+++ b/moped-editor/src/layouts/DashboardLayout/Footer.js
@@ -15,17 +15,17 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 /**
- * Async function that updates the mostRecentTag state based on API call to Github "tag" endpoint
+ * Async function that retrieves most recent tag from an API call to Github "tag" endpoint
  */
-const getMostRecentGithubTags = async (setMostRecentTag) => {
+const getMostRecentGithubTags = async () => {
   const githubTagsApiEndpoint =
     "https://api.github.com/repos/cityofaustin/atd-moped/tags";
   const response = await fetch(githubTagsApiEndpoint);
   const data = await response.json();
   if (get(data, 0)) {
-    setMostRecentTag(data[0].name);
+    return data[0].name;
   } else {
-    setMostRecentTag(`v${pckg.version}`);
+    return `v${pckg.version}`;
   }
 };
 
@@ -34,8 +34,9 @@ const Footer = () => {
   const [mostRecentTag, setMostRecentTag] = useState(`v${pckg.version}`); // use default tag
 
   useEffect(() => {
-    getMostRecentGithubTags(setMostRecentTag);
-  }, [setMostRecentTag]);
+    const tag = getMostRecentGithubTags();
+    setMostRecentTag(tag);
+  }, []);
 
   return (
     <div className={classes.root}>

--- a/moped-editor/src/layouts/DashboardLayout/Footer.js
+++ b/moped-editor/src/layouts/DashboardLayout/Footer.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import ExternalLink from "../../components/ExternalLink";
-import { get } from "lodash";
 
 var pckg = require("../../../package.json");
 
@@ -14,29 +13,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-/**
- * Async function that retrieves most recent tag from an API call to Github "tag" endpoint
- */
-const getMostRecentGithubTags = async () => {
-  const githubTagsApiEndpoint =
-    "https://api.github.com/repos/cityofaustin/atd-moped/tags";
-  const response = await fetch(githubTagsApiEndpoint);
-  const data = await response.json();
-  if (get(data, 0)) {
-    return data[0].name;
-  } else {
-    return `v${pckg.version}`;
-  }
-};
-
 const Footer = () => {
   const classes = useStyles();
-  const [mostRecentTag, setMostRecentTag] = useState(`v${pckg.version}`); // use default tag
-
-  useEffect(() => {
-    const tag = getMostRecentGithubTags();
-    setMostRecentTag(tag);
-  }, []);
 
   return (
     <div className={classes.root}>
@@ -44,7 +22,7 @@ const Footer = () => {
         Moped{" "}
         <ExternalLink
           text={`v${pckg.version}`}
-          url={`https://github.com/cityofaustin/atd-moped/releases/tag/${mostRecentTag}`}
+          url="https://github.com/cityofaustin/atd-moped/releases/latest"
           linkColor="inherit"
         />
       </Typography>

--- a/moped-editor/src/layouts/DashboardLayout/Footer.js
+++ b/moped-editor/src/layouts/DashboardLayout/Footer.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { Typography } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import ExternalLink from "../../components/ExternalLink";
 import { get } from "lodash";
 
 var pckg = require("../../../package.json");
 
-
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     paddingTop: theme.spacing(1),
     paddingLeft: theme.spacing(4),
@@ -15,28 +14,28 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+/**
+ * Async function that updates the mostRecentTag state based on API call to Github "tag" endpoint
+ */
+const getMostRecentGithubTags = async (setMostRecentTag) => {
+  const githubTagsApiEndpoint =
+    "https://api.github.com/repos/cityofaustin/atd-moped/tags";
+  const response = await fetch(githubTagsApiEndpoint);
+  const data = await response.json();
+  if (get(data, 0)) {
+    setMostRecentTag(data[0].name);
+  } else {
+    setMostRecentTag(`v${pckg.version}`);
+  }
+};
+
 const Footer = () => {
   const classes = useStyles();
   const [mostRecentTag, setMostRecentTag] = useState(`v${pckg.version}`); // use default tag
 
   useEffect(() => {
-    getMostRecentGithubTags();
-  });
-
-  /**
-   * Async function that updates the mostRecentTag state based on API callto Github "tag" endpoint
-   */
-  const getMostRecentGithubTags = async () => {
-    const githubTagsApiEndpoint =
-      "https://api.github.com/repos/cityofaustin/atd-moped/tags";
-    const response = await fetch(githubTagsApiEndpoint);
-    const data = await response.json();
-    if (get(data, 0)) {
-      setMostRecentTag(data[0].name);
-    } else {
-      setMostRecentTag(`v${pckg.version}`)
-    }
-  };
+    getMostRecentGithubTags(setMostRecentTag);
+  }, [setMostRecentTag]);
 
   return (
     <div className={classes.root}>

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -41,7 +41,7 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
       {
         headerName: "Contract #",
         field: "contract_number",
-        width: 125,
+        width: 150,
         defaultVisible: true,
       },
       {

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -22,7 +22,6 @@ import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
 import DeleteConfirmationModal from "../DeleteConfirmationModal";
 import { FormattedDateString } from "src/utils/dateAndTime";
 
-
 /** Hook that provides memoized column settings */
 const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
   useMemo(() => {
@@ -42,7 +41,7 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
       {
         headerName: "Contract #",
         field: "contract_number",
-        width: 150,
+        width: 125,
         defaultVisible: true,
       },
       {
@@ -74,14 +73,18 @@ const useColumns = ({ deleteInProgress, onDeleteActivity, setEditActivity }) =>
       {
         headerName: "Work Order Link",
         field: "work_order_url",
-        width: 150,
+        width: 175,
         defaultVisible: true,
         renderCell: ({ row }) =>
           row.work_order_url ? (
             <Link
               href={row.work_order_url}
               target={"_blank"}
-              sx={{ overflow: "hidden", textOverflow: "ellipsis" }}
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "block",
+              }}
             >
               {row.work_order_url}
             </Link>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19047

Just needed to set the Link to display as `block` for the other styles to take effect. 

I also decided to move a function out of the Footer definition, just to try to cut down on the calls to get the github tag. 

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->

https://deploy-preview-1426--atd-moped-main.netlify.app/moped/projects/2039?tab=funding

**Steps to test:**

I updated the project linked above to have the same long link as the project in the issue description, so compare above to https://mobility.austin.gov/moped/projects/3598?tab=funding



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added test for version link 
