### PR TITLE
Change default DB name in env template

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.4.0
+        image: hasura/graphql-engine:v2.47.0
         depends_on:
             - moped-pgsql
         expose:

--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.46.0
+        image: hasura/graphql-engine:v2.4.0
         depends_on:
             - moped-pgsql
         expose:
@@ -25,7 +25,7 @@ services:
 
 
     moped-pgsql:
-        image: "frankinaustin/pg16-postgis35:latest"
+        image: "frankinaustin/frankinaustin/postgis:16-3.5"
         volumes:
             - moped-db-vol:/var/lib/postgresql/data
         expose:

--- a/moped-database/env_template
+++ b/moped-database/env_template
@@ -1,4 +1,4 @@
 export MOPED_RR_PASSWORD=
 export MOPED_RR_USERNAME=
 export MOPED_RR_HOST=moped-read-replica.austinmobility.io
-export MOPED_RR_DB=atd_moped
+export MOPED_RR_DB=moped

--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -27,7 +27,7 @@ function __get_platform() {
 
 function __set_postgresql_image() {
   __get_platform;
-  HASURA_CLUSTER_POSTGRES_IMAGE="frankinaustin/postgis:12-3.4";
+  HASURA_CLUSTER_POSTGRES_IMAGE="frankinaustin/postgis:16-3.5";
   echo "Database Docker Image: ${HASURA_CLUSTER_POSTGRES_IMAGE}"
 }
 


### PR DESCRIPTION
We are renaming the production moped database when we transfer it today, and this PR reflects that in the environment template.

@mddilley & @chiaberry: I am so surprised that this is the extent of what I think needs to be renamed in the codebase. Do you all agree?


---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
