### PR TITLE
Handle outdated advanced search urls

### DIFF
--- a/moped-editor/src/utils/errorHandling.js
+++ b/moped-editor/src/utils/errorHandling.js
@@ -1,0 +1,8 @@
+/**
+ * Throws error to be displayed in the fallback component rendered through the ApolloErrorHandler component
+ * @param {string} message - the error message to be displayed in the FallbackComponent
+ * throws {Error} Error object intercepted by FallbackComponent
+ */
+export const throwFallbackComponentError = (message) => {
+  throw Error(message);
+};

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -277,8 +277,8 @@ export const useColumns = ({ hiddenColumns }) => {
           if (row.task_orders && row?.task_orders.length > 0) {
             return (
               <div>
-                {row.task_orders.map((taskOrder) => (
-                  <span key={taskOrder.task_order} style={{ display: "block" }}>
+                {row.task_orders.map((taskOrder, i) => (
+                  <span key={i} style={{ display: "block" }}>
                     {taskOrder.task_order}
                   </span>
                 ))}

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -5,6 +5,7 @@ import { FILTERS_COMMON_OPERATORS } from "src/components/GridTable/FiltersCommon
 import { parseGqlString } from "src/utils/gridTableHelpers";
 import { addDays, parseISO, format } from "date-fns";
 import { useMakeFilterState } from "src/components/GridTable/helpers";
+import { throwFallbackComponentError } from "src/utils/errorHandling";
 
 /* Names of advanced search URL parameters */
 export const advancedSearchFilterParamName = "filters";
@@ -15,7 +16,7 @@ export const advancedSearchIsOrParamName = "isOr";
  * @param {Object} filters - Stores filters assigned random id and nests column, operator, and value
  * @return Object
  */
-const makeAdvancedSearchWhereFilters = (filters, searchParams) =>
+const makeAdvancedSearchWhereFilters = (filters) =>
   Object.keys(filters)
     .map((filter) => {
       let { field, value, operator } = filters[filter];
@@ -24,11 +25,8 @@ const makeAdvancedSearchWhereFilters = (filters, searchParams) =>
       const filterConfigForField = PROJECT_LIST_VIEW_FILTERS_CONFIG[field];
 
       if (!filterConfigForField) {
-        const savedViewId = searchParams.get("savedViewId");
-        throw new Error(
-          `Field ${field} in this url no longer exists. ${
-            savedViewId ? `(Saved view ID: ${savedViewId})` : ""
-          }`
+        throwFallbackComponentError(
+          `Field ${field} in this url no longer exists in the project list.`
         );
       }
 

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -15,13 +15,23 @@ export const advancedSearchIsOrParamName = "isOr";
  * @param {Object} filters - Stores filters assigned random id and nests column, operator, and value
  * @return Object
  */
-const makeAdvancedSearchWhereFilters = (filters) =>
+const makeAdvancedSearchWhereFilters = (filters, searchParams) =>
   Object.keys(filters)
     .map((filter) => {
       let { field, value, operator } = filters[filter];
 
       // Use field name to get the filter config and GraphQL operator config for that field
       const filterConfigForField = PROJECT_LIST_VIEW_FILTERS_CONFIG[field];
+
+      if (!filterConfigForField) {
+        const savedViewId = searchParams.get("savedViewId");
+        throw new Error(
+          `Field ${field} in this url no longer exists. ${
+            savedViewId ? `(Saved view ID: ${savedViewId})` : ""
+          }`
+        );
+      }
+
       const { type } = filterConfigForField;
 
       // Use operator name to get the GraphQL operator config for that operator
@@ -110,7 +120,10 @@ export const useAdvancedSearch = () => {
   const [filters, setFilters] = useState(initialFilterState);
 
   const advancedSearchWhereString = useMemo(() => {
-    const advancedFilters = makeAdvancedSearchWhereFilters(filters);
+    const advancedFilters = makeAdvancedSearchWhereFilters(
+      filters,
+      searchParams
+    );
     if (advancedFilters.length === 0) return null;
 
     const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -118,10 +118,7 @@ export const useAdvancedSearch = () => {
   const [filters, setFilters] = useState(initialFilterState);
 
   const advancedSearchWhereString = useMemo(() => {
-    const advancedFilters = makeAdvancedSearchWhereFilters(
-      filters,
-      searchParams
-    );
+    const advancedFilters = makeAdvancedSearchWhereFilters(filters);
     if (advancedFilters.length === 0) return null;
 
     const bracketedFilters = advancedFilters.map((filter) => `{ ${filter} }`);


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19687

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1480--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22current_phases%22%2C%22operator%22%3A%22string_equals_case_insensitive%22%2C%22value%22%3A%22Planned%22%7D%5D&isOr=false

**Steps to test:**
1. Go to [this link](https://deploy-preview-1480--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22current_phases%22%2C%22operator%22%3A%22string_equals_case_insensitive%22%2C%22value%22%3A%22Planned%22%7D%5D&isOr=false) that contains a non-existent field name in the filter search params part of the url
2. Read the error message displayed in the app and check if it makes sense to you
3. Click the "click here" link to navigate to the DTS service request form. Make sure the error message is populated inside the **Describe the problem** input in the form

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added `Manually edit your copied URL in your browser with a invalid field name and see that an error message appears identifying the invalid field`
