### PR TITLE
Add `marginRight` and flex`<Box/>` to prevent text/button overlap

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -26,6 +26,8 @@ const useStyles = makeStyles((theme) => ({
   },
   listItemText: {
     marginLeft: theme.spacing(1),
+    flexGrow: 1, 
+    marginRight: '48px',
   },
   additionalListItemText: {
     display: "block",
@@ -61,23 +63,25 @@ export default function ComponentListItem({
         ref={component._ref}
       >
         {isComponentMapped ? Icon : <ErrorOutlineIcon color="error" />}
-        <ListItemText
-          className={classes.listItemText}
-          primary={primary}
-          secondary={
-            <>
-              <>{secondary}</>
-              <span className={classes.additionalListItemText}>
-                {additionalListItemText}
-              </span>
-            </>
-          }
-        />
-        <ListItemSecondaryAction>
-          <IconButton color="primary" onClick={onZoomClick} size="large">
-            <ZoomInIcon />
-          </IconButton>
-        </ListItemSecondaryAction>
+        <Box display="flex" alignItems="center" width="100%">
+          <ListItemText
+            className={classes.listItemText}
+            primary={primary}
+            secondary={
+              <>
+                <>{secondary}</>
+                <span className={classes.additionalListItemText}>
+                  {additionalListItemText}
+                </span>
+              </>
+            }
+          />
+          <ListItemSecondaryAction>
+            <IconButton color="primary" onClick={onZoomClick} size="large">
+              <ZoomInIcon />
+            </IconButton>
+          </ListItemSecondaryAction>
+        </Box>
       </ListItemButton>
       <Collapse in={isExpanded}>
         {isExpanded ? (


### PR DESCRIPTION
## Associated issues

Fixes https://github.com/cityofaustin/atd-data-tech/issues/17689

### Before

<img width="508" alt="Screenshot 2024-06-05 at 5 48 43 PM" src="https://github.com/cityofaustin/atd-data-tech/assets/37249039/8ca7fd7a-8483-4eed-a780-89a3e92f5ec3">

### After

![Screenshot 2024-10-14 at 4 13 34 PM](https://github.com/user-attachments/assets/31f55531-1c29-4b92-bb36-0bb37a8aa604)


## Testing
**URL to test:** 
[https://deploy-preview-1455--atd-moped-main.netlify.app/moped/projects/2037?tab=map](https://deploy-preview-1455--atd-moped-main.netlify.app/moped/projects/2037?tab=map)

**Steps to test:**
1. Look at the existing components and confirm the Component name text does not overlap with the Zoom In Icon. 
2. Create a new component with a long name (ex: a traffic signal like 25: MLK & Congress).

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
