### PR TITLE
Fix "ALL PROJECTS" link to navigate back to filtered project list from any project tab

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectView.js
+++ b/moped-editor/src/views/projects/projectView/ProjectView.js
@@ -181,6 +181,7 @@ const ProjectView = () => {
   const allProjectsLink = !previousProjectListViewQueryString
     ? "/moped/projects"
     : `/moped/projects${previousProjectListViewQueryString}`;
+
   /**
    * @constant {boolean} isEditing - When true, it signals a child component we want to edit the project name
    * @constant {boolean} dialogOpen - When true, the dialog shows
@@ -221,10 +222,18 @@ const ProjectView = () => {
    */
   const handleChange = useCallback(
     (event, newTab) => {
-      setSearchParams({ tab: TABS[newTab].param });
+      // Preserve the queryString state when changing tabs
+      setSearchParams(
+        {
+          tab: TABS[newTab].param,
+        },
+        {
+          state: locationState, // Preserve the location state when changing tabs
+        }
+      );
       if (newTab === 0) refetch();
     },
-    [refetch, setSearchParams]
+    [refetch, setSearchParams, locationState]
   );
 
   /**


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21179

## Testing
Deploy preview or local

**URL to test:** 
https://deploy-preview-1569--atd-moped-main.netlify.app/moped/session/signin

**Steps to test:**

1. Go to the project list view and apply some advanced filters
1. Click a project link to visit the summary project of one of the results
1. Click the "ALL PROJECTS" link in the top left to navigate back to the filtered search results.
1. Now, click another project link to go to a summary page again
1. Click the "Timeline" tab (or any other tab) and then the "ALL PROJECTS" link
1. See that the previous advanced filters on the project list are saved in state


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test to say: "Navigate to a result in the advanced search and then click through a few tabs in the project summary, then click "All projects" breadcrumb to return to that advanced search"  
