### PR TITLE
Fix missing value for project created by

### DIFF
--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -71,6 +71,7 @@ const NewProjectView = () => {
       project_name_secondary:
         projectSecondaryName?.length > 0 ? projectSecondaryName : null,
       project_description: description,
+      added_by: userId,
       // Use potential phase as default
       moped_proj_phases: {
         data: [


### PR DESCRIPTION
## Associated issues
None

This fixes a bug where the user ID of the project creator is missing from the create mutation payload.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local or deploy preview

**Steps to test:**
1. Create new a project in Moped
2. Check the project list table and make sure the **Created By** column contains the user you are logged in as

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
