### PR TITLE
Add new project tags to help track SS4A grant funding (Patch into production)

### DIFF
--- a/moped-database/migrations/1734112355149_add_ss4a_proj_tags/down.sql
+++ b/moped-database/migrations/1734112355149_add_ss4a_proj_tags/down.sql
@@ -1,5 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- INSERT INTO moped_tags (name, type, slug, is_deleted) VALUES
--- ('SS4A Vision Zero 2022', 'Work Plan', 'ss4a_vision_zero_2022', FALSE),
--- ('SS4A Vision Zero 2024', 'Work Plan', 'ss4a_vision_zero_2024', FALSE);
+DELETE FROM public.moped_tags WHERE slug = 'ss4a_vision_zero_2022' OR slug = 'ss4a_vision_zero_2024';

--- a/moped-database/migrations/1734112355149_add_ss4a_proj_tags/down.sql
+++ b/moped-database/migrations/1734112355149_add_ss4a_proj_tags/down.sql
@@ -1,0 +1,5 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- INSERT INTO moped_tags (name, type, slug, is_deleted) VALUES
+-- ('SS4A Vision Zero 2022', 'Work Plan', 'ss4a_vision_zero_2022', FALSE),
+-- ('SS4A Vision Zero 2024', 'Work Plan', 'ss4a_vision_zero_2024', FALSE);

--- a/moped-database/migrations/1734112355149_add_ss4a_proj_tags/up.sql
+++ b/moped-database/migrations/1734112355149_add_ss4a_proj_tags/up.sql
@@ -1,0 +1,3 @@
+INSERT INTO moped_tags (name, type, slug, is_deleted) VALUES
+('SS4A Vision Zero 2022', 'Work Plan', 'ss4a_vision_zero_2022', FALSE),
+('SS4A Vision Zero 2024', 'Work Plan', 'ss4a_vision_zero_2024', FALSE);

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -15,8 +15,14 @@ CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
 funding_sources_lookup AS (
     SELECT
         mpf.project_id,
-        string_agg(DISTINCT mfs.funding_source_name, ', '::text ORDER BY mfs.funding_source_name) AS funding_source_name,
-        string_agg(DISTINCT mfp.funding_program_name, ', '::text ORDER BY mfp.funding_program_name) AS funding_program_names,
+        string_agg(
+            DISTINCT mfs.funding_source_name, ', '::text
+            ORDER BY mfs.funding_source_name
+        ) AS funding_source_name,
+        string_agg(
+            DISTINCT mfp.funding_program_name, ', '::text
+            ORDER BY mfp.funding_program_name
+        ) AS funding_program_names,
         string_agg(
             DISTINCT
             CASE
@@ -24,7 +30,8 @@ funding_sources_lookup AS (
                 WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
                 WHEN mfp.funding_program_name IS NOT null THEN mfp.funding_program_name
                 ELSE null::text
-            END, ', '::text ORDER BY (
+            END, ', '::text
+            ORDER BY (
                 CASE
                     WHEN mfs.funding_source_name IS NOT null AND mfp.funding_program_name IS NOT null THEN concat(mfs.funding_source_name, ' - ', mfp.funding_program_name)
                     WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
@@ -170,7 +177,10 @@ min_estimated_phase_dates AS (
 project_component_work_types AS (
     SELECT
         mpc.project_id,
-        string_agg(DISTINCT mwt.name, ', '::text ORDER BY mwt.name) AS component_work_type_names
+        string_agg(
+            DISTINCT mwt.name, ', '::text
+            ORDER BY mwt.name
+        ) AS component_work_type_names
     FROM moped_proj_components mpc
     LEFT JOIN moped_proj_component_work_types mpcwt ON mpcwt.project_component_id = mpc.project_component_id
     LEFT JOIN moped_work_types mwt ON mwt.id = mpcwt.work_type_id

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "homepage": "/moped",
   "private": false,
   "repository": {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20257

This PR adds two new tags named `SS4A Vision Zero 2022` and `SS4A Vision Zero 2024`

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start your local stack
2. Browse your local DB's `moped_tags` table and see that there are two new tags with the names above in the description
3. Run the down migration and see that the two new tags are removed
4. Run the up migration again and test that you can add and save these new tags to a project

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
