### PR TITLE
Add snackbar to dashboard view

### DIFF
--- a/moped-editor/src/views/dashboard/DashboardTimelineModal.js
+++ b/moped-editor/src/views/dashboard/DashboardTimelineModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import {
   Box,
   CardContent,
@@ -15,6 +15,7 @@ import { useQuery } from "@apollo/client";
 import ApolloErrorHandler from "src/components/ApolloErrorHandler";
 import ProjectMilestones from "../projects/projectView/ProjectMilestones";
 import ProjectPhases from "../projects/projectView/ProjectPhases";
+import FeedbackSnackbar from "src/components/FeedbackSnackbar";
 
 const useStyles = makeStyles((theme) => ({
   clickableDiv: {
@@ -48,6 +49,38 @@ const DashboardTimelineModal = ({
     setIsDialogOpen(false);
     dashboardRefetch();
   };
+
+  /* Snackbar state and handler for phase and milestone update feedback */
+  const [snackbarState, setSnackbarState] = useState(false);
+
+  /**
+   * Wrapper around snackbar state setter
+   * @param {boolean} open - The new state of open
+   * @param {String} message - The message for the snackbar
+   * @param {String} severity - The severity color of the snackbar
+   * @param {Object} error - The error to be displayed and logged
+   */
+  const handleSnackbar = useCallback(
+    (open, message, severity, error) => {
+      // if there is an error, render error message,
+      // otherwise, render success message
+      if (error) {
+        setSnackbarState({
+          open: open,
+          message: `${message}. Refresh the page to try again.`,
+          severity: severity,
+        });
+        console.error(error);
+      } else {
+        setSnackbarState({
+          open: open,
+          message: message,
+          severity: severity,
+        });
+      }
+    },
+    [setSnackbarState]
+  );
 
   return (
     <>
@@ -88,6 +121,7 @@ const DashboardTimelineModal = ({
                         loading={loading}
                         data={data}
                         refetch={refetch}
+                        handleSnackbar={handleSnackbar}
                       />
                     )}
                     {table === "milestones" && (
@@ -96,6 +130,7 @@ const DashboardTimelineModal = ({
                         loading={loading}
                         data={data}
                         refetch={refetch}
+                        handleSnackbar={handleSnackbar}
                       />
                     )}
                   </Box>
@@ -105,6 +140,10 @@ const DashboardTimelineModal = ({
           </ApolloErrorHandler>
         </DialogContent>
       </Dialog>
+      <FeedbackSnackbar
+        snackbarState={snackbarState}
+        handleSnackbar={handleSnackbar}
+      />
     </>
   );
 };

--- a/moped-editor/src/views/dashboard/DashboardTimelineModal.js
+++ b/moped-editor/src/views/dashboard/DashboardTimelineModal.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import {
   Box,
   CardContent,
@@ -15,7 +15,6 @@ import { useQuery } from "@apollo/client";
 import ApolloErrorHandler from "src/components/ApolloErrorHandler";
 import ProjectMilestones from "../projects/projectView/ProjectMilestones";
 import ProjectPhases from "../projects/projectView/ProjectPhases";
-import FeedbackSnackbar from "src/components/FeedbackSnackbar";
 
 const useStyles = makeStyles((theme) => ({
   clickableDiv: {
@@ -28,6 +27,7 @@ const DashboardTimelineModal = ({
   projectId,
   projectName,
   dashboardRefetch,
+  handleSnackbar,
   children,
 }) => {
   const classes = useStyles();
@@ -49,38 +49,6 @@ const DashboardTimelineModal = ({
     setIsDialogOpen(false);
     dashboardRefetch();
   };
-
-  /* Snackbar state and handler for phase and milestone update feedback */
-  const [snackbarState, setSnackbarState] = useState(false);
-
-  /**
-   * Wrapper around snackbar state setter
-   * @param {boolean} open - The new state of open
-   * @param {String} message - The message for the snackbar
-   * @param {String} severity - The severity color of the snackbar
-   * @param {Object} error - The error to be displayed and logged
-   */
-  const handleSnackbar = useCallback(
-    (open, message, severity, error) => {
-      // if there is an error, render error message,
-      // otherwise, render success message
-      if (error) {
-        setSnackbarState({
-          open: open,
-          message: `${message}. Refresh the page to try again.`,
-          severity: severity,
-        });
-        console.error(error);
-      } else {
-        setSnackbarState({
-          open: open,
-          message: message,
-          severity: severity,
-        });
-      }
-    },
-    [setSnackbarState]
-  );
 
   return (
     <>
@@ -140,10 +108,6 @@ const DashboardTimelineModal = ({
           </ApolloErrorHandler>
         </DialogContent>
       </Dialog>
-      <FeedbackSnackbar
-        snackbarState={snackbarState}
-        handleSnackbar={handleSnackbar}
-      />
     </>
   );
 };

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -277,6 +277,7 @@ const DashboardView = () => {
           table="milestones"
           projectId={entry.project_id}
           projectName={entry.project.project_name_full}
+          handleSnackbar={handleSnackbar}
           dashboardRefetch={refetch}
         >
           <MilestoneProgressMeter


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/20860

Adds the snackbar to the dashboard view for feedback on the mutations in the phase and milestone modals

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local or the deploy preview when it is done

**Steps to test:**
1. Follow a project or add yourself to a project team
2. Click into the status badge and add or update a phase. You will see a snackbar appear after editing
3. Do the same with the milestone progress chart

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
