### PR TITLE
Update moped_workgroup to reflect reorganization

### DIFF
--- a/moped-database/metadata/tables.yaml
+++ b/moped-database/metadata/tables.yaml
@@ -5466,25 +5466,28 @@
     - role: moped-admin
       permission:
         columns:
+          - date_added
+          - is_deleted
           - workgroup_id
           - workgroup_name
-          - date_added
         filter: {}
         allow_aggregations: true
     - role: moped-editor
       permission:
         columns:
+          - date_added
+          - is_deleted
           - workgroup_id
           - workgroup_name
-          - date_added
         filter: {}
         allow_aggregations: true
     - role: moped-viewer
       permission:
         columns:
-          - workgroup_name
-          - workgroup_id
           - date_added
+          - is_deleted
+          - workgroup_id
+          - workgroup_name
         filter: {}
         allow_aggregations: true
 - table:

--- a/moped-database/migrations/1734717637542_update_workgroups/down.sql
+++ b/moped-database/migrations/1734717637542_update_workgroups/down.sql
@@ -1,0 +1,3 @@
+-- Updating moped_workgroup table will be up only. If we need to revert, we will need do it manually or
+-- update with a future migration.
+SELECT 0;

--- a/moped-database/migrations/1734717637542_update_workgroups/up.sql
+++ b/moped-database/migrations/1734717637542_update_workgroups/up.sql
@@ -1,0 +1,37 @@
+-- Add soft deletes to workgroup table
+ALTER TABLE moped_workgroup ADD is_deleted boolean DEFAULT FALSE;
+COMMENT ON COLUMN moped_workgroup.is_deleted IS 'Indicates soft deletion';
+
+INSERT INTO moped_workgroup ("workgroup_name", "workgroup_abbreviation", "department_id") VALUES
+('Sidewalks and Urban Trails', 'SUTD', 11);
+
+-- Soft delete existing workgroup records that are merging into the new one
+UPDATE moped_workgroup SET is_deleted = TRUE WHERE workgroup_name IN ('Sidewalks', 'Urban Trails');
+
+-- Find existing users records that are associated with the workgroups that are merging
+-- and update them to the new workgroup row for SUTD
+WITH user_todos AS (
+    SELECT workgroup_id AS ids
+    FROM
+        moped_workgroup
+    WHERE
+        workgroup_name IN (
+            'Sidewalks',
+            'Urban Trails'
+        )
+),
+
+new_workgroup_row AS (
+    SELECT workgroup_id AS id
+    FROM
+        moped_workgroup
+    WHERE
+        workgroup_name = 'Sidewalks and Urban Trails'
+)
+
+UPDATE
+moped_users
+SET
+    workgroup_id = (SELECT id FROM new_workgroup_row)
+WHERE
+    workgroup_id IN (SELECT ids FROM user_todos);

--- a/moped-editor/src/queries/workgroups.js
+++ b/moped-editor/src/queries/workgroups.js
@@ -2,7 +2,10 @@ import { gql } from "@apollo/client";
 
 export const WORKGROUPS_QUERY = gql`
   query GetWorkgroups {
-    moped_workgroup(order_by: {workgroup_name: asc}) {
+    moped_workgroup(
+      order_by: { workgroup_name: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
       workgroup_id
       workgroup_name
     }


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19854

This PR updates workgroups with [Sidewalks and Urban Trails](https://www.austintexas.gov/department/transportation-public-works) and updates any users with Sidewalks or Urban Trails as their workgroup to fall under the new workgroup.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
1. Start your local stack with production data
2. Explore the `moped_workgroup` table and see that:
   - there is now a soft-delete column
   - the Sidewalks row is soft-deleted
   - the Urban Trails row is soft-deleted
   - there is now a row for Sidewalks and Urban Trails (SUTD)
3. Log into the Moped app as an admin (`Moped Test Admin` in our vault or your own account) so you can see the staff form in later steps and then go to the Staff tab
4. Filter the staff table's **Workgroup** column to `Sidewalks` and you should only see users with `Sidewalks and Urban Trails` workgroups
5. Click the "Add Staff" button and check the input for **Workgroup** to make sure that only `Sidewalks and Urban Trails` is available to select
6. Note a user from this table that has SUTD as their workgroup. Then, go to a project and add this user to a project team. You should see that the workgroup shown in the table is accurate too.
7. You can test these steps with the test editor account too but the "Add Staff" button should not be available.
---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
