### PR TITLE
Docker compose restart pragma

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - 'HASURA_GRAPHQL_JWT_SECRET={"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}'
             - HASURA_GRAPHQL_ADMIN_SECRET=hasurapassword
             - ACTIVITY_LOG_API_SECRET=hasurapassword
+            - HASURA_GRAPHQL_NO_OF_RETRIES=30
         command: ["graphql-engine", "serve",  "--enable-console"]
 
 

--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -2,7 +2,6 @@
 services:
     hasura:
         image: hasura/graphql-engine:v2.43.0
-        restart: always
         depends_on:
             - moped-pgsql
         expose:


### PR DESCRIPTION
# Associated issues

This PR is intended to close https://github.com/cityofaustin/atd-data-tech/issues/18960. 

# Testing

This is the easiest thing to test in the world. Please check out this branch, `cd` into the `moped-database` directory, and execute a `hasura-cluster start`. Did it work? Did you get a running postgres container and a running graphql-engine container?

## A note on testing this

The number of retries is chosen out of thin air -- it can be 30, 300, 3000, whatever -- just not 1. It needs to be large enough to keep `graphql-engine` retrying the PG container long enough for the PG container to initialize the fresh DB, which it does on start before it begins accepting connections. I'm asking that everyone who is a regular moped contributor to test this because really, I want to test that this magic number 30 works for all of us. Essentially whoever has the slowest disk or the slowest computer overall will be the person who determines if 30 is suitable. 

# Background

_This is copy borrowed from a conversation between @mddilley and myself._

> Super short story, is that here’s what happens when you fire up the DB compose stack without a restart pragma or my proposed solution:

> 1) Both the DB and the graphql-engine containers fire up at the same time.
> 2) The DB container takes maybe 5-10 seconds to initialize itself before it accept connections
> 3) The graphql-engine container reaches out to the PG container during this initialization and finds that it is not yet accepting connections and terminates.

> It’s because of this, we have this restart pragma where the compose system restarts it over and over until the PG container is initialized, essentially making a “retry connection” functionality.

> So, I propose, instead of using the restart functionality, we rather ask the `graphql-engine` container to retry using the environment variable `HASURA_GRAPHQL_NO_OF_RETRIES`, like [this](https://github.com/cityofaustin/atd-moped/pull/1442/files).

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
