### PR TITLE
Render component phase in the component map list item

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/queries/components.js
+++ b/moped-editor/src/queries/components.js
@@ -106,6 +106,7 @@ export const PROJECT_COMPONENT_FIELDS = gql`
       phase_id
       phase_name
       phase_name_simple
+      phase_key
       moped_subphases {
         subphase_id
         subphase_name

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -12,6 +12,7 @@ import IconButton from "@mui/material/IconButton";
 import ListItemText from "@mui/material/ListItemText";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { COLORS } from "./mapStyleSettings";
+import ProjectStatusBadge from "../ProjectStatusBadge";
 import {
   useComponentListItemText,
   getIsComponentMapped,
@@ -26,8 +27,8 @@ const useStyles = makeStyles((theme) => ({
   },
   listItemText: {
     marginLeft: theme.spacing(1),
-    flexGrow: 1, 
-    marginRight: '48px',
+    flexGrow: 1,
+    marginRight: "48px",
   },
   additionalListItemText: {
     display: "block",
@@ -83,6 +84,16 @@ export default function ComponentListItem({
           </ListItemSecondaryAction>
         </Box>
       </ListItemButton>
+      {!!component.moped_phase && (
+        <Box width="100%">
+          <ProjectStatusBadge
+            phaseName={component.moped_phase?.phase_name}
+            // phaseKey={component.moped_phase.phase_key}
+            condensed
+            clickable
+          />{" "}
+        </Box>
+      )}
       <Collapse in={isExpanded}>
         {isExpanded ? (
           <List component="div" disablePadding dense>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -85,10 +85,10 @@ export default function ComponentListItem({
             </ListItemSecondaryAction>
           </Box>
           {!!component.moped_phase && (
-            <Box width="100%" sx={{ py: 0.5 }}>
+            <Box width="100%" sx={isExpanded ? { pt: 0.5 } : { py: 0.5 }}>
               <ProjectStatusBadge
                 phaseName={component.moped_phase?.phase_name}
-                // phaseKey={component.moped_phase.phase_key}
+                phaseKey={component.moped_phase?.phase_key}
                 condensed
                 clickable
               />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -90,7 +90,6 @@ export default function ComponentListItem({
                 phaseName={component.moped_phase?.phase_name}
                 phaseKey={component.moped_phase?.phase_key}
                 condensed
-                clickable
               />
             </Box>
           )}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
   listItemText: {
     marginLeft: theme.spacing(1),
     flexGrow: 1,
-    marginRight: "48px",
+    marginRight: theme.spacing(6),
   },
   additionalListItemText: {
     display: "block",

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -85,8 +85,7 @@ export default function ComponentListItem({
             </ListItemSecondaryAction>
           </Box>
           {!!component.moped_phase && (
-            //<Box width="100%" sx={isExpanded ? { pt: 0.5 } : { py: 0.5 }}>
-              <Box width="100%" sx={{ py: 0.5 }}>
+            <Box width="100%" sx={{ my: 0.5, ml: 1 }}>
               <ProjectStatusBadge
                 phaseName={component.moped_phase?.phase_name}
                 phaseKey={component.moped_phase?.phase_key}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -64,36 +64,38 @@ export default function ComponentListItem({
         ref={component._ref}
       >
         {isComponentMapped ? Icon : <ErrorOutlineIcon color="error" />}
-        <Box display="flex" alignItems="center" width="100%">
-          <ListItemText
-            className={classes.listItemText}
-            primary={primary}
-            secondary={
-              <>
-                <>{secondary}</>
-                <span className={classes.additionalListItemText}>
-                  {additionalListItemText}
-                </span>
-              </>
-            }
-          />
-          <ListItemSecondaryAction>
-            <IconButton color="primary" onClick={onZoomClick} size="large">
-              <ZoomInIcon />
-            </IconButton>
-          </ListItemSecondaryAction>
+        <Box>
+          <Box display="flex" alignItems="center" width="100%">
+            <ListItemText
+              className={classes.listItemText}
+              primary={primary}
+              secondary={
+                <>
+                  <>{secondary}</>
+                  <span className={classes.additionalListItemText}>
+                    {additionalListItemText}
+                  </span>
+                </>
+              }
+            />
+            <ListItemSecondaryAction>
+              <IconButton color="primary" onClick={onZoomClick} size="large">
+                <ZoomInIcon />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </Box>
+          {!!component.moped_phase && (
+            <Box width="100%" sx={{ py: 0.5 }}>
+              <ProjectStatusBadge
+                phaseName={component.moped_phase?.phase_name}
+                // phaseKey={component.moped_phase.phase_key}
+                condensed
+                clickable
+              />
+            </Box>
+          )}
         </Box>
       </ListItemButton>
-      {!!component.moped_phase && (
-        <Box width="100%">
-          <ProjectStatusBadge
-            phaseName={component.moped_phase?.phase_name}
-            // phaseKey={component.moped_phase.phase_key}
-            condensed
-            clickable
-          />{" "}
-        </Box>
-      )}
       <Collapse in={isExpanded}>
         {isExpanded ? (
           <List component="div" disablePadding dense>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentListItem.js
@@ -85,7 +85,8 @@ export default function ComponentListItem({
             </ListItemSecondaryAction>
           </Box>
           {!!component.moped_phase && (
-            <Box width="100%" sx={isExpanded ? { pt: 0.5 } : { py: 0.5 }}>
+            //<Box width="100%" sx={isExpanded ? { pt: 0.5 } : { py: 0.5 }}>
+              <Box width="100%" sx={{ py: 0.5 }}>
               <ProjectStatusBadge
                 phaseName={component.moped_phase?.phase_name}
                 phaseKey={component.moped_phase?.phase_key}

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -194,6 +194,11 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
     refetch().then(() => setEditPhase(null));
   };
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditPhase(params.row);
+  };
+
   return (
     <>
       <DataGridPro
@@ -208,6 +213,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         hideFooter
         localeText={{ noRowsLabel: "No phases" }}
         rows={data?.moped_proj_phases || []}
+        onCellDoubleClick={doubleClickListener}
         slots={{
           toolbar: ProjectPhaseToolbar,
         }}

--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -194,11 +194,6 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
     refetch().then(() => setEditPhase(null));
   };
 
-  // Open activity edit modal when double clicking in a cell
-  const doubleClickListener = (params) => {
-    setEditPhase(params.row);
-  };
-
   return (
     <>
       <DataGridPro
@@ -213,7 +208,6 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         hideFooter
         localeText={{ noRowsLabel: "No phases" }}
         rows={data?.moped_proj_phases || []}
-        onCellDoubleClick={doubleClickListener}
         slots={{
           toolbar: ProjectPhaseToolbar,
         }}

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -213,7 +213,6 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
-
   /**
    * Initialize which columns should be visible - must be memoized to safely
    * be used with useHiddenColumnsSettings hook

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -213,10 +213,6 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
-  // Open activity edit modal when double clicking in a cell
-  const doubleClickListener = (params) => {
-    setEditActivity(params.row);
-  };
 
   /**
    * Initialize which columns should be visible - must be memoized to safely
@@ -263,7 +259,6 @@ const ProjectWorkActivitiesTable = () => {
           slotProps={{
             toolbar: { onClick: onClickAddActivity },
           }}
-          onCellDoubleClick={doubleClickListener}
         />
       </Box>
       {editActivity && (

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -213,6 +213,11 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditActivity(params.row);
+  };
+
   /**
    * Initialize which columns should be visible - must be memoized to safely
    * be used with useHiddenColumnsSettings hook
@@ -258,6 +263,7 @@ const ProjectWorkActivitiesTable = () => {
           slotProps={{
             toolbar: { onClick: onClickAddActivity },
           }}
+          onCellDoubleClick={doubleClickListener}
         />
       </Box>
       {editActivity && (


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11429

## Testing
**URL to test:** 

https://deploy-preview-1473--atd-moped-main.netlify.app/moped/projects/1951?tab=map

**Steps to test:**

I linked a project above that has a component with a different phase from its project, and I gave the component a location description and a long description. 

Test by adding more components with or without phases. 

One thing to note, is that if a component has a phase defined, it will show the badge, even if the component is in the same phase as the parent project. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added "Notice that the component list item now has a phase badge."
