### PR TITLE
Clear/remove component phase if toggle is switched off

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -165,6 +165,7 @@ const ComponentForm = ({
   const [useComponentPhase, setUseComponentPhase] = useState(
     !!initialFormValues?.phase || !!initialFormValues?.completionDate
   );
+  const [hasToggledPhaseSwitch, setHasToggledPhaseSwitch] = useState(false);
 
   useResetDependentFieldOnParentFieldChange({
     parentValue: watch("phase"),
@@ -228,8 +229,18 @@ const ComponentForm = ({
     setValue,
   });
 
+  const handleFormSubmit = (formData) => {
+    // If the phase switch is off, null out phase-related values before saving
+    if (!useComponentPhase) {
+      formData.phase = null;
+      formData.subphase = null;
+      formData.completionDate = null;
+    }
+    onSave(formData);
+  };
+
   return (
-    <form onSubmit={handleSubmit(onSave)}>
+    <form onSubmit={handleSubmit(handleFormSubmit)}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <ControlledAutocomplete
@@ -377,10 +388,12 @@ const ComponentForm = ({
             control={
               <Switch
                 checked={useComponentPhase}
-                onChange={() => setUseComponentPhase(!useComponentPhase)}
+                onChange={() => {
+                  setUseComponentPhase(!useComponentPhase);
+                  setHasToggledPhaseSwitch(true);
+                }}
                 name="useComponentPhase"
                 color="primary"
-                disabled={!!phase || !!completionDate}
               />
             }
             labelPlacement="start"
@@ -457,7 +470,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={!isDirty || areFormErrors}
+            disabled={(!isDirty && !hasToggledPhaseSwitch) || areFormErrors}
           >
             {hasGeometry ? "Save" : formButtonText}
           </Button>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20061

## Testing
**URL to test:** 
[Deploy preview](https://deploy-preview-1532--atd-moped-main.netlify.app/moped/projects/1822?tab=map&project_component_id=2724) or local

**Steps to test:**
1. Create a **new** component for a project in the map tab
2. By default, "Use component phase" should be toggled off.
3. Toggle it on, and select any Phase from the dropdown.
4. Toggle it off, and back on. The Phase you select should persist. 
5. Complete the form so you can click "Continue", select a geometry, and Save.
6. Edit the component you just created or any other component with an **existing** component phase.
7. By default, the toggle should be on with the phase field(s) displayed. Confirm you can edit these fields and save.
8. Additionally, confirm that when you edit a component with an existing component phase, the toggle button doesn't clear the fields.
9. Toggle the component phase off and Save.
10. Reopen that component and confirm that Saving actually nulled out the phase field(s). 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test to say "Edit the component attributes and switch the "Use component phase" toggle off and save again. You should see the component phase badge removed. Edit the component attributes yet again to confirm the component phase, subphase, and completion data have been removed." 
