### PR TITLE
updates_atd_project_owner_to_tpw_project_owner

### DIFF
--- a/moped-database/migrations/1735855851119_update_atd_project_owner_to_tpw_project_owner/down.sql
+++ b/moped-database/migrations/1735855851119_update_atd_project_owner_to_tpw_project_owner/down.sql
@@ -1,0 +1,10 @@
+INSERT INTO moped_project_roles (project_role_id, project_role_name, active_role, role_order, project_role_description)
+VALUES (0, 'Unknown', TRUE, 999, 'Unknown Role');
+
+UPDATE moped_project_roles
+SET project_role_description = 'Supervises contractor activities for approval before invoicing; accepts work on behalf of ATD and coordinates with other divisions'
+WHERE project_role_id = 12;
+
+UPDATE moped_project_roles
+SET project_role_name = 'ATD Project Owner'
+WHERE project_role_id = 5;

--- a/moped-database/migrations/1735855851119_update_atd_project_owner_to_tpw_project_owner/up.sql
+++ b/moped-database/migrations/1735855851119_update_atd_project_owner_to_tpw_project_owner/up.sql
@@ -1,0 +1,10 @@
+UPDATE moped_project_roles
+SET project_role_name = 'TPW Project Owner'
+WHERE project_role_id = 5;
+
+UPDATE moped_project_roles
+SET project_role_description = 'Supervises contractor activities for approval before invoicing; accepts work on behalf of TPW and coordinates with other divisions'
+WHERE project_role_id = 12;
+
+DELETE FROM moped_project_roles
+WHERE project_role_id = 0;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -204,7 +204,7 @@ export const TEAM_QUERY = gql`
     }
     moped_project_roles(
       order_by: { project_role_name: asc }
-      where: { project_role_id: { _gt: 0 }, active_role: { _eq: true } }
+      where: { active_role: { _eq: true } }
     ) {
       project_role_id
       project_role_name


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/20178

this pr does some additional cleanup to the Moped database to reflect the departmental reorganization

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
local because database changes

**Steps to test:**
- apply migrations to your local db and spin up a db client using prod data
- check in `moped_project_roles` that the 'ATD Project Owner' role has been renamed to 'TPW Project Owner'
- check the 'Inspector' project role description to confirm 'ATD' was changed to 'TPW'
- check that there is no longer an 'Unknown Role' with `project_role_id` = 0 (I confirmed that there were no references to this record in `moped_proj_personnel_roles`)
- in Moped, go to a project's team table and confirm the table displays without error (I removed the filter in `TEAM_QUERY` for `project_role_id` greater than 0, the only instance of this filter in the app)
- edit a record and select the 'Project role' dropdown to confirm there is no 'Unknown Role' option
- run the down migration and check that the changes are reverted, with 'TPW' becoming 'ATD' in both cases above and the 'Unknown Role' record and dropdown option reappearing

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
