### PR TITLE
Fix how we hide the project view feedback snackbar

### DIFF
--- a/moped-editor/src/components/FeedbackSnackbar.js
+++ b/moped-editor/src/components/FeedbackSnackbar.js
@@ -51,8 +51,13 @@ export const useSnackbar = () => {
   /**
    * Callback to reset the snackbar state on snackbar close
    */
-  const handleSnackbarClose = () =>
+  const handleSnackbarClose = (_, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
     setSnackbarState({ open: false, message: "", severity: "" });
+  };
 
   return { snackbarState, handleSnackbar, handleSnackbarClose };
 };

--- a/moped-editor/src/components/FeedbackSnackbar.js
+++ b/moped-editor/src/components/FeedbackSnackbar.js
@@ -1,6 +1,43 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { Alert } from "@mui/material";
 import { Snackbar } from "@mui/material";
+
+export const useSnackbar = () => {
+  const [snackbarState, setSnackbarState] = useState(false);
+
+  /**
+   * Wrapper around snackbar state setter
+   * @param {boolean} open - The new state of open
+   * @param {String} message - The message for the snackbar
+   * @param {String} severity - The severity color of the snackbar
+   * @param {Object} error - The error to be displayed and logged
+   */
+  const handleSnackbar = useCallback(
+    (open, message, severity, error) => {
+      // if there is an error, render error message,
+      // otherwise, render success message
+      if (error) {
+        setSnackbarState({
+          open: open,
+          message: `${message}. Refresh the page to try again.`,
+          severity: severity,
+        });
+        console.error(error);
+      } else {
+        setSnackbarState({
+          open: open,
+          message: message,
+          severity: severity,
+        });
+      }
+    },
+    [setSnackbarState]
+  );
+
+  const handleSnackbarClose = () => handleSnackbar(false, "", "");
+
+  return { snackbarState, handleSnackbar, handleSnackbarClose };
+};
 
 /**
  * A project summary snackbar

--- a/moped-editor/src/components/FeedbackSnackbar.js
+++ b/moped-editor/src/components/FeedbackSnackbar.js
@@ -6,7 +6,7 @@ import { Snackbar } from "@mui/material";
  * Custom hook to manage snackbar state
  * @returns {Object} - snackbarState, handleSnackbar, handleSnackbarClose
  */
