### PR TITLE
Add length validation to description inputs that are sent to the components AGOL feature service

### DIFF
--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -1,2 +1,10 @@
 export const substantialCompletionDateTooltipText =
   "The earliest confirmed date of any Complete or Post-construction phase";
+
+/**
+ * Number of characters that falls below max set in the project and component description fields
+ * sent to AGOL from component_arcgis_online_view database view
+ * Names: project_description, component_description, component_location_description
+ * See Field settings at https://austin.maps.arcgis.com/home/item.html?id=1c084c8756a84e6db7e2796c98c850a2#data
+ */
+export const agolDescriptionCharacterMax = 5000;

--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -2,15 +2,13 @@ export const substantialCompletionDateTooltipText =
   "The earliest confirmed date of any Complete or Post-construction phase";
 
 /**
- * Number of characters that falls below max set in the project and component description fields
- * sent to AGOL from component_arcgis_online_view database view
- * Names: project_description, component_description, component_location_description
+ * Number of string characters that fall below maximum set in fields sent to AGOL from
+ * component_arcgis_online_view database view.
+ * Key example: component_location_description (AGOL) -> componentLocationDescription
  * See Field settings at https://austin.maps.arcgis.com/home/item.html?id=1c084c8756a84e6db7e2796c98c850a2#data
  */
-export const agolDescriptionCharacterMax = 5000;
-
-// TODO: Should these all different limits
-// Based of max char queries in prod:
-// 2000 for project description
-// 5000 for component description
-// 500 for location description
+export const agolFieldCharMax = {
+  projectDescription: 2000,
+  componentDescription: 5000,
+  componentLocationDescription: 500,
+};

--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -8,3 +8,9 @@ export const substantialCompletionDateTooltipText =
  * See Field settings at https://austin.maps.arcgis.com/home/item.html?id=1c084c8756a84e6db7e2796c98c850a2#data
  */
 export const agolDescriptionCharacterMax = 5000;
