### PR TITLE
Add Signage - All Way Stop component type

### DIFF
--- a/moped-database/migrations/1731971700176_add_all_way_comp/down.sql
+++ b/moped-database/migrations/1731971700176_add_all_way_comp/down.sql
@@ -1,0 +1,2 @@
+-- if we delete the component in the future, we will soft delete and leave existing data intact
+SELECT 0;

--- a/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
+++ b/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
@@ -1,0 +1,37 @@
+-- add bike share station component type (point) to moped_components table if it doesn't already exist
+INSERT INTO moped_components (component_name, component_subtype, line_representation, feature_layer_id)
+SELECT
+    'Signage',
+    'All Way',
+    FALSE,
+    5
+WHERE NOT EXISTS (
+        SELECT *
+        FROM
+            moped_components
+        WHERE (component_name, component_subtype, line_representation, feature_layer_id) = ('Signage', 'All Way', FALSE, 5)
+    );
+
+-- insert new, mod, and replacement work types for bike share station in moped_component_work_types table
+WITH inserts_todo AS (
+    SELECT
+        mwt.id AS work_type_id,
+        mc.component_id AS component_id
+    FROM
+        moped_work_types AS mwt,
+        moped_components AS mc
+    WHERE
+        mwt.name IN (
+            'New'
+        )
+        AND mc.component_name = 'Signage'
+        AND mc.component_subtype = 'All Way'
+)
+
+INSERT INTO moped_component_work_types (work_type_id, component_id)
+SELECT
+    work_type_id,
+    component_id
+FROM
+    inserts_todo
+ON CONFLICT DO NOTHING;

--- a/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
+++ b/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
@@ -2,14 +2,14 @@
 INSERT INTO moped_components (component_name, component_subtype, line_representation, feature_layer_id)
 SELECT
     'Signage',
-    'All Way',
+    'All Way Stop',
     FALSE,
     5
 WHERE NOT EXISTS (
         SELECT *
         FROM
             moped_components
-        WHERE (component_name, component_subtype, line_representation, feature_layer_id) = ('Signage', 'All Way', FALSE, 5)
+        WHERE (component_name, component_subtype, line_representation, feature_layer_id) = ('Signage', 'All Way Stop', FALSE, 5)
     );
 
 -- insert new, mod, and replacement work types for bike share station in moped_component_work_types table
@@ -25,7 +25,7 @@ WITH inserts_todo AS (
             'New'
         )
         AND mc.component_name = 'Signage'
-        AND mc.component_subtype = 'All Way'
+        AND mc.component_subtype = 'All Way Stop'
 )
 
 INSERT INTO moped_component_work_types (work_type_id, component_id)

--- a/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
+++ b/moped-database/migrations/1731971700176_add_all_way_comp/up.sql
@@ -1,4 +1,4 @@
--- add bike share station component type (point) to moped_components table if it doesn't already exist
+-- add Signage - All Way Stop type (point) to moped_components table if it doesn't already exist
 INSERT INTO moped_components (component_name, component_subtype, line_representation, feature_layer_id)
 SELECT
     'Signage',
@@ -12,7 +12,7 @@ WHERE NOT EXISTS (
         WHERE (component_name, component_subtype, line_representation, feature_layer_id) = ('Signage', 'All Way Stop', FALSE, 5)
     );
 
--- insert new, mod, and replacement work types for bike share station in moped_component_work_types table
+-- insert new work type for Signage - All Way Stop in moped_component_work_types table
 WITH inserts_todo AS (
     SELECT
         mwt.id AS work_type_id,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19747

This PR adds a component type named **Signage - All Way Stop** and its associated work types.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start up your local stack and test creating a new intersection component called **Signage - All Way Stop**
2. See that **New** is the only available component work type
3. When mapping the component, you should see that it selects from the intersections point layer.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
