### PR TITLE
Update phase badge colors

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
+++ b/moped-editor/src/views/projects/projectView/ProjectStatusBadge.js
@@ -77,8 +77,8 @@ export const styleMapping = {
     icon: PlayCircleOutlineOutlinedIcon,
   },
   construction: {
-    color: white,
-    background: backgroundColors.success,
+    color: primary,
+    background: backgroundColors.warning,
     icon: PlayCircleOutlineOutlinedIcon,
   },
   post_construction: {
@@ -88,7 +88,7 @@ export const styleMapping = {
   },
   potential: {
     color: primary,
-    background: backgroundColors.warning,
+    background: backgroundColors.default,
     icon: RemoveCircleOutlineOutlinedIcon,
   },
   canceled: {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20514

This PR updates the status badge background colors and text to put more emphasis on projects in construction and less emphasis on potential projects. It also differentiates construction with a simple phase of "Construction" from other phases that have a simple phase of "Active" and are green.

## Testing
**URL to test:** 
<!---
 [branch-name]--atd-moped-main.netlify.app/moped/ if test instance or deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/ 
--->
https://deploy-preview-1525--atd-moped-main.netlify.app/moped/dev/lookups#moped-phases

**Steps to test:**
1. Go to the deploy preview to see the updated phase colors in the Data dictionary
2. See that "Potential" is badge is now grey with black text and the "Construction" badge is now orange with black text
3. The badge component or badge colors are also used in:
   - project list view
   - dashboard view
   - projects map view (project components shown in phase color on map)
   - project summary view (project phase and also in the Subprojects table)
   - project components map on component list items of components that have a phase set
   - project notes statuses

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
