### PR TITLE
Migrate subproject funding modal to DataGridPro

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -408,8 +408,7 @@ const ProjectFundingTable = () => {
             proj_funding_id: id,
           },
         })
-          .then(() => refetch())
-          .then(() => setIsDeleteConfirmationOpen(false))
+          .then(() => refetch().then(() => setIsDeleteConfirmationOpen(false)))
           .catch((error) => {
             setSnackbarState({
               open: true,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -24,7 +24,6 @@ import {
   DELETE_PROJECT_FUNDING,
 } from "../../../../queries/funding";
 
-import { getDatabaseId, useUser } from "../../../../auth/user";
 import FundingDeptUnitAutocomplete from "./FundingDeptUnitAutocomplete";
 import DollarAmountIntegerField from "./DollarAmountIntegerField";
 import DataGridTextField from "../DataGridTextField";
@@ -245,12 +244,6 @@ const ProjectFundingTable = () => {
   const apiRef = useGridApiRef();
   const classes = useStyles();
 
-  /**
-   * User Hook
-   * @type {object} CognitoUserSession
-   */
-  const { user } = useUser();
-
   /** Params Hook
    * @type {integer} projectId
    * */
@@ -335,8 +328,6 @@ const ProjectFundingTable = () => {
     },
     [apiRef]
   );
-
-  const userId = getDatabaseId(user);
 
   /**
    * Wrapper around snackbar state setter

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -408,7 +408,8 @@ const ProjectFundingTable = () => {
             proj_funding_id: id,
           },
         })
-          .then(() => refetch().then(() => setIsDeleteConfirmationOpen(false)))
+          .then(() => refetch())
+          .then(() => setIsDeleteConfirmationOpen(false))
           .catch((error) => {
             setSnackbarState({
               open: true,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -626,9 +626,9 @@ const ProjectFundingTable = () => {
         eCaprisID={eCaprisID}
         fdusArray={fdusArray}
         addProjectFunding={addProjectFunding}
-        userId={userId}
         projectId={projectId}
         setSnackbarState={setSnackbarState}
+        refetch={refetch}
       />
     </ApolloErrorHandler>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -21,14 +21,14 @@ const useColumns = () =>
       {
         headerName: "FDU",
         field: "fdu",
-        editable: false,
-        width: 250,
+        display: "flex",
+        flex: 1,
       },
       {
         headerName: "Unit name",
         field: "unit_long_name",
-        width: 200,
-        editable: false,
+        display: "flex",
+        flex: 2,
       },
     ];
   }, []);
@@ -156,6 +156,7 @@ const SubprojectFundingModal = ({
           }}
           pagination
           pageSizeOptions={[PAGE_SIZE]}
+          hideFooter={filteredData.length < PAGE_SIZE}
           localeText={{ noRowsLabel: "No FDUs available" }}
           checkboxSelection
           onRowSelectionModelChange={handleRowSelection}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -154,7 +154,6 @@ const SubprojectFundingModal = ({
           }}
           pagination
           pageSizeOptions={[PAGE_SIZE]}
-          hideFooter={filteredData.length < PAGE_SIZE}
           localeText={{ noRowsLabel: "No FDUs available" }}
           checkboxSelection
           onRowSelectionModelChange={handleRowSelection}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Button,
   Box,
@@ -16,10 +16,19 @@ import MaterialTable from "@material-table/core";
 import typography from "../../../../theme/typography";
 
 // DataGrid
-import { DataGridPro, useGridApiRef } from "@mui/x-data-grid-pro";
+import {
+  DataGridPro,
+  GRID_CHECKBOX_SELECTION_COL_DEF,
+  useGridApiRef,
+} from "@mui/x-data-grid-pro";
+
 import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
 
 const columns = [
+  {
+    ...GRID_CHECKBOX_SELECTION_COL_DEF,
+    width: 100,
+  },
   {
     field: "fdu",
     title: "FDU",
@@ -75,6 +84,13 @@ const SubprojectFundingModal = ({
   // Filter the list of fdus to remove one(s) already on funding sources table
   const filteredData = data.filter((fdu) => !fdusArray.includes(fdu.fdu));
 
+  // DataGrid
+  const apiRef = useGridApiRef();
+  const dataGridColumns = useColumns();
+
+  // TODO: Previous component hide pagination if less than 11 rows
+  // TODO: Add checkbox column to select rows
+  // TODO: Disable button if no rows selected using DataGridPro
   const handleAddFunding = () => {
     const newFunds = [];
     // format record to match generic records added
@@ -122,9 +138,12 @@ const SubprojectFundingModal = ({
     setSelectedFdus([]);
   };
 
-  // DataGrid
-  const apiRef = useGridApiRef();
-  const dataGridColumns = useColumns();
+  const handleRowSelection = (selectedRows) => {
+    const selectedFduRecords = selectedRows.map((fdu) =>
+      filteredData.find((record) => record.fdu === fdu)
+    );
+    setSelectedFdus(selectedFduRecords);
+  };
 
   return (
     <Dialog
@@ -179,13 +198,14 @@ const SubprojectFundingModal = ({
           columns={dataGridColumns}
           rows={filteredData}
           getRowId={(row) => row.fdu}
-          disableRowSelectionOnClick
+          // disableRowSelectionOnClick
           toolbar
           density="comfortable"
           getRowHeight={() => "auto"}
-          rowCount={1}
           hideFooter
           localeText={{ noRowsLabel: "No FDUs available" }}
+          checkboxSelection
+          onRowSelectionModelChange={handleRowSelection}
           // initialState={{ pinnedColumns: { left: ["select"] } }}
         />
         <Box my={3} sx={{ display: "flex", flexDirection: "row-reverse" }}>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -6,40 +6,16 @@ import {
   DialogTitle,
   DialogContent,
   IconButton,
-  Typography,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import AddCircle from "@mui/icons-material/AddCircle";
-import { useSocrataJson } from "src/utils/socrataHelpers";
-import MaterialTable from "@material-table/core";
-
-import typography from "../../../../theme/typography";
-
-// DataGrid
 import {
   DataGridPro,
   GRID_CHECKBOX_SELECTION_COL_DEF,
   useGridApiRef,
 } from "@mui/x-data-grid-pro";
-
+import CloseIcon from "@mui/icons-material/Close";
+import AddCircle from "@mui/icons-material/AddCircle";
+import { useSocrataJson } from "src/utils/socrataHelpers";
 import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
-
-const columns = [
-  {
-    ...GRID_CHECKBOX_SELECTION_COL_DEF,
-    width: 100,
-  },
-  {
-    field: "fdu",
-    title: "FDU",
-    cellStyle: { padding: "12px" },
-  },
-  {
-    field: "unit_long_name",
-    title: "Unit name",
-    cellStyle: { padding: "12px" },
-  },
-];
 
 const useColumns = () =>
   useMemo(() => {
@@ -47,7 +23,6 @@ const useColumns = () =>
       {
         headerName: "FDU",
         field: "fdu",
-        // renderCell: ({ row }) => row.moped_milestone?.milestone_name,
         editable: false,
         width: 250,
       },
@@ -70,11 +45,6 @@ const SubprojectFundingModal = ({
   setSnackbarState,
   refetch,
 }) => {
-  const typographyStyle = {
-    fontFamily: typography.fontFamily,
-    fontSize: "14px",
-  };
-
   const { data } = useSocrataJson(
     `https://data.austintexas.gov/resource/jega-nqf6.json?dept_unit_status=Active&sp_number_txt=${eCaprisID}&$limit=9999`
   );
@@ -89,8 +59,6 @@ const SubprojectFundingModal = ({
   const dataGridColumns = useColumns();
 
   // TODO: Previous component hide pagination if less than 11 rows
-  // TODO: Add checkbox column to select rows
-  // TODO: Disable button if no rows selected using DataGridPro
   const handleAddFunding = () => {
     const newFunds = [];
     // format record to match generic records added
@@ -166,30 +134,6 @@ const SubprojectFundingModal = ({
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        <MaterialTable
-          columns={columns}
-          data={filteredData}
-          localization={{
-            body: {
-              emptyDataSourceMessage: (
-                <Typography>No FDUs available</Typography>
-              ),
-            },
-          }}
-          options={{
-            ...(filteredData.length < 11 && {
-              paging: false,
-            }),
-            search: false,
-            toolbar: false,
-            tableLayout: "fixed",
-            selection: true,
-            rowStyle: typographyStyle,
-            pageSize: 10,
-            showSelectAllCheckbox: false,
-          }}
-          onSelectionChange={(rows) => setSelectedFdus(rows)}
-        />
         <DataGridPro
           sx={dataGridProStyleOverrides}
           apiRef={apiRef}
@@ -198,7 +142,6 @@ const SubprojectFundingModal = ({
           columns={dataGridColumns}
           rows={filteredData}
           getRowId={(row) => row.fdu}
-          // disableRowSelectionOnClick
           toolbar
           density="comfortable"
           getRowHeight={() => "auto"}
@@ -206,7 +149,6 @@ const SubprojectFundingModal = ({
           localeText={{ noRowsLabel: "No FDUs available" }}
           checkboxSelection
           onRowSelectionModelChange={handleRowSelection}
-          // initialState={{ pinnedColumns: { left: ["select"] } }}
         />
         <Box my={3} sx={{ display: "flex", flexDirection: "row-reverse" }}>
           <Button

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -57,9 +57,9 @@ const SubprojectFundingModal = ({
   eCaprisID,
   fdusArray,
   addProjectFunding,
-  userId,
   projectId,
   setSnackbarState,
+  refetch,
 }) => {
   const typographyStyle = {
     fontFamily: typography.fontFamily,
@@ -105,7 +105,9 @@ const SubprojectFundingModal = ({
         objects: newFunds,
       },
     })
-      .then(() => handleDialogClose())
+      .then(() => {
+        refetch().then(() => handleDialogClose());
+      })
       .catch((error) => {
         setSnackbarState({
           open: true,
@@ -123,13 +125,6 @@ const SubprojectFundingModal = ({
   // DataGrid
   const apiRef = useGridApiRef();
   const dataGridColumns = useColumns();
-  const [rows, setRows] = useState([]);
-
-  useEffect(() => {
-    if (data && data.length > 0) {
-      setRows(data);
-    }
-  }, [data]);
 
   return (
     <Dialog
@@ -182,14 +177,15 @@ const SubprojectFundingModal = ({
           ref={apiRef}
           autoHeight
           columns={dataGridColumns}
-          rows={rows}
-          getRowId={(row) => row.sub_project_id}
+          rows={filteredData}
+          getRowId={(row) => row.fdu}
           disableRowSelectionOnClick
           toolbar
           density="comfortable"
           getRowHeight={() => "auto"}
+          rowCount={1}
           hideFooter
-          localeText={{ noRowsLabel: "No subprojects to display" }}
+          localeText={{ noRowsLabel: "No FDUs available" }}
           // initialState={{ pinnedColumns: { left: ["select"] } }}
         />
         <Box my={3} sx={{ display: "flex", flexDirection: "row-reverse" }}>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -46,13 +46,11 @@ const SubprojectFundingModal = ({
   const { data } = useSocrataJson(
     `https://data.austintexas.gov/resource/jega-nqf6.json?dept_unit_status=Active&sp_number_txt=${eCaprisID}&$limit=9999`
   );
-
-  const [selectedFdus, setSelectedFdus] = useState([]);
-
   // Filter the list of fdus to remove one(s) already on funding sources table
   const filteredData = data.filter((fdu) => !fdusArray.includes(fdu.fdu));
 
-  // DataGrid
+  const [selectedFdus, setSelectedFdus] = useState([]);
+
   const dataGridColumns = useColumns();
 
   const handleAddFunding = useCallback(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Button,
   Box,
@@ -15,6 +15,10 @@ import MaterialTable from "@material-table/core";
 
 import typography from "../../../../theme/typography";
 
+// DataGrid
+import { DataGridPro, useGridApiRef } from "@mui/x-data-grid-pro";
+import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
+
 const columns = [
   {
     field: "fdu",
@@ -27,6 +31,25 @@ const columns = [
     cellStyle: { padding: "12px" },
   },
 ];
+
+const useColumns = () =>
+  useMemo(() => {
+    return [
+      {
+        headerName: "FDU",
+        field: "fdu",
+        // renderCell: ({ row }) => row.moped_milestone?.milestone_name,
+        editable: false,
+        width: 250,
+      },
+      {
+        headerName: "Unit name",
+        field: "unit_long_name",
+        width: 200,
+        editable: false,
+      },
+    ];
+  }, []);
 
 const SubprojectFundingModal = ({
   isDialogOpen,
@@ -97,6 +120,11 @@ const SubprojectFundingModal = ({
     setSelectedFdus([]);
   };
 
+  // DataGrid
+  const apiRef = useGridApiRef();
+  const dataGridColumns = useColumns();
+  const [rows, setRows] = useState([]);
+
   return (
     <Dialog
       open={isDialogOpen}
@@ -141,6 +169,22 @@ const SubprojectFundingModal = ({
             showSelectAllCheckbox: false,
           }}
           onSelectionChange={(rows) => setSelectedFdus(rows)}
+        />
+        <DataGridPro
+          sx={dataGridProStyleOverrides}
+          apiRef={apiRef}
+          ref={apiRef}
+          autoHeight
+          columns={dataGridColumns}
+          rows={rows}
+          getRowId={(row) => row.sub_project_id}
+          disableRowSelectionOnClick
+          toolbar
+          density="comfortable"
+          getRowHeight={() => "auto"}
+          hideFooter
+          localeText={{ noRowsLabel: "No subprojects to display" }}
+          // initialState={{ pinnedColumns: { left: ["select"] } }}
         />
         <Box my={3} sx={{ display: "flex", flexDirection: "row-reverse" }}>
           <Button

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/SubprojectFundingModal.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Button,
   Box,
@@ -124,6 +124,12 @@ const SubprojectFundingModal = ({
   const apiRef = useGridApiRef();
   const dataGridColumns = useColumns();
   const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      setRows(data);
+    }
+  }, [data]);
 
   return (
     <Dialog


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/18179

This PR migrates the eCapris subproject funding source table in the "FROM ECAPRIS" modal to use DataGridPro.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local or [deploy preview](https://deploy-preview-1517--atd-moped-main.netlify.app/moped/)

**Steps to test:**

This table fetches rows from an open dataset by the eCapris subproject ID set on a project. Some IDs match many results while other only match a few so you can use both **11280.006** which will show 18 rows in the table and **7333.001** which will show 4 rows in the table.

You can find other eCapris subproject IDs to test using [this query on the open dataset](https://data.austintexas.gov/Transportation-and-Mobility/Transportation-Capital-Project-Financial-Codes/jega-nqf6/explore/query/SELECT%20%60sp_number_txt%60%2C%20count%28DISTINCT%20%60fdu%60%29%20AS%20%60count_distinct_fdu%60%0AWHERE%20caseless_one_of%28%60dept_unit_status%60%2C%20%22Active%22%29%0AGROUP%20BY%20%60sp_number_txt%60%0AORDER%20BY%20%60count_distinct_fdu%60%20DESC%20NULL%20LAST/page/filter) - you just have to remove the comma in the `SP_NUMBER_TXT` column.

1. Create a new project and set `11280.006` as the eCapris subproject ID in the project summary view or in the Funding tab.
2. In the Funding tab, add a new funding source using the "from eCapris" option.
3. A modal will open up to show the table, and you should be able to select one, some, or all FDU rows. Notice that the "Add Funding Source" button is only enabled if a row(s) is selected. The columns are also sortable.
4. Add one or more rows, and you should see new funding source rows populated with:
   - Status is "Confirmed"
   - Fund and Dept-unit
   - Amount is $0
5. Also notice that once a funding source is added from the modal, then you can no longer add it. Delete some funding sources from the table and notice that you can added them again from the modal.
6. Try these steps again with the subproject ID set to `7333.001` to see how the table hides pagination if there are 10 or less rows in the table.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
