### PR TITLE
Change Post Construction badge color to match Completed

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
+++ b/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
@@ -83,7 +83,7 @@ export const styleMapping = {
   },
   post_construction: {
     color: white,
-    background: backgroundColors.success,
+    background: backgroundColors.info,
     icon: PlayCircleOutlineOutlinedIcon,
   },
   potential: {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19256

## Testing
**URL to test:** 

https://deploy-preview-1440--atd-moped-main.netlify.app/moped/projects?map=false&filters=%5B%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22agave%22%7D%2C%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22kingfisher%22%7D%2C%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22loblolly%22%7D%5D&isOr=true

**Steps to test:**

Go to the deploy preview, I have prefiltered projects with post construction, planned and preconstruction statuses. Toggle on the map tab and you can see that the project in post construction is in blue. [Here](https://moped.austinmobility.io/moped/projects?map=false&filters=%5B%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22agave%22%7D%2C%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22kingfisher%22%7D%2C%7B%22field%22%3A%22project_name_full%22%2C%22operator%22%3A%22string_contains_case_insensitive%22%2C%22value%22%3A%22loblolly%22%7D%5D&isOr=true) are the same projects filtered on staging. Check the map here, everything is green.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
