### PR TITLE
Handle invalid operators in project list view search params

### DIFF
--- a/moped-editor/src/components/ApolloErrorHandler.js
+++ b/moped-editor/src/components/ApolloErrorHandler.js
@@ -1,10 +1,10 @@
 import React from "react";
 import Backdrop from "@mui/material/Backdrop";
 import CircularProgress from "@mui/material/CircularProgress";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import FallbackComponent from "./FallbackComponent";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   backdrop: {
     zIndex: theme.zIndex.drawer + 1,
     color: "#fff",
@@ -20,12 +20,14 @@ const useStyles = makeStyles(theme => ({
  * @return {JSX.Element}
  * @constructor
  */
-const ApolloErrorHandler = props => {
+const ApolloErrorHandler = (props) => {
   const classes = useStyles();
 
   // Error Variables
   const error = props?.error ?? null;
-  const errorString = error ? JSON.stringify(error, Object.getOwnPropertyNames(error)) : "";
+  const errorString = error
+    ? JSON.stringify(error, Object.getOwnPropertyNames(error))
+    : "";
   const jwtError = errorString.includes("JWT") || errorString.includes("token");
 
   if (jwtError) {
@@ -41,7 +43,7 @@ const ApolloErrorHandler = props => {
           <CircularProgress color="inherit" />
         </Backdrop>
       ) : error ? (
-        <FallbackComponent error={error}/>
+        <FallbackComponent error={error} />
       ) : (
         props.children
       )}

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -26,7 +26,7 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 
       if (!filterConfigForField) {
         throwFallbackComponentError(
-          `Field ${field} in this url no longer exists in the project list.`
+          `Field ${field} in this URL no longer exists in the project list.`
         );
       }
 
@@ -37,7 +37,7 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 
       if (!operatorConfig) {
         throwFallbackComponentError(
-          `Operator ${operator} in this url does not exist.`
+          `Operator ${operator} in this URL no longer exists in the project list.`
         );
       }
 

--- a/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
+++ b/moped-editor/src/views/projects/projectsListView/useProjectListViewQuery/useAdvancedSearch.js
@@ -34,6 +34,13 @@ const makeAdvancedSearchWhereFilters = (filters) =>
 
       // Use operator name to get the GraphQL operator config for that operator
       const operatorConfig = FILTERS_COMMON_OPERATORS[operator];
+
+      if (!operatorConfig) {
+        throwFallbackComponentError(
+          `Operator ${operator} in this url does not exist.`
+        );
+      }
+
       let {
         envelope,
         specialNullValue,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21145

This issue mentions doing further research to refine future improvements to make this even better, i started looking into that and will post my findings in the issue but i want to go ahead and get this PR reviewed

## Testing
**URL to test:** 
https://deploy-preview-1545--atd-moped-main.netlify.app/moped/

**Steps to test**
1. Go to the [following](https://deploy-preview-1545--atd-moped-main.netlify.app/moped/projects/?filters=[{%22field%22%3A%22project_and_child_project_council_districts%22%2C%22operator%22%3A%22council_districts_array_contain%22%2C%22value%22%3A%227%22}]&isOr=false) URL and see the new more helpful error message
2. Compare with the [previous](https://mobility.austin.gov/moped/projects/?filters=%5B%7B%22field%22%3A%22project_and_child_project_council_districts%22%2C%22operator%22%3A%22council_districts_array_contain%22%2C%22value%22%3A%227%22%7D%5D&isOr=false) unhelpful error message


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test to read: "Manually edit your copied URL in your browser with a invalid field name and see that an error message appears identifying the invalid field. Now, test manually removing a letter from an operator, and you should see a similar error message identifying the invalid operator." 
