### PR TITLE
Add fund status table to Data Dictionary with funding status descriptions

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -1767,18 +1767,21 @@
         columns:
           - funding_status_id
           - funding_status_name
+          - funding_status_description
         filter: {}
     - role: moped-editor
       permission:
         columns:
           - funding_status_id
           - funding_status_name
+          - funding_status_description
         filter: {}
     - role: moped-viewer
       permission:
         columns:
           - funding_status_id
           - funding_status_name
+          - funding_status_description
         filter: {}
 - table:
     name: moped_funds

--- a/moped-database/migrations/1735340549358_add-funding-status-description/down.sql
+++ b/moped-database/migrations/1735340549358_add-funding-status-description/down.sql
@@ -1,0 +1,3 @@
+-- Remove the funding_status_description column
+ALTER TABLE "public"."moped_fund_status" 
+DROP COLUMN "funding_status_description";

--- a/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
+++ b/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
@@ -8,7 +8,7 @@ SET "funding_status_description" = CASE "funding_status_name"
     WHEN 'Tentative' THEN 'In conversation about possible funding commitment'
     WHEN 'Confirmed' THEN 'Commitment to funding'
     WHEN 'Available' THEN 'Funding is available, e.g. private developer'
-    WHEN 'Funding setup requested' THEN NULL
+    WHEN 'Funding setup requested' THEN 'Requested that funding be set up in eCAPRIS'
     WHEN 'Set up' THEN 'Funding has been set up in eCAPRIS; has FDU'
     ELSE "funding_status_description"
 END;

--- a/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
+++ b/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
@@ -1,14 +1,14 @@
-   ALTER TABLE "public"."moped_fund_status" 
-   ADD COLUMN "funding_status_description" text NULL;
+ALTER TABLE "public"."moped_fund_status" 
+ADD COLUMN "funding_status_description" text NULL;
 
-   COMMENT ON COLUMN "public"."moped_fund_status"."funding_status_description" IS 'Description of the funding status';
+COMMENT ON COLUMN "public"."moped_fund_status"."funding_status_description" IS 'Description of the funding status';
 
-   UPDATE "public"."moped_fund_status"
-   SET "funding_status_description" = CASE "funding_status_name"
-       WHEN 'Tentative' THEN 'In conversation about possible funding commitment'
-       WHEN 'Confirmed' THEN 'Commitment to funding'
-       WHEN 'Available' THEN 'Funding is available, e.g. private developer'
-       WHEN 'Funding setup requested' THEN NULL
-       WHEN 'Set up' THEN 'Funding has been set up in eCAPRIS; has FDU'
-       ELSE "funding_status_description"
-   END;
+UPDATE "public"."moped_fund_status"
+SET "funding_status_description" = CASE "funding_status_name"
+    WHEN 'Tentative' THEN 'In conversation about possible funding commitment'
+    WHEN 'Confirmed' THEN 'Commitment to funding'
+    WHEN 'Available' THEN 'Funding is available, e.g. private developer'
+    WHEN 'Funding setup requested' THEN NULL
+    WHEN 'Set up' THEN 'Funding has been set up in eCAPRIS; has FDU'
+    ELSE "funding_status_description"
+END;

