### PR TITLE
Update project fund sources to reflect reorganization

### DIFF
--- a/moped-database/migrations/1730931541884_reorg_funding_sources/down.sql
+++ b/moped-database/migrations/1730931541884_reorg_funding_sources/down.sql
@@ -1,0 +1,3 @@
+-- Updating funding sources will be up only. If we need to revert, we will need do it manually or
+-- update with a future migration.
+SELECT 0;

--- a/moped-database/migrations/1730931541884_reorg_funding_sources/up.sql
+++ b/moped-database/migrations/1730931541884_reorg_funding_sources/up.sql
@@ -3,3 +3,31 @@ INSERT INTO "public"."moped_fund_sources" ("funding_source_name") VALUES
 ('Austin Transportation and Public Works');
 
 UPDATE moped_fund_sources SET is_deleted = true WHERE funding_source_name IN ('Austin Transportation', 'Public Works');
+
+-- Find existing project funding records that are associated with the funding sources that are merging
+-- and update them to the new funding source called Austin Transportation and Public Works
+WITH funding_source_todos AS (
+    SELECT funding_source_id AS ids
+    FROM
+        moped_fund_sources
+    WHERE
+        funding_source_name IN (
+            'Austin Transportation',
+            'Public Works'
+        )
+),
+
+new_funding_source_row AS (
+    SELECT funding_source_id AS id
+    FROM
+        moped_fund_sources
+    WHERE
+        funding_source_name = 'Austin Transportation and Public Works'
+)
+
+UPDATE
+moped_proj_funding
+SET
+    funding_source_id = (SELECT id FROM new_funding_source_row)
+WHERE
+    funding_source_id IN (SELECT ids FROM funding_source_todos);

--- a/moped-database/migrations/1730931541884_reorg_funding_sources/up.sql
+++ b/moped-database/migrations/1730931541884_reorg_funding_sources/up.sql
@@ -1,0 +1,5 @@
+-- Insert new funding source and soft-delete existing funding sources that are merging into the new one
+INSERT INTO "public"."moped_fund_sources" ("funding_source_name") VALUES
+('Austin Transportation and Public Works');
+
+UPDATE moped_fund_sources SET is_deleted = true WHERE funding_source_name IN ('Austin Transportation', 'Public Works');


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/19853

This PR updates the funding source lookup table to reflect the merge of ATD and PWD into TPW.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start your local stack and replicate from the production read replica. Then, use the two test queries below to see that there are now no project funding records that use the soft-deleted `Austin Transportation` and `Public Works` rows. There should be around 66 rows associated with the new TPW funding source.
2. Run the same queries on the production read replica to see that the opposite is true.
3. Check a project like ids 399, 3491, or 553 to see that the project funding records in the Funding table for these projects now show `Austin Transportation and Public Works` as the funding source.
4. Try to add a new funding row in the table, and see that only `Austin Transportation and Public Works` is shown as a selectable source and not `Austin Transportation` and `Public Works`.
5. Check the activity log, and you should see an activity updating the funding source that was done by `Data and Tech Admin` 🤖 You can check the history in the activity log too and see that the original creates and updates reflect the pre-merger names.
6. You can also check the funding columns in the `project_list_view` and `component_arcgis_online_view` database views to see that these changes work downstream as well.

**Check for project funding rows with either ATD or PWD as the funding source**
```sql
WITH funding_source_todos AS (
    SELECT funding_source_id AS ids
    FROM
        moped_fund_sources
    WHERE
        funding_source_name IN (
            'Austin Transportation',
            'Public Works'
        )
)
SELECT * FROM moped_proj_funding WHERE funding_source_id IN(SELECT ids FROM funding_source_todos);
```

**Check for project funding rows with either TPW as the funding source**
```sql
WITH funding_source_todos AS (
    SELECT funding_source_id AS ids
    FROM
        moped_fund_sources
    WHERE
        funding_source_name = 'Austin Transportation and Public Works'
)
SELECT * FROM moped_proj_funding WHERE funding_source_id IN(SELECT ids FROM funding_source_todos);
```

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
