### PR TITLE
Patch Moped AGOL ETL to handle invalid HTML (into `main`)

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -254,21 +254,20 @@ def main(args):
 
             features = all_features[feature_type]
 
-            # Check project status updates for valid or invalid HTML; escape html if needed
+            # Check project status updates for valid or invalid HTML; escape HTML if needed
             for record in features:
                 id = record["attributes"]["project_id"]
 
                 status_update = record["attributes"]["project_status_update"]
 
                 if has_html_tags(status_update):
-                    print(f"HTML tags found in project_id: {id}")
                     if not is_valid_HTML_tag(status_update):
-                        print(f"Invalid HTML tag found in project_id: {id}")
+                        logger.info(
+                            f"Invalid HTML tag found in project_id: {id}. Escaping HTML..."
+                        )
                         record["attributes"]["project_status_update"] = html.escape(
                             status_update
                         )
-                else:
-                    print(f"No HTML tags found in project_id: {id}")
 
             logger.info(
                 f"Uploading {len(features)} features in chunks of {UPLOAD_CHUNK_SIZE}..."

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -260,7 +260,7 @@ def main(args):
 
                 status_update = record["attributes"]["project_status_update"]
 
-                if has_html_tags(status_update):
+                if status_update != None and has_html_tags(status_update):
                     if not is_valid_HTML_tag(status_update):
                         logger.info(
                             f"Invalid HTML tag found in project_id: {id}. Escaping HTML..."

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -55,6 +55,34 @@ def is_valid_HTML_tag(html_string_to_check):
     return html_string_to_check == str(soup)
 
 
+def handle_status_updates(features):
+    """Check project status updates for valid or invalid HTML; escape HTML if needed.
+    Project status updates can be plain text, valid HTML, or invalid HTML. If invalid HTML is found,
+    the content of the update is escaped to prevent it from being rejected by AGOL (504 or 400 error).
+
+    Args:
+        features (list): list of Esri feature objects
+
+    Returns:
+        list: list of Esri feature objects with status update HTML escaped if needed
+    """
+    for record in features:
+        id = record["attributes"]["project_id"]
+
+        status_update = record["attributes"]["project_status_update"]
+
+        if status_update != None and has_html_tags(status_update):
+            if not is_valid_HTML_tag(status_update):
+                logger.info(
+                    f"Invalid HTML tag found in project_id: {id}. Escaping HTML..."
+                )
+                record["attributes"]["project_status_update"] = html.escape(
+                    status_update
+                )
+
+    return features
+
+
 def get_esri_geometry_key(geometry):
     """Identify the name of the geometry property that will hold coordinate data in an
     Esri feature object.
@@ -219,7 +247,9 @@ def main(args):
     if args.full:
         for feature_type in ["points", "lines", "combined", "exploded"]:
             logger.info(f"Processing {feature_type} features...")
-            features = all_features[feature_type]
+            features_of_type = all_features[feature_type]
+
+            features = handle_status_updates(features_of_type)
 
             logger.info("Deleting all existing features...")
             delete_all_features(feature_type)
@@ -252,22 +282,9 @@ def main(args):
                 logger.info(f"Deleting features with project ids {joined_project_ids}")
                 delete_features_by_project_ids(feature_type, joined_project_ids)
 
-            features = all_features[feature_type]
+            features_of_type = all_features[feature_type]
 
-            # Check project status updates for valid or invalid HTML; escape HTML if needed
-            for record in features:
-                id = record["attributes"]["project_id"]
-
-                status_update = record["attributes"]["project_status_update"]
-
-                if status_update != None and has_html_tags(status_update):
-                    if not is_valid_HTML_tag(status_update):
-                        logger.info(
-                            f"Invalid HTML tag found in project_id: {id}. Escaping HTML..."
-                        )
-                        record["attributes"]["project_status_update"] = html.escape(
-                            status_update
-                        )
+            features = handle_status_updates(features_of_type)
 
             logger.info(
                 f"Uploading {len(features)} features in chunks of {UPLOAD_CHUNK_SIZE}..."

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -4,10 +4,10 @@
 import argparse
 import logging
 import json
-import urllib.parse
-from bs4 import BeautifulSoup
-from html.parser import HTMLParser
+import html
 from datetime import datetime, timezone, timedelta
+
+from bs4 import BeautifulSoup
 
 from process.logging import get_logger
 from settings import (
@@ -265,9 +265,8 @@ def main(args):
                         print(f"HTML tags found in project_id: {id}")
                         if not is_valid_HTML_tag(status_update):
                             print(f"Invalid HTML tag found in project_id: {id}")
-                            print(urllib.parse.quote_plus(status_update))
-                            record["attributes"]["project_status_update"] = (
-                                urllib.parse.quote_plus(status_update)
+                            record["attributes"]["project_status_update"] = html.escape(
+                                status_update
                             )
                     else:
                         print(f"No HTML tags found in project_id: {id}")

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -258,18 +258,17 @@ def main(args):
             for record in features:
                 id = record["attributes"]["project_id"]
 
-                if id == 3601 or id == 3608 or id == 129:
-                    status_update = record["attributes"]["project_status_update"]
+                status_update = record["attributes"]["project_status_update"]
 
-                    if has_html_tags(status_update):
-                        print(f"HTML tags found in project_id: {id}")
-                        if not is_valid_HTML_tag(status_update):
-                            print(f"Invalid HTML tag found in project_id: {id}")
-                            record["attributes"]["project_status_update"] = html.escape(
-                                status_update
-                            )
-                    else:
-                        print(f"No HTML tags found in project_id: {id}")
+                if has_html_tags(status_update):
+                    print(f"HTML tags found in project_id: {id}")
+                    if not is_valid_HTML_tag(status_update):
+                        print(f"Invalid HTML tag found in project_id: {id}")
+                        record["attributes"]["project_status_update"] = html.escape(
+                            status_update
+                        )
+                else:
+                    print(f"No HTML tags found in project_id: {id}")
 
             logger.info(
                 f"Uploading {len(features)} features in chunks of {UPLOAD_CHUNK_SIZE}..."

--- a/moped-etl/arcgis/requirements.txt
+++ b/moped-etl/arcgis/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.*
+beautifulsoup4==4.12.*

--- a/moped-etl/arcgis/utils.py
+++ b/moped-etl/arcgis/utils.py
@@ -76,6 +76,7 @@ def handle_arcgis_response(response_data):
         return
 
     if response_data.get("error"):
+        print(response_data)
         # sometimes there is an error in the root of the response object 👍
         raise ValueError(response_data["error"])
 

--- a/moped-etl/arcgis/utils.py
+++ b/moped-etl/arcgis/utils.py
@@ -76,7 +76,6 @@ def handle_arcgis_response(response_data):
         return
 
     if response_data.get("error"):
-        print(response_data)
         # sometimes there is an error in the root of the response object 👍
         raise ValueError(response_data["error"])
 


### PR DESCRIPTION
## Associated issues
n/a

See https://austininnovation.slack.com/archives/CHZE6BC6L/p1727122151675579

I'll keep running the ETL manually tomorrow to give us time to review. Thanks y'all!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
n/a

**Steps to test:**
1. Start the local stack and get a fresh snapshot
2. Go to `atd-moped/moped-etl/arcgis` and follow the readme to set up your `env_file`
3. Run the ETL (the date arg in the command captures the project status update to project 3601 that surfaced the bug):
```bash
$ docker compose run arcgis -d 2024-09-23T19:18:34.543Z
```
4. You should see the script run and log one instance of the message `Invalid HTML tag found in project_id: 3601. Escaping HTML...` for project 3601. Other than the message, you'll see the script deleting updated features from the 4 AGOL layers and replacing the features for the updated projects.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
