### PR TITLE
check if export column exists before attempting download

### DIFF
--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useCsvExport.js
@@ -113,6 +113,10 @@ const buildRecordEntry = (
       : Object.keys(exportConfig);
   // For each column in the export configuration
   columnsToExport.forEach((column) => {
+    // check if column exists
+    if (!exportConfig[column]) {
+      return;
+    }
     // column label and data formatting function
     const { label, filter } = exportConfig[column];
     // Determine the new column name, if available.


### PR DESCRIPTION
## Associated issues

Closes https://github.com/cityofaustin/atd-data-tech/issues/20659

Mike found a bug while testing the Zacate release, that if a user had the type column visible before it was removed from the codebase, localStorage still has that column in its visible column config. 



## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**

in your localStorage as the column config
`['project_id', 'current_phase', 'project_lead', 'updated_at', 'type_name', 'funding_source_and_program_names', 'substantial_completion_date', 'parent_project_id', 'components', 'project_id', 'parent_project_name']` 

see that you can still download visible columns, even tho the type_name column is 🗑️ 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
