### PR TITLE
Show user email in team table dropdown choices

### DIFF
--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -165,6 +165,7 @@ export const TEAM_QUERY = gql`
           last_name
           user_id
           is_deleted
+          email
           moped_workgroup {
             workgroup_id
             workgroup_name
@@ -199,6 +200,7 @@ export const TEAM_QUERY = gql`
       workgroup_id
       user_id
       is_deleted
+      email
     }
     moped_workgroup(
       order_by: { workgroup_id: asc }

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -38,17 +38,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const useTeamNameLookup = (data) =>
-  useMemo(() => {
-    if (!data) {
-      return {};
-    }
-    return data.moped_users.reduce((obj, item) => {
-      obj[item.user_id] = `${item.first_name} ${item.last_name}`;
-      return obj;
-    }, {});
-  }, [data]);
-
 const useWorkgroupLookup = (data) =>
   useMemo(() => {
     if (!data) {
@@ -81,7 +70,6 @@ const useColumns = ({
   handleCancelClick,
   handleDeleteOpen,
   classes,
-  teamNameLookup,
   usingShiftKey,
   workgroupLookup,
   userWorkgroupLookup,
@@ -109,7 +97,6 @@ const useColumns = ({
         },
         preProcessEditCellProps: (params) => {
           // Enforce required field
-          console.log(params.props)
           const hasError =
             !params.props.value || params.props.value.length === 0;
           return { ...params.props, error: hasError };
@@ -217,7 +204,6 @@ const useColumns = ({
     handleCancelClick,
     handleDeleteOpen,
     classes,
-    teamNameLookup,
     usingShiftKey,
     workgroupLookup,
     userWorkgroupLookup,
@@ -258,7 +244,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     }
   }, [data]);
 
-  const teamNameLookup = useTeamNameLookup(data);
   const workgroupLookup = useWorkgroupLookup(data);
   const userWorkgroupLookup = useUserWorkgroupLookup(data);
 
@@ -523,7 +508,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     handleCancelClick,
     handleDeleteOpen,
     classes,
-    teamNameLookup,
     usingShiftKey,
     workgroupLookup,
     userWorkgroupLookup,

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -93,7 +93,7 @@ const useColumns = ({
         field: "moped_user",
         width: 250,
         editable: true,
-        valueGetter: (user) => {
+        valueFormatter: (user) => {
           return user ? `${user.first_name} ${user.last_name}` : "";
         },
         renderEditCell: (props) => {
@@ -103,6 +103,7 @@ const useColumns = ({
               name={"user"}
               value={props.row.moped_user}
               nameLookup={teamNameLookup}
+              options={data.moped_users}
               error={props.error}
               userWorkgroupLookup={userWorkgroupLookup}
             />
@@ -345,6 +346,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         isNew: true,
         roleIds: [],
         project_personnel_id: id,
+        moped_user: {},
       },
       ...oldRows,
     ]);

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -102,15 +102,14 @@ const useColumns = ({
               {...props}
               name={"user"}
               value={props.row.moped_user}
-              nameLookup={teamNameLookup}
               options={data.moped_users}
               error={props.error}
-              userWorkgroupLookup={userWorkgroupLookup}
             />
           );
         },
         preProcessEditCellProps: (params) => {
           // Enforce required field
+          console.log(params.props)
           const hasError =
             !params.props.value || params.props.value.length === 0;
           return { ...params.props, error: hasError };

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -49,17 +49,6 @@ const useWorkgroupLookup = (data) =>
     }, {});
   }, [data]);
 
-const useUserWorkgroupLookup = (data) =>
-  useMemo(() => {
-    if (!data) {
-      return {};
-    }
-    return data.moped_users.reduce((obj, item) => {
-      obj[item.user_id] = item.workgroup_id;
-      return obj;
-    }, {});
-  }, [data]);
-
 const requiredFields = ["moped_user", "moped_proj_personnel_roles"];
 
 const useColumns = ({
@@ -72,7 +61,6 @@ const useColumns = ({
   classes,
   usingShiftKey,
   workgroupLookup,
-  userWorkgroupLookup,
 }) =>
   useMemo(() => {
     return [
@@ -206,7 +194,6 @@ const useColumns = ({
     classes,
     usingShiftKey,
     workgroupLookup,
-    userWorkgroupLookup,
   ]);
 
 const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
@@ -245,7 +232,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
   }, [data]);
 
   const workgroupLookup = useWorkgroupLookup(data);
-  const userWorkgroupLookup = useUserWorkgroupLookup(data);
 
   /**
    * Construct a moped_project_personnel object that can be passed to an insert mutation
@@ -510,7 +496,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     classes,
     usingShiftKey,
     workgroupLookup,
-    userWorkgroupLookup,
   });
 
   const processRowUpdateMemoized = useCallback(

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -1,5 +1,10 @@
 import React from "react";
-import { Autocomplete, TextField, FormControl } from "@mui/material";
+import {
+  Autocomplete,
+  TextField,
+  FormControl,
+  ListItemText,
+} from "@mui/material";
 import { useGridApiContext } from "@mui/x-data-grid-pro";
 import { useTheme } from "@mui/material/styles";
 
@@ -51,12 +56,23 @@ const TeamAutocompleteComponent = ({
   };
 
   const isOptionEqualToValue = (option, value) => {
-    // if 
     return value?.user_id === option?.user_id;
   };
 
   const getOptionLabel = (option) => {
     return option.user_id ? `${option.first_name} ${option.last_name}` : "";
+  };
+
+  const renderOption = (props, option, state) => {
+    console.log(props, state);
+    return (
+      <ListItemText
+        key={option.user_id}
+        inset
+        primary={`${option.first_name} ${option.last_name}`}
+        secondary={option.email}
+      />
+    );
   };
 
   return (
@@ -70,7 +86,8 @@ const TeamAutocompleteComponent = ({
         isOptionEqualToValue={(option, value) =>
           isOptionEqualToValue(option, value)
         }
-        value={value || null}
+        renderOption={renderOption}
+        value={value?.user_id ? value : null}
         sx={{ paddingTop: theme.spacing(1) }}
         onChange={(event, newValue) => {
           handleChange(event, newValue);

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -3,6 +3,7 @@ import {
   Autocomplete,
   TextField,
   FormControl,
+  ListItem,
   ListItemText,
 } from "@mui/material";
 import { useGridApiContext } from "@mui/x-data-grid-pro";
@@ -24,10 +25,8 @@ const TeamAutocompleteComponent = ({
   value,
   field,
   hasFocus,
-  nameLookup,
   error,
   name,
-  userWorkgroupLookup,
   options,
 }) => {
   const theme = useTheme();
@@ -41,17 +40,16 @@ const TeamAutocompleteComponent = ({
   }, [hasFocus]);
 
   const handleChange = (event, newValue) => {
-    const personnelValue = nameLookup[newValue];
     apiRef.current.setEditCellValue({
       id,
       field,
-      value: personnelValue ?? null,
+      value: newValue,
     });
     // Also update the corresponding workgroup field with the selected user's workgroup id
     apiRef.current.setEditCellValue({
       id,
       field: "moped_workgroup",
-      value: { workgroup_id: userWorkgroupLookup[newValue] },
+      value: { workgroup_id: newValue?.workgroup_id },
     });
   };
 
@@ -63,15 +61,14 @@ const TeamAutocompleteComponent = ({
     return option.user_id ? `${option.first_name} ${option.last_name}` : "";
   };
 
-  const renderOption = (props, option, state) => {
-    console.log(props, state);
+  const renderOption = (props, option) => {
     return (
-      <ListItemText
-        key={option.user_id}
-        inset
-        primary={`${option.first_name} ${option.last_name}`}
-        secondary={option.email}
-      />
+      <ListItem {...props} key={option.user_id}>
+        <ListItemText
+          primary={`${option.first_name} ${option.last_name}`}
+          secondary={option.email}
+        />
+      </ListItem>
     );
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -23,6 +23,7 @@ const TeamAutocompleteComponent = ({
   error,
   name,
   userWorkgroupLookup,
+  options,
 }) => {
   const theme = useTheme();
   const apiRef = useGridApiContext();
@@ -49,32 +50,13 @@ const TeamAutocompleteComponent = ({
     });
   };
 
-  const options = Object.keys(nameLookup);
-
   const isOptionEqualToValue = (option, value) => {
-    // if the value is a number, use the idFromValue nameLookup to find if option is equal to Value
-    // If the value is an object, use the user_id to find if option is equal to Value
-    let idFromValue;
-    if (typeof value === "string") {
-      idFromValue = Object.keys(nameLookup).find(
-        (key) => nameLookup[key] === value
-      );
-    } else if (typeof value === "object") {
-      idFromValue = value.user_id;
-    }
-
-    if (Number(option) === Number(idFromValue)) {
-      return true;
-    } else {
-      return false;
-    }
+    // if 
+    return value?.user_id === option?.user_id;
   };
 
   const getOptionLabel = (option) => {
-    if (typeof option === "string" && !nameLookup[option]) {
-      return option;
-    }
-    return nameLookup[option] || "";
+    return option.user_id ? `${option.first_name} ${option.last_name}` : "";
   };
 
   return (
@@ -84,6 +66,7 @@ const TeamAutocompleteComponent = ({
         name={name}
         options={options}
         getOptionLabel={getOptionLabel}
+        getOptionKey={(option) => option.user_id}
         isOptionEqualToValue={(option, value) =>
           isOptionEqualToValue(option, value)
         }


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20880

## Testing
**URL to test:** 

https://deploy-preview-1535--atd-moped-main.netlify.app/moped/projects/

![Screenshot 2025-02-12 at 9 55 43 AM](https://github.com/user-attachments/assets/86bc9b56-f915-4e76-b2f9-af17077fbb0c)


**Steps to test:**

In order to add the email address I changed how the table/field handles its value, moving from just the name or id to the entire moped_user object. (I am going to do something similar to other fields when I refactor all of the autocomplete fields in a next PR). So please test all of the operations with the autocomplete

1. Add a new user
2. Search for Amenity -- there are two of her in the staging dataset, and you should only see two in this list. Current behavior in staging is for her name to multiply as you keep searching for her. 
3. choose anyone, fill out the rest of the row. 
4. Leave some required fields blank. check the error message still appears
5. Try these same steps on existing records. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test to "Navigate to the Team tab. Add a team member to your project with a note and two roles. Notice that the team member's email is shown as secondary text."
