### PR TITLE
Add click-away listener to advanced search dropdown

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -443,43 +443,6 @@ const Filters = ({
                   fullWidth
                   className={classes.formControl}
                 >
-                  {/* <InputLabel
-                    id={`filter-operator-select-${filterIndex}-label`}
-                  >
-                    Operator
-                  </InputLabel> */}
-                  {/* <Select
-                    variant="standard"
-                    fullWidth
-                    disabled={operators.length === 0}
-                    labelId={`filter-operator-select-${filterIndex}-label`}
-                    id={`filter-operator-select-${filterIndex}`}
-                    value={operator || ""}
-                    onChange={(e) =>
-                      handleFilterOperatorChange(
-                        filterIndex,
-                        e.target.value,
-                        lookupTable,
-                        lookupOperators
-                      )
-                    }
-                    label="field"
-                    data-testid="operator-select"
-                  >
-                    {operators.map((operator, operatorIndex) => {
-                      const label = FILTERS_COMMON_OPERATORS[operator]?.label;
-                      return (
-                        <MenuItem
-                          value={operator}
-                          key={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
-                          id={`filter-operator-select-item-${filterIndex}-${operatorIndex}`}
-                          data-testid={label}
-                        >
-                          {label}
-                        </MenuItem>
-                      );
-                    })}
-                  </Select> */}
                   <Autocomplete
                     value={operator || null}
                     options={operators}

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -5,10 +5,7 @@ import { useQuery } from "@apollo/client";
 import {
   Button,
   TextField,
-  InputLabel,
-  Select,
   FormControl,
-  MenuItem,
   Grid,
   Hidden,
   Icon,
@@ -126,8 +123,6 @@ const Filters = ({
    */
   const classes = useStyles();
 
-  console.log(Object.values(filtersConfig), "values filter config");
-
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 
   if (error) console.error(error);
@@ -160,8 +155,6 @@ const Filters = ({
     filtersConfig,
     data
   );
-
-  console.log(autocompleteOptionsMap, "auto complete options");
 
   /**
    * Handles the click event on the field drop-down menu
@@ -393,8 +386,6 @@ const Filters = ({
         const { label, type } = fieldConfig ?? {};
         const operators = fieldConfig?.operators ?? [];
 
-        console.log(operators, "operators");
-
         /* If the field uses a lookup table, get the table and field names  */
         const { table_name: lookupTable, operators: lookupOperators } =
           fieldConfig?.lookup ?? {};
@@ -490,16 +481,16 @@ const Filters = ({
                     })}
                   </Select> */}
                   <Autocomplete
-                    value={operator || ""}
+                    value={operator || null}
                     options={operators}
                     disabled={operators.length === 0}
                     getOptionLabel={(operator) =>
-                      operator ? FILTERS_COMMON_OPERATORS[operator]?.label : ""
+                      FILTERS_COMMON_OPERATORS[operator]?.label || ""
                     }
-                    onChange={(e) =>
+                    onChange={(e, value) =>
                       handleFilterOperatorChange(
                         filterIndex,
-                        e.target.value,
+                        value,
                         lookupTable,
                         lookupOperators
                       )

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -126,6 +126,8 @@ const Filters = ({
    */
   const classes = useStyles();
 
+  console.log(Object.values(filtersConfig), "values filter config");
+
   const { loading, error, data } = useQuery(LOOKUP_TABLES_QUERY);
 
   if (error) console.error(error);
@@ -154,7 +156,12 @@ const Filters = ({
   /* Some features like all/any radios require more than one filter to appear */
   const areMoreThanOneFilters = filterParameters.length > 1;
 
-  const autocompleteOptionsMap = useCreateAutocompleteOptions(filtersConfig, data);
+  const autocompleteOptionsMap = useCreateAutocompleteOptions(
+    filtersConfig,
+    data
+  );
+
+  console.log(autocompleteOptionsMap, "auto complete options");
 
   /**
    * Handles the click event on the field drop-down menu
@@ -386,11 +393,11 @@ const Filters = ({
         const { label, type } = fieldConfig ?? {};
         const operators = fieldConfig?.operators ?? [];
 
+        console.log(operators, "operators");
+
         /* If the field uses a lookup table, get the table and field names  */
-        const {
-          table_name: lookupTable,
-          operators: lookupOperators,
-        } = fieldConfig?.lookup ?? {};
+        const { table_name: lookupTable, operators: lookupOperators } =
+          fieldConfig?.lookup ?? {};
 
         /* Check filter row validity */
         const isValidInput = checkIsValidInput(filter, type);
@@ -445,12 +452,12 @@ const Filters = ({
                   fullWidth
                   className={classes.formControl}
                 >
-                  <InputLabel
+                  {/* <InputLabel
                     id={`filter-operator-select-${filterIndex}-label`}
                   >
                     Operator
-                  </InputLabel>
-                  <Select
+                  </InputLabel> */}
+                  {/* <Select
                     variant="standard"
                     fullWidth
                     disabled={operators.length === 0}
@@ -481,7 +488,30 @@ const Filters = ({
                         </MenuItem>
                       );
                     })}
-                  </Select>
+                  </Select> */}
+                  <Autocomplete
+                    value={operator || ""}
+                    options={operators}
+                    disabled={operators.length === 0}
+                    getOptionLabel={(operator) =>
+                      operator ? FILTERS_COMMON_OPERATORS[operator]?.label : ""
+                    }
+                    onChange={(e) =>
+                      handleFilterOperatorChange(
+                        filterIndex,
+                        e.target.value,
+                        lookupTable,
+                        lookupOperators
+                      )
+                    }
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        variant="standard"
+                        label={"Operator"}
+                      />
+                    )}
+                  />
                 </FormControl>
               </Grid>
 

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -445,6 +445,7 @@ const Filters = ({
                 >
                   <Autocomplete
                     value={operator || null}
+                    id={`filter-operator-select-${filterIndex}`}
                     options={operators}
                     disabled={operators.length === 0}
                     getOptionLabel={(operator) =>

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -7,6 +7,7 @@ import {
   Grid,
   Paper,
   Popper,
+  ClickAwayListener,
 } from "@mui/material";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
@@ -244,18 +245,20 @@ const Search = ({
         placement={"bottom"}
         className={classes.advancedSearchRoot}
       >
-        <Paper className={classes.advancedSearchPaper}>
-          <Filters
-            setFilters={setFilters}
-            handleAdvancedSearchClose={handleAdvancedSearchClose}
-            filtersConfig={filtersConfig}
-            resetSimpleSearch={resetSimpleSearch}
-            isOr={isOr}
-            setIsOr={setIsOr}
-            setSearchParams={setSearchParams}
-            searchParams={searchParams}
-          />
-        </Paper>
+        <ClickAwayListener onClickAway={handleAdvancedSearchClose}>
+          <Paper className={classes.advancedSearchPaper}>
+            <Filters
+              setFilters={setFilters}
+              handleAdvancedSearchClose={handleAdvancedSearchClose}
+              filtersConfig={filtersConfig}
+              resetSimpleSearch={resetSimpleSearch}
+              isOr={isOr}
+              setIsOr={setIsOr}
+              setSearchParams={setSearchParams}
+              searchParams={searchParams}
+            />
+          </Paper>
+        </ClickAwayListener>
       </Popper>
     </div>
   );

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -245,6 +245,9 @@ const Search = ({
         placement={"bottom"}
         className={classes.advancedSearchRoot}
       >
+        {/* FYI: you cannot use a Select component inside the click away listener
+        as discussed in this thread https://github.com/mui/material-ui/issues/25578 
+        so we have opted to use Autocompletes instead*/}
         <ClickAwayListener onClickAway={handleAdvancedSearchClose}>
           <Paper className={classes.advancedSearchPaper}>
             <Filters


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19413

I decided to address the regression discussed in [this thread](https://austininnovation.slack.com/archives/CNUEPKLB1/p1731007753509409) by changing the select input to an autocomplete, like @mddilley suggested at the end of that thread. Now you  can select an operator without triggering the clickaway event!

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
[Netlify](https://deploy-preview-1492--atd-moped-main.netlify.app/moped/projects)

**Steps to test:**
1. Test opening the advanced search and clicking outside of it to close it.
2. Test adding filters, selecting operators, etc, searching, etc.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
