### PR TITLE
Add length validation to project status update input

### DIFF
--- a/moped-editor/src/constants/projects.js
+++ b/moped-editor/src/constants/projects.js
@@ -53,4 +53,11 @@ export const agolValidation = {
       `Secondary name must be ${projectNamesCharMax} characters or less`
     )
     .nullable(),
+  projectStatusUpdate: yup
+    .string()
+    .max(
+      agolFieldCharMax.string,
+      `Status update must be ${agolFieldCharMax.string} characters or less`
+    )
+    .nullable(),
 };

--- a/moped-editor/src/utils/validation.js
+++ b/moped-editor/src/utils/validation.js
@@ -1,7 +1,7 @@
 /**
  * Wrapper function for Yup.validateSync that returns formatted errors
  * See https://github.com/jquense/yup?tab=readme-ov-file#schemavalidatesyncvalue-any-options-object-infertypeschema
- * @param {object} value - Key-value pairs of the field to validate
+ * @param {object} value - Key-value pairs of the fields to validate
  * @param {object} yupValidationSchema - The Yup validation schema to use
  * @returns {object|null} - Returns an object with errors or null if no errors
  */

--- a/moped-editor/src/utils/validationHelpers.js
+++ b/moped-editor/src/utils/validationHelpers.js
@@ -1,0 +1,23 @@
+/**
+ * Wrapper function for Yup.validateSync that returns formatted errors
+ * See https://github.com/jquense/yup?tab=readme-ov-file#schemavalidatesyncvalue-any-options-object-infertypeschema
+ * @param {object} value - Key-value pairs of the field to validate
+ * @param {object} yupValidationSchema - The Yup validation schema to use
+ * @returns {object|null} - Returns an object with errors or null if no errors
+ */
+export const yupValidator = (value, yupValidationSchema) => {
+  try {
+    yupValidationSchema.validateSync(value, { abortEarly: false });
+    return null;
+  } catch (yupError) {
+    // Collect the fields and error messages from the Yup error object
+    const errorMessages = {};
+    if (yupError.inner) {
+      yupError.inner.forEach((err) => {
+        errorMessages[err.path] = err.message;
+      });
+    }
+
+    return errorMessages;
+  }
+};

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -12,7 +12,7 @@ import {
   FormHelperText,
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import ProjectSaveButton from "../newProjectView/ProjectSaveButton";
+import ProjectSaveButton from "src/views/projects/newProjectView/ProjectSaveButton";
 import ToolbarPlugin from "./ToolbarPlugin";
 
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
@@ -29,7 +29,7 @@ import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { LinkNode } from "@lexical/link";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { ListNode, ListItemNode } from "@lexical/list";
-import EditorTheme from "./EditorTheme";
+import EditorTheme from "src/views/projects/projectView/EditorTheme.js";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -213,22 +213,17 @@ const NoteInput = ({
 
   const [validationErrors, setValidationErrors] = useState(null);
 
-  const validateContent = useCallback(
-    (htmlContent) => {
-      const errors = validator ? validator(htmlContent) : null;
-      if (errors) {
-        setValidationErrors(errors);
-      } else {
-        setValidationErrors(null);
-      }
-    },
-    [validator]
-  );
-
   // Validate content when the note text or note type changes
   useEffect(() => {
-    validateContent(noteText);
-  }, [noteText, newNoteType, editingNoteType, validateContent]);
+    const errors = validator
+      ? validator({ projectStatusUpdate: noteText })
+      : null;
+    if (errors) {
+      setValidationErrors(errors);
+    } else {
+      setValidationErrors(null);
+    }
+  }, [noteText, newNoteType, editingNoteType, validator]);
 
   const onChange = (htmlContent) => {
     setNoteText(htmlContent);

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -215,9 +215,9 @@ const NoteInput = ({
 
   // Validate content when the note text or note type changes
   useEffect(() => {
-    if (validator === null) return;
-
-    const errors = validator({ projectStatusUpdate: noteText });
+    const errors = validator
+      ? validator({ projectStatusUpdate: noteText })
+      : null;
 
     if (errors) {
       setValidationErrors(errors);
@@ -301,7 +301,7 @@ const NoteInput = ({
             )}
             <ProjectSaveButton
               // disable save button if no text
-              disabled={!noteText || validationErrors}
+              disabled={!noteText || Boolean(validationErrors)}
               label={<>Save</>}
               loading={noteAddLoading}
               success={noteAddSuccess}

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import ProjectSaveButton from "src/views/projects/newProjectView/ProjectSaveButton";
-import ToolbarPlugin from "./ToolbarPlugin";
+import ToolbarPlugin from "src/views/projects/projectView/ToolbarPlugin";
 
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
@@ -29,7 +29,7 @@ import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { LinkNode } from "@lexical/link";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { ListNode, ListItemNode } from "@lexical/list";
-import EditorTheme from "src/views/projects/projectView/EditorTheme.js";
+import EditorTheme from "src/views/projects/projectView/EditorTheme";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -215,9 +215,10 @@ const NoteInput = ({
 
   // Validate content when the note text or note type changes
   useEffect(() => {
-    const errors = validator
-      ? validator({ projectStatusUpdate: noteText })
-      : null;
+    if (validator === null) return;
+
+    const errors = validator({ projectStatusUpdate: noteText });
+
     if (errors) {
       setValidationErrors(errors);
     } else {
@@ -247,11 +248,7 @@ const NoteInput = ({
               />
               <HistoryPlugin />
               <AutoFocusPlugin />
-              <OnChangePlugin
-                onChange={onChange}
-                validator={validator}
-                setValidationErrors={setValidationErrors}
-              />
+              <OnChangePlugin onChange={onChange} />
               <OnSavePlugin noteAddSuccess={noteAddSuccess} />
               <OnEditPlugin
                 htmlContent={noteText}

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -200,7 +200,7 @@ const NoteInput = ({
   setNewNoteType,
   editingNoteType,
   setEditingNoteType,
-  editingNote,
+  isEditingNote,
   noteAddLoading,
   noteAddSuccess,
   submitNewNote,
@@ -253,7 +253,10 @@ const NoteInput = ({
                 setValidationErrors={setValidationErrors}
               />
               <OnSavePlugin noteAddSuccess={noteAddSuccess} />
-              <OnEditPlugin htmlContent={noteText} editingNote={editingNote} />
+              <OnEditPlugin
+                htmlContent={noteText}
+                editingNote={isEditingNote}
+              />
               <LinkPlugin />
               <ListPlugin />
             </Box>
@@ -276,7 +279,7 @@ const NoteInput = ({
         >
           {!isStatusEditModal && (
             <FormControl>
-              {!editingNote ? (
+              {!isEditingNote ? (
                 <NoteTypeRadioButtons
                   defaultValue={newNoteType}
                   onChange={(e) => setNewNoteType(Number(e.target.value))}
@@ -292,7 +295,7 @@ const NoteInput = ({
         </Grid>
         <Grid item>
           <Box pb={2} display="flex" style={{ justifyContent: "flex-end" }}>
-            {editingNote && (
+            {isEditingNote && (
               <div className={classes.cancelButton}>
                 <Button variant="text" onClick={cancelNoteEdit}>
                   Cancel
@@ -305,7 +308,7 @@ const NoteInput = ({
               label={<>Save</>}
               loading={noteAddLoading}
               success={noteAddSuccess}
-              handleButtonClick={editingNote ? submitEditNote : submitNewNote}
+              handleButtonClick={isEditingNote ? submitEditNote : submitNewNote}
             />
           </Box>
         </Grid>

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -30,6 +30,47 @@ import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { ListNode, ListItemNode } from "@lexical/list";
 import EditorTheme from "./EditorTheme";
 
+import * as Yup from "yup";
+
+// TODO: Add validation check if the note is a status update (project_note_type = 2)
+// TODO: Render error message in red helper text below the editor
+// TODO: Add reusable validation schema to src/constants/projects.js (does this need its own? or can it be generalized?)
+const validationSchema = Yup.object().shape({
+  editorContent: Yup.string().max(
+    2000,
+    "Status update must be 2000 characters or less"
+  ),
+});
+
+// TODO: Adapt this to the Lexical editor code
+const validateEditor = async () => {
+  try {
+    // Extract plain text from editor state
+    const editorText = editorState
+      ? editorState.read(() => {
+          return $getRoot().getTextContent();
+        })
+      : "";
+
+    // Validate with Yup
+    await validationSchema.validate(
+      { editorContent: editorText },
+      { abortEarly: false }
+    );
+    return true;
+  } catch (yupError) {
+    // Handle Yup validation errors
+    const formattedErrors = {};
+    if (yupError.inner) {
+      yupError.inner.forEach((err) => {
+        formattedErrors[err.path] = err.message;
+      });
+    }
+    setErrors(formattedErrors);
+    return false;
+  }
+};
+
 const useStyles = makeStyles((theme) => ({
   root: {
     width: "100%",

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -43,7 +43,7 @@ const validationSchema = Yup.object().shape({
 });
 
 // TODO: Adapt this to the Lexical editor code
-const validateEditor = async () => {
+const validateHtmlContent = (htmlContent) => {
   try {
     // Extract plain text from editor state
     const editorText = editorState
@@ -143,6 +143,11 @@ const OnChangePlugin = ({ onChange }) => {
         const htmlContent = isEditorEmpty
           ? null
           : $generateHtmlFromNodes(editor, null);
+
+        // TODO: Validate here
+        console.log("htmlContent", htmlContent?.length);
+        validateHtmlContent(htmlContent);
+
         onChange(htmlContent);
       });
     });

--- a/moped-editor/src/views/projects/projectView/NoteInput.js
+++ b/moped-editor/src/views/projects/projectView/NoteInput.js
@@ -191,7 +191,7 @@ const initialConfig = {
  * @param {function} cancelNoteEdit - Function to cancel note editing
  * @param {boolean} isStatusEditModal - Flag indicating if the note component is in a status edit modal
  * @param {function} validator - Function to validate the note using Yup schema and validate()-generated errors
- * @returns
+ * @returns JSX.Element
  */
 const NoteInput = ({
   noteText,

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -149,7 +149,6 @@ const ProjectNotes = ({
   const isStatusUpdate =
     (!isEditingNote && newNoteType === STATUS_UPDATE_TYPE_ID) ||
     (isEditingNote && editingNoteType === STATUS_UPDATE_TYPE_ID);
-  console.log(isStatusUpdate);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -30,7 +30,8 @@ import NoteInput from "./NoteInput";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
 import ProjectStatusBadge from "./ProjectStatusBadge";
 
-import * as Yup from "yup";
+import * as yup from "yup";
+import { yupValidator } from "src/utils/validationHelpers";
 
 import "./ProjectNotes.css";
 
@@ -46,6 +47,7 @@ import {
   makeUSExpandedFormDateFromTimeStampTZ,
 } from "src/utils/dateAndTime";
 import { getUserFullName } from "src/utils/userNames";
+import { agolValidation } from "src/constants/projects";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -89,35 +91,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-// TODO: Render error message in red helper text below the editor
-// TODO: Add reusable validation schema to src/constants/projects.js (does this need its own? or can it be generalized?)
-const validationSchema = Yup.object().shape({
-  editorContent: Yup.string()
-    .max(2000, "Status update must be 2000 characters or less")
-    .nullable(),
+const validationSchema = yup.object().shape({
+  projectStatusUpdate: agolValidation.projectStatusUpdate,
 });
 
-// TODO: Adapt this to the Lexical editor code
-const validator = (htmlContent) => {
-  try {
-    // Validate with Yup
-    validationSchema.validateSync(
-      { editorContent: htmlContent },
-      { abortEarly: false }
-    );
-    return true;
-  } catch (yupError) {
-    // Handle Yup validation errors
-    const formattedErrors = {};
-    if (yupError.inner) {
-      yupError.inner.forEach((err) => {
-        formattedErrors[err.path] = err.message;
-      });
-    }
-
-    return formattedErrors;
-  }
-};
+const validator = (value) => yupValidator(value, validationSchema);
 
 // Lookup array to convert project note types to a human readable interpretation
 // The zeroth item in the list is intentionally blank; the notes are 1-indexed.

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -488,6 +488,7 @@ const ProjectNotes = (props) => {
                                   editingNoteType={editingNoteType}
                                   setEditingNoteType={setEditingNoteType}
                                   isStatusEditModal={isStatusEditModal}
+                                  validator={isStatusUpdate ? validator : null}
                                 />
                               ) : (
                                 <Typography

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -26,14 +26,14 @@ import { useQuery, useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import parse from "html-react-parser";
 import DOMPurify from "dompurify";
-import NoteInput from "./NoteInput";
-import DeleteConfirmationModal from "./DeleteConfirmationModal";
-import ProjectStatusBadge from "./ProjectStatusBadge";
+import NoteInput from "src/views/projects/projectView/NoteInput";
+import DeleteConfirmationModal from "src/views/projects/projectView/DeleteConfirmationModal";
+import ProjectStatusBadge from "src/views/projects/projectView/ProjectStatusBadge";
 
 import * as yup from "yup";
-import { yupValidator } from "src/utils/validationHelpers";
+import { yupValidator } from "src/utils/validation";
 
-import "./ProjectNotes.css";
+import "src/views/projects/projectView/ProjectNotes.css";
 
 // Query
 import {
@@ -219,7 +219,7 @@ const ProjectNotes = ({
         objects: [
           {
             project_note: DOMPurify.sanitize(noteText),
-            project_id: noteProjectId,
+            project_id: Number(noteProjectId),
             project_note_type: newNoteType,
             phase_id: noteCurrentPhaseId,
           },
@@ -254,7 +254,7 @@ const ProjectNotes = ({
     editExistingNote({
       variables: {
         projectNote: DOMPurify.sanitize(noteText),
-        projectId: noteProjectId,
+        projectId: Number(noteProjectId),
         projectNoteId: noteId,
         projectNoteType: editingNoteType,
       },

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -101,6 +101,17 @@ const projectNoteTypes = ["", "Internal Note", "Status Update"];
 export const STATUS_UPDATE_TYPE_ID = 2;
 export const INTERNAL_NOTE_TYPE_ID = 1;
 
+/**
+ * ProjectNotes component that is rendered in the ProjectView and ProjectSummaryStatusUpdate
+ * @param {boolean} isStatusEditModal - true if the component is being used in the ProjectSummaryStatusUpdate modal
+ * @param {string} currentPhaseId - The phase ID of the current phase
+ * @param {object} projectData - The project data passed from ProjectView
+ * @param {function} handleSnackbar - Function to handle snackbar notifications
+ * @param {function} closeModalDialog - Function to close the modal dialog
+ * @param {function} refetchProjectSummary - Function to refetch the project summary data
+ * @param {string} projectId - The project ID if rendered in the ProjectSummaryStatusUpdate modal
+ * @returns JSX.Element
+ */
 const ProjectNotes = ({
   modal: isStatusEditModal,
   currentPhaseId,

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -147,8 +147,9 @@ const ProjectNotes = ({
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
 
   const isStatusUpdate =
-    newNoteType === STATUS_UPDATE_TYPE_ID ||
-    editingNoteType === STATUS_UPDATE_TYPE_ID;
+    (!isEditingNote && newNoteType === STATUS_UPDATE_TYPE_ID) ||
+    (isEditingNote && editingNoteType === STATUS_UPDATE_TYPE_ID);
+  console.log(isStatusUpdate);
 
   // if component is being used in edit modal from dashboard
   // get project id from props instead of url params


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21263

This PR adds yup schema validation to status update entry to keep us under the length limit in the AGOL feature service. I also add some docs and updated some variable names and assignments as I was thinking through the code.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1575--atd-moped-main.netlify.app/moped/ or local


**Steps to test:**
1. Find your favorite ipsum generator (https://pizzaipsum.com/, https://baconipsum.com/)
2. Go to a project summary and click into the Status update area to create a new status update
3. Enter a long update, and you should see a validation error message in red and the save button should be disabled when it becomes too long
4. Change the text to be very short and save to make sure you can still create a new status update
5. Now go to the **Notes** tab and try creating a really long internal note. You should see no error message and the save button should never disable
6. Now, use the radio toggle to switch to **Status update** note type
7. You should see an immediate validation error and the save button disable. You can then make the note longer or shorter to see the validation state change
8. Save a valid status update and see it display below the rich text editor
9. Click the pencil to edit your status update, and test the same steps of changes the length and type. It should behave exactly as in the other steps.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
