### PR TITLE
updates phases table to use mui confirmation modal

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -248,7 +248,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         refetch={refetch}
       />
       <DeleteConfirmationModal
-        type={"project phase"}
+        type={"phase"}
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -177,7 +177,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         .then(() => refetch())
         .then(() => setIsDeleteConfirmationOpen(false));
     },
-    [deleteInProgress, refetch]
+    [deletePhase, refetch]
   );
 
   const columns = useColumns({

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -20,9 +20,10 @@ import {
   useSubphaseNameLookup,
 } from "./ProjectPhase/helpers";
 import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
+import DeleteConfirmationModal from "./DeleteConfirmationModal";
 
 /** Hook that provides memoized column settings */
-const useColumns = ({ deleteInProgress, onDeletePhase, setEditPhase }) =>
+const useColumns = ({ deleteInProgress, handleDeleteOpen, setEditPhase }) =>
   useMemo(() => {
     return [
       {
@@ -133,7 +134,7 @@ const useColumns = ({ deleteInProgress, onDeletePhase, setEditPhase }) =>
                 aria-label="delete"
                 sx={{ color: "inherit" }}
                 onClick={() =>
-                  onDeletePhase({ project_phase_id: row.project_phase_id })
+                  handleDeleteOpen({ project_phase_id: row.project_phase_id })
                 }
               >
                 <DeleteOutlineIcon />
@@ -143,7 +144,7 @@ const useColumns = ({ deleteInProgress, onDeletePhase, setEditPhase }) =>
         },
       },
     ];
-  }, [deleteInProgress, onDeletePhase, setEditPhase]);
+  }, [deleteInProgress, handleDeleteOpen, setEditPhase]);
 
 /**
  * ProjectPhases Component - renders Project Phase table
@@ -153,29 +154,36 @@ const useColumns = ({ deleteInProgress, onDeletePhase, setEditPhase }) =>
 const ProjectPhases = ({ projectId, data, refetch }) => {
   const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
   const [editPhase, setEditPhase] = useState(null);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] =
+    useState(false);
+  const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   const [deletePhase, { loading: deleteInProgress }] =
     useMutation(DELETE_PROJECT_PHASE);
 
   const onClickAddPhase = () => setEditPhase({ project_id: projectId });
 
-  const onDeletePhase = useCallback(
-    ({ project_phase_id }) => {
-      window.confirm("Are you sure you want to delete this phase?") &&
-        deletePhase({
-          variables: { project_phase_id },
-          refetchQueries: ["ProjectSummary"],
-        }).then(() => {
-          refetch();
-        });
+  const handleDeleteOpen = useCallback(({ project_phase_id }) => {
+    setIsDeleteConfirmationOpen(true);
+    setDeleteConfirmationId(project_phase_id);
+  }, []);
+
+  const handleDeleteClick = useCallback(
+    (id) => () => {
+      deletePhase({
+        variables: { project_phase_id: id },
+        refetchQueries: ["ProjectSummary"],
+      })
+        .then(() => refetch())
+        .then(() => setIsDeleteConfirmationOpen(false));
     },
-    [deletePhase, refetch]
+    [deleteInProgress, refetch]
   );
 
   const columns = useColumns({
     setEditPhase,
     deleteInProgress,
-    onDeletePhase,
+    handleDeleteOpen,
   });
 
   const currentProjectPhaseIds = useCurrentProjectPhaseIDs(
@@ -238,6 +246,12 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         subphaseNameLookup={subphaseNameLookup}
         projectId={projectId}
         refetch={refetch}
+      />
+      <DeleteConfirmationModal
+        type={"project phase"}
+        submitDelete={handleDeleteClick(deleteConfirmationId)}
+        isDeleteConfirmationOpen={isDeleteConfirmationOpen}
+        setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
       />
     </>
   );


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/19436

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1467--atd-moped-main.netlify.app/

**Steps to test:**
- go to a project's timeline tab and click the delete icon next to a phase
- confirm that an mui confirmation modal appears asking 'Are you sure you want to delete this phase?'
- click 'delete' and confirm the correct phase was deleted

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
