### PR TITLE
Fix sorting in team, milestone, and funding tables

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -142,6 +142,8 @@ const useColumns = ({
         width: 200,
         editable: true,
         valueFormatter: (value) => value?.funding_source_name,
+        sortComparator: (v1, v2) =>
+          v1.funding_source_name.localeCompare(v2.funding_source_name),
         renderEditCell: (props) => (
           <LookupAutocompleteComponent
             {...props}
@@ -157,6 +159,8 @@ const useColumns = ({
         width: 200,
         editable: true,
         valueFormatter: (value) => value?.funding_program_name,
+        sortComparator: (v1, v2) =>
+          v1.funding_program_name.localeCompare(v2.funding_program_name),
         renderEditCell: (props) => (
           <LookupAutocompleteComponent
             {...props}
@@ -178,11 +182,19 @@ const useColumns = ({
         field: "funding_status_id",
         editable: true,
         width: 200,
-        renderCell: ({ value }) =>
+        valueFormatter: (value) =>
           getLookupValueByID(
             data["moped_fund_status"],
             "funding_status",
             value
+          ),
+        sortComparator: (v1, v2) =>
+          getLookupValueByID(
+            data["moped_fund_status"],
+            "funding_status",
+            v1
+          ).localeCompare(
+            getLookupValueByID(data["moped_fund_status"], "funding_status", v2)
           ),
         renderEditCell: (props) => (
           <LookupSelectComponent
@@ -200,6 +212,10 @@ const useColumns = ({
         editable: true,
         valueFormatter: (value) =>
           !!value?.fund_name ? `${value?.fund_id} | ${value?.fund_name}` : "",
+        sortComparator: (v1, v2) =>
+          `${v1?.fund_id} | ${v1?.fund_name}`.localeCompare(
+            `${v2?.fund_id} | ${v2?.fund_name}`
+          ),
         renderEditCell: (props) => (
           <LookupAutocompleteComponent
             {...props}
@@ -220,6 +236,12 @@ const useColumns = ({
             ? `${value?.dept} | ${value?.unit} |
               ${value?.unit_long_name}`
             : "",
+        sortComparator: (v1, v2) =>
+          `${v1?.dept} | ${v1?.unit} |
+              ${v1?.unit_long_name}`.localeCompare(
+            `${v2?.dept} | ${v2?.unit} |
+              ${v2?.unit_long_name}`
+          ),
         renderEditCell: (props) => (
           <LookupAutocompleteComponent
             {...props}

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -58,6 +58,8 @@ const useColumns = ({
         headerName: "Milestone",
         field: "moped_milestone",
         renderCell: ({ row }) => row.moped_milestone?.milestone_name,
+        sortComparator: (v1, v2) =>
+          v1.milestone_name.localeCompare(v2.milestone_name),
         // input validation:
         preProcessEditCellProps: (params) => ({
           ...params.props,
@@ -92,8 +94,8 @@ const useColumns = ({
         field: "moped_milestone_related_phase",
         editable: true, // this is to be able to use the renderEditCell option to update the related phase
         // during editing -- the input field is always disabled
-        renderCell: (props) =>
-          phaseNameLookup[props.row.moped_milestone?.related_phase_id] ?? "",
+        valueGetter: (value, row) =>
+          phaseNameLookup[row.moped_milestone?.related_phase_id] ?? "",
         width: 150,
         renderEditCell: (props) => (
           <ViewOnlyTextField

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -57,7 +57,7 @@ const useColumns = ({
       {
         headerName: "Milestone",
         field: "moped_milestone",
-        renderCell: ({ row }) => row.moped_milestone?.milestone_name,
+        valueFormatter: (value) => value?.milestone_name,
         sortComparator: (v1, v2) =>
           v1.milestone_name.localeCompare(v2.milestone_name),
         // input validation:

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -82,6 +82,10 @@ const useColumns = ({
         valueFormatter: (user) => {
           return user ? `${user.first_name} ${user.last_name}` : "";
         },
+        sortComparator: (v1, v2) =>
+          `${v1.first_name} ${v1.last_name}`.localeCompare(
+            `${v2.first_name} ${v2.last_name}`
+          ),
         renderEditCell: (props) => {
           // the team member object for the current row
           const currentRowMember =
@@ -128,6 +132,8 @@ const useColumns = ({
         editable: true,
         width: 200,
         valueFormatter: (workgroup) => workgroup?.workgroup_name ?? "",
+        sortComparator: (v1, v2) =>
+          v1.workgroup_name.localeCompare(v2.workgroup_name),
         renderEditCell: (props) => (
           <ViewOnlyTextField
             {...props}
@@ -144,6 +150,7 @@ const useColumns = ({
         field: "moped_proj_personnel_roles",
         width: 200,
         editable: true,
+        sortable: false,
         renderHeader: () => (
           <div className={classes.roleHeader}>
             Role{" "}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21366

The problem is that in any column where we are using a function to render the cell without actually changing the internal value of the row (such as `valueFormatter`, `renderCell`), the datagrid internal sort is trying to sort on the fields internal value, not what is rendering in the cell. Oftentimes that value is an Object so the sorting just doesnt work, or in cases like the funding status, it was sorting the under the hood value, not what users see in the column on the front end. 

This means we either need to use a custom sort function on these columns or use `valueGetter` instead which actually sets the value, but in order to implement that we would have to refactor a lot, like the `LookupAutocompleteComponent` and `LookupSelectComponent` components, and even then im not 100% how feasible that is. So for the purpose of fixing these bugs already i opted for the straightforward solution using the custom sorts.



## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
[Netlify](https://deploy-preview-1570--atd-moped-main.netlify.app/moped/session/signin)

**Steps to test:**
1. Test out all the sorting in the Teams, Funding, and Milestones tables.
2. Also test adding new rows to these tables, editing, and deleting


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
