### PR TITLE
Update moped_department to reflect reorganization

### DIFF
--- a/moped-database/migrations/1732661952305_department_reorg/down.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/down.sql
@@ -1,0 +1,3 @@
+-- Updating moped_department table will be up only. If we need to revert, we will need do it manually or
+-- update with a future migration.
+SELECT 0;

--- a/moped-database/migrations/1732661952305_department_reorg/up.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/up.sql
@@ -3,3 +3,34 @@ ALTER TABLE moped_department ADD is_deleted boolean DEFAULT FALSE;
 
 INSERT INTO "public"."moped_department" ("department_name", "department_abbreviation", "organization_id") VALUES
 ('Austin Transportation and Public Works', 'TPW', 1);
+
+-- Soft delete existing department records that are merging into the new one
+UPDATE moped_department SET is_deleted = TRUE WHERE department_name IN ('Austin Transportation', 'Public Works');
+
+-- Find existing workgroup records that are associated with the departments that are merging
+-- and update them to the new department row called Austin Transportation and Public Works
+WITH department_todos AS (
+    SELECT department_id AS ids
+    FROM
+        moped_department
+    WHERE
+        department_name IN (
+            'Austin Transportation',
+            'Public Works'
+        )
+),
+
+new_department_row AS (
+    SELECT department_id AS id
+    FROM
+        moped_department
+    WHERE
+        department_name = 'Austin Transportation and Public Works'
+)
+
+UPDATE
+moped_workgroup
+SET
+    department_id = (SELECT id FROM new_department_row)
+WHERE
+    department_id IN (SELECT ids FROM department_todos);

--- a/moped-database/migrations/1732661952305_department_reorg/up.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/up.sql
@@ -1,0 +1,5 @@
+-- Add soft deletes to department table
+ALTER TABLE moped_department ADD is_deleted boolean DEFAULT FALSE;
+
+INSERT INTO "public"."moped_department" ("department_name", "department_abbreviation", "organization_id") VALUES
+('Austin Transportation and Public Works', 'TPW', 1);

--- a/moped-database/migrations/1732661952305_department_reorg/up.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/up.sql
@@ -82,3 +82,6 @@ REFERENCES moped_organization ("organization_id");
 ALTER TABLE moped_department
 ADD CONSTRAINT moped_entity_organization_id_fkey FOREIGN KEY ("organization_id")
 REFERENCES moped_organization ("organization_id");
+
+-- Remove row with 0 for id and 'None' for name; we're not using it and null is more appropriate for entities and workgroups with no department
+DELETE FROM moped_department WHERE department_id = 0;

--- a/moped-database/migrations/1732661952305_department_reorg/up.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/up.sql
@@ -80,7 +80,7 @@ ADD CONSTRAINT moped_entity_organization_id_fkey FOREIGN KEY ("organization_id")
 REFERENCES moped_organization ("organization_id");
 
 ALTER TABLE moped_department
-ADD CONSTRAINT moped_entity_organization_id_fkey FOREIGN KEY ("organization_id")
+ADD CONSTRAINT moped_department_organization_id_fkey FOREIGN KEY ("organization_id")
 REFERENCES moped_organization ("organization_id");
 
 -- Remove row with 0 for id and 'None' for name; we're not using it and null is more appropriate for entities and workgroups with no department

--- a/moped-database/migrations/1732661952305_department_reorg/up.sql
+++ b/moped-database/migrations/1732661952305_department_reorg/up.sql
@@ -68,3 +68,17 @@ WHERE
 ALTER TABLE moped_entity
 ADD CONSTRAINT moped_entity_department_id_fkey FOREIGN KEY ("department_id")
 REFERENCES moped_department ("department_id");
+
+-- Add foreign key constraints to entity table workgroup_id column
+ALTER TABLE moped_entity
+ADD CONSTRAINT moped_entity_workgroup_id_fkey FOREIGN KEY ("workgroup_id")
+REFERENCES moped_workgroup ("workgroup_id");
+
+-- Add foreign key constraints to department and entity tables for organization_id columns
+ALTER TABLE moped_entity
+ADD CONSTRAINT moped_entity_organization_id_fkey FOREIGN KEY ("organization_id")
+REFERENCES moped_organization ("organization_id");
+
+ALTER TABLE moped_department
+ADD CONSTRAINT moped_entity_organization_id_fkey FOREIGN KEY ("organization_id")
+REFERENCES moped_organization ("organization_id");

--- a/moped-etl/README.md
+++ b/moped-etl/README.md
@@ -1,3 +1,3 @@
 # Moped ETLs
 
-These ETLs are scheduled through our [Airflow](https://github.com/cityofaustin/atd-airflow) deployment. Each folder contains a containerized Python script and the Docker images are updated through Github Action workflows. 
+These ETLs are scheduled through our [Airflow](https://github.com/cityofaustin/atd-airflow) deployment. Each folder contains a containerized Python script and the Docker images are updated through GitHub Action workflows. 

--- a/moped-etl/README.md
+++ b/moped-etl/README.md
@@ -1,0 +1,3 @@
+# Moped ETLs
+
+These ETLs are scheduled through our [Airflow](https://github.com/cityofaustin/atd-airflow) deployment. Each folder contains a containerized Python script and the Docker images are updated through Github Action workflows. 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19852
Closes https://github.com/cityofaustin/atd-data-tech/issues/19717

This PR updates the department table to merge ATD and PWD into TPW. It also adds some foreign key constraints that are missing where primary key values from the workgroup, department, and organization tables are used in other tables. It also removes an outdated row in `moped_department` that had an id of 0 and value of 'None' that is not used.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start your local stack and explore the `moped_department` table in your local database. You can connect to the production or staging database to compare the changes in this PR to the current schema and values.
2. You should see that this table now has an `is_deleted` column with the ATD and PWD columns marked at `TRUE`
3. You should also see a new row for TPW and also that the row with id = 0 is now gone
4. Check the `department_id` column in the `moped_workgroup` table and see that all rows (except for CPO) now have the value that points to the TPW row in the department table. Previously, some we marked as ATD and some PWD.
5. Check the `department_id` column in the `moped_entity` table and see that all rows that were marked as ATD or PWD now have the value that points to the TPW row in the `department_id` column.
6. You should also see new foreign key relationship to show:
   - `moped_entity` uses ids from the `moped_department` table
   - `moped_entity` uses ids from the `moped_workgroup` table
   - `moped_entity` uses ids from the `moped_organization` table
   - `moped_department` uses ids from the `moped_organization` table
7. Read over the ETL readme and see if it makes sense

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
