### PR TITLE
Add component work types summary field to project summary view

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5557,6 +5557,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers
@@ -5609,6 +5610,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers
@@ -5661,6 +5663,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -151,6 +151,10 @@ export const SUMMARY_QUERY = gql`
         ...projectComponentFields
       }
     }
+    project_list_view(where: { project_id: { _eq: $projectId } }) {
+      component_work_type_names
+      project_id
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -5,8 +5,6 @@ import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
 
 import { Grid, CardContent, CircularProgress } from "@mui/material";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -22,7 +20,7 @@ import ProjectSummaryInterimID from "./ProjectSummaryInterimID";
 import ProjectSummaryAutocomplete from "./ProjectSummaryAutocomplete";
 import ProjectSummaryProjectPartners from "./ProjectSummaryProjectPartners";
 import ProjectSummaryCouncilDistricts from "./ProjectSummaryCouncilDistricts";
-import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
+import ProjectSummaryComponentWorkTypes from "./ProjectSummaryComponentWorkTypes";
 
 import SubprojectsTable from "./SubprojectsTable";
 import TagsSection from "./TagsSection";
@@ -237,23 +235,10 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
                 />
               </Grid>
               <Grid item xs={12}>
-                <Grid item xs={12} className={classes.fieldGridItem}>
-                  <Typography className={classes.fieldLabel}>
-                    Component work types
-                  </Typography>
-                  <Box
-                    display="flex"
-                    justifyContent="flex-start"
-                    className={classes.fieldBox}
-                  >
-                    <ProjectSummaryLabel
-                      text={data?.project_list_view?.[0]?.component_work_type_names.split(
-                        ", "
-                      )}
-                      className={classes.fieldLabelTextNoHover}
-                    />
-                  </Box>
-                </Grid>
+                <ProjectSummaryComponentWorkTypes
+                  data={data}
+                  classes={classes}
+                />
               </Grid>
               <Grid item xs={12}>
                 <ProjectSummaryAutocomplete

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -5,6 +5,8 @@ import ProjectSummaryMap from "./ProjectSummaryMap";
 import ProjectSummaryStatusUpdate from "./ProjectSummaryStatusUpdate";
 
 import { Grid, CardContent, CircularProgress } from "@mui/material";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import ApolloErrorHandler from "../../../../components/ApolloErrorHandler";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -20,6 +22,7 @@ import ProjectSummaryInterimID from "./ProjectSummaryInterimID";
 import ProjectSummaryAutocomplete from "./ProjectSummaryAutocomplete";
 import ProjectSummaryProjectPartners from "./ProjectSummaryProjectPartners";
 import ProjectSummaryCouncilDistricts from "./ProjectSummaryCouncilDistricts";
+import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 
 import SubprojectsTable from "./SubprojectsTable";
 import TagsSection from "./TagsSection";
@@ -234,6 +237,25 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
                 />
               </Grid>
               <Grid item xs={12}>
+                <Grid item xs={12} className={classes.fieldGridItem}>
+                  <Typography className={classes.fieldLabel}>
+                    Component work types
+                  </Typography>
+                  <Box
+                    display="flex"
+                    justifyContent="flex-start"
+                    className={classes.fieldBox}
+                  >
+                    <ProjectSummaryLabel
+                      text={data?.project_list_view?.[0]?.component_work_type_names.split(
+                        ", "
+                      )}
+                      className={classes.fieldLabelTextNoHover}
+                    />
+                  </Box>
+                </Grid>
+              </Grid>
+              <Grid item xs={12}>
                 <ProjectSummaryAutocomplete
                   field="Public process"
                   idColumn={"id"}
@@ -288,8 +310,6 @@ const ProjectSummary = ({ loading, error, data, refetch, listViewQuery }) => {
                 <ProjectSummaryWorkOrders
                   classes={classes}
                   project={data?.moped_project?.[0]}
-                  refetch={refetch}
-                  snackbarHandle={snackbarHandle}
                 />
               </Grid>
             </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Grid, Box, Typography, Icon, TextField } from "@mui/material";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
-import { Autocomplete } from '@mui/material';
+import { Autocomplete } from "@mui/material";
 
 import { useMutation } from "@apollo/client";
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryComponentWorkTypes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryComponentWorkTypes.js
@@ -10,6 +10,11 @@ import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/P
  * @constructor
  */
 const ProjectSummaryComponentWorkTypes = ({ classes, data }) => {
+  const componentWorkTypes =
+    data?.project_list_view?.[0]?.component_work_type_names;
+  /* component_work_type_names is a comma-separated list in the database view */
+  const componentWorkTypesArray = componentWorkTypes?.split(", ") ?? [];
+
   return (
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Typography className={classes.fieldLabel}>
@@ -21,9 +26,7 @@ const ProjectSummaryComponentWorkTypes = ({ classes, data }) => {
         className={classes.fieldBox}
       >
         <ProjectSummaryLabel
-          text={data?.project_list_view?.[0]?.component_work_type_names.split(
-            ", "
-          )}
+          text={componentWorkTypesArray}
           className={classes.fieldLabelTextNoHover}
         />
       </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryComponentWorkTypes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryComponentWorkTypes.js
@@ -1,0 +1,34 @@
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
+
+/**
+ * @param {Object} data - The query data
+ * @param {Object} classes - The shared style settings
+ * @return {JSX.Element}
+ * @constructor
+ */
+const ProjectSummaryComponentWorkTypes = ({ classes, data }) => {
+  return (
+    <Grid item xs={12} className={classes.fieldGridItem}>
+      <Typography className={classes.fieldLabel}>
+        Component work types
+      </Typography>
+      <Box
+        display="flex"
+        justifyContent="flex-start"
+        className={classes.fieldBox}
+      >
+        <ProjectSummaryLabel
+          text={data?.project_list_view?.[0]?.component_work_type_names.split(
+            ", "
+          )}
+          className={classes.fieldLabelTextNoHover}
+        />
+      </Box>
+    </Grid>
+  );
+};
+
+export default ProjectSummaryComponentWorkTypes;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -148,7 +148,8 @@ const ProjectSummaryProjectPartners = ({
                   width: 450,
                 },
               }}
-              className={classes.fieldSelectItem}>
+              className={classes.fieldSelectItem}
+            >
               {entityList.map((entity) => (
                 <MenuItem key={entity.entity_id} value={entity.entity_id}>
                   <Checkbox

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryWorkOrders.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryWorkOrders.js
@@ -8,18 +8,11 @@ import ExternalLink from "src/components/ExternalLink";
 /**
  * ProjectSummaryWorkOrders Component
  * @param {Object} project - Current project being viewed
- * @param {function} refetch - The refetch function from apollo
  * @param {Object} classes - The shared style settings
- * @param {function} snackbarHandle - The function to show the snackbar
  * @returns {JSX.Element}
  * @constructor
  */
-const ProjectSummaryWorkOrders = ({
-  project,
-  refetch,
-  classes,
-  snackbarHandle,
-}) => {
+const ProjectSummaryWorkOrders = ({ project, classes }) => {
   const knackProjectURL = project?.knack_project_id
     ? `https://atd.knack.com/amd#work-orders/?view_713_filters=%7B%22match%22%3A%22and%22%2C%22rules%22%3A%5B%7B%22field%22%3A%22field_4133%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%22${project.project_id}%22%7D%5D%7D`
     : "";


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20019

This PR updates the project summary to display the list of component work types. There are also some Prettier changes that came along as I was looking at our components that render the summary items.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local because of the Hasura metadata update

**Steps to test:**
1. Start your local stack and create a new, non-signal project
2. Go to the summary view and see the new item called `Component work types`
3. Since the new project has no components, the UI should show `-`
4. Now, add a component with a few works types to the project
5. Back in the summary view, you should see each component work types in a list with each type on a new line. The list should not highlight when hovered since it is not editable in the summary view.
6. You can try adding more components and work types to see the list update

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
