### PR TITLE
Make Dashboard modals show full project name

### DIFF
--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -202,7 +202,7 @@ const DashboardView = () => {
         <DashboardTimelineModal
           table="phases"
           projectId={entry.project_id}
-          projectName={entry.project.project_name}
+          projectName={entry.project.project_name_full}
           dashboardRefetch={refetch}
         >
           <ProjectStatusBadge
@@ -222,7 +222,7 @@ const DashboardView = () => {
       render: (entry) => (
         <DashboardStatusModal
           projectId={entry.project_id}
-          projectName={entry.project.project_name}
+          projectName={entry.project.project_name_full}
           currentPhaseId={entry.current_phase_id}
           modalParent="dashboard"
           statusUpdate={entry.status_update}
@@ -241,7 +241,7 @@ const DashboardView = () => {
         <DashboardTimelineModal
           table="milestones"
           projectId={entry.project_id}
-          projectName={entry.project.project_name}
+          projectName={entry.project.project_name_full}
           dashboardRefetch={refetch}
         >
           <MilestoneProgressMeter


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19820

## Testing
**URL to test:** 
https://deploy-preview-1494--atd-moped-main.netlify.app/moped/projects/1965/

**Steps to test:**

1. Follow the project linked above, or follow/create any project that has a secondary name. 
2. Go to the dashboard tab, find your project either in my projects or following
3. Click the status badge, a modal will pop up. Confirm the full name is at the top of the modal 
4. Click on status update/comment. Same deal, modal appears, confirm full name.
5. Now click on the milestones percent completed. Modal appears, confirm full name appears at the top. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
