### PR TITLE
Update team table so that duplicate team members cannot be added

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -73,15 +73,18 @@ const useColumns = ({
           return user ? `${user.first_name} ${user.last_name}` : "";
         },
         renderEditCell: (props) => {
+          // the team member object for the current row
           const currentRowMember =
             data?.moped_project_by_pk?.moped_proj_personnel.filter(
               (user) => user.project_personnel_id === props.id
             );
+          // the existing team members on this project
           const existingTeamMembers =
             data?.moped_project_by_pk?.moped_proj_personnel.map(
               (option) => option.moped_user.email
             );
           // filter out existing team members from list of options unless they are the current row member
+          // that way the current member remains an option when editing a row
           const teamMembersWithoutDuplicates = data?.moped_users.filter(
             (user) => {
               return (

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -73,15 +73,22 @@ const useColumns = ({
           return user ? `${user.first_name} ${user.last_name}` : "";
         },
         renderEditCell: (props) => {
-          const currentTeamMembers =
+          const currentRowMember =
+            data?.moped_project_by_pk?.moped_proj_personnel.filter(
+              (user) => user.project_personnel_id === props.id
+            );
+          const existingTeamMembers =
             data?.moped_project_by_pk?.moped_proj_personnel.map(
               (option) => option.moped_user.email
             );
-          // filter out current team members from list of moped users unless they are the row.moped_user.email
+          // filter out existing team members from list of options unless they are the current row member
           const teamMembersWithoutDuplicates = data?.moped_users.filter(
-            (user) =>
-              !currentTeamMembers.includes(user.email) ||
-              user.email === props.row.moped_user.email
+            (user) => {
+              return (
+                !existingTeamMembers.includes(user.email) ||
+                user.email === currentRowMember?.[0]?.moped_user.email
+              );
+            }
           );
           return (
             <TeamAutocompleteComponent
@@ -90,6 +97,7 @@ const useColumns = ({
               value={props.row.moped_user}
               options={teamMembersWithoutDuplicates}
               error={props.error}
+              workgroupLookup={workgroupLookup}
             />
           );
         },

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -73,12 +73,22 @@ const useColumns = ({
           return user ? `${user.first_name} ${user.last_name}` : "";
         },
         renderEditCell: (props) => {
+          const currentTeamMembers =
+            data?.moped_project_by_pk?.moped_proj_personnel.map(
+              (option) => option.moped_user.email
+            );
+          // filter out current team members from list of moped users unless they are the row.moped_user.email
+          const teamMembersWithoutDuplicates = data?.moped_users.filter(
+            (user) =>
+              !currentTeamMembers.includes(user.email) ||
+              user.email === props.row.moped_user.email
+          );
           return (
             <TeamAutocompleteComponent
               {...props}
               name={"user"}
               value={props.row.moped_user}
-              options={data.moped_users}
+              options={teamMembersWithoutDuplicates}
               error={props.error}
             />
           );

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -89,20 +89,18 @@ const useColumns = ({
             );
           // filter out existing team members from list of options unless they are the current row member
           // that way the current member remains an option when editing a row
-          const teamMembersWithoutDuplicates = data?.moped_users.filter(
-            (user) => {
-              return (
-                !existingTeamMembers.includes(user.user_id) ||
-                user.user_id === currentRowMember?.moped_user.user_id
-              );
-            }
-          );
+          const unassignedTeamMembers = data?.moped_users.filter((user) => {
+            return (
+              !existingTeamMembers.includes(user.user_id) ||
+              user.user_id === currentRowMember?.moped_user.user_id
+            );
+          });
           return (
             <TeamAutocompleteComponent
               {...props}
               name={"user"}
               value={props.row.moped_user}
-              options={teamMembersWithoutDuplicates}
+              options={unassignedTeamMembers}
               error={props.error}
               workgroupLookup={workgroupLookup}
             />

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -49,6 +49,14 @@ const useWorkgroupLookup = (data) =>
     }, {});
   }, [data]);
 
+// returns a list of user ids for the existing team members on this project
+const useExistingTeamMembers = (data) =>
+  useMemo(() => {
+    return data?.moped_project_by_pk?.moped_proj_personnel.map(
+      (option) => option.moped_user.user_id
+    );
+  }, [data]);
+
 const requiredFields = ["moped_user", "moped_proj_personnel_roles"];
 
 const useColumns = ({
@@ -61,6 +69,7 @@ const useColumns = ({
   classes,
   usingShiftKey,
   workgroupLookup,
+  existingTeamMembers,
 }) =>
   useMemo(() => {
     return [
@@ -75,21 +84,16 @@ const useColumns = ({
         renderEditCell: (props) => {
           // the team member object for the current row
           const currentRowMember =
-            data?.moped_project_by_pk?.moped_proj_personnel.filter(
+            data?.moped_project_by_pk?.moped_proj_personnel.find(
               (user) => user.project_personnel_id === props.id
-            );
-          // the existing team members on this project
-          const existingTeamMembers =
-            data?.moped_project_by_pk?.moped_proj_personnel.map(
-              (option) => option.moped_user.email
             );
           // filter out existing team members from list of options unless they are the current row member
           // that way the current member remains an option when editing a row
           const teamMembersWithoutDuplicates = data?.moped_users.filter(
             (user) => {
               return (
-                !existingTeamMembers.includes(user.email) ||
-                user.email === currentRowMember?.[0]?.moped_user.email
+                !existingTeamMembers.includes(user.user_id) ||
+                user.user_id === currentRowMember?.moped_user.user_id
               );
             }
           );
@@ -215,6 +219,7 @@ const useColumns = ({
     classes,
     usingShiftKey,
     workgroupLookup,
+    existingTeamMembers,
   ]);
 
 const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
@@ -253,6 +258,8 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
   }, [data]);
 
   const workgroupLookup = useWorkgroupLookup(data);
+
+  const existingTeamMembers = useExistingTeamMembers(data);
 
   /**
    * Construct a moped_project_personnel object that can be passed to an insert mutation
@@ -517,6 +524,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     classes,
     usingShiftKey,
     workgroupLookup,
+    existingTeamMembers,
   });
 
   const processRowUpdateMemoized = useCallback(

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -27,6 +27,7 @@ const TeamAutocompleteComponent = ({
   error,
   name,
   options,
+  workgroupLookup,
 }) => {
   const theme = useTheme();
   const apiRef = useGridApiContext();
@@ -48,7 +49,10 @@ const TeamAutocompleteComponent = ({
     apiRef.current.setEditCellValue({
       id,
       field: "moped_workgroup",
-      value: { workgroup_id: newValue?.workgroup_id },
+      value: {
+        workgroup_id: newValue?.workgroup_id,
+        workgroup_name: workgroupLookup[newValue?.workgroup_id],
+      },
     });
   };
 

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -17,6 +17,7 @@ import { useTheme } from "@mui/material/styles";
  * @param {Boolean} error - toggles error style in textfield
  * @param {Object} name - name of the field
  * @param {Object} options - moped users to use in team member select
+ * @param {Object} workgroupLookup - lookup object to map workgroup ids to names
  * @return {JSX.Element}
  */
 const TeamAutocompleteComponent = ({

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/TeamAutocompleteComponent.js
@@ -14,10 +14,9 @@ import { useTheme } from "@mui/material/styles";
  * @param {String} value - field value
  * @param {String} field - name of field
  * @param {Boolean} hasFocus - does this field have focus
- * @param {Object} nameLookup - maps user id to user name
  * @param {Boolean} error - toggles error style in textfield
  * @param {Object} name - name of the field
- * @param {Object} userWorkgroupLookup - mapping of user ids to their corresponding workgroup ids
+ * @param {Object} options - moped users to use in team member select
  * @return {JSX.Element}
  */
 const TeamAutocompleteComponent = ({


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21199

Even though theres minimal code changes i found this to be way more complicated to untangle/implement than i thought it would! 

## Testing
**URL to test:** 
https://deploy-preview-1551--atd-moped-main.netlify.app/moped/

**Steps to test:**
1. Test adding new members to a team table. You shouldnt be able to add members that are already on the team, they shouldnt be an option
2. Edit a team member row. You shouldnt see options for members that are already on the team, but you should be able to click on a diff member and then click back to the original member of the row before you edited it and save that, therefore not really updating anything.
3. Test deleting members, updating, adding fields, etc try to break something!
4. See that the [object Object] on the workgroup field is no longer showing when saving new team member edits


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test: `Verify that you cannot add a team member without selecting a team member name and at least one role. Also verify that you can't add the same person to one project more than once.` 
