### PR TITLE
Fix duplicate components in AGOL dataset when moving component from one project to another

### DIFF
--- a/moped-database/migrations/1745362473411_update_orig_proj_audit_trigger/down.sql
+++ b/moped-database/migrations/1745362473411_update_orig_proj_audit_trigger/down.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION public.update_self_and_project_updated_audit_fields()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- Update the updated_at field in the current row of the triggering table only on update
+    IF (TG_OP = 'UPDATE') THEN
+        NEW.updated_at := NOW();
+    END IF;
+
+    -- Update the updated_at and updated_by_user_id fields in the related row of moped_project
+    UPDATE moped_project
+    SET updated_at = NEW.updated_at,
+        updated_by_user_id = NEW.updated_by_user_id
+    WHERE project_id = NEW.project_id;
+
+    RETURN NEW;
+END;
+$function$

--- a/moped-database/migrations/1745362473411_update_orig_proj_audit_trigger/up.sql
+++ b/moped-database/migrations/1745362473411_update_orig_proj_audit_trigger/up.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION public.update_self_and_project_updated_audit_fields()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- Update the updated_at field in the current row of the triggering table only on update
+    IF (TG_OP = 'UPDATE') THEN
+        NEW.updated_at := NOW();
+        
+        -- Update the old project if project_id was changed
+        IF OLD.project_id IS DISTINCT FROM NEW.project_id THEN
+            UPDATE moped_project
+            SET updated_at = NEW.updated_at,
+                updated_by_user_id = NEW.updated_by_user_id
+            WHERE project_id = OLD.project_id;
+        END IF;
+    END IF;
+    
+    -- Always Update the updated_at and updated_by_user_id fields in the related row of moped_project
+    UPDATE moped_project
+    SET updated_at = NEW.updated_at,
+        updated_by_user_id = NEW.updated_by_user_id
+    WHERE project_id = NEW.project_id;
+    
+    RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/22214

This PR updates the `update_self_and_project_updated_audit_fields()` DB trigger to watch for a different `project_id` when updating the project audit fields. If it is different, which happens when moving a component from one project to another, then the trigger updates the audit fields of both the new and the old project.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local

**Steps to test:**
1. Start your local stack with production data
2. Open these two projects:
   - https://localhost:3000/moped/projects/2873
   - https://localhost:3000/moped/projects/2935
3. Now, run the new down migration: `hasura migrate apply --down 1`
4. Run the SQL below so you can check on the changing values of the audit fields after the next steps
5. Go to the component map in project 2873 and move a component to project 2935
6. Re-run the SQL to see that the `updated_at` and `updated_by_user_id` only updated in project 2935
7. Now, run the new up migration: `hasura migrate apply --up 1`
8. Go to the component map in project 2873 and move another component to project 2935
9. Re-run the SQL to see that the `updated_at` and `updated_by_user_id` updates in both project 2873 and project 2935
10. When the ETL sees updated timestamps in both projects, it will delete and replace all components associated with both projects. This closes the loop on the duplicates that are being created.

```sql
-- Use to check audit fields
SELECT
	project_id,
	updated_at,
	updated_by_user_id
FROM
	moped_project
WHERE
	project_id IN (2873, 2935)
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