-export const useSnackbar = () => {
+export const useFeedbackSnackbar = () => {
   /**
    * State for the snackbar
    * @property {boolean} open - Whether the snackbar is open

--- a/moped-editor/src/components/FeedbackSnackbar.js
+++ b/moped-editor/src/components/FeedbackSnackbar.js
@@ -1,33 +1,27 @@
 import React from "react";
-import { Alert } from '@mui/material';
+import { Alert } from "@mui/material";
 import { Snackbar } from "@mui/material";
 
 /**
  * A project summary snackbar
  * @param {Object} snackbarState - The message you would like to see
- * @param {function} handleSnackbar - The function to update state
+ * @param {function} handleSnackbarClose - Callback function on snackbar close
  * @param {Number} timeOut - Time out in milliseconds (default: 5000 milliseconds--for five seconds)
  * @returns {JSX.Element}
  * @constructor
  */
 const FeedbackSnackbar = ({
   snackbarState,
-  handleSnackbar,
-  timeOut = 7000,
+  handleSnackbarClose,
+  timeOut = 5000,
 }) => {
-  // Careful not to update your own state, break cycle here...
-  if (snackbarState?.open === false) return null;
-  // Close event
-  const handleSnackbarClose = () => handleSnackbar(false, "", "");
-  // Timeout closure
-  setTimeout(() => handleSnackbarClose(), timeOut);
-
   return (
     <Snackbar
       anchorOrigin={{ vertical: "top", horizontal: "right" }}
       open={snackbarState.open}
       onClose={handleSnackbarClose}
       key={"datatable-snackbar"}
+      autoHideDuration={timeOut}
     >
       <Alert onClose={handleSnackbarClose} severity={snackbarState.severity}>
         {snackbarState.message}

--- a/moped-editor/src/components/FeedbackSnackbar.js
+++ b/moped-editor/src/components/FeedbackSnackbar.js
@@ -2,14 +2,28 @@ import React, { useCallback, useState } from "react";
 import { Alert } from "@mui/material";
 import { Snackbar } from "@mui/material";
 
+/**
+ * Custom hook to manage snackbar state
+ * @returns {Object} - snackbarState, handleSnackbar, handleSnackbarClose
+ */
 export const useSnackbar = () => {
-  const [snackbarState, setSnackbarState] = useState(false);
+  /**
+   * State for the snackbar
+   * @property {boolean} open - Whether the snackbar is open
+   * @property {String} message - The message to display in the snackbar
+   * @property {String} severity - The MUI Alert severity of the snackbar ("success", "error", "warning", "info")
+   */
+  const [snackbarState, setSnackbarState] = useState({
+    open: false,
+    message: "",
+    severity: "",
+  });
 
   /**
    * Wrapper around snackbar state setter
    * @param {boolean} open - The new state of open
    * @param {String} message - The message for the snackbar
-   * @param {String} severity - The severity color of the snackbar
+   * @param {String} severity - The MUI Alert severity of the snackbar ("success", "error", "warning", "info")
    * @param {Object} error - The error to be displayed and logged
    */
   const handleSnackbar = useCallback(
@@ -34,14 +48,18 @@ export const useSnackbar = () => {
     [setSnackbarState]
   );
 
-  const handleSnackbarClose = () => handleSnackbar(false, "", "");
+  /**
+   * Callback to reset the snackbar state on snackbar close
+   */
+  const handleSnackbarClose = () =>
+    setSnackbarState({ open: false, message: "", severity: "" });
 
   return { snackbarState, handleSnackbar, handleSnackbarClose };
 };
 
 /**
- * A project summary snackbar
- * @param {Object} snackbarState - The message you would like to see
+ * A feedback summary snackbar to show on success or error events
+ * @param {Object} snackbarState - snackbar state object: { open, message, severity }
  * @param {function} handleSnackbarClose - Callback function on snackbar close
  * @param {Number} timeOut - Time out in milliseconds (default: 5000 milliseconds--for five seconds)
  * @returns {JSX.Element}

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { format } from "date-fns";
 
@@ -24,7 +24,7 @@ import DashboardStatusModal from "./DashboardStatusModal";
 import DashboardTimelineModal from "./DashboardTimelineModal";
 import ProjectStatusBadge from "../projects/projectView/ProjectStatusBadge";
 import MilestoneProgressMeter from "./MilestoneProgressMeter";
-import FeedbackSnackbar from "src/components/FeedbackSnackbar";
+import FeedbackSnackbar, { useSnackbar } from "src/components/FeedbackSnackbar";
 
 import typography from "../../theme/typography";
 
@@ -112,39 +112,7 @@ const DashboardView = () => {
     fetchPolicy: "no-cache",
   });
 
-  /* Snackbar state and handler for phase and milestone update feedback */
-  const [snackbarState, setSnackbarState] = useState(false);
-
-  /**
-   * Wrapper around snackbar state setter
-   * @param {boolean} open - The new state of open
-   * @param {String} message - The message for the snackbar
-   * @param {String} severity - The severity color of the snackbar
-   * @param {Object} error - The error to be displayed and logged
-   */
-  const handleSnackbar = useCallback(
-    (open, message, severity, error) => {
-      // if there is an error, render error message,
-      // otherwise, render success message
-      if (error) {
-        setSnackbarState({
-          open: open,
-          message: `${message}. Refresh the page to try again.`,
-          severity: severity,
-        });
-        console.error(error);
-      } else {
-        setSnackbarState({
-          open: open,
-          message: message,
-          severity: severity,
-        });
-      }
-    },
-    [setSnackbarState]
-  );
-
-  const handleSnackbarClose = () => handleSnackbar(false, "", "");
+  const { snackbarState, handleSnackbar, handleSnackbarClose } = useSnackbar();
 
   if (error) {
     console.log(error);

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -24,7 +24,9 @@ import DashboardStatusModal from "./DashboardStatusModal";
 import DashboardTimelineModal from "./DashboardTimelineModal";
 import ProjectStatusBadge from "../projects/projectView/ProjectStatusBadge";
 import MilestoneProgressMeter from "./MilestoneProgressMeter";
-import FeedbackSnackbar, { useSnackbar } from "src/components/FeedbackSnackbar";
+import FeedbackSnackbar, {
+  useFeedbackSnackbar,
+} from "src/components/FeedbackSnackbar";
 
 import typography from "../../theme/typography";
 
@@ -112,7 +114,8 @@ const DashboardView = () => {
     fetchPolicy: "no-cache",
   });
 
-  const { snackbarState, handleSnackbar, handleSnackbarClose } = useSnackbar();
+  const { snackbarState, handleSnackbar, handleSnackbarClose } =
+    useFeedbackSnackbar();
 
   if (error) {
     console.log(error);

--- a/moped-editor/src/views/dashboard/DashboardView.js
+++ b/moped-editor/src/views/dashboard/DashboardView.js
@@ -144,6 +144,8 @@ const DashboardView = () => {
     [setSnackbarState]
   );
 
+  const handleSnackbarClose = () => handleSnackbar(false, "", "");
+
   if (error) {
     console.log(error);
   }
@@ -371,7 +373,7 @@ const DashboardView = () => {
         </Container>
         <FeedbackSnackbar
           snackbarState={snackbarState}
-          handleSnackbar={handleSnackbar}
+          handleSnackbarClose={handleSnackbarClose}
         />
       </Page>
     </ActivityMetrics>

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -65,7 +65,7 @@ import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import NotFoundView from "../../errors/NotFoundView";
 import ProjectListViewQueryContext from "src/components/QueryContextProvider";
 import FallbackComponent from "src/components/FallbackComponent";
-import FeedbackSnackbar from "src/components/FeedbackSnackbar";
+import FeedbackSnackbar, { useSnackbar } from "src/components/FeedbackSnackbar";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -199,38 +199,7 @@ const ProjectView = () => {
   const userSessionData = getSessionDatabaseData();
   const userId = userSessionData?.user_id;
 
-  const [snackbarState, setSnackbarState] = useState(false);
-
-  /**
-   * Wrapper around snackbar state setter
-   * @param {boolean} open - The new state of open
-   * @param {String} message - The message for the snackbar
-   * @param {String} severity - The severity color of the snackbar
-   * @param {Object} error - The error to be displayed and logged
-   */
-  const handleSnackbar = useCallback(
-    (open, message, severity, error) => {
-      // if there is an error, render error message,
-      // otherwise, render success message
-      if (error) {
-        setSnackbarState({
-          open: open,
-          message: `${message}. Refresh the page to try again.`,
-          severity: severity,
-        });
-        console.error(error);
-      } else {
-        setSnackbarState({
-          open: open,
-          message: message,
-          severity: severity,
-        });
-      }
-    },
-    [setSnackbarState]
-  );
-
-  const handleSnackbarClose = () => handleSnackbar(false, "", "");
+  const { snackbarState, handleSnackbar, handleSnackbarClose } = useSnackbar();
 
   /**
    * The query to gather the project summary data

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -65,7 +65,9 @@ import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import NotFoundView from "../../errors/NotFoundView";
 import ProjectListViewQueryContext from "src/components/QueryContextProvider";
 import FallbackComponent from "src/components/FallbackComponent";
-import FeedbackSnackbar, { useSnackbar } from "src/components/FeedbackSnackbar";
+import FeedbackSnackbar, {
+  useFeedbackSnackbar,
+} from "src/components/FeedbackSnackbar";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -199,7 +201,8 @@ const ProjectView = () => {
   const userSessionData = getSessionDatabaseData();
   const userId = userSessionData?.user_id;
 
-  const { snackbarState, handleSnackbar, handleSnackbarClose } = useSnackbar();
+  const { snackbarState, handleSnackbar, handleSnackbarClose } =
+    useFeedbackSnackbar();
 
   /**
    * The query to gather the project summary data

--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -191,7 +191,6 @@ const ProjectView = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogState, setDialogState] = useState(null);
   const [anchorElement, setAnchorElement] = useState(null);
-  const [snackbarState, setSnackbarState] = useState(false);
 
   const menuOpen = Boolean(anchorElement);
 
@@ -199,6 +198,8 @@ const ProjectView = () => {
 
   const userSessionData = getSessionDatabaseData();
   const userId = userSessionData?.user_id;
+
+  const [snackbarState, setSnackbarState] = useState(false);
 
   /**
    * Wrapper around snackbar state setter
@@ -228,6 +229,8 @@ const ProjectView = () => {
     },
     [setSnackbarState]
   );
+
+  const handleSnackbarClose = () => handleSnackbar(false, "", "");
 
   /**
    * The query to gather the project summary data
@@ -664,7 +667,7 @@ const ProjectView = () => {
       )}
       <FeedbackSnackbar
         snackbarState={snackbarState}
-        handleSnackbar={handleSnackbar}
+        handleSnackbarClose={handleSnackbarClose}
       />
     </ApolloErrorHandler>
   );


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20772

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local or deploy preview

**Steps to test:**
1. Project summary view
   - Test updated a project summary input like Lead or Description
   - Make sure you see the success feedback when saving
   - Throttle your connection speed in browser to "offline" and make sure you still see error feedback when you try to save a change
2. Dashboard
   - Test updating phases, milestones, and notes through the dashboard widgets
   - Test when "offline" to make sure error feedback works too.
3. Last, I left any enhancements that concern handling multiple snackbars at once out of scope here. There are some [cool solutions to this in the MUI docs](https://mui.com/material-ui/react-snackbar/#common-examples), but, for now, I just avoided naming our custom hook as `useSnackbar` since it conflicts with a dependency used in one of these examples.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
