### PR TITLE
Remove current phase edge case handling from current_phase_view database view

### DIFF
--- a/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/down.sql
+++ b/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/down.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW current_phase_view AS SELECT DISTINCT ON (mpp.project_id, mpp.is_current_phase)
+    mpp.project_id,
+    mpp.project_phase_id,
+    mpp.phase_id,
+    mp.phase_name,
+    mp.phase_key,
+    mp.phase_name_simple
+FROM moped_proj_phases mpp
+LEFT JOIN moped_phases mp ON mp.phase_id = mpp.phase_id
+WHERE mpp.is_deleted = false AND mpp.is_current_phase = true
+ORDER BY mpp.project_id, mpp.is_current_phase, mpp.project_phase_id;

--- a/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
+++ b/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
@@ -8,5 +8,5 @@ CREATE OR REPLACE VIEW current_phase_view AS SELECT
     mp.phase_name_simple
 FROM moped_proj_phases mpp
 LEFT JOIN moped_phases mp ON mp.phase_id = mpp.phase_id
-WHERE mpp.is_deleted = false AND mpp.is_current_phase = true
-ORDER BY mpp.project_id, mpp.is_current_phase, mpp.project_phase_id;
+WHERE mpp.is_deleted = false AND mpp.is_current_phase = true;
+

--- a/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
+++ b/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
@@ -1,0 +1,12 @@
+-- Removes DISTINCT ON handling which was causing query timeouts
+CREATE OR REPLACE VIEW current_phase_view AS SELECT
+    mpp.project_id,
+    mpp.project_phase_id,
+    mpp.phase_id,
+    mp.phase_name,
+    mp.phase_key,
+    mp.phase_name_simple
+FROM moped_proj_phases mpp
+LEFT JOIN moped_phases mp ON mp.phase_id = mpp.phase_id
+WHERE mpp.is_deleted = false AND mpp.is_current_phase = true
+ORDER BY mpp.project_id, mpp.is_current_phase, mpp.project_phase_id;

--- a/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
+++ b/moped-database/migrations/1742416187184_update_current_phase_view_drop_distinct_on/up.sql
@@ -1,4 +1,4 @@
--- Removes DISTINCT ON handling which was causing query timeouts
+-- Removes DISTINCT ON handling and ORDER BY which was causing query timeouts
 CREATE OR REPLACE VIEW current_phase_view AS SELECT
     mpp.project_id,
     mpp.project_phase_id,
@@ -9,4 +9,3 @@ CREATE OR REPLACE VIEW current_phase_view AS SELECT
 FROM moped_proj_phases mpp
 LEFT JOIN moped_phases mp ON mp.phase_id = mpp.phase_id
 WHERE mpp.is_deleted = false AND mpp.is_current_phase = true;
-

--- a/moped-database/views/current_phase_view.sql
+++ b/moped-database/views/current_phase_view.sql
@@ -9,5 +9,4 @@ CREATE OR REPLACE VIEW current_phase_view AS SELECT
     mp.phase_name_simple
 FROM moped_proj_phases mpp
 LEFT JOIN moped_phases mp ON mp.phase_id = mpp.phase_id
-WHERE mpp.is_deleted = false AND mpp.is_current_phase = true
-ORDER BY mpp.project_id, mpp.is_current_phase, mpp.project_phase_id;
+WHERE mpp.is_deleted = false AND mpp.is_current_phase = true;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21593

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local preferably for prod data

**Steps to test:**
1. Apply migration
2. Replicate prod data so we can rly make sure everything is snappy and no more timeouts
3. Test "Status is Complete" advanced search filter, this was timing out for me on prod and now is super fast
4. Test other options
5. Test down migration


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
