### PR TITLE
Restore the fancy double click modal triggering

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectPhases.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhases.js
@@ -123,7 +123,7 @@ const useColumns = ({ deleteInProgress, handleDeleteOpen, setEditPhase }) =>
           return deleteInProgress ? (
             <CircularProgress color="primary" size={20} />
           ) : (
-            <div style={{display: "flex"}}>
+            <div style={{ display: "flex" }}>
               <IconButton
                 aria-label="edit"
                 sx={{ color: "inherit" }}
@@ -203,6 +203,11 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
     refetch().then(() => setEditPhase(null));
   };
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditPhase(params.row);
+  };
+
   return (
     <>
       <DataGridPro
@@ -218,6 +223,7 @@ const ProjectPhases = ({ projectId, data, refetch }) => {
         localeText={{ noRowsLabel: "No phases" }}
         initialState={{ pinnedColumns: { right: ["_edit"] } }}
         rows={data?.moped_proj_phases || []}
+        onCellDoubleClick={doubleClickListener}
         slots={{
           toolbar: ProjectPhaseToolbar,
         }}

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.js
@@ -213,6 +213,11 @@ const ProjectWorkActivitiesTable = () => {
     setEditActivity,
   });
 
+  // Open activity edit modal when double clicking in a cell
+  const doubleClickListener = (params) => {
+    setEditActivity(params.row);
+  };
+
   /**
    * Initialize which columns should be visible - must be memoized to safely
    * be used with useHiddenColumnsSettings hook
@@ -258,6 +263,7 @@ const ProjectWorkActivitiesTable = () => {
           slotProps={{
             toolbar: { onClick: onClickAddActivity },
           }}
+          onCellDoubleClick={doubleClickListener}
         />
       </Box>
       {editActivity && (


### PR DESCRIPTION
## Associated issues
Reintroducing the changes in https://github.com/cityofaustin/atd-moped/pull/1471 that we accidentally reverted

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Deploy preview

**Steps to test:**
These are the same changes from https://github.com/cityofaustin/atd-moped/pull/1471 so compare the two? I tested locally, and this works just like in the original PR.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
