### PR TITLE
Fix missed project and component deletes in AGOL ETL incremental runs

### DIFF
--- a/moped-etl/arcgis/README.md
+++ b/moped-etl/arcgis/README.md
@@ -37,4 +37,4 @@ The fourth layer is sourced from a derivative view, `exploded_component_arcgis_o
 To run the script without making changes to the AGOL dataset, use the `-t` flag (`--test`) to fetch the project IDs to delete and the component data to use for AGOL record replacement. This is useful to observe what projects have updated and what component data will be transferred without updating the production AGOL dataset.
 
 1. Run the script with the test flag and any of the available options above:
-   - `docker compose run arcgis -d` to start the script in test mode with the default interval of changes over the last week.
+   - `docker compose run arcgis -d <timestamptz> -t` to start the script in test mode with the default interval of changes over the last week.

--- a/moped-etl/arcgis/README.md
+++ b/moped-etl/arcgis/README.md
@@ -31,3 +31,10 @@ The fourth layer is sourced from a derivative view, `exploded_component_arcgis_o
    - `docker compose run arcgis -f` to start the script with a full refresh.
    - `docker compose run arcgis -d <timestamptz>` to start the script with a refresh since the given timestamp.
    - `docker compose run --entrypoint /bin/bash arcgis` to start a shell inside the container.
+
+## Testing the Script
+
+To run the script without making changes to the AGOL dataset, use the `-t` flag (`--test`) to fetch the project IDs to delete and the component data to use for AGOL record replacement. This is useful to observe what projects have updated and what component data will be transferred without updating the production AGOL dataset.
+
+1. Run the script with the test flag and any of the available options above:
+   - `docker compose run arcgis -d` to start the script in test mode with the default interval of changes over the last week.

