### PR TITLE
Update Moped entities to reflect reorganization

### DIFF
--- a/moped-database/migrations/1736442550315_update_entities/down.sql
+++ b/moped-database/migrations/1736442550315_update_entities/down.sql
@@ -1,0 +1,3 @@
+-- Updating moped_entity table will be up only. If we need to revert, we will need do it manually or
+-- update with a future migration.
+SELECT 0;

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -147,7 +147,7 @@ WHERE
 -- UPDATE PROJECT LEADS
 
 -- Find and update projects that need lead to be updated to COA TPW Sidewalks and Urban Trails
-WITH project_sponsor_todos AS (
+WITH project_lead_todos AS (
     SELECT entity_id AS ids
     FROM
         moped_entity
@@ -171,10 +171,10 @@ moped_project
 SET
     project_lead_id = (SELECT id FROM new_entity_row)
 WHERE
-    project_lead_id IN (SELECT ids FROM project_sponsor_todos);
+    project_lead_id IN (SELECT ids FROM project_lead_todos);
 
 -- Find and update projects that need lead to be updated to COA TPW
-WITH project_sponsor_todos AS (
+WITH project_lead_todos AS (
     SELECT entity_id AS ids
     FROM
         moped_entity
@@ -198,12 +198,60 @@ moped_project
 SET
     project_lead_id = (SELECT id FROM new_entity_row)
 WHERE
-    project_lead_id IN (SELECT ids FROM project_sponsor_todos);
+    project_lead_id IN (SELECT ids FROM project_lead_todos);
 
+-- UPDATE PROJECT PARTNERS
 
+-- Find and update projects that need lead to be updated to COA TPW Sidewalks and Urban Trails
+WITH project_partner_todos AS (
+    SELECT entity_id AS ids
+    FROM
+        moped_entity
+    WHERE
+        entity_name IN (
+            'COA PWD Sidewalks & Special Projects',
+            'COA PWD Urban Trails'
+        )
+),
 
--- TODO: UPDATE PROJECT PARTNERS
--- Replace any entity_id values that match COA PWD Sidewalks & Special Projects or COA PWD Urban Trails with the entity id of the new COA TPW Sidewalks and Urban Trails row
--- Replace any entity_id values that match COA ATD or COA PWD with the entity id of the new COA TPW
+new_entity_row AS (
+    SELECT entity_id AS id
+    FROM
+        moped_entity
+    WHERE
+        entity_name = 'COA TPW Sidewalks and Urban Trails'
+)
 
--- TODO: Filter soft-deleted entities in the app
+UPDATE
+moped_proj_partners
+SET
+    entity_id = (SELECT id FROM new_entity_row)
+WHERE
+    entity_id IN (SELECT ids FROM project_partner_todos);
+
+-- Find and update projects that need lead to be updated to COA TPW
+WITH project_partner_todos AS (
+    SELECT entity_id AS ids
+    FROM
+        moped_entity
+    WHERE
+        entity_name IN (
+            'COA ATD',
+            'COA PWD'
+        )
+),
+
+new_entity_row AS (
+    SELECT entity_id AS id
+    FROM
+        moped_entity
+    WHERE
+        entity_name = 'COA TPW'
+)
+
+UPDATE
+moped_project
+SET
+    entity_id = (SELECT id FROM new_entity_row)
+WHERE
+    entity_id IN (SELECT ids FROM project_partner_todos);

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -146,6 +146,61 @@ WHERE
 
 -- UPDATE PROJECT LEADS
 
+-- Find and update projects that need lead to be updated to COA TPW Sidewalks and Urban Trails
+WITH project_sponsor_todos AS (
+    SELECT entity_id AS ids
+    FROM
+        moped_entity
+    WHERE
+        entity_name IN (
+            'COA PWD Sidewalks & Special Projects',
+            'COA PWD Urban Trails'
+        )
+),
+
+new_entity_row AS (
+    SELECT entity_id AS id
+    FROM
+        moped_entity
+    WHERE
+        entity_name = 'COA TPW Sidewalks and Urban Trails'
+)
+
+UPDATE
+moped_project
+SET
+    project_lead_id = (SELECT id FROM new_entity_row)
+WHERE
+    project_lead_id IN (SELECT ids FROM project_sponsor_todos);
+
+-- Find and update projects that need lead to be updated to COA TPW
+WITH project_sponsor_todos AS (
+    SELECT entity_id AS ids
+    FROM
+        moped_entity
+    WHERE
+        entity_name IN (
+            'COA ATD',
+            'COA PWD'
+        )
+),
+
+new_entity_row AS (
+    SELECT entity_id AS id
+    FROM
+        moped_entity
+    WHERE
+        entity_name = 'COA TPW'
+)
+
+UPDATE
+moped_project
+SET
+    project_lead_id = (SELECT id FROM new_entity_row)
+WHERE
+    project_lead_id IN (SELECT ids FROM project_sponsor_todos);
+
+
 
 -- TODO: UPDATE PROJECT PARTNERS
 -- Replace any entity_id values that match COA PWD Sidewalks & Special Projects or COA PWD Urban Trails with the entity id of the new COA TPW Sidewalks and Urban Trails row

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -9,11 +9,46 @@ ALTER COLUMN is_deleted SET NOT NULL;
 ALTER TABLE moped_entity
 ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
 
----- moped_workgroup
-SELECT workgroup_id FROM moped_workgroup WHERE workgroup_name = 'Sidewalks and Urban Trails';
+-- Insert new COA TPW Sidewalks and Urban Trails entity with appropriate department_id, workgroup_id, and organization_id
+WITH
+workgroup_todo AS (
+    SELECT workgroup_id
+    FROM
+        moped_workgroup
+    WHERE
+        workgroup_name = 'Sidewalks and Urban Trails'
+),
 
--- moped_organization
-SELECT organization_id FROM moped_organization WHERE organization_name = 'City of Austin';
+organization_todo AS (
+    SELECT organization_id
+    FROM
+        moped_organization
+    WHERE
+        organization_name = 'City of Austin'
+),
 
--- moped_department
-SELECT department_id FROM moped_department WHERE department_name = 'Austin Transportation and Public Works';
+department_todo AS (
+    SELECT department_id
+    FROM
+        moped_department
+    WHERE
+        department_name = 'Austin Transportation and Public Works'
+)
+
+INSERT INTO
+moped_entity (entity_name, department_id, workgroup_id, organization_id)
+SELECT
+    'COA TPW Sidewalks and Urban Trails' AS entity_name,
+    d.department_id,
+    w.workgroup_id,
+    o.organization_id
+FROM
+    department_todo AS d,
+    workgroup_todo AS w,
+    organization_todo AS o;
+
+
+-- Create new rows:
+-- 2. COA TPW
+--    department_id is id that matches Austin Transportation and Public Works in moped_department table
+--    workgroup_id is NULL

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -9,6 +9,12 @@ ALTER COLUMN is_deleted SET NOT NULL;
 ALTER TABLE moped_entity
 ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
 
+
+-- Soft delete the old entities
+UPDATE moped_entity
+SET is_deleted = TRUE
+WHERE name IN ('COA PWD Sidewalks & Special Projects', 'COA PWD Urban Trails', 'COA ATD', 'COA PWD');
+
 -- Insert new COA TPW Sidewalks and Urban Trails entity with appropriate department_id, workgroup_id, and organization_id
 WITH
 workgroup_todo AS (
@@ -47,8 +53,20 @@ FROM
     workgroup_todo AS w,
     organization_todo AS o;
 
+-- Insert new row for COA TPW with appropriate department_id and organization_id (no associated workgroup)
+WITH organization_todo AS (
+    SELECT organization_id FROM moped_organization WHERE organization_name = 'City of Austin'
+),
 
--- Create new rows:
--- 2. COA TPW
---    department_id is id that matches Austin Transportation and Public Works in moped_department table
---    workgroup_id is NULL
+department_todo AS (
+    SELECT department_id FROM moped_department WHERE department_name = 'Austin Transportation and Public Works'
+)
+
+INSERT INTO moped_entity (entity_name, department_id, workgroup_id, organization_id, is_deleted)
+SELECT
+    'COA TPW' AS entity_name,
+    d.department_id,
+    NULL AS workgroup_id,
+    o.organization_id,
+    FALSE AS is_deleted
+FROM department_todo AS d, organization_todo AS o;

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -8,3 +8,12 @@ ALTER COLUMN is_deleted SET NOT NULL;
 -- Add is_deleted to moped_entity
 ALTER TABLE moped_entity
 ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
+
+---- moped_workgroup
+SELECT workgroup_id FROM moped_workgroup WHERE workgroup_name = 'Sidewalks and Urban Trails';
+
+-- moped_organization
+SELECT organization_id FROM moped_organization WHERE organization_name = 'City of Austin';
+
+-- moped_department
+SELECT department_id FROM moped_department WHERE department_name = 'Austin Transportation and Public Works';

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -1,0 +1,10 @@
+-- Make is_deleted non-nullable in moped_workgroup and moped_department
+ALTER TABLE moped_workgroup
+ALTER COLUMN is_deleted SET NOT NULL;
+
+ALTER TABLE moped_department
+ALTER COLUMN is_deleted SET NOT NULL;
+
+-- Add is_deleted to moped_entity
+ALTER TABLE moped_entity
+ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -13,7 +13,7 @@ ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
 -- Soft delete the old entities
 UPDATE moped_entity
 SET is_deleted = TRUE
-WHERE name IN ('COA PWD Sidewalks & Special Projects', 'COA PWD Urban Trails', 'COA ATD', 'COA PWD');
+WHERE entity_name IN ('COA PWD Sidewalks & Special Projects', 'COA PWD Urban Trails', 'COA ATD', 'COA PWD');
 
 -- Insert new COA TPW Sidewalks and Urban Trails entity with appropriate department_id, workgroup_id, and organization_id
 WITH
@@ -81,12 +81,6 @@ WHERE
         OR entity_name LIKE '%PWD%'
     )
     AND (entity_name NOT IN ('COA PWD Sidewalks & Special Projects', 'COA PWD Urban Trails', 'COA ATD', 'COA PWD'));
-
--- TODO: Update project sponsors with new entity values
--- Replace any sponsor_id values that match COA PWD Sidewalks & Special Projects or COA PWD Urban Trails with the entity id of the new COA TPW Sidewalks and Urban Trails row
--- Replace any sponsor_id values that match COA ATD or COA PWD with the entity id of the new COA TPW row
--- Replace any project_lead_id values that match COA PWD Sidewalks & Special Projects or COA PWD Urban Trails with the entity id of the new COA TPW Sidewalks and Urban Trails row
--- Replace any project_lead_id values that match COA ATD or COA PWD with the entity id of the new COA TPW row
 
 -- UPDATE PROJECT SPONSORS
 
@@ -250,7 +244,7 @@ new_entity_row AS (
 )
 
 UPDATE
-moped_project
+moped_proj_partners
 SET
     entity_id = (SELECT id FROM new_entity_row)
 WHERE

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -45,13 +45,13 @@ INSERT INTO
 moped_entity (entity_name, department_id, workgroup_id, organization_id)
 SELECT
     'COA TPW Sidewalks and Urban Trails' AS entity_name,
-    d.department_id,
-    w.workgroup_id,
-    o.organization_id
+    department.department_id,
+    workgroup.workgroup_id,
+    organization.organization_id
 FROM
-    department AS d,
-    workgroup AS w,
-    organization AS o;
+    department,
+    workgroup,
+    organization;
 
 -- Insert new row for COA TPW with appropriate department_id and organization_id (no associated workgroup)
 WITH organization AS (
@@ -65,11 +65,11 @@ department AS (
 INSERT INTO moped_entity (entity_name, department_id, workgroup_id, organization_id, is_deleted)
 SELECT
     'COA TPW' AS entity_name,
-    d.department_id,
+    department.department_id,
     NULL AS workgroup_id,
-    o.organization_id,
+    organization.organization_id,
     FALSE AS is_deleted
-FROM department AS d, organization AS o;
+FROM department, organization;
 
 -- Find any records (except the soft-deleted above) that have either ATD or PWD in them and replace with TPW
 UPDATE moped_entity

--- a/moped-database/migrations/1736442550315_update_entities/up.sql
+++ b/moped-database/migrations/1736442550315_update_entities/up.sql
@@ -70,3 +70,14 @@ SELECT
     o.organization_id,
     FALSE AS is_deleted
 FROM department_todo AS d, organization_todo AS o;
+
+-- Find any records (except the soft-deleted above) that have either ATD or PWD in them and replace with TPW
+UPDATE moped_entity
+SET
+    entity_name = REPLACE(REPLACE(entity_name, 'ATD', 'TPW'), 'PWD', 'TPW')
+WHERE
+    (
+        entity_name LIKE '%ATD%'
+        OR entity_name LIKE '%PWD%'
+    )
+    AND (entity_name NOT IN ('COA PWD Sidewalks & Special Projects', 'COA PWD Urban Trails', 'COA ATD', 'COA PWD'));

--- a/moped-database/recipes/copy_component_work_types_from_other_component.sql
+++ b/moped-database/recipes/copy_component_work_types_from_other_component.sql
@@ -1,0 +1,26 @@
+-- This example inserts the same moped_component_work_types work types as the Trail - Shared Use Path (Paved) component
+-- into the new Trail - Shared Use Path (Paved Dual Trail) component.
+-- This is useful when creating a new component that is similar to an existing component.
+-- See https://github.com/cityofaustin/atd-moped/pull/1191
+WITH inserts_todo AS (
+    SELECT
+        work_type_id,
+        'Trail' AS component_name,
+        'Shared Use Path (Paved Dual Trail)' AS component_subtype
+    FROM
+        moped_component_work_types AS mcwt
+    LEFT JOIN moped_work_types AS mwt ON mcwt.work_type_id = mwt.id
+    LEFT JOIN moped_components AS mc ON mcwt.component_id = mc.component_id
+    WHERE
+        mc.component_subtype LIKE 'Shared Use Path (Paved)'
+)
+
+INSERT INTO moped_component_work_types (component_id, work_type_id)
+SELECT
+    mc.component_id,
+    inserts_todo.work_type_id
+FROM
+    inserts_todo
+    -- gets the component id of the new component we created
+LEFT JOIN moped_components AS mc ON inserts_todo.component_name = mc.component_name
+    AND inserts_todo.component_subtype = mc.component_subtype;

--- a/moped-database/recipes/update_merged_funding_sources.sql
+++ b/moped-database/recipes/update_merged_funding_sources.sql
@@ -1,0 +1,28 @@
+-- This example finds existing project funding sources that are associated with the sources that merged
+-- and updates them to the new funding source.
+-- See https://github.com/cityofaustin/atd-moped/pull/1486
+WITH funding_source_todos AS (
+    SELECT funding_source_id AS ids
+    FROM
+        moped_fund_sources
+    WHERE
+        funding_source_name IN (
+            'Austin Transportation',
+            'Public Works'
+        )
+),
+
+new_funding_source_row AS (
+    SELECT funding_source_id AS id
+    FROM
+        moped_fund_sources
+    WHERE
+        funding_source_name = 'Austin Transportation and Public Works'
+)
+
+UPDATE
+moped_proj_funding
+SET
+    funding_source_id = (SELECT id FROM new_funding_source_row)
+WHERE
+    funding_source_id IN (SELECT ids FROM funding_source_todos);

--- a/moped-database/recipes/update_merged_workgroups.sql
+++ b/moped-database/recipes/update_merged_workgroups.sql
@@ -1,0 +1,29 @@
+-- This example finds all users who were previously in the 'Sidewalks' or 'Urban Trails' workgroups and sets their 
+-- workgroup to the new, merged workgroup called 'Sidewalks and Urban Trails'.
+-- This is useful when merging workgroups and needing to update all users associated with the old workgroups.
+-- See https://github.com/cityofaustin/atd-moped/pull/1515
+WITH user_todos AS (
+    SELECT workgroup_id AS ids
+    FROM
+        moped_workgroup
+    WHERE
+        workgroup_name IN (
+            'Sidewalks',
+            'Urban Trails'
+        )
+),
+
+new_workgroup_row AS (
+    SELECT workgroup_id AS id
+    FROM
+        moped_workgroup
+    WHERE
+        workgroup_name = 'Sidewalks and Urban Trails'
+)
+
+UPDATE
+moped_users
+SET
+    workgroup_id = (SELECT id FROM new_workgroup_row)
+WHERE
+    workgroup_id IN (SELECT ids FROM user_todos);

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -108,7 +108,10 @@ export const SUMMARY_QUERY = gql`
       phase_name
       phase_order
     }
-    moped_entity(order_by: { entity_name: asc }) {
+    moped_entity(
+      order_by: { entity_name: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
       entity_id
       entity_name
     }
@@ -968,7 +971,10 @@ export const LOOKUP_TABLES_QUERY = gql`
       type_id
       type_name
     }
-    moped_entity(order_by: { entity_id: asc }) {
+    moped_entity(
+      order_by: { entity_id: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
       entity_id
       entity_name
     }

--- a/moped-editor/src/queries/tableLookups.js
+++ b/moped-editor/src/queries/tableLookups.js
@@ -55,7 +55,10 @@ export const TABLE_LOOKUPS_QUERY = gql`
       slug
       type
     }
-    moped_entity(order_by: { entity_name: asc }) {
+    moped_entity(
+      order_by: { entity_name: asc }
+      where: { is_deleted: { _eq: false } }
+    ) {
       entity_id
       entity_name
     }


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19855
Closes https://github.com/cityofaustin/atd-data-tech/issues/20038

This PR updates the `moped_entity` table to move from `ATD` and `PWD` to `TPW`

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
Local

**Steps to test:**
TBD

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
