### PR TITLE
Limit one of the same team member to a single project with DB constraing

### DIFF
--- a/moped-database/migrations/1744343940108_add_unique_constraint_to_moped_proj_personnel/down.sql
+++ b/moped-database/migrations/1744343940108_add_unique_constraint_to_moped_proj_personnel/down.sql
@@ -1,0 +1,2 @@
+-- Remove the unique index
+DROP INDEX IF EXISTS moped_proj_personnel_project_id_user_id_key; 

--- a/moped-database/migrations/1744343940108_add_unique_constraint_to_moped_proj_personnel/up.sql
+++ b/moped-database/migrations/1744343940108_add_unique_constraint_to_moped_proj_personnel/up.sql
@@ -1,0 +1,70 @@
+-- Create a temporary table to store the roles from duplicate records
+CREATE TEMP TABLE temp_duplicate_roles AS
+WITH duplicates AS (
+    SELECT 
+        project_id,
+        user_id,
+        COUNT(*) as duplicate_count
+    FROM
+        moped_proj_personnel
+    WHERE is_deleted = FALSE   
+    GROUP BY
+        project_id,
+        user_id
+    HAVING
+        COUNT(*) > 1
+)
+SELECT 
+    p.project_personnel_id,
+    p.project_id,
+    p.user_id,
+    r.project_role_id
+FROM moped_proj_personnel p
+JOIN duplicates d ON p.project_id = d.project_id AND p.user_id = d.user_id
+JOIN moped_proj_personnel_roles r ON p.project_personnel_id = r.project_personnel_id
+WHERE p.is_deleted = FALSE;
+
+-- Keep the first record for each project/user pair and mark others as deleted
+WITH first_records AS (
+    SELECT DISTINCT ON (project_id, user_id)
+        project_personnel_id
+    FROM moped_proj_personnel
+    WHERE is_deleted = FALSE
+    ORDER BY project_id, user_id, project_personnel_id
+)
+UPDATE moped_proj_personnel
+SET is_deleted = TRUE
+WHERE project_personnel_id NOT IN (SELECT project_personnel_id FROM first_records)
+AND is_deleted = FALSE;
+
+-- Ensure all roles from deleted records are associated with the kept record
+INSERT INTO moped_proj_personnel_roles (project_personnel_id, project_role_id, is_deleted)
+SELECT 
+    fr.project_personnel_id,
+    tdr.project_role_id,
+    FALSE
+FROM temp_duplicate_roles tdr
+JOIN (
+    SELECT DISTINCT ON (project_id, user_id)
+        project_personnel_id,
+        project_id,
+        user_id
+    FROM moped_proj_personnel
+    WHERE is_deleted = FALSE
+    ORDER BY project_id, user_id, project_personnel_id
+) fr ON tdr.project_id = fr.project_id AND tdr.user_id = fr.user_id
+WHERE NOT EXISTS (
+    SELECT 1 
+    FROM moped_proj_personnel_roles pr 
+    WHERE pr.project_personnel_id = fr.project_personnel_id 
+    AND pr.project_role_id = tdr.project_role_id
+    AND pr.is_deleted = FALSE
+);
+
+-- Clean up temporary table
+DROP TABLE temp_duplicate_roles;
+
+-- Add unique constraint to prevent duplicate project personnel entries using a partial index
+CREATE UNIQUE INDEX moped_proj_personnel_project_id_user_id_key 
+ON moped_proj_personnel (project_id, user_id) 
+WHERE is_deleted = FALSE;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21292

<img width="545" alt="Screenshot 2025-04-10 at 10 57 56 PM" src="https://github.com/user-attachments/assets/a3792837-1725-4981-a918-ae794d71a380" />


## Testing
Local

**Steps to test:**

- Replicate a copy of prod data (It might make sense to do this on `main` and then switch to this branch so the new migration doesn't run automatically with the `replicate` command)
- Run this query provided by Mike:
```
SELECT
    project_id,
    user_id,
    COUNT(*) as duplicate_count
FROM
    moped_proj_personnel
WHERE is_deleted = FALSE   
GROUP BY
    project_id,
    user_id
HAVING
    COUNT(*) > 1;
```
- Note the project ids with duplicate moped_proj_personnel instances. In my case, 4 records in prod had duplicates of the same team member on a single project.
  - Bonus: Look at the project's Team tab and confirm the duplicate team member entries in the UI.
- <img width="292" alt="Screenshot 2025-04-10 at 10 52 58 PM" src="https://github.com/user-attachments/assets/07998a1c-161a-4402-ab36-2d9bd355e1b3" />
- Run the migration in this PR with `hasura migrate apply`
- Rerun the query above not confirm that all the duplicates are removed. 
  - Bonus: Look at the record in the Moped Editor to see duplicate team member entry removed. 
- In a DB GUI or Hasura Console, try to insert a duplicate record (same project_id and user_id) to verify the unique constraint is being enforced.
  - ex:
```
  INSERT INTO moped_proj_personnel (
    project_id,
    user_id
) VALUES (
    2095,  -- project_id
    192
);
```
- Test the down migration runs successfully. 
  - Bonus: Try to insert a duplicate record (same project_id and user_id) to verify the constraint is gone after the down migration runs.



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