--- a/moped-etl/arcgis/README.md
+++ b/moped-etl/arcgis/README.md
@@ -37,4 +37,4 @@ The fourth layer is sourced from a derivative view, `exploded_component_arcgis_o
 To run the script without making changes to the AGOL dataset, use the `-t` flag (`--test`) to fetch the project IDs to delete and the component data to use for AGOL record replacement. This is useful to observe what projects have updated and what component data will be transferred without updating the production AGOL dataset.
 
 1. Run the script with the test flag and any of the available options above:
-   - `docker compose run arcgis -d <timestamptz> -t` to start the script in test mode with the default interval of changes over the last week.
+   - `docker compose run arcgis -d <timestamptz> -t` to start the script in test mode with a refresh since the given timestamp.

--- a/moped-etl/arcgis/cli.py
+++ b/moped-etl/arcgis/cli.py
@@ -1,0 +1,37 @@
+import argparse
+from datetime import datetime, timezone, timedelta
+
+
+def get_cli_args():
+    """Create the CLI and parse args
+
+    Returns:
+        argparse.Namespace: The CLI namespace
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-d",
+        "--date",
+        type=str,
+        nargs="?",
+        const=(datetime.now(timezone.utc) - timedelta(days=7)).isoformat(),
+        default=None,
+        help="ISO date string with TZ offset (ex. 2024-06-28T00:06:16.360805+00:00) of latest updated_at value to find project records to update. Defaults to 7 days ago if -d is used without a value.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--full",
+        action="store_true",
+        help="Delete and replace all project components.",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--test",
+        action="store_true",
+        help="Run script without making changes to the AGOL dataset",
+    )
+
+    return parser.parse_args()

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -222,9 +222,12 @@ def main(args):
     get_token()
 
     variables = (
-        {"where": {}}
+        {"project_where": {}, "component_where": {}}
         if args.full
-        else {"where": {"project_updated_at": {"_gt": args.date}}}
+        else {
+            "project_where": {"updated_at": {"_gt": args.date}},
+            "component_where": {"project_updated_at": {"_gt": args.date}},
+        }
     )
 
     logger.info(
@@ -237,7 +240,7 @@ def main(args):
 
     exploded_data = make_hasura_request(
         query=EXPLODED_COMPONENTS_QUERY_BY_LAST_UPDATE_DATE,
-        variables=variables,
+        variables={"where": variables["component_where"]},
     )["exploded_component_arcgis_online_view"]
 
     all_features = make_all_features(data, exploded_data)

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -265,7 +265,7 @@ def main(args):
                 if not args.test:
                     add_features(feature_type, feature_chunk)
     else:
-        # Get project IDs have been updated (including soft-deleted projects) for deletes
+        # Get project IDs that have been updated (including soft-deleted projects) for deletes
         project_ids_for_delete = [project["project_id"] for project in projects_data]
 
         # Delete outdated feature from AGOL and add updated features

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -220,6 +220,7 @@ def main(args):
     logger.info("Getting token...")
     get_token()
 
+    # Pass filters to the GraphQL query: none if full replace OR include a date filter for incremental updates
     variables = (
         {"project_where": {}, "component_where": {}}
         if args.full

--- a/moped-etl/arcgis/components_to_agol.py
+++ b/moped-etl/arcgis/components_to_agol.py
@@ -219,7 +219,7 @@ def make_all_features(data, exploded_geometry):
 
 def main(args):
     logger.info("Getting token...")
-    # get_token()
+    get_token()
 
     variables = (
         {"project_where": {}, "component_where": {}}
@@ -263,37 +263,29 @@ def main(args):
                 logger.info("Uploading chunk....")
                 add_features(feature_type, feature_chunk)
     else:
-        # Get unique project IDs that need to have features deleted & replaced
+        # Get project IDs have been updated (including soft-deleted projects) for deletes
         project_ids_for_delete = [project["project_id"] for project in projects_data]
-        print(project_ids_for_replace)
-        print(project_ids_for_delete)
-        print(len(all_features["points"]))
-
-        # TODO get all project IDs to delete
-        # TODO find the difference so we can delete the remaining rows at the end (the missed deletes)
 
         # Delete outdated feature from AGOL and add updated features
-        # for feature_type in ["points", "lines", "combined", "exploded"]:
-        #     logger.info(f"Processing {feature_type} features...")
-        #     features_of_type = all_features[feature_type]
-        #     features = handle_status_updates(features_of_type)
+        for feature_type in ["points", "lines", "combined", "exploded"]:
+            logger.info(f"Processing {feature_type} features...")
+            features_of_type = all_features[feature_type]
+            features = handle_status_updates(features_of_type)
 
-        #     logger.info(
-        #         f"Deleting all {len(all_features[feature_type])} existing features in {feature_type} layer for updated projects in chunks of {UPLOAD_CHUNK_SIZE}..."
-        #     )
-        #     for delete_chunk in chunks(
-        #         project_ids_for_feature_delete, UPLOAD_CHUNK_SIZE
-        #     ):
-        #         joined_project_ids = ", ".join(str(x) for x in delete_chunk)
-        #         logger.info(f"Deleting features with project ids {joined_project_ids}")
-        #         delete_features_by_project_ids(feature_type, joined_project_ids)
+            logger.info(
+                f"Deleting all existing features in {feature_type} layer for updated projects in chunks of {UPLOAD_CHUNK_SIZE}..."
+            )
+            for delete_chunk in chunks(project_ids_for_delete, UPLOAD_CHUNK_SIZE):
+                joined_project_ids = ", ".join(str(x) for x in delete_chunk)
+                logger.info(f"Deleting features with project ids {joined_project_ids}")
+                delete_features_by_project_ids(feature_type, joined_project_ids)
 
-        #     logger.info(
-        #         f"Uploading {len(features)} features in chunks of {UPLOAD_CHUNK_SIZE}..."
-        #     )
-        #     for feature_chunk in chunks(features, UPLOAD_CHUNK_SIZE):
-        #         logger.info("Uploading chunk....")
-        #         add_features(feature_type, feature_chunk)
+            logger.info(
+                f"Uploading {len(features)} features in chunks of {UPLOAD_CHUNK_SIZE}..."
+            )
+            for feature_chunk in chunks(features, UPLOAD_CHUNK_SIZE):
+                logger.info("Uploading chunk....")
+                add_features(feature_type, feature_chunk)
 
 
 if __name__ == "__main__":

--- a/moped-etl/arcgis/settings.py
+++ b/moped-etl/arcgis/settings.py
@@ -3,11 +3,11 @@ UPLOAD_CHUNK_SIZE = 100
 LAYER_IDS = {"points": 0, "lines": 1, "combined": 2, "exploded": 3}
 
 COMPONENTS_QUERY_BY_LAST_UPDATE_DATE = """
-query GetProjectsComponents($where: component_arcgis_online_view_bool_exp!) {
-  moped_project(where: $projectWhere) {
+query GetProjectsComponents($project_where: moped_project_bool_exp!, $component_where: component_arcgis_online_view_bool_exp!) {
+  moped_project(where: $project_where) {
     project_id
   }
-  component_arcgis_online_view(where: $componentWhere) {
+  component_arcgis_online_view(where: $component_where) {
     component_categories
     component_description
     component_id

--- a/moped-etl/arcgis/settings.py
+++ b/moped-etl/arcgis/settings.py
@@ -4,7 +4,10 @@ LAYER_IDS = {"points": 0, "lines": 1, "combined": 2, "exploded": 3}
 
 COMPONENTS_QUERY_BY_LAST_UPDATE_DATE = """
 query GetProjectsComponents($where: component_arcgis_online_view_bool_exp!) {
-  component_arcgis_online_view(where: $where) {
+  moped_project(where: $projectWhere) {
+    project_id
+  }
+  component_arcgis_online_view(where: $componentWhere) {
     component_categories
     component_description
     component_id


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19233

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**

**Note: I added a test mode (dry run) that does not update the AGOL dataset to make it easier to test this fix.**
1. Generate an ISO string timestamp using this JS or however you'd like
```js
const dateObj = new Date();
dateObj.toISOString();
```
2. Start your local Moped stack and set up an `env_file` for this script using the instructions in the readme if needed
3. Create a new project and add one point type component (like Bike Box) to **delete** in a later step
4. Create another new project and add one line type component (like Bike Lane) to **edit** in a later step
5. Run the script in test mode from `atd-moped/moped-etl/arcgis` with your ISO string timestamp:
```shell
docker compose run arcgis -d 2024-10-07T21:18:42.586Z -t
```
6. You should see `Deleting features with project ids <your two new project ids>...` logged four times and also see the counts 1, 1, 2, and 1 logged for each type associated with the 4 AGOL layers. This is showing that 1 point feature, 1 line feature, 2 combined (point and line), and one exploded point feature would be transferred if this was not a test/dry run.
7. Now, get a fresh timestamp and then add a project lead to the project with the bike lane. This tests a project edit and the resulting AGOL dataset update. Its features will be deleted from the AGOL dataset and the updated feature rows are transferred.
8. Run the script again in test mode with your newest timestamp
9. Now you should see `Deleting features with project ids <your bike lane project id>...` logged four times and also see the counts 0, 1, 1, 0 logged this time (1 line type and 1 combined type).
10. Get a new timestamp and then delete your bike box project. This tests what should happen when a project is deleted. Its features will be deleted from the AGOL dataset and no new feature rows are transferred.
11. Run the script again in test mode with your newest timestamp
12. Now you should see `Deleting features with project ids <your bike box project id>...` logged four times and see 0, 0, 0, 0 logged for each type since we don't have any features to transfer for the deleted project.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
