### PR TITLE
Fix funding table to not save on clickaway when there is no change

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -459,11 +459,11 @@ const ProjectFundingTable = ({ handleSnackbar }) => {
         : updateProjectFundingData.funding_description;
 
     updateProjectFundingData.funding_source_id =
-      updateProjectFundingData.moped_fund_source?.funding_source_id;
+      updateProjectFundingData.moped_fund_source?.funding_source_id || null;
     delete updateProjectFundingData.moped_fund_source;
 
     updateProjectFundingData.funding_program_id =
-      updateProjectFundingData.moped_fund_program?.funding_program_id;
+      updateProjectFundingData.moped_fund_program?.funding_program_id || null;
     delete updateProjectFundingData.moped_fund_program;
 
     if (updatedRow.isNew) {
@@ -504,6 +504,8 @@ const ProjectFundingTable = ({ handleSnackbar }) => {
     } else {
       // Remove __typename since we removed it from updatedRow and check if the row has changed
       delete originalRow.__typename;
+      delete originalRow.moped_fund_source;
+      delete originalRow.moped_fund_program;
       const hasRowChanged = !isEqual(updatedRow, originalRow);
 
       if (!hasRowChanged) {


### PR DESCRIPTION
## Associated issues
n/a

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local or deploy preview

**Steps to test:**
These came straight from the QA sheet. 🍝 

1. Use "Add funding source" button to add a blank funding source to the funding table.
2. Fill out all fields and save the row - verify that you can't use a funding amount with a decimal or non-numeric characters
3. Double-click a cell to edit. Click away to cancel without editing. This should not create a new edit event in the activity log. Now, edit a value this way. This should save the edit and create an activity log row.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
