### PR TITLE
adds MAP Transit Enhancement tags

### DIFF
--- a/moped-database/migrations/1729117324147_create_new_component_tags_for_map_transit_enhancement/down.sql
+++ b/moped-database/migrations/1729117324147_create_new_component_tags_for_map_transit_enhancement/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM public.moped_component_tags WHERE slug IN ('map_transit_enhancement_2025', 'map_transit_enhancement_2024', 'map_transit_enhancement_2023', 'map_transit_enhancement_2022');

--- a/moped-database/migrations/1729117324147_create_new_component_tags_for_map_transit_enhancement/up.sql
+++ b/moped-database/migrations/1729117324147_create_new_component_tags_for_map_transit_enhancement/up.sql
@@ -1,0 +1,5 @@
+INSERT INTO public.moped_component_tags ("type", name, slug) VALUES
+('MAP Transit Enhancement', '2022', 'map_transit_enhancement_2022'),
+('MAP Transit Enhancement', '2023', 'map_transit_enhancement_2023'),
+('MAP Transit Enhancement', '2024', 'map_transit_enhancement_2024'),
+('MAP Transit Enhancement', '2025', 'map_transit_enhancement_2025');


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/19489

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local

**Steps to test:**
- go to a project and add or edit a component
- in the tags dropdown, check to see the following tags are visible
  - MAP Transit Enhancement - 2022
  - MAP Transit Enhancement - 2023
  - MAP Transit Enhancement - 2024
  - MAP Transit Enhancement - 2025
- run the down migration and ensure those tags are removed

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
~- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
