### PR TITLE
Remove loading state from description error prop

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -129,7 +129,7 @@ const ProjectSummaryProjectDescription = ({
               name="description"
               size="small"
               control={control}
-              error={errors?.description || loading}
+              error={errors?.description}
               helperText={errors?.description?.message}
             />
             <IconButton


### PR DESCRIPTION
## Associated issues
None. This fixes a UI bug from [my PR](https://github.com/cityofaustin/atd-moped/pull/1533) where loading state is triggering error highlighting briefly.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
[Deploy preview](https://deploy-preview-1536--atd-moped-main.netlify.app/moped/projects)

**Steps to test:**
1. Make an edit to a project description and make sure the text input doesn't highlight red while the change is saving

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
