### PR TITLE
Make DataGridPro table button dropdowns close after item selection

### DIFF
--- a/moped-editor/src/components/ButtonDropdownMenu.js
+++ b/moped-editor/src/components/ButtonDropdownMenu.js
@@ -67,7 +67,7 @@ const ButtonDropdownMenu = ({
     setAnchorEl(null);
   };
 
-  const useActionDialog = () => {
+  const handleActionDialog = () => {
     openActionDialog(true)
     setAnchorEl(null)
   }
@@ -106,7 +106,7 @@ const ButtonDropdownMenu = ({
           </ListItemIcon>
           {firstOptionText}
         </MenuItem>
-        <MenuItem onClick={useActionDialog}>
+        <MenuItem onClick={handleActionDialog}>
           <ListItemIcon>
             {secondOptionIcon ? (
               <PlaylistAddIcon fontSize="small" />

--- a/moped-editor/src/components/ButtonDropdownMenu.js
+++ b/moped-editor/src/components/ButtonDropdownMenu.js
@@ -67,6 +67,11 @@ const ButtonDropdownMenu = ({
     setAnchorEl(null);
   };
 
+  const useActionDialog = () => {
+    openActionDialog(true)
+    setAnchorEl(null)
+  }
+
   return (
     <div>
       <Button
@@ -101,7 +106,7 @@ const ButtonDropdownMenu = ({
           </ListItemIcon>
           {firstOptionText}
         </MenuItem>
-        <MenuItem onClick={() => openActionDialog(true)}>
+        <MenuItem onClick={useActionDialog}>
           <ListItemIcon>
             {secondOptionIcon ? (
               <PlaylistAddIcon fontSize="small" />


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19647

## Testing
**URL to test:** 

https://deploy-preview-1485--atd-moped-main.netlify.app/moped/projects/1973?tab=timeline


**Steps to test:**

Click the Add Phase or Add Milestone button, it shows a menu "add [one record] / From template" 
Click From template. The menu closes when the modal appears. 
Compare to https://moped.austinmobility.io/moped/projects/1822?tab=timeline, where the dropdown menu stays open. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
