### PR TITLE
Double click to open editor modal

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -194,6 +194,11 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
     refetch().then(() => setEditPhase(null));
   };
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditPhase(params.row);
+  };
+
   return (
     <>
       <DataGridPro
@@ -208,6 +213,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         hideFooter
         localeText={{ noRowsLabel: "No phases" }}
         rows={data?.moped_proj_phases || []}
+        onCellDoubleClick={doubleClickListener}
         slots={{
           toolbar: ProjectPhaseToolbar,
         }}

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -213,6 +213,11 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditActivity(params.row);
+  };
+
   /**
    * Initialize which columns should be visible - must be memoized to safely
    * be used with useHiddenColumnsSettings hook
@@ -258,6 +263,7 @@ const ProjectWorkActivitiesTable = () => {
           slotProps={{
             toolbar: { onClick: onClickAddActivity },
           }}
+          onCellDoubleClick={doubleClickListener}
         />
       </Box>
       {editActivity && (


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19499

## Testing
**URL to test:** 

https://deploy-preview-1471--atd-moped-main.netlify.app/moped/projects/2039?tab=funding

**Steps to test:**

Check out the Work Activities table on the Funding tab and the Phases table on the Timeline tab. 
Double click in any of the cells to bring up the edit modal. 

Question -- would you want to be able to hit Enter when a cell is selected and also have the edit modal pop up?

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
