### PR TITLE
adds substantial completion date tooltip

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -315,7 +315,7 @@ export const useColumns = ({ hiddenColumns }) => {
       {
         headerName: "Substantial completion date",
         field: "substantial_completion_date",
-        description: "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-Construction)",
+        description: "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)",
         valueFormatter: (value) => value && formatDateType(value),
         width: COLUMN_WIDTHS.small,
       },

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -315,6 +315,7 @@ export const useColumns = ({ hiddenColumns }) => {
       {
         headerName: "Substantial completion date",
         field: "substantial_completion_date",
+        description: "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-Construction)",
         valueFormatter: (value) => value && formatDateType(value),
         width: COLUMN_WIDTHS.small,
       },

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -7,6 +7,7 @@ import ExternalLink from "../../../components/ExternalLink";
 import ProjectStatusBadge from "../projectView/ProjectStatusBadge";
 import RenderSignalLink from "../../../components/RenderSignalLink";
 import { PROJECT_LIST_VIEW_QUERY_CONFIG } from "./ProjectsListViewQueryConf";
+import { substantialCompletionDateTooltipText } from "../../../constants/projects";
 import theme from "src/theme";
 
 export const filterNullValues = (value) => {
@@ -315,7 +316,7 @@ export const useColumns = ({ hiddenColumns }) => {
       {
         headerName: "Substantial completion date",
         field: "substantial_completion_date",
-        description: "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)",
+        description: substantialCompletionDateTooltipText,
         valueFormatter: (value) => value && formatDateType(value),
         width: COLUMN_WIDTHS.medium,
       },


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/19259

based off pr  https://github.com/cityofaustin/atd-moped/pull/1453

I believe the placement of this definition is centralized since we can import this helper object into the project view, but please let me know if there would be a better place to store it!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1454--atd-moped-main.netlify.app/

**Steps to test:**
- in the projects list view, hover over 'Substantial completion date'
- note that a tooltip appears reading 'The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-Construction)'

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added to sort by headers test 
