### PR TITLE
Fix files table to only remove row from state after mutation succeeds

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -357,9 +357,6 @@ const ProjectFiles = ({ handleSnackbar }) => {
   // handles row delete
   const handleDeleteClick = useCallback(
     (id) => () => {
-      // remove row from rows in state
-      setRows(rows.filter((row) => row.project_file_id !== id));
-
       deleteProjectFileAttachment({
         variables: {
           fileId: id,
@@ -367,6 +364,8 @@ const ProjectFiles = ({ handleSnackbar }) => {
       })
         .then(() => refetch())
         .then(() => {
+          // remove row from rows in state
+          setRows(rows.filter((row) => row.project_file_id !== id));
           setIsDeleteConfirmationOpen(false);
           handleSnackbar(true, "File deleted", "success");
         })


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20881

## Testing
**URL to test:** 

https://deploy-preview-1555--atd-moped-main.netlify.app/moped/

**Steps to test:**

1. Go to a project's files table with files (like project [290](https://localhost:3000/moped/projects/290?tab=files) in a production snapshot) or add some files
2. Use your browser dev tools to set your connection to "Offline"
3. Delete a file and see that an error snackbar appears and the row does not change. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
