### PR TITLE
Add click-away listener to advanced search dropdown

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -1,7 +1,14 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useSearchParams } from "react-router-dom";
-import { Box, Button, Grid, Paper, Popper } from "@mui/material";
+import {
+  Box,
+  Button,
+  Grid,
+  Paper,
+  Popper,
+  ClickAwayListener,
+} from "@mui/material";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import Hidden from "@mui/material/Hidden";
@@ -238,18 +245,20 @@ const Search = ({
         placement={"bottom"}
         className={classes.advancedSearchRoot}
       >
-        <Paper className={classes.advancedSearchPaper}>
-          <Filters
-            setFilters={setFilters}
-            handleAdvancedSearchClose={handleAdvancedSearchClose}
-            filtersConfig={filtersConfig}
-            resetSimpleSearch={resetSimpleSearch}
-            isOr={isOr}
-            setIsOr={setIsOr}
-            setSearchParams={setSearchParams}
-            searchParams={searchParams}
-          />
-        </Paper>
+        <ClickAwayListener onClickAway={handleAdvancedSearchClose}>
+          <Paper className={classes.advancedSearchPaper}>
+            <Filters
+              setFilters={setFilters}
+              handleAdvancedSearchClose={handleAdvancedSearchClose}
+              filtersConfig={filtersConfig}
+              resetSimpleSearch={resetSimpleSearch}
+              isOr={isOr}
+              setIsOr={setIsOr}
+              setSearchParams={setSearchParams}
+              searchParams={searchParams}
+            />
+          </Paper>
+        </ClickAwayListener>
       </Popper>
     </div>
   );


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19413

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1470--atd-moped-main.netlify.app/moped/projects

**Steps to test:**
Open the advanced search filter, now click out of it to close it.


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