--- a/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
+++ b/moped-database/migrations/1735340549358_add-funding-status-description/up.sql
@@ -1,0 +1,14 @@
+   ALTER TABLE "public"."moped_fund_status" 
+   ADD COLUMN "funding_status_description" text NULL;
+
+   COMMENT ON COLUMN "public"."moped_fund_status"."funding_status_description" IS 'Description of the funding status';
+
+   UPDATE "public"."moped_fund_status"
+   SET "funding_status_description" = CASE "funding_status_name"
+       WHEN 'Tentative' THEN 'In conversation about possible funding commitment'
+       WHEN 'Confirmed' THEN 'Commitment to funding'
+       WHEN 'Available' THEN 'Funding is available, e.g. private developer'
+       WHEN 'Funding setup requested' THEN NULL
+       WHEN 'Set up' THEN 'Funding has been set up in eCAPRIS; has FDU'
+       ELSE "funding_status_description"
+   END;

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -15,8 +15,14 @@ CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
 funding_sources_lookup AS (
     SELECT
         mpf.project_id,
-        string_agg(DISTINCT mfs.funding_source_name, ', '::text ORDER BY mfs.funding_source_name) AS funding_source_name,
-        string_agg(DISTINCT mfp.funding_program_name, ', '::text ORDER BY mfp.funding_program_name) AS funding_program_names,
+        string_agg(
+            DISTINCT mfs.funding_source_name, ', '::text
+            ORDER BY mfs.funding_source_name
+        ) AS funding_source_name,
+        string_agg(
+            DISTINCT mfp.funding_program_name, ', '::text
+            ORDER BY mfp.funding_program_name
+        ) AS funding_program_names,
         string_agg(
             DISTINCT
             CASE
@@ -24,7 +30,8 @@ funding_sources_lookup AS (
                 WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
                 WHEN mfp.funding_program_name IS NOT null THEN mfp.funding_program_name
                 ELSE null::text
-            END, ', '::text ORDER BY (
+            END, ', '::text
+            ORDER BY (
                 CASE
                     WHEN mfs.funding_source_name IS NOT null AND mfp.funding_program_name IS NOT null THEN concat(mfs.funding_source_name, ' - ', mfp.funding_program_name)
                     WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
@@ -170,7 +177,10 @@ min_estimated_phase_dates AS (
 project_component_work_types AS (
     SELECT
         mpc.project_id,
-        string_agg(DISTINCT mwt.name, ', '::text ORDER BY mwt.name) AS component_work_type_names
+        string_agg(
+            DISTINCT mwt.name, ', '::text
+            ORDER BY mwt.name
+        ) AS component_work_type_names
     FROM moped_proj_components mpc
     LEFT JOIN moped_proj_component_work_types mpcwt ON mpcwt.project_component_id = mpc.project_component_id
     LEFT JOIN moped_work_types mwt ON mwt.id = mpcwt.work_type_id

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -75,5 +75,9 @@ export const TABLE_LOOKUPS_QUERY = gql`
       project_role_name
       project_role_description
     }
+    moped_fund_status(where: { funding_status_id: { _neq: 0 } }) {
+      funding_status_name
+      funding_status_id
+    }
   }
 `;

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -78,6 +78,7 @@ export const TABLE_LOOKUPS_QUERY = gql`
     moped_fund_status(where: { funding_status_id: { _neq: 0 } }) {
       funding_status_name
       funding_status_id
+      funding_status_description
     }
   }
 `;

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -75,7 +75,10 @@ export const TABLE_LOOKUPS_QUERY = gql`
       project_role_name
       project_role_description
     }
-    moped_fund_status(where: { funding_status_id: { _neq: 0 } }) {
+    moped_fund_status(
+      # Filter out the "Archived" status
+      where: { funding_status_id: { _neq: 0 } }
+    ) {
       funding_status_name
       funding_status_id
       funding_status_description

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -223,4 +223,22 @@ export const SETTINGS = [
       },
     ],
   },
+  {
+    key: "moped_fund_status",
+    label: "Fund Status",
+    columns: [
+      {
+        key: "funding_status_id",
+        label: "Status ID",
+      },
+      {
+        key: "funding_status_name",
+        label: "Name",
+      },
+      {
+        key: "funding_status_description",
+        label: "Description",
+      },
+    ],
+  },
 ];

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -122,6 +122,24 @@ export const SETTINGS = [
     ],
   },
   {
+    key: "moped_fund_status",
+    label: "Fund Status",
+    columns: [
+      {
+        key: "funding_status_id",
+        label: "Status ID",
+      },
+      {
+        key: "funding_status_name",
+        label: "Name",
+      },
+      {
+        key: "funding_status_description",
+        label: "Description",
+      },
+    ],
+  },
+  {
     key: "moped_milestones",
     label: "Milestones",
     columns: [
@@ -220,24 +238,6 @@ export const SETTINGS = [
       {
         key: "slug",
         label: "Slug",
-      },
-    ],
-  },
-  {
-    key: "moped_fund_status",
-    label: "Fund Status",
-    columns: [
-      {
-        key: "funding_status_id",
-        label: "Status ID",
-      },
-      {
-        key: "funding_status_name",
-        label: "Name",
-      },
-      {
-        key: "funding_status_description",
-        label: "Description",
       },
     ],
   },


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19665

![Screenshot 2024-12-27 at 4 09 45 PM](https://github.com/user-attachments/assets/89201ce7-eb52-4897-988a-50ad6cf52560)

## Testing
**URL to test:** 
Test locally since there is a migration required.

**Steps to test:**
1. Run local migrations
2. Go to https://localhost:3000/moped/dev/lookups
3. Click the "FUND STATUS" button on the far right of the lookups listed and confirm it takes you to the new lookup table at the bottom of the page AND/OR use this link with an anchor tag: https://localhost:3000/moped/dev/lookups#moped-fund_status
4. After scrolling to the bottom of the page, you should see the Fund Status lookups listed as pictured in the screenshot above.
5. (Optional) Test the down migration with a command like `hasura migrate apply --down 1` and confirm that the `funding_status_description` field is dropped properly.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
