### PR TITLE
Patch 2.21.1

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -22,7 +22,7 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $generateHtmlFromNodes, $generateNodesFromDOM } from "@lexical/html";
-import { $getRoot } from "lexical";
+import { $createParagraphNode, $getRoot, $isTextNode } from "lexical";
 import { $isRootTextContentEmpty } from "@lexical/text";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { LinkNode } from "@lexical/link";
@@ -145,9 +145,20 @@ const OnEditPlugin = ({ htmlContent, editingNote }) => {
         const parser = new DOMParser();
         const dom = parser.parseFromString(htmlContent, "text/html");
         const nodes = $generateNodesFromDOM(editor, dom);
+        console.log(nodes);
         // Append nodes serialized from html to EditorState
         nodes.forEach((node) => {
-          $getRoot().append(node);
+          // If this is a TextNode, this note was created as non-rich text. We need to wrap with a paragraph
+          const isTextNode = $isTextNode(node);
+
+          if (isTextNode) {
+            const p = $createParagraphNode();
+            p.append(node);
+
+            $getRoot().append(p);
+          } else {
+            $getRoot().append(node);
+          }
         });
       });
     editor.focus();

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -145,7 +145,6 @@ const OnEditPlugin = ({ htmlContent, editingNote }) => {
         const parser = new DOMParser();
         const dom = parser.parseFromString(htmlContent, "text/html");
         const nodes = $generateNodesFromDOM(editor, dom);
-        console.log(nodes);
         // Append nodes serialized from html to EditorState
         nodes.forEach((node) => {
           // If this is a TextNode, this note was created as non-rich text. We need to wrap with a paragraph node.

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -148,10 +148,11 @@ const OnEditPlugin = ({ htmlContent, editingNote }) => {
         console.log(nodes);
         // Append nodes serialized from html to EditorState
         nodes.forEach((node) => {
-          // If this is a TextNode, this note was created as non-rich text. We need to wrap with a paragraph
+          // If this is a TextNode, this note was created as non-rich text. We need to wrap with a paragraph node.
           const isTextNode = $isTextNode(node);
 
           if (isTextNode) {
+            // Create empty ParagraphNode, append TextNode, and then append ParagraphNode to root.
             const p = $createParagraphNode();
             p.append(node);
 

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -354,8 +354,8 @@ const ProjectNotes = (props) => {
                     /**
                      * Only allow the user who wrote the status to edit it
                      */
-                    const editableNote = true;
-                    // userSessionData.user_id === item.created_by_user_id;
+                    const editableNote =
+                      userSessionData.user_id === item.created_by_user_id;
                     return (
                       <React.Fragment key={item.project_note_id}>
                         <ListItem alignItems="flex-start">

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -354,8 +354,8 @@ const ProjectNotes = (props) => {
                     /**
                      * Only allow the user who wrote the status to edit it
                      */
-                    const editableNote =
-                      userSessionData.user_id === item.created_by_user_id;
+                    const editableNote = true;
+                    // userSessionData.user_id === item.created_by_user_id;
                     return (
                       <React.Fragment key={item.project_note_id}>
                         <ListItem alignItems="flex-start">
@@ -364,7 +364,9 @@ const ProjectNotes = (props) => {
                           </ListItemAvatar>
                           <ListItemText
                             className={editableNote ? classes.editableNote : ""}
-                            secondaryTypographyProps={{className: classes.editButtons}}
+                            secondaryTypographyProps={{
+                              className: classes.editButtons,
+                            }}
                             primary={
                               <>
                                 <Typography
@@ -443,9 +445,7 @@ const ProjectNotes = (props) => {
                                     onClick={() => editNote(i, item)}
                                     size="large"
                                   >
-                                    <EditIcon
-                                      className={classes.editButtons}
-                                    />
+                                    <EditIcon className={classes.editButtons} />
                                   </IconButton>
                                 )}
                                 {!editingNote && (


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19538

This PR updates the Lexical `OnEditPlugin` to handle status updates created through the input in the `ProjectPhaseForm` which is not saved as rich text. **This patch will save non-rich text status updates as rich text even though they were not originally saved that way** which I think is fine since we are already primarily creating notes this way. I'll create an issue to see what adding the Lexical editor to this form would look like though wrapping it in Reach Hook Form could get bumpy.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1459--atd-moped-main.netlify.app/moped/projects/

**Steps to test:**
1. Go to a project timeline in staging ([like this one](https://moped.austinmobility.io/moped/projects/2045?tab=timeline)) and create or edit a phase and add a status update before saving. This will create a new status update that you can see in the **Notes** tab.
<img width="655" alt="Screenshot 2024-10-21 at 12 31 34 PM" src="https://github.com/user-attachments/assets/895034ff-5547-4228-9380-250073fa05ba">

2. Go to the **Notes** tab and edit the status update that you just created. Notice that the editor opens up but does not show text.
3. Now, do the same in this deploy preview. Notice that the content of the status update does display as expected when opening in the **Notes** tab.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test to check if Phase status updates can be edited in the **Notes** tab
