### PR TITLE
Fix warnings in Component Form

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -404,6 +404,7 @@ const ComponentForm = ({
                 name="phase"
                 control={control}
                 autoFocus
+                sOptionEqualToValue={isOptionEqualToValue}
               />
             </Grid>
             {subphaseOptions.length !== 0 && (
@@ -414,6 +415,7 @@ const ComponentForm = ({
                   options={subphaseOptions}
                   name="subphase"
                   control={control}
+                  isOptionEqualToValue={isOptionEqualToValue}
                 />
               </Grid>
             )}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -404,7 +404,7 @@ const ComponentForm = ({
                 name="phase"
                 control={control}
                 autoFocus
-                sOptionEqualToValue={isOptionEqualToValue}
+                isOptionEqualToValue={isOptionEqualToValue}
               />
             </Grid>
             {subphaseOptions.length !== 0 && (

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/utils/form.js
@@ -1,7 +1,10 @@
 import { useMemo, useEffect, useState } from "react";
 import { Icon } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import { featureSchoolBeaconRecordToKnackSchoolBeaconRecord, featureSignalsRecordToKnackSignalRecord } from "src/utils/signalComponentHelpers";
+import {
+  featureSchoolBeaconRecordToKnackSchoolBeaconRecord,
+  featureSignalsRecordToKnackSignalRecord,
+} from "src/utils/signalComponentHelpers";
 import { isSignalComponent } from "./componentList";
 import {
   RoomOutlined as RoomOutlinedIcon,


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19221

## Testing
**URL to test:** 

https://deploy-preview-1443--atd-moped-main.netlify.app/moped

**Steps to test:**

Go to a project's map, add a component or edit an existing component. 
Open your developer console, make sure you have default levels on, or at least able to see warnings. 
Toggle on "use component phase"

![Screenshot 2024-10-09 at 9 41 55 AM](https://github.com/user-attachments/assets/5dde03c2-9f5f-48d5-8a0b-dd22d4803cf8)

Choose a phase and subphase. The warning does not appear. 

However, if you choose a phase and a subphase, and then switch to a different phase with subphases, you will see the warning appear. The form [resets the subphase](https://github.com/cityofaustin/atd-moped/blob/main/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js#L169) when the phase changes, but the new phase's options are loaded in the autocomplete before that happens. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
