### PR TITLE
Update Name column in Files table so that long names don't render outside of cells

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -48,7 +48,7 @@ const useStyles = makeStyles(() => ({
   uploadFileButton: {
     float: "right",
   },
-  downloadLink: {
+  ellipsisOverflow: {
     cursor: "pointer",
     overflow: "hidden",
     display: "block",
@@ -88,6 +88,11 @@ const useColumns = ({
         field: "file_name",
         width: 200,
         editable: true,
+        renderCell: ({ row }) => (
+          <Typography className={classes.ellipsisOverflow}>
+            {row?.file_name}
+          </Typography>
+        ),
         // validate input
         preProcessEditCellProps: (params) => {
           const hasError =
@@ -108,7 +113,7 @@ const useColumns = ({
           if (row.file_key) {
             return (
               <Link
-                className={classes.downloadLink}
+                className={classes.ellipsisOverflow}
                 onClick={() => downloadFileAttachment(row?.file_key, token)}
               >
                 {cleanUpFileKey(row?.file_key)}
@@ -117,7 +122,7 @@ const useColumns = ({
           }
           return isValidUrl(row?.file_url) ? (
             <ExternalLink
-              linkProps={{ className: classes.downloadLink }}
+              linkProps={{ className: classes.ellipsisOverflow }}
               url={row?.file_url}
               text={row?.file_url}
             />


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19873

### Before
<img width="1464" alt="Screenshot 2024-11-20 at 9 13 10 PM" src="https://github.com/user-attachments/assets/ff356bcb-bf7f-48d3-a93a-b3ead30ec0f6">

### After
<img width="1464" alt="Screenshot 2024-11-20 at 9 13 33 PM" src="https://github.com/user-attachments/assets/9613803e-16bf-443f-bce7-a8e3f50fb86d">

## Testing
**URL to test:** 
https://deploy-preview-1490--atd-moped-main.netlify.app/moped/projects/1822?tab=files

**Steps to test:**
- Add a file to a project with a very long `Name`. Something over ~25 characters should be enough depending on your viewport. For example, [this project](https://deploy-preview-1490--atd-moped-main.netlify.app/moped/projects/1822?tab=files) in the deploy preview.
- Confirm that the long name has been shorted with the ellipsis `...` styling right before it would overflow into an adjacent cell.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
