### PR TITLE
Add project phase status badges to the Data dictionary

### DIFF
--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -4,6 +4,7 @@ export const TABLE_LOOKUPS_QUERY = gql`
   query TableLookupQuery {
     moped_phases(order_by: { phase_order: asc }) {
       phase_id
+      phase_key
       phase_name
       phase_name_simple
       phase_description

--- a/moped-editor/src/views/dev/LookupsView/RecordTable.js
+++ b/moped-editor/src/views/dev/LookupsView/RecordTable.js
@@ -14,7 +14,7 @@ import CircularProgress from "@mui/material/CircularProgress";
  * @returns { JSX } an MUI TableCell component with the row/column value
  */
 const WrappedTableCell = ({ row, column: { key, handler } }) => {
-  return <TableCell>{handler ? handler(row[key]) : row[key]}</TableCell>;
+  return <TableCell>{handler ? handler(row[key], row) : row[key]}</TableCell>;
 };
 
 /**

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -42,12 +42,19 @@ const workTypeHandler = (workTypes) =>
     <div key={workType.moped_work_type.id}>{workType.moped_work_type.name}</div>
   ));
 
-const statusBadgeHandler = (phaseName) => {
-  const phaseKey = phaseName.toLowerCase().replace(/[\s/-]/g, "_");
-  return (
-    <ProjectStatusBadge phaseKey={phaseKey} phaseName={phaseName} condensed />
-  );
-};
+/**
+ * Uses phase name and phase key from row object to render status badge
+ * @param {string} phaseName - phase name
+ * @param {Object} row a single Moped record object as returned from Hasura
+ * @returns ProjectStatusBadge component
+ */
+const statusBadgeHandler = (phaseName, row) => (
+  <ProjectStatusBadge
+    phaseKey={row.phase_key}
+    phaseName={phaseName}
+    condensed
+  />
+);
 
 /**
  * Definitions for data tables.

--- a/moped-editor/src/views/dev/LookupsView/settings.js
+++ b/moped-editor/src/views/dev/LookupsView/settings.js
@@ -1,3 +1,5 @@
+import ProjectStatusBadge from "src/views/projects/projectView/ProjectStatusBadge";
+
 /**
  * Parses an array of phase-subphases into an array of subphase names
  * @param {Object[]} subphases - array of moped_subphases objects
@@ -39,6 +41,13 @@ const workTypeHandler = (workTypes) =>
   workTypes.map((workType) => (
     <div key={workType.moped_work_type.id}>{workType.moped_work_type.name}</div>
   ));
+
+const statusBadgeHandler = (phaseName) => {
+  const phaseKey = phaseName.toLowerCase().replace(/[\s/-]/g, "_");
+  return (
+    <ProjectStatusBadge phaseKey={phaseKey} phaseName={phaseName} condensed />
+  );
+};
 
 /**
  * Definitions for data tables.
@@ -167,6 +176,7 @@ export const SETTINGS = [
       {
         key: "phase_name",
         label: "Phase name",
+        handler: statusBadgeHandler,
       },
       {
         key: "phase_name_simple",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20325

## Testing
**URL to test:** 

https://deploy-preview-1513--atd-moped-main.netlify.app/moped/dev/lookups#moped-phases

**Steps to test:**

There are now badges on the table instead of just the phase name. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
