### PR TITLE
adds components dropdown and contains not operator

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersCommonOperators.js
+++ b/moped-editor/src/components/GridTable/FiltersCommonOperators.js
@@ -14,7 +14,7 @@ export const FILTERS_COMMON_OPERATORS = {
   },
   string_contains_not_case_insensitive: {
     operator: "_nilike",
-    label: "contains not",
+    label: "does not contain",
     description: "String is NOT contained in field (case-insensitive)",
     envelope: "%{VALUE}%",
     type: "string",

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -978,6 +978,10 @@ export const LOOKUP_TABLES_QUERY = gql`
       phase_id
       phase_name
     }
+    moped_components(order_by: { component_name_full: asc }) {
+      component_id
+      component_name_full
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -31,6 +31,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -45,6 +46,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -59,6 +61,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -73,6 +76,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -105,12 +109,14 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       getOptionLabel: (option) => option.type_name,
       operators: [
         "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
         "string_does_not_equal_case_insensitive",
       ],
     },
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -152,6 +158,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_blank",
@@ -171,6 +178,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_null",
@@ -195,6 +203,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_null",
@@ -219,6 +228,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_null",
@@ -235,6 +245,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       getOptionLabel: (option) => option.entity_name,
       operators: [
         "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
         "string_does_not_equal_case_insensitive",
       ],
@@ -242,6 +253,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_begins_with_case_insensitive",
@@ -258,6 +270,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_equals_case_insensitive",
@@ -274,11 +287,15 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     lookup: {
       table_name: "moped_fund_sources",
       getOptionLabel: (option) => option.funding_source_name,
-      operators: ["string_contains_case_insensitive"],
+      operators: [
+        "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive"
+      ],
     },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_is_null",
       "string_is_not_null",
     ],
@@ -291,6 +308,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_equals_case_insensitive",
@@ -339,12 +357,14 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       getOptionLabel: (option) => `${option.first_name} ${option.last_name}`,
       operators: [
         "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
       ],
     },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_is_null",
@@ -361,12 +381,14 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       getOptionLabel: (option) => `${option.first_name} ${option.last_name}`,
       operators: [
         "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
       ],
     },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_is_null",
@@ -381,6 +403,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_equals_case_insensitive",
@@ -397,6 +420,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_equals_case_insensitive",
@@ -413,11 +437,15 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     lookup: {
       table_name: "moped_tags",
       getOptionLabel: (option) => option.name,
-      operators: ["string_contains_case_insensitive"],
+      operators: [
+        "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
+      ],
     },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_null",
@@ -442,6 +470,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
     ],
@@ -464,6 +493,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_equals_case_insensitive",
       "string_does_not_equal_case_insensitive",
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_begins_with_case_insensitive",
       "string_ends_with_case_insensitive",
       "string_is_null",
@@ -498,9 +528,18 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     label: "Components",
     placeholder: "component",
     type: "string",
+    lookup: {
+      table_name: "moped_components",
+      getOptionLabel: (option) => `${option.component_name_full}`,
+      operators: [
+        "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive"
+      ],
+    },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
       "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
       "string_is_null",
       "string_is_not_null",
     ],

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -173,7 +173,10 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     lookup: {
       table_name: "moped_users",
       getOptionLabel: (option) => `${option.first_name} ${option.last_name}`,
-      operators: ["string_contains_case_insensitive"],
+      operators: [
+        "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
+      ],
     },
     defaultOperator: "string_contains_case_insensitive",
     operators: [
@@ -359,6 +362,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_contains_case_insensitive",
         "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
+        "string_does_not_equal_case_insensitive",
       ],
     },
     defaultOperator: "string_contains_case_insensitive",
@@ -383,6 +387,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
         "string_contains_case_insensitive",
         "string_contains_not_case_insensitive",
         "string_equals_case_insensitive",
+        "string_does_not_equal_case_insensitive",
       ],
     },
     defaultOperator: "string_contains_case_insensitive",

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -80,7 +80,7 @@ const makeAdvancedSearchWhereFilters = (filters) =>
         }
       }
       // If we would like to return results that do not contain a particular string, we should return null values as well
-      if (gqlOperator.includes("_nilike") && envelope) {
+      if (gqlOperator.includes("_nilike")) {
         whereString = `_or: [ { ${whereString} }, { ${field}: { ${`_is_null`}: true } }]`
       }
       return whereString;

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -79,6 +79,10 @@ const makeAdvancedSearchWhereFilters = (filters) =>
           whereString = `${field}: { ${"_gte"}: ${nextDay} }`;
         }
       }
+      // If we would like to return results that do not contain a particular string, we should return null values as well
+      if (gqlOperator.includes("_nilike") && envelope) {
+        whereString = `_or: [ { ${whereString} }, { ${field}: { ${`_is_null`}: true } }]`
+      }
       return whereString;
     })
     .filter((value) => value !== null);


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/19052

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1439--atd-moped-main.netlify.app/

**Steps to test:**
- note the number of records in the project view with no filters applied
- add an advanced filter for 'components' 'contains', select an option and note the number of records
- replace the filter with the same query but using the 'does not contain' operator, and note whether the number of records makes up the difference. also check to make sure records with no value in the 'component' field appear.
- repeat the steps with the 'is' and 'is not' operators for a different field (such as 'type')
- confirm that fields with the 'is' and 'contains' operators also include their opposites

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added to the existing "contains" test to check the sum of "contains" and "does not contain" to make sure it equals the total number of projects
