### PR TITLE
Show substantial completion date in the Phases table of the project Timeline tab

### DIFF
--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -1,2 +1,2 @@
 export const substantialCompletionDateTooltipText =
-  "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)";
+  "The earliest confirmed date of any Complete or Post-construction phase";

--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -1,0 +1,2 @@
+export const substantialCompletionDateTooltipText =
+  "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)";

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -1021,3 +1021,12 @@ export const GET_PROJECTS_GEOGRAPHIES = gql`
     }
   }
 `;
+
+export const GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE = gql`
+  query MopedProjectCompletionDate($projectId: Int) {
+    project_list_view(where: { project_id: { _eq: $projectId } }) {
+      substantial_completion_date
+      project_id
+    }
+  }
+`;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -1025,12 +1025,3 @@ export const GET_PROJECTS_GEOGRAPHIES = gql`
     }
   }
 `;
-
-export const GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE = gql`
-  query MopedProjectCompletionDate($projectId: Int) {
-    project_list_view(where: { project_id: { _eq: $projectId } }) {
-      substantial_completion_date
-      project_id
-    }
-  }
-`;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -325,6 +325,10 @@ export const TIMELINE_QUERY = gql`
         related_phase_id
       }
     }
+    project_list_view(where: { project_id: { _eq: $projectId } }) {
+      substantial_completion_date
+      project_id
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -73,7 +73,6 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     color: theme.palette.text.secondary,
     fontSize: ".8rem",
-    margin: "8px 0",
   },
   fieldBox: {
     maxWidth: "10rem",

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -91,6 +91,9 @@ const useStyles = makeStyles((theme) => ({
       cursor: "pointer",
     },
   },
+  toolbarTitle: {
+    marginBottom: theme.spacing(1)
+  }
 }));
 
 // memoized hook to concatanate fund dept and unit ids into an fdu string

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingToolbar.js
@@ -17,7 +17,7 @@ const ProjectFundingToolbar = ({
 }) => (
   <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
     <div>
-      <Typography variant="h2" color="primary" style={{ paddingTop: "1em" }}>
+      <Typography variant="h2" color="primary">
         Funding sources
       </Typography>
       <ProjectSummaryProjectECapris

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingToolbar.js
@@ -17,7 +17,7 @@ const ProjectFundingToolbar = ({
 }) => (
   <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
     <div>
-      <Typography variant="h2" color="primary">
+      <Typography variant="h2" color="primary" className={classes.toolbarTitle}>
         Funding sources
       </Typography>
       <ProjectSummaryProjectECapris
@@ -45,7 +45,6 @@ const ProjectFundingToolbar = ({
         variant="contained"
         color="primary"
         startIcon={<AddCircleIcon />}
-        // ref={addActionRef}
         onClick={onClick}
       >
         Add Funding Source

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
@@ -6,7 +6,7 @@ import ProjectSubstantialCompletionDate from "./ProjectSubstantialCompletionDate
 const ProjectPhaseToolbar = ({ addAction, setIsDialogOpen, completionDate }) => (
   <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
     <div>
-      <Typography variant="h2" color="primary" style={{ paddingTop: "1em" }}>
+      <Typography variant="h2" color="primary">
         Phases
       </Typography>
       <ProjectSubstantialCompletionDate completionDate={completionDate} />

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
@@ -3,13 +3,13 @@ import ButtonDropdownMenu from "src/components/ButtonDropdownMenu";
 import ProjectSubstantialCompletionDate from "./ProjectSubstantialCompletionDate";
 
 /** Custom toolbar title that resembles material table titles  */
-const ProjectPhaseToolbar = ({ addAction, setIsDialogOpen }) => (
+const ProjectPhaseToolbar = ({ addAction, setIsDialogOpen, completionDate }) => (
   <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
     <div>
       <Typography variant="h2" color="primary" style={{ paddingTop: "1em" }}>
         Phases
       </Typography>
-      <ProjectSubstantialCompletionDate text="test" />
+      <ProjectSubstantialCompletionDate completionDate={completionDate} />
     </div>
     <div style={{ padding: "1rem" }}>
       <ButtonDropdownMenu

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
@@ -1,12 +1,21 @@
 import { Box, Typography } from "@mui/material";
 import ButtonDropdownMenu from "src/components/ButtonDropdownMenu";
 import ProjectSubstantialCompletionDate from "./ProjectSubstantialCompletionDate";
+import theme from "src/theme";
 
 /** Custom toolbar title that resembles material table titles  */
-const ProjectPhaseToolbar = ({ addAction, setIsDialogOpen, completionDate }) => (
+const ProjectPhaseToolbar = ({
+  addAction,
+  setIsDialogOpen,
+  completionDate,
+}) => (
   <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
     <div>
-      <Typography variant="h2" color="primary">
+      <Typography
+        variant="h2"
+        color="primary"
+        sx={{ marginBottom: theme.spacing(1) }}
+      >
         Phases
       </Typography>
       <ProjectSubstantialCompletionDate completionDate={completionDate} />

--- a/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhaseToolbar.js
@@ -1,13 +1,16 @@
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
+import { Box, Typography } from "@mui/material";
 import ButtonDropdownMenu from "src/components/ButtonDropdownMenu";
+import ProjectSubstantialCompletionDate from "./ProjectSubstantialCompletionDate";
 
 /** Custom toolbar title that resembles material table titles  */
 const ProjectPhaseToolbar = ({ addAction, setIsDialogOpen }) => (
-  <Box display="flex" justifyContent="space-between">
-    <Typography variant="h2" color="primary" style={{ padding: "1em" }}>
-      Phases
-    </Typography>
+  <Box display="flex" justifyContent="space-between" sx={{ margin: "1em" }}>
+    <div>
+      <Typography variant="h2" color="primary" style={{ paddingTop: "1em" }}>
+        Phases
+      </Typography>
+      <ProjectSubstantialCompletionDate text="test" />
+    </div>
     <div style={{ padding: "1rem" }}>
       <ButtonDropdownMenu
         addAction={addAction}

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useMutation, useQuery } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import { CircularProgress, Box, IconButton } from "@mui/material";
 import { DataGridPro } from "@mui/x-data-grid-pro";
 import { green } from "@mui/material/colors";
@@ -12,10 +12,7 @@ import ProjectPhaseToolbar from "./ProjectPhaseToolbar";
 import PhaseTemplateModal from "./PhaseTemplateModal";
 import ProjectPhaseDialog from "./ProjectPhaseDialog";
 import ProjectPhaseDateConfirmationPopover from "./ProjectPhaseDateConfirmationPopover";
-import {
-  DELETE_PROJECT_PHASE,
-  GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE,
-} from "src/queries/project";
+import { DELETE_PROJECT_PHASE } from "src/queries/project";
 import {
   useCurrentProjectPhaseIDs,
   useCurrentPhaseIds,
@@ -160,13 +157,6 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
   const [deletePhase, { loading: deleteInProgress }] =
     useMutation(DELETE_PROJECT_PHASE);
 
-  const { data: completionDateData, refetch: refetchCompletionDate } = useQuery(
-    GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE,
-    {
-      variables: { projectId: Number(projectId) },
-    }
-  );
-
   const onClickAddPhase = () => setEditPhase({ project_id: projectId });
 
   const onDeletePhase = useCallback(
@@ -177,10 +167,9 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
           refetchQueries: ["ProjectSummary"],
         }).then(() => {
           refetch();
-          refetchCompletionDate();
         });
     },
-    [deletePhase, refetch, refetchCompletionDate]
+    [deletePhase, refetch]
   );
 
   const columns = useColumns({
@@ -199,12 +188,10 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
   const subphaseNameLookup = useSubphaseNameLookup(data?.moped_subphases || []);
 
   const completionDate =
-    completionDateData?.project_list_view[0]["substantial_completion_date"];
+    data?.project_list_view[0]["substantial_completion_date"];
 
   const onSubmitCallback = () => {
-    refetchCompletionDate().then(() =>
-      refetch().then(() => setEditPhase(null))
-    );
+    refetch().then(() => setEditPhase(null));
   };
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -160,7 +160,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
   const [deletePhase, { loading: deleteInProgress }] =
     useMutation(DELETE_PROJECT_PHASE);
 
-  const { data: completionDateData } = useQuery(
+  const { data: completionDateData, refetch: refetchCompletionDate } = useQuery(
     GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE,
     {
       variables: { projectId: Number(projectId) },
@@ -177,9 +177,10 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
           refetchQueries: ["ProjectSummary"],
         }).then(() => {
           refetch();
+          refetchCompletionDate();
         });
     },
-    [deletePhase, refetch]
+    [deletePhase, refetch, refetchCompletionDate]
   );
 
   const columns = useColumns({
@@ -201,7 +202,9 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
     completionDateData?.project_list_view[0]["substantial_completion_date"];
 
   const onSubmitCallback = () => {
-    refetch().then(() => setEditPhase(null));
+    refetchCompletionDate().then(() =>
+      refetch().then(() => setEditPhase(null))
+    );
   };
 
   return (

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useMutation } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import { CircularProgress, Box, IconButton } from "@mui/material";
 import { DataGridPro } from "@mui/x-data-grid-pro";
 import { green } from "@mui/material/colors";
@@ -12,7 +12,10 @@ import ProjectPhaseToolbar from "./ProjectPhaseToolbar";
 import PhaseTemplateModal from "./PhaseTemplateModal";
 import ProjectPhaseDialog from "./ProjectPhaseDialog";
 import ProjectPhaseDateConfirmationPopover from "./ProjectPhaseDateConfirmationPopover";
-import { DELETE_PROJECT_PHASE } from "src/queries/project";
+import {
+  DELETE_PROJECT_PHASE,
+  GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE,
+} from "src/queries/project";
 import {
   useCurrentProjectPhaseIDs,
   useCurrentPhaseIds,
@@ -157,6 +160,13 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
   const [deletePhase, { loading: deleteInProgress }] =
     useMutation(DELETE_PROJECT_PHASE);
 
+  const { data: completionDateData } = useQuery(
+    GET_PROJECT_SUBSTANTIAL_COMPLETION_DATE,
+    {
+      variables: { projectId: Number(projectId) },
+    }
+  );
+
   const onClickAddPhase = () => setEditPhase({ project_id: projectId });
 
   const onDeletePhase = useCallback(
@@ -187,6 +197,9 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
 
   const subphaseNameLookup = useSubphaseNameLookup(data?.moped_subphases || []);
 
+  const completionDate =
+    completionDateData?.project_list_view[0]["substantial_completion_date"];
+
   const onSubmitCallback = () => {
     refetch().then(() => setEditPhase(null));
   };
@@ -212,6 +225,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
           toolbar: {
             addAction: onClickAddPhase,
             setIsDialogOpen: setIsTemplateDialogOpen,
+            completionDate: completionDate,
           },
         }}
       />

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -1,0 +1,75 @@
+import { Box, Typography, Tooltip } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+
+const useStyles = makeStyles((theme) => ({
+    // fieldGridItem: {
+    //     margin: theme.spacing(2),
+    //   },
+    //   linkIcon: {
+    //     fontSize: "1rem",
+    //   },
+    //   editIconFunding: {
+    //     cursor: "pointer",
+    //     margin: "0.5rem",
+    //     fontSize: "1.5rem",
+    //   },
+    //   editIconContainer: {
+    //     minWidth: "8rem",
+    //     marginLeft: "8px",
+    //   },
+    //   editIconButton: {
+    //     margin: "8px 0",
+    //     padding: "8px",
+    //   },
+    //   editIconConfirm: {
+    //     cursor: "pointer",
+    //     margin: ".25rem 0",
+    //     fontSize: "24px",
+    //   },
+      fieldLabel: {
+        width: "100%",
+        color: theme.palette.text.secondary,
+        fontSize: ".8rem",
+        margin: "8px 0",
+      },
+      fieldBox: {
+        maxWidth: "10rem",
+      },
+      fieldLabelText: {
+        width: "calc(100% - 2rem)",
+        paddingLeft: theme.spacing(0.5),
+      },
+}));
+
+const ProjectSubstantialCompletionDate = ({
+  text,
+  tooltipText,
+}) => {
+  const classes = useStyles();
+  return (
+    <>
+      <Typography className={classes.fieldLabel}>
+        Substantial completion date
+      </Typography>
+      <Box
+        display="flex"
+        justifyContent="flex-start"
+        className={classes.fieldBox}
+      >
+        <Tooltip placement="bottom-start" title={tooltipText || ""}>
+          <Typography
+            className={classes.fieldLabelText}
+            component="span"
+          >
+            {/* If there is no input, render a "-" */}
+            {text.length === 0 && <span>-</span>}
+            {/* i dont think we need the span do we*/}
+            <span>{text}</span>
+          </Typography>
+        </Tooltip>
+      </Box>
+    </>
+  );
+};
+
+export default ProjectSubstantialCompletionDate;

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -2,49 +2,49 @@ import { Box, Typography, Tooltip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
-    // fieldGridItem: {
-    //     margin: theme.spacing(2),
-    //   },
-    //   linkIcon: {
-    //     fontSize: "1rem",
-    //   },
-    //   editIconFunding: {
-    //     cursor: "pointer",
-    //     margin: "0.5rem",
-    //     fontSize: "1.5rem",
-    //   },
-    //   editIconContainer: {
-    //     minWidth: "8rem",
-    //     marginLeft: "8px",
-    //   },
-    //   editIconButton: {
-    //     margin: "8px 0",
-    //     padding: "8px",
-    //   },
-    //   editIconConfirm: {
-    //     cursor: "pointer",
-    //     margin: ".25rem 0",
-    //     fontSize: "24px",
-    //   },
-      fieldLabel: {
-        width: "100%",
-        color: theme.palette.text.secondary,
-        fontSize: ".8rem",
-        margin: "8px 0",
-      },
-      fieldBox: {
-        maxWidth: "10rem",
-      },
-      fieldLabelText: {
-        width: "calc(100% - 2rem)",
-        paddingLeft: theme.spacing(0.5),
-      },
+  // fieldGridItem: {
+  //     margin: theme.spacing(2),
+  //   },
+  //   linkIcon: {
+  //     fontSize: "1rem",
+  //   },
+  //   editIconFunding: {
+  //     cursor: "pointer",
+  //     margin: "0.5rem",
+  //     fontSize: "1.5rem",
+  //   },
+  //   editIconContainer: {
+  //     minWidth: "8rem",
+  //     marginLeft: "8px",
+  //   },
+  //   editIconButton: {
+  //     margin: "8px 0",
+  //     padding: "8px",
+  //   },
+  //   editIconConfirm: {
+  //     cursor: "pointer",
+  //     margin: ".25rem 0",
+  //     fontSize: "24px",
+  //   },
+  fieldLabel: {
+    width: "100%",
+    color: theme.palette.text.secondary,
+    fontSize: ".8rem",
+    margin: "8px 0",
+  },
+  fieldBox: {
+    maxWidth: "10rem",
+  },
+  fieldLabelText: {
+    width: "calc(100% - 2rem)",
+    paddingLeft: theme.spacing(0.5),
+  },
 }));
 
-const ProjectSubstantialCompletionDate = ({
-  text,
-  tooltipText,
-}) => {
+const completionDateTooltipText =
+  "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)";
+
+const ProjectSubstantialCompletionDate = ({ completionDate }) => {
   const classes = useStyles();
   return (
     <>
@@ -56,15 +56,12 @@ const ProjectSubstantialCompletionDate = ({
         justifyContent="flex-start"
         className={classes.fieldBox}
       >
-        <Tooltip placement="bottom-start" title={tooltipText || ""}>
-          <Typography
-            className={classes.fieldLabelText}
-            component="span"
-          >
+        <Tooltip placement="bottom-start" title={completionDateTooltipText}>
+          <Typography className={classes.fieldLabelText} component="span">
             {/* If there is no input, render a "-" */}
-            {text.length === 0 && <span>-</span>}
+            {(!completionDate || completionDate.length === 0) && <span>-</span>}
             {/* i dont think we need the span do we*/}
-            <span>{text}</span>
+            <span>{completionDate}</span>
           </Typography>
         </Tooltip>
       </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -1,6 +1,7 @@
 import { Box, Typography, Tooltip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { formatDateType } from "src/utils/dateAndTime";
+import { substantialCompletionDateTooltipText } from "src/constants/projects";
 
 const useStyles = makeStyles((theme) => ({
   fieldLabel: {
@@ -16,9 +17,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const completionDateTooltipText =
-  "The earliest confirmed start date of a project phase that has a simple phase name of Complete (Complete or Post-construction)";
-
 const ProjectSubstantialCompletionDate = ({ completionDate }) => {
   const classes = useStyles();
   return (
@@ -31,7 +29,10 @@ const ProjectSubstantialCompletionDate = ({ completionDate }) => {
         justifyContent="flex-start"
         className={classes.fieldBox}
       >
-        <Tooltip placement="bottom-start" title={completionDateTooltipText}>
+        <Tooltip
+          placement="bottom-start"
+          title={substantialCompletionDateTooltipText}
+        >
           <Typography className={classes.fieldLabelText} component="span">
             {
               // If there is no input, render a "-"

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -7,7 +7,6 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     color: theme.palette.text.secondary,
     fontSize: ".8rem",
-    margin: "8px 0",
   },
   fieldBox: {
     maxWidth: "10rem",

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -33,10 +33,10 @@ const ProjectSubstantialCompletionDate = ({ completionDate }) => {
       >
         <Tooltip placement="bottom-start" title={completionDateTooltipText}>
           <Typography className={classes.fieldLabelText} component="span">
-            {/* If there is no input, render a "-" */}
-            {(!completionDate || completionDate.length === 0) && <span>-</span>}
-            {/* i dont think we need the span do we*/}
-            <span>{formatDateType(completionDate)}</span>
+            {
+              // If there is no input, render a "-"
+              completionDate ? formatDateType(completionDate) : "-"
+            }
           </Typography>
         </Tooltip>
       </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSubstantialCompletionDate.js
@@ -1,31 +1,8 @@
 import { Box, Typography, Tooltip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
+import { formatDateType } from "src/utils/dateAndTime";
 
 const useStyles = makeStyles((theme) => ({
-  // fieldGridItem: {
-  //     margin: theme.spacing(2),
-  //   },
-  //   linkIcon: {
-  //     fontSize: "1rem",
-  //   },
-  //   editIconFunding: {
-  //     cursor: "pointer",
-  //     margin: "0.5rem",
-  //     fontSize: "1.5rem",
-  //   },
-  //   editIconContainer: {
-  //     minWidth: "8rem",
-  //     marginLeft: "8px",
-  //   },
-  //   editIconButton: {
-  //     margin: "8px 0",
-  //     padding: "8px",
-  //   },
-  //   editIconConfirm: {
-  //     cursor: "pointer",
-  //     margin: ".25rem 0",
-  //     fontSize: "24px",
-  //   },
   fieldLabel: {
     width: "100%",
     color: theme.palette.text.secondary,
@@ -37,7 +14,6 @@ const useStyles = makeStyles((theme) => ({
   },
   fieldLabelText: {
     width: "calc(100% - 2rem)",
-    paddingLeft: theme.spacing(0.5),
   },
 }));
 
@@ -61,7 +37,7 @@ const ProjectSubstantialCompletionDate = ({ completionDate }) => {
             {/* If there is no input, render a "-" */}
             {(!completionDate || completionDate.length === 0) && <span>-</span>}
             {/* i dont think we need the span do we*/}
-            <span>{completionDate}</span>
+            <span>{formatDateType(completionDate)}</span>
           </Typography>
         </Tooltip>
       </Box>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19258

## Testing
**URL to test:** 

https://deploy-preview-1456--atd-moped-main.netlify.app/moped/projects

**Steps to test:**

Find a project with a substantial completion date (like [this one](https://deploy-preview-1456--atd-moped-main.netlify.app/moped/projects/1848?tab=timeline)) You can see the date now!
Hover over the date to get the tooltip. It is the same text as [Tilly's tooltip PR](https://github.com/cityofaustin/atd-moped/pull/1454).

Now find a project without a completion date, or create a new project. Check that you don't see any date under the Phases title, especially not the dreaded 1/1/1970. 

Add a confirmed date for post construction or complete phase, upon submitting the edit, you should see the date update in the component. 


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added check for substantial completion date to the end of the testing of Complete phase
