### PR TITLE
Add dropdown options to council district search in project list view

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -992,6 +992,10 @@ export const LOOKUP_TABLES_QUERY = gql`
       component_id
       component_name_full
     }
+    layer_council_district {
+      id
+      council_district
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -571,6 +571,14 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     label: "Council districts",
     placeholder: "District",
     type: "array",
+    lookup: {
+      table_name: "layer_council_district",
+      getOptionLabel: (option) => `${option.council_district}`,
+      operators: [
+        "council_districts_array_contains",
+        "council_districts_array_is",
+      ],
+    },
     defaultOperator: "council_districts_array_contains",
     operators: [
       "council_districts_array_contains",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -573,7 +573,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
     type: "array",
     lookup: {
       table_name: "layer_council_district",
-      getOptionLabel: (option) => `${option.council_district}`,
+      getOptionLabel: (option) => String(option.council_district),
       operators: [
         "council_districts_array_contains",
         "council_districts_array_is",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19889

## Testing
**URL to test:** 

https://deploy-preview-1489--atd-moped-main.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22project_and_child_project_council_districts%22%2C%22operator%22%3A%22council_districts_array_contains%22%2C%22value%22%3A%226%22%7D%5D&isOr=false

**Steps to test:**

> Add dropdown options from layer_council_districts table to display when the is and contains operators are used for the council district advanced search

Confirm you see the dropdown options when searching on is and contains

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