+
+// TODO: Should these all different limits
+// Based of max char queries in prod:
+// 2000 for project description
+// 5000 for component description
+// 500 for location description

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -80,6 +80,7 @@ const DefineProjectForm = ({
       </Grid>
       <Grid container spacing={3} style={{ margin: 20 }}>
         <Grid item xs={6}>
+          {/* TODO: Add limit here too */}
           <TextField
             variant="standard"
             required

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { TextField, Grid, InputLabel, Switch, Box } from "@mui/material";
-import SignalAutocomplete from "./SignalAutocomplete";
+import SignalAutocomplete from "src/views/projects/newProjectView/SignalAutocomplete";
 
 const DefineProjectForm = ({
   projectDetails,
@@ -80,7 +80,6 @@ const DefineProjectForm = ({
       </Grid>
       <Grid container spacing={3} style={{ margin: 20 }}>
         <Grid item xs={6}>
-          {/* TODO: Add limit here too */}
           <TextField
             variant="standard"
             required
@@ -90,8 +89,8 @@ const DefineProjectForm = ({
             type="text"
             fullWidth
             value={projectDetails.project_description}
-            error={descriptionError}
-            helperText="Required"
+            error={descriptionError !== null}
+            helperText={descriptionError?.message || "Required"}
             InputLabelProps={{ required: false }}
             onChange={(e) => handleFieldChange(e.target.value, e.target.name)}
           />

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -24,7 +24,7 @@ import {
   useSignalStateManager,
   generateProjectComponent,
 } from "src/utils/signalComponentHelpers";
-import { agolDescriptionCharacterMax } from "src/constants/projects";
+import { agolFieldCharMax } from "src/constants/projects";
 
 /**
  * Styles
@@ -124,10 +124,10 @@ const NewProjectView = () => {
       setDescriptionError({ message: "Required" });
     } else if (
       projectDetails.project_description.trim().length >
-      agolDescriptionCharacterMax
+      agolFieldCharMax.projectDescription
     ) {
       setDescriptionError({
-        message: `Description must be ${agolDescriptionCharacterMax} characters or less`,
+        message: `Description must be ${agolFieldCharMax.projectDescription} characters or less`,
       });
     }
 
@@ -135,7 +135,7 @@ const NewProjectView = () => {
       projectDetails.project_name.trim().length > 0 &&
       projectDetails.project_description.trim().length > 0 &&
       projectDetails.project_description.trim().length <=
-        agolDescriptionCharacterMax
+        agolFieldCharMax.projectDescription
     ) {
       // Reset errors and set loading state
       setDescriptionError(null);

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -15,15 +15,16 @@ import {
   SIGNAL_COMPONENTS_QUERY,
   ADD_PROJECT,
   PROJECT_FOLLOW,
-} from "../../../queries/project";
+} from "src/queries/project";
 
-import { getSessionDatabaseData } from "../../../auth/user";
+import { getSessionDatabaseData } from "src/auth/user";
 
 import ProjectSaveButton from "./ProjectSaveButton";
 import {
   useSignalStateManager,
   generateProjectComponent,
 } from "src/utils/signalComponentHelpers";
+import { agolDescriptionCharacterMax } from "src/constants/projects";
 
 /**
  * Styles
@@ -63,7 +64,7 @@ const NewProjectView = () => {
    * Form State
    * @type {Object} projectDetails - The current state of project details
    * @type {boolean} nameError - When true, it denotes an error in the name
-   * @type {boolean} descriptionError - When true, it denotes an error in the project description
+   * @type {Object} descriptionError - Object containing the error message, Ex. { message: "Error message" }
    * @type {Object} signalRecord - The signal record to be inserted into a project and its component
    */
   const [projectDetails, setProjectDetails] = useState({
@@ -72,7 +73,7 @@ const NewProjectView = () => {
     project_name_secondary: "",
   });
   const [nameError, setNameError] = useState(false);
-  const [descriptionError, setDescriptionError] = useState(false);
+  const [descriptionError, setDescriptionError] = useState(null);
   const [signalRecord, setSignalRecord] = useState(null);
 
   /**
@@ -120,13 +121,25 @@ const NewProjectView = () => {
       setNameError(true);
     }
     if (projectDetails.project_description.trim().length === 0) {
-      setDescriptionError(true);
+      setDescriptionError({ message: "Required" });
+    } else if (
+      projectDetails.project_description.trim().length >
+      agolDescriptionCharacterMax
+    ) {
+      setDescriptionError({
+        message: `Description must be ${agolDescriptionCharacterMax} characters or less`,
+      });
     }
 
     if (
       projectDetails.project_name.trim().length > 0 &&
-      projectDetails.project_description.trim().length > 0
+      projectDetails.project_description.trim().length > 0 &&
+      projectDetails.project_description.trim().length <=
+        agolDescriptionCharacterMax
     ) {
+      // Reset errors and set loading state
+      setDescriptionError(null);
+      setNameError(false);
       setLoading(true);
 
       /**

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -81,7 +81,7 @@ const validationSchema = yup.object().shape({
     .string()
     .max(
       agolDescriptionCharacterMax,
-      `Description must be at most ${agolDescriptionCharacterMax} characters`
+      `Description must be ${agolDescriptionCharacterMax} characters or less`
     )
     .nullable()
     .optional(),
@@ -94,7 +94,7 @@ const validationSchema = yup.object().shape({
     .string()
     .max(
       agolDescriptionCharacterMax,
-      `Location description must be at most ${agolDescriptionCharacterMax} characters`
+      `Location description must be ${agolDescriptionCharacterMax} characters or less`
     )
     .nullable()
     .optional(),

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -76,13 +76,13 @@ const validationSchema = yup.object().shape({
           "Required if a phase with phase name simple of Complete is selected"
         ),
     }),
-  description: yup.string().nullable().optional(),
+  description: yup.string().max(10000).nullable().optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
   signal: yup.object().nullable(),
   schoolBeacon: yup.object().nullable(),
   srtsId: yup.string().nullable().optional(),
-  locationDescription: yup.string().nullable().optional(),
+  locationDescription: yup.string().max(10000).nullable().optional(),
 });
 
 const ComponentForm = ({
@@ -347,6 +347,8 @@ const ComponentForm = ({
             name="locationDescription"
             size="small"
             control={control}
+            error={errors?.locationDescription}
+            helperText={errors?.locationDescription?.message}
           />
         </Grid>
         <Grid item xs={12}>
@@ -358,6 +360,8 @@ const ComponentForm = ({
             multiline
             minRows={4}
             control={control}
+            error={errors?.description}
+            helperText={errors?.description?.message}
           />
         </Grid>
         <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -40,6 +40,7 @@ import {
   SOCRATA_ENDPOINT_SCHOOL_BEACONS,
 } from "src/utils/signalComponentHelpers";
 import ComponentProperties from "src/views/projects/projectView/ProjectComponents/ComponentProperties";
+import { agolDescriptionCharacterMax } from "src/constants/projects";
 
 import * as yup from "yup";
 
@@ -78,7 +79,10 @@ const validationSchema = yup.object().shape({
     }),
   description: yup
     .string()
-    .max(10000, "Description must be at most 10,000 characters")
+    .max(
+      agolDescriptionCharacterMax,
+      `Description must be at most ${agolDescriptionCharacterMax} characters`
+    )
     .nullable()
     .optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
@@ -88,7 +92,10 @@ const validationSchema = yup.object().shape({
   srtsId: yup.string().nullable().optional(),
   locationDescription: yup
     .string()
-    .max(10000, "Location description must be at most 10,000 characters")
+    .max(
+      agolDescriptionCharacterMax,
+      `Location description must be at most ${agolDescriptionCharacterMax} characters`
+    )
     .nullable()
     .optional(),
 });

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -9,10 +9,10 @@ import {
   FormControlLabel,
   FormHelperText,
 } from "@mui/material";
-import DateFieldEditComponent from "../DateFieldEditComponent";
+import DateFieldEditComponent from "src/views/projects/projectView/DateFieldEditComponent";
 import { CheckCircle } from "@mui/icons-material";
 import { GET_COMPONENTS_FORM_OPTIONS } from "src/queries/components";
-import KnackComponentAutocomplete from "./KnackComponentAutocomplete";
+import KnackComponentAutocomplete from "src/views/projects/projectView/ProjectComponents/KnackComponentAutocomplete";
 import {
   ComponentOptionWithIcon,
   DEFAULT_COMPONENT_WORK_TYPE_OPTION,
@@ -28,8 +28,8 @@ import {
   getOptionLabel,
   isOptionEqualToValue,
   isPhaseOptionSimpleComplete,
-} from "./utils/form";
-import ControlledAutocomplete from "../../../../components/forms/ControlledAutocomplete";
+} from "src/views/projects/projectView/ProjectComponents/utils/form";
+import ControlledAutocomplete from "src/components/forms/ControlledAutocomplete";
 import ControlledTextInput from "src/components/forms/ControlledTextInput";
 import {
   getSignalOptionLabel,
@@ -39,7 +39,7 @@ import {
   getSchoolZoneBeaconOptionSelected,
   SOCRATA_ENDPOINT_SCHOOL_BEACONS,
 } from "src/utils/signalComponentHelpers";
-import ComponentProperties from "./ComponentProperties";
+import ComponentProperties from "src/views/projects/projectView/ProjectComponents/ComponentProperties";
 
 import * as yup from "yup";
 
@@ -76,13 +76,21 @@ const validationSchema = yup.object().shape({
           "Required if a phase with phase name simple of Complete is selected"
         ),
     }),
-  description: yup.string().max(10000).nullable().optional(),
+  description: yup
+    .string()
+    .max(10000, "Description must be at most 10,000 characters")
+    .nullable()
+    .optional(),
   work_types: yup.array().of(yup.object()).min(1).required(),
   // Signal field is required if the selected component inserts into the feature_signals table
   signal: yup.object().nullable(),
   schoolBeacon: yup.object().nullable(),
   srtsId: yup.string().nullable().optional(),
-  locationDescription: yup.string().max(10000).nullable().optional(),
+  locationDescription: yup
+    .string()
+    .max(10000, "Location description must be at most 10,000 characters")
+    .nullable()
+    .optional(),
 });
 
 const ComponentForm = ({

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -40,7 +40,7 @@ import {
   SOCRATA_ENDPOINT_SCHOOL_BEACONS,
 } from "src/utils/signalComponentHelpers";
 import ComponentProperties from "src/views/projects/projectView/ProjectComponents/ComponentProperties";
-import { agolDescriptionCharacterMax } from "src/constants/projects";
+import { agolFieldCharMax } from "src/constants/projects";
 
 import * as yup from "yup";
 
@@ -80,8 +80,8 @@ const validationSchema = yup.object().shape({
   description: yup
     .string()
     .max(
-      agolDescriptionCharacterMax,
-      `Description must be ${agolDescriptionCharacterMax} characters or less`
+      agolFieldCharMax.componentDescription,
+      `Description must be ${agolFieldCharMax.componentDescription} characters or less`
     )
     .nullable()
     .optional(),
@@ -93,8 +93,8 @@ const validationSchema = yup.object().shape({
   locationDescription: yup
     .string()
     .max(
-      agolDescriptionCharacterMax,
-      `Location description must be ${agolDescriptionCharacterMax} characters or less`
+      agolFieldCharMax.componentLocationDescription,
+      `Location description must be ${agolFieldCharMax.componentLocationDescription} characters or less`
     )
     .nullable()
     .optional(),

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -15,10 +15,10 @@ const validationSchema = yup.object().shape({
     .string()
     .max(
       agolDescriptionCharacterMax,
-      `Description must be at most ${agolDescriptionCharacterMax} characters`
+      `Description must be ${agolDescriptionCharacterMax} characters or less`
     )
     .nullable()
-    .required("Description cannot be blank"),
+    .required("Required"),
 });
 
 /**
@@ -51,7 +51,6 @@ const ProjectSummaryProjectDescription = ({
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-  console.log(errors);
 
   const [editMode, setEditMode] = useState(false);
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -8,14 +8,14 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import ControlledTextInput from "src/components/forms/ControlledTextInput";
 import * as yup from "yup";
-import { agolDescriptionCharacterMax } from "src/constants/projects";
+import { agolFieldCharMax } from "src/constants/projects";
 
 const validationSchema = yup.object().shape({
   description: yup
     .string()
     .max(
-      agolDescriptionCharacterMax,
-      `Description must be ${agolDescriptionCharacterMax} characters or less`
+      agolFieldCharMax.projectDescription,
+      `Description must be ${agolFieldCharMax.projectDescription} characters or less`
     )
     .nullable()
     .required("Required"),

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -1,17 +1,21 @@
 import React, { useState } from "react";
 import { Box, Grid, Icon, Typography, IconButton } from "@mui/material";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
-import * as yup from "yup";
 
 import { PROJECT_UPDATE_DESCRIPTION } from "src/queries/project";
 import { useMutation } from "@apollo/client";
-import ControlledTextInput from "src/components/forms/ControlledTextInput";
 import { useForm } from "react-hook-form";
+import ControlledTextInput from "src/components/forms/ControlledTextInput";
+import * as yup from "yup";
+import { agolDescriptionCharacterMax } from "src/constants/projects";
 
 const validationSchema = yup.object().shape({
   description: yup
     .string()
-    .max(10000, "Description must be at most 10,000 characters")
+    .max(
+      agolDescriptionCharacterMax,
+      `Description must be at most ${agolDescriptionCharacterMax} characters`
+    )
     .required("Description cannot be blank"),
 });
 
@@ -83,43 +87,36 @@ const ProjectSummaryProjectDescription = ({
     <Grid item xs={12} className={classes.fieldGridItem}>
       <Typography className={classes.fieldLabel}>Description</Typography>
       {editMode && (
-        <form onSubmit={handleSubmit(handleProjectDescriptionSave)}>
-          <Box
-            display="flex"
-            justifyContent="flex-start"
-            className={classes.fieldBox}
-            flexWrap="nowrap"
-            alignItems="center"
-          >
-            <ControlledTextInput
-              variant="standard"
-              fullWidth
-              autoFocus
-              multiline
-              rows={4}
-              id="moped-project-description"
-              name="description"
-              label={null}
-              size="small"
-              control={control}
-              error={errors?.description}
-              helperText={errors?.description?.message}
-            />
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+          className={classes.fieldBox}
+          flexWrap="nowrap"
+          alignItems="center"
+          component="form"
+          onSubmit={handleSubmit(handleProjectDescriptionSave)}
+        >
+          <ControlledTextInput
+            variant="standard"
+            fullWidth
+            autoFocus
+            multiline
+            rows={4}
+            name="description"
+            size="small"
+            control={control}
+            error={errors?.description}
+            helperText={errors?.description?.message}
+          />
 
-            <IconButton
-              onClick={handleProjectDescriptionSave}
-              size="large"
-              disabled={errors?.description}
-              type="submit"
-            >
-              <Icon>check</Icon>
-            </IconButton>
+          <IconButton size="large" disabled={errors?.description} type="submit">
+            <Icon>check</Icon>
+          </IconButton>
 
-            <IconButton onClick={handleProjectDescriptionClose} size="large">
-              <Icon>close</Icon>
-            </IconButton>
-          </Box>
-        </form>
+          <IconButton onClick={handleProjectDescriptionClose} size="large">
+            <Icon>close</Icon>
+          </IconButton>
+        </Box>
       )}
       {!editMode && (
         <Box


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20421

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local or deploy preview

**Steps to test:**
TBD

```sql
SELECT
	moped_proj_components.project_id,
	LENGTH(moped_proj_components.description) AS component_description_length,
	LENGTH(moped_proj_components.location_description) AS component_location_description_length,
	LENGTH(moped_project.project_description) AS project_description_length
FROM
	moped_proj_components
	LEFT JOIN moped_project ON moped_project.project_id = moped_proj_components.project_id
WHERE
	TRUE
	AND moped_proj_components.description IS NOT NULL
	AND moped_proj_components.location_description IS NOT NULL
	AND moped_project.project_description IS NOT NULL;
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
