### PR TITLE
Update component phase inputs to require both phase and completion date if phase simple is "Complete"

### DIFF
--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -105,6 +105,7 @@ export const PROJECT_COMPONENT_FIELDS = gql`
     moped_phase {
       phase_id
       phase_name
+      phase_name_simple
       moped_subphases {
         subphase_id
         subphase_name

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -34,13 +34,14 @@ export const GET_COMPONENTS_FORM_OPTIONS = gql`
     moped_phases(order_by: { phase_order: asc }) {
       phase_name
       phase_id
+      phase_name_simple
       moped_subphases {
         subphase_id
         subphase_name
       }
     }
     moped_component_tags(
-      order_by: [{ type: asc }, {name: asc}]
+      order_by: [{ type: asc }, { name: asc }]
       where: { is_deleted: { _eq: false } }
     ) {
       name

--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -5,12 +5,15 @@ import { parseISO, format } from "date-fns";
 /**
  * DateFieldEditComponent - renders a Date type Calendar select
  * @param {object} props - Values passed through Material Table `editComponent`
+ * @param {function} props.onChange - callback function to update the value
+ * @param {string} props.value - the current value
+ * @param {object} props.textFieldProps - additional props to pass to the picker's TextField
  * @return {JSX.Element}
  * @constructor
  */
 
 const DateFieldEditComponent = React.forwardRef(
-  ({ onChange, value, ...props }, ref) => {
+  ({ onChange, value, textFieldProps, ...props }, ref) => {
     const handleDateChange = (date) => {
       const newDate = date ? format(date, "yyyy-MM-dd") : null;
       onChange(newDate);
@@ -25,10 +28,7 @@ const DateFieldEditComponent = React.forwardRef(
         InputProps={{ style: { minWidth: "100px" } }}
         slotProps={{
           actionBar: { actions: ["accept", "cancel", "clear"] },
-          textField: {
-            helperText: "bad date",
-            error: true,
-          },
+          textField: textFieldProps,
         }}
         {...props}
       />

--- a/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
+++ b/moped-editor/src/views/projects/projectView/DateFieldEditComponent.js
@@ -23,7 +23,13 @@ const DateFieldEditComponent = React.forwardRef(
         value={value ? parseISO(value) : null}
         onChange={handleDateChange}
         InputProps={{ style: { minWidth: "100px" } }}
-        slotProps={{ actionBar: { actions: ["accept", "cancel", "clear"] } }}
+        slotProps={{
+          actionBar: { actions: ["accept", "cancel", "clear"] },
+          textField: {
+            helperText: "bad date",
+            error: true,
+          },
+        }}
         {...props}
       />
     );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -200,7 +200,8 @@ const ComponentForm = ({
     setValue,
   });
 
-  console.log({ phase, completionDate, errors });
+  // TODO: Clear completion date error when phase is cleared
+  // TODO: Integrate phase simple = Complete logic
 
   return (
     <form onSubmit={handleSubmit(onSave)}>
@@ -354,6 +355,8 @@ const ComponentForm = ({
                 name="phase"
                 control={control}
                 autoFocus
+                error={errors?.phase}
+                helperText={errors?.phase?.message}
               />
             </Grid>
             {subphaseOptions.length !== 0 && (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -201,9 +201,6 @@ const ComponentForm = ({
     setValue,
   });
 
-  // TODO: Clear completion date error when phase is cleared
-  // TODO: Integrate phase simple = Complete logic
-
   return (
     <form onSubmit={handleSubmit(onSave)}>
       <Grid container spacing={2}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -27,6 +27,7 @@ import {
   useResetDependentFieldOnParentFieldChange,
   getOptionLabel,
   isOptionEqualToValue,
+  isPhaseOptionSimpleComplete,
 } from "./utils/form";
 import ControlledAutocomplete from "../../../../components/forms/ControlledAutocomplete";
 import ControlledTextInput from "src/components/forms/ControlledTextInput";
@@ -60,8 +61,12 @@ const validationSchema = yup.object().shape({
     .nullable()
     .optional()
     .when("phase", {
-      is: (phase) => phase !== null,
-      then: yup.date().required("Enter completion date if a phase is selected"),
+      is: (phase) => isPhaseOptionSimpleComplete(phase),
+      then: yup
+        .date()
+        .required(
+          "Required if a phase with phase name simple of Complete is selected"
+        ),
     }),
   description: yup.string().nullable().optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
@@ -121,8 +126,7 @@ const ComponentForm = ({
     "signal",
   ]);
 
-  const isPhaseNameSimpleComplete =
-    phase?.data?.phase_name_simple === "Complete";
+  const isPhaseNameSimpleComplete = isPhaseOptionSimpleComplete(phase);
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const assetFeatureTable =
     component?.data?.asset_feature_layer?.internal_table;
@@ -367,7 +371,8 @@ const ComponentForm = ({
                 />
               </Grid>
             )}
-            {isPhaseNameSimpleComplete && (
+            {(isPhaseNameSimpleComplete ||
+              initialFormValues.completionDate) && (
               <Grid item xs={12}>
                 <Controller
                   id="completion-date"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -353,8 +353,6 @@ const ComponentForm = ({
                 name="phase"
                 control={control}
                 autoFocus
-                error={errors?.phase}
-                helperText={errors?.phase?.message}
               />
             </Grid>
             {subphaseOptions.length !== 0 && (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -366,8 +366,7 @@ const ComponentForm = ({
                 />
               </Grid>
             )}
-            {(isPhaseNameSimpleComplete ||
-              initialFormValues?.completionDate) && (
+            {(isPhaseNameSimpleComplete || completionDate) && (
               <Grid item xs={12}>
                 <Controller
                   id="completion-date"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -367,7 +367,7 @@ const ComponentForm = ({
               </Grid>
             )}
             {(isPhaseNameSimpleComplete ||
-              initialFormValues.completionDate) && (
+              initialFormValues?.completionDate) && (
               <Grid item xs={12}>
                 <Controller
                   id="completion-date"

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -383,6 +383,7 @@ const ComponentForm = ({
                         textFieldProps={{
                           helperText: errors?.completionDate?.message,
                           error: Boolean(errors?.completionDate),
+                          size: "small",
                         }}
                       />
                     );

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -49,41 +49,27 @@ const defaultFormValues = {
   srtsId: null,
 };
 
-const validationSchema = yup.object().shape(
-  {
-    component: yup.object().required(),
-    subcomponents: yup.array().optional(),
-    phase: yup
-      .object()
-      .nullable()
-      .optional()
-      .when("completionDate", {
-        is: (completionDate) => completionDate !== null,
-        then: yup
-          .object()
-          .required("Enter a phase if a completion date is entered"),
-      }),
-    subphase: yup.object().nullable().optional(),
-    tags: yup.array().optional(),
-    completionDate: yup
-      .date()
-      .nullable()
-      .optional()
-      .when("phase", {
-        is: (phase) => phase !== null,
-        then: yup
-          .date()
-          .required("Enter completion date if a phase is selected"),
-      }),
-    description: yup.string().nullable().optional(),
-    work_types: yup.array().of(yup.object()).min(1).required(),
-    // Signal field is required if the selected component inserts into the feature_signals table
-    signal: yup.object().nullable(),
-    srtsId: yup.string().nullable().optional(),
-    locationDescription: yup.string().nullable().optional(),
-  },
-  [["phase", "completionDate"]]
-);
+const validationSchema = yup.object().shape({
+  component: yup.object().required(),
+  subcomponents: yup.array().optional(),
+  phase: yup.object().nullable().optional(),
+  subphase: yup.object().nullable().optional(),
+  tags: yup.array().optional(),
+  completionDate: yup
+    .date()
+    .nullable()
+    .optional()
+    .when("phase", {
+      is: (phase) => phase !== null,
+      then: yup.date().required("Enter completion date if a phase is selected"),
+    }),
+  description: yup.string().nullable().optional(),
+  work_types: yup.array().of(yup.object()).min(1).required(),
+  // Signal field is required if the selected component inserts into the feature_signals table
+  signal: yup.object().nullable(),
+  srtsId: yup.string().nullable().optional(),
+  locationDescription: yup.string().nullable().optional(),
+});
 
 const ComponentForm = ({
   formButtonText,
@@ -134,6 +120,9 @@ const ComponentForm = ({
     "subcomponents",
     "signal",
   ]);
+
+  const isPhaseNameSimpleComplete =
+    phase?.data?.phase_name_simple === "Complete";
   const subphaseOptions = useSubphaseOptions(phase?.data.moped_subphases);
   const assetFeatureTable =
     component?.data?.asset_feature_layer?.internal_table;
@@ -158,6 +147,14 @@ const ComponentForm = ({
     dependentFieldName: "subphase",
     comparisonVariable: "value",
     valueToSet: defaultFormValues.subphase,
+    setValue,
+  });
+
+  useResetDependentFieldOnParentFieldChange({
+    parentValue: watch("phase"),
+    dependentFieldName: "completionDate",
+    comparisonVariable: "value",
+    valueToSet: defaultFormValues.completionDate,
     setValue,
   });
 
@@ -370,28 +367,30 @@ const ComponentForm = ({
                 />
               </Grid>
             )}
-            <Grid item xs={12}>
-              <Controller
-                id="completion-date"
-                name="completionDate"
-                control={control}
-                render={({ field }) => {
-                  return (
-                    <DateFieldEditComponent
-                      {...field}
-                      value={field.value}
-                      onChange={field.onChange}
-                      variant="outlined"
-                      label={"Completion date"}
-                      textFieldProps={{
-                        helperText: errors?.completionDate?.message,
-                        error: Boolean(errors?.completionDate),
-                      }}
-                    />
-                  );
-                }}
-              />
-            </Grid>
+            {isPhaseNameSimpleComplete && (
+              <Grid item xs={12}>
+                <Controller
+                  id="completion-date"
+                  name="completionDate"
+                  control={control}
+                  render={({ field }) => {
+                    return (
+                      <DateFieldEditComponent
+                        {...field}
+                        value={field.value}
+                        onChange={field.onChange}
+                        variant="outlined"
+                        label={"Completion date"}
+                        textFieldProps={{
+                          helperText: errors?.completionDate?.message,
+                          error: Boolean(errors?.completionDate),
+                        }}
+                      />
+                    );
+                  }}
+                />
+              </Grid>
+            )}
           </>
         )}
       </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -49,29 +49,41 @@ const defaultFormValues = {
   srtsId: null,
 };
 
-const validationSchema = yup.object().shape({
-  component: yup.object().required(),
-  subcomponents: yup.array().optional(),
-  phase: yup.object().nullable().optional(),
-  subphase: yup.object().nullable().optional(),
-  tags: yup.array().optional(),
-  completionDate: yup
-    .date()
-    .nullable()
-    .optional()
-    .when("phase", {
-      is: (phase) => !!phase,
-      then: yup
-        .date()
-        .required("Must enter phase completion date if a phase is selected"),
-    }),
-  description: yup.string().nullable().optional(),
-  work_types: yup.array().of(yup.object()).min(1).required(),
-  // Signal field is required if the selected component inserts into the feature_signals table
-  signal: yup.object().nullable(),
-  srtsId: yup.string().nullable().optional(),
-  locationDescription: yup.string().nullable().optional(),
-});
+const validationSchema = yup.object().shape(
+  {
+    component: yup.object().required(),
+    subcomponents: yup.array().optional(),
+    phase: yup
+      .object()
+      .nullable()
+      .optional()
+      .when("completionDate", {
+        is: (completionDate) => completionDate !== null,
+        then: yup
+          .object()
+          .required("Enter a phase if a completion date is entered"),
+      }),
+    subphase: yup.object().nullable().optional(),
+    tags: yup.array().optional(),
+    completionDate: yup
+      .date()
+      .nullable()
+      .optional()
+      .when("phase", {
+        is: (phase) => phase !== null,
+        then: yup
+          .date()
+          .required("Enter completion date if a phase is selected"),
+      }),
+    description: yup.string().nullable().optional(),
+    work_types: yup.array().of(yup.object()).min(1).required(),
+    // Signal field is required if the selected component inserts into the feature_signals table
+    signal: yup.object().nullable(),
+    srtsId: yup.string().nullable().optional(),
+    locationDescription: yup.string().nullable().optional(),
+  },
+  [["phase", "completionDate"]]
+);
 
 const ComponentForm = ({
   formButtonText,
@@ -188,7 +200,7 @@ const ComponentForm = ({
     setValue,
   });
 
-  console.log(errors);
+  console.log({ phase, completionDate, errors });
 
   return (
     <form onSubmit={handleSubmit(onSave)}>
@@ -368,6 +380,10 @@ const ComponentForm = ({
                       onChange={field.onChange}
                       variant="outlined"
                       label={"Completion date"}
+                      textFieldProps={{
+                        helperText: errors?.completionDate?.message,
+                        error: Boolean(errors?.completionDate),
+                      }}
                     />
                   );
                 }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -55,7 +55,16 @@ const validationSchema = yup.object().shape({
   phase: yup.object().nullable().optional(),
   subphase: yup.object().nullable().optional(),
   tags: yup.array().optional(),
-  completionDate: yup.date().nullable().optional(),
+  completionDate: yup
+    .date()
+    .nullable()
+    .optional()
+    .when("phase", {
+      is: (phase) => !!phase,
+      then: yup
+        .date()
+        .required("Must enter phase completion date if a phase is selected"),
+    }),
   description: yup.string().nullable().optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
@@ -178,6 +187,8 @@ const ComponentForm = ({
       : "",
     setValue,
   });
+
+  console.log(errors);
 
   return (
     <form onSubmit={handleSubmit(onSave)}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -394,7 +394,7 @@ export const useResetDependentFieldOnParentFieldChange = ({
       return;
     }
 
-    setValue(dependentFieldName, valueToSet);
+    setValue(dependentFieldName, valueToSet, { shouldValidate: true });
     setPreviousParentValue(parentValue);
   }, [
     parentValue,

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -141,6 +141,14 @@ export const useWorkTypeOptions = (componentId, optionsData) =>
   }, [componentId, optionsData]);
 
 /**
+ * Take a phase option record and check if it is has "Complete" for phase name simple
+ * @param {Object} phase Phase option chosen from the phase autocomplete or from the existing phase data
+ * @returns {Boolean} true if the phase's simple name is "Complete", false otherwise
+ */
+export const isPhaseOptionSimpleComplete = (phase) =>
+  Boolean(phase?.data?.phase_name_simple === "Complete");
+
+/**
  * Take the moped_phases records data response and create options for a MUI autocomplete
  * @param {Object} data Data returned with moped_phases records
  * @returns {Array} The options with value, label, and full data object to produce the phases options


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19113

This PR updates the component form validation and behavior so that:
- Completion Date is required if the Phase is **Complete** or **Post-Construction** (both have a simple name of Complete - see `moped_phases` table for reference)
- Completion Date is only available to be added if the Phase is **Complete** or **Post-Construction**

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1430--atd-moped-main.netlify.app/

**Steps to test:**
1. Go to an existing project and create a new component in the map tab
2. While using the create form, toggle the **Use component phase** switch on and choose any phase except for **Complete** or **Post-Construction**
3. You should see that the **Completion Date** field is now hidden with any phase except for **Complete** or **Post-Construction**
4. Now, choose **Complete** or **Post-Construction** and notice that a validation error requires you to enter a **Completion Date** if you have chosen either
5. Save your component and try editing the phase and completion date too
6. Try out different orders of adding **Complete** and then a **Completion Date** and then clearing the date or phase to make sure that the form **Continue** (creating) or **Save** (editing) is active when the validation requirements are met.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
