### PR TITLE
Add component work types to project list view and make exportable/searchable

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5557,6 +5557,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers
@@ -5609,6 +5610,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers
@@ -5661,6 +5663,7 @@
         columns:
           - added_by
           - children_project_ids
+          - component_work_type_names
           - components
           - construction_start_date
           - contract_numbers

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -996,6 +996,13 @@ export const LOOKUP_TABLES_QUERY = gql`
       id
       council_district
     }
+    moped_work_types(
+      order_by: { name: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
+      id
+      name
+    }
   }
 `;
 

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -116,6 +116,6 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
     label: "Council districts",
   },
   component_work_type_names: {
-    label: "Work types",
+    label: "Component work types",
   },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -115,4 +115,7 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
   project_and_child_project_council_districts: {
     label: "Council districts",
   },
+  component_work_type_names: {
+    label: "Work Types",
+  },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewExportConf.js
@@ -116,6 +116,6 @@ export const PROJECT_LIST_VIEW_EXPORT_CONFIG = {
     label: "Council districts",
   },
   component_work_type_names: {
-    label: "Work Types",
+    label: "Work types",
   },
 };

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -127,7 +127,7 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
   },
   component_work_type_names: {
     name: "component_work_type_names",
-    label: "Work types",
+    label: "Component work types",
     type: "string",
     defaultOperator: "string_contains_case_insensitive",
     lookup: {

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -136,17 +136,11 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       operators: [
         "string_contains_case_insensitive",
         "string_contains_not_case_insensitive",
-        "string_equals_case_insensitive",
-        "string_does_not_equal_case_insensitive",
       ],
     },
     operators: [
       "string_contains_case_insensitive",
       "string_contains_not_case_insensitive",
-      "string_equals_case_insensitive",
-      "string_does_not_equal_case_insensitive",
-      "string_begins_with_case_insensitive",
-      "string_ends_with_case_insensitive",
       "string_is_null",
       "string_is_not_null",
     ],

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewFiltersConf.js
@@ -125,6 +125,32 @@ export const PROJECT_LIST_VIEW_FILTERS_CONFIG = {
       "string_is_not_null",
     ],
   },
+  component_work_type_names: {
+    name: "component_work_type_names",
+    label: "Work types",
+    type: "string",
+    defaultOperator: "string_contains_case_insensitive",
+    lookup: {
+      table_name: "moped_work_types",
+      getOptionLabel: (option) => option.name,
+      operators: [
+        "string_contains_case_insensitive",
+        "string_contains_not_case_insensitive",
+        "string_equals_case_insensitive",
+        "string_does_not_equal_case_insensitive",
+      ],
+    },
+    operators: [
+      "string_contains_case_insensitive",
+      "string_contains_not_case_insensitive",
+      "string_equals_case_insensitive",
+      "string_does_not_equal_case_insensitive",
+      "string_begins_with_case_insensitive",
+      "string_ends_with_case_insensitive",
+      "string_is_null",
+      "string_is_not_null",
+    ],
+  },
   updated_at: {
     name: "updated_at",
     label: "Modified",

--- a/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
+++ b/moped-editor/src/views/projects/projectsListView/ProjectsListViewQueryConf.js
@@ -319,6 +319,12 @@ export const PROJECT_LIST_VIEW_QUERY_CONFIG = {
       defaultHidden: true,
       showInTable: true,
     },
+   component_work_type_names: {
+      type: "array",
+      sortable: true,
+      defaultHidden: true,
+      showInTable: true,
+    },
   },
 };
 

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -295,6 +295,13 @@ export const useColumns = ({ hiddenColumns }) => {
         width: COLUMN_WIDTHS.medium,
       },
       {
+        headerName: "Work Types",
+        field: "component_work_type_names",
+        renderCell: ({ row }) =>
+          renderSplitListDisplayBlock(row, "component_work_type_names"),
+        width: COLUMN_WIDTHS.medium,
+      },
+      {
         headerName: "Funding",
         field: "funding_source_and_program_names",
         cellStyle: { whiteSpace: "noWrap" },

--- a/moped-editor/src/views/projects/projectsListView/helpers.js
+++ b/moped-editor/src/views/projects/projectsListView/helpers.js
@@ -295,7 +295,7 @@ export const useColumns = ({ hiddenColumns }) => {
         width: COLUMN_WIDTHS.medium,
       },
       {
-        headerName: "Work Types",
+        headerName: "Component work types",
         field: "component_work_type_names",
         renderCell: ({ row }) =>
           renderSplitListDisplayBlock(row, "component_work_type_names"),


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20020

## Testing
**URL to test:** 

you will need to test locally because of metadata until Mike's PR gets merged
use prod data if you can

**Steps to test:**

1. from the projects page, click on the columns menu in the upper left hand corner of the table and toggle on the  "Component work types" column
2. Try sorting on that column
3. With the column visible, download records. confirm the column is in your csv
4. now try to advanced search on work types. contains, is, is blank etc


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
