### PR TITLE
Add/edit tags to track decomissioned components and add protection type subcomponents to Access Control components

### DIFF
--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
@@ -1,4 +1,8 @@
--- if we delete the component tag in the future, we will soft delete and leave existing data intact
+-- if we delete the added component tag in the future, we will soft delete and leave existing data intact
+
+-- Remove unique constraint to allow for duplicate component/subcomponent associations
+ALTER TABLE moped_components_subcomponents
+DROP CONSTRAINT unique_component_subcomponents;
 
 -- Restore previous component tag name
 UPDATE moped_component_tags SET name = 'Upgrades Existing', type = 'Bikeways - Performance Measure', slug = 'bikeways_performance_measure_upgrades_existing'

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
@@ -1,0 +1,2 @@
+-- if we delete the component tag in the future, we will soft delete and leave existing data intact
+SELECT 0;

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
@@ -1,2 +1,5 @@
 -- if we delete the component tag in the future, we will soft delete and leave existing data intact
-SELECT 0;
+
+-- Restore previous component tag name
+UPDATE moped_component_tags SET name = 'Upgrades Existing'
+WHERE slug = 'bikeways_performance_measure_upgrades_existing';

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/down.sql
@@ -1,5 +1,5 @@
 -- if we delete the component tag in the future, we will soft delete and leave existing data intact
 
 -- Restore previous component tag name
-UPDATE moped_component_tags SET name = 'Upgrades Existing'
-WHERE slug = 'bikeways_performance_measure_upgrades_existing';
+UPDATE moped_component_tags SET name = 'Upgrades Existing', type = 'Bikeways - Performance Measure', slug = 'bikeways_performance_measure_upgrades_existing'
+WHERE slug = 'upgrades_existing_component';

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
@@ -1,0 +1,48 @@
+-- Insert new tag to mark decommissioned components
+INSERT INTO moped_tags (name, type, slug) VALUES
+('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');
+
+-- Update existing component tag name to include 'component' in name
+
+-- Associate protection type subcomponents with Access Control components
+WITH inserts_todo AS (
+    SELECT
+        work_type_id,
+        'Trail' AS component_name,
+        'Shared Use Path (Paved Dual Trail)' AS component_subtype
+    FROM
+        moped_component_work_types AS mcwt
+    LEFT JOIN moped_work_types AS mwt ON mcwt.work_type_id = mwt.id
+    LEFT JOIN moped_components AS mc ON mcwt.component_id = mc.component_id
+    WHERE
+        mc.component_subtype LIKE 'Shared Use Path (Paved)'
+)
+
+INSERT INTO moped_component_work_types (component_id, work_type_id)
+SELECT
+    mc.component_id,
+    inserts_todo.work_type_id
+FROM
+    inserts_todo
+    -- gets the component id of the new component we created
+LEFT JOIN moped_components AS mc ON inserts_todo.component_name = mc.component_name
+    AND inserts_todo.component_subtype = mc.component_subtype;
+
+-- Components
+-- Access Control - Median
+-- Access Control - Driveway Closure
+-- Access Control - Driveway Modification
+-- Access Control - Hardened Centerline
+-- Subcomponents
+-- Protection Type - Car free
+-- Protection Type - Concrete
+-- Protection Type - Concrete and on-street parking
+-- Protection Type - Concrete traffic bump
+-- Protection Type - Concrete with landscape
+-- Protection Type - Flex posts
+-- Protection Type - Flex posts (City Post)
+-- Protection Type - Flex posts with curb stops
+-- Protection Type - Flex posts with on-street parking
+-- Protection Type - Planters
+-- Protection Type - Raised & behind curb
+-- Protection Type - ZICLA Barriers

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
@@ -5,10 +5,6 @@ UNIQUE (component_id, subcomponent_id);
 
 COMMENT ON CONSTRAINT unique_component_subcomponents ON moped_components_subcomponents IS 'Ensures no duplicate component/subcomponent associations';
 
--- Alter moped_component_tags table to allow null names for new tags and updates to existing tags with empty names
-ALTER TABLE moped_component_tags
-ALTER COLUMN name DROP NOT NULL;
-
 -- Insert new tag to mark decommissioned components
 INSERT INTO moped_component_tags (name, type, slug) VALUES
 ('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
@@ -1,3 +1,14 @@
+-- Add unique constraint to ensure no duplicate component/subcomponent associations
+ALTER TABLE moped_components_subcomponents
+ADD CONSTRAINT unique_component_subcomponents
+UNIQUE (component_id, subcomponent_id);
+
+COMMENT ON CONSTRAINT unique_component_subcomponents ON moped_components_subcomponents IS 'Ensures no duplicate component/subcomponent associations';
+
+-- Alter moped_component_tags table to allow null names for new tags and updates to existing tags with empty names
+ALTER TABLE moped_component_tags
+ALTER COLUMN name DROP NOT NULL;
+
 -- Insert new tag to mark decommissioned components
 INSERT INTO moped_component_tags (name, type, slug) VALUES
 ('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
@@ -2,41 +2,43 @@
 INSERT INTO moped_component_tags (name, type, slug) VALUES
 ('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');
 
--- Update existing component tag name to include 'component' in name
+-- Update existing component tag from 'Bikeways - Performance Measure - Upgrades Existing` to
+-- 'Upgrades Existing Component'
 UPDATE moped_component_tags SET name = '', type = 'Upgrades Existing Component', slug = 'upgrades_existing_component'
 WHERE slug = 'bikeways_performance_measure_upgrades_existing';
 
 -- Associate protection type subcomponents with Access Control components
 -- The CTE produces all combinations of defined components and subcomponents IDs
 WITH
-	inserts_todo AS (
-		SELECT
-			moped_components.component_id,
-			moped_subcomponents.subcomponent_id
-		FROM
-			moped_components
-			CROSS JOIN moped_subcomponents
-		WHERE
-			moped_components.component_name_full IN ('Access Control - Median', 'Access Control - Driveway Closure', 'Access Control - Driveway Modification', 'Access Control - Hardened Centerline')
-			AND moped_subcomponents.subcomponent_name IN (
-				'Protection Type - Car free',
-				'Protection Type - Concrete',
-				'Protection Type - Concrete and on-street parking',
-				'Protection Type - Concrete traffic bump',
-				'Protection Type - Concrete with landscape',
-				'Protection Type - Flex posts',
-				'Protection Type - Flex posts (City Post)',
-				'Protection Type - Flex posts with curb stops',
-				'Protection Type - Flex posts with on-street parking',
-				'Protection Type - Planters',
-				'Protection Type - Raised & behind curb',
-				'Protection Type - ZICLA Barriers'
-			)
-	)
+inserts_todo AS (
+    SELECT
+        moped_components.component_id,
+        moped_subcomponents.subcomponent_id
+    FROM
+        moped_components
+    CROSS JOIN moped_subcomponents
+    WHERE
+        moped_components.component_name_full IN ('Access Control - Median', 'Access Control - Driveway Closure', 'Access Control - Driveway Modification', 'Access Control - Hardened Centerline')
+        AND moped_subcomponents.subcomponent_name IN (
+            'Protection Type - Car free',
+            'Protection Type - Concrete',
+            'Protection Type - Concrete and on-street parking',
+            'Protection Type - Concrete traffic bump',
+            'Protection Type - Concrete with landscape',
+            'Protection Type - Flex posts',
+            'Protection Type - Flex posts (City Post)',
+            'Protection Type - Flex posts with curb stops',
+            'Protection Type - Flex posts with on-street parking',
+            'Protection Type - Planters',
+            'Protection Type - Raised & behind curb',
+            'Protection Type - ZICLA Barriers'
+        )
+)
+
 INSERT INTO
-	moped_components_subcomponents (component_id, subcomponent_id)
+moped_components_subcomponents (component_id, subcomponent_id)
 SELECT
-	inserts_todo.component_id,
-	inserts_todo.subcomponent_id
+    inserts_todo.component_id,
+    inserts_todo.subcomponent_id
 FROM
-	inserts_todo;
+    inserts_todo;

--- a/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
+++ b/moped-database/migrations/1745881623802_decom_and_new_subcomponents/up.sql
@@ -3,46 +3,39 @@ INSERT INTO moped_tags (name, type, slug) VALUES
 ('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');
 
 -- Update existing component tag name to include 'component' in name
+UPDATE moped_component_tags SET name = 'Upgrades Existing Component'
+WHERE slug = 'bikeways_performance_measure_upgrades_existing';
 
 -- Associate protection type subcomponents with Access Control components
-WITH inserts_todo AS (
-    SELECT
-        work_type_id,
-        'Trail' AS component_name,
-        'Shared Use Path (Paved Dual Trail)' AS component_subtype
-    FROM
-        moped_component_work_types AS mcwt
-    LEFT JOIN moped_work_types AS mwt ON mcwt.work_type_id = mwt.id
-    LEFT JOIN moped_components AS mc ON mcwt.component_id = mc.component_id
-    WHERE
-        mc.component_subtype LIKE 'Shared Use Path (Paved)'
-)
-
-INSERT INTO moped_component_work_types (component_id, work_type_id)
+WITH
+	inserts_todo AS (
+		SELECT
+			moped_components.component_id,
+			moped_subcomponents.subcomponent_id
+		FROM
+			moped_components
+			CROSS JOIN moped_subcomponents
+		WHERE
+			moped_components.component_name_full IN ('Access Control - Median', 'Access Control - Driveway Closure', 'Access Control - Driveway Modification', 'Access Control - Hardened Centerline')
+			AND moped_subcomponents.subcomponent_name IN (
+				'Protection Type - Car free',
+				'Protection Type - Concrete',
+				'Protection Type - Concrete and on-street parking',
+				'Protection Type - Concrete traffic bump',
+				'Protection Type - Concrete with landscape',
+				'Protection Type - Flex posts',
+				'Protection Type - Flex posts (City Post)',
+				'Protection Type - Flex posts with curb stops',
+				'Protection Type - Flex posts with on-street parking',
+				'Protection Type - Planters',
+				'Protection Type - Raised & behind curb',
+				'Protection Type - ZICLA Barriers'
+			)
+	)
+INSERT INTO
+	moped_components_subcomponents (component_id, subcomponent_id)
 SELECT
-    mc.component_id,
-    inserts_todo.work_type_id
+	inserts_todo.component_id,
+	inserts_todo.subcomponent_id
 FROM
-    inserts_todo
-    -- gets the component id of the new component we created
-LEFT JOIN moped_components AS mc ON inserts_todo.component_name = mc.component_name
-    AND inserts_todo.component_subtype = mc.component_subtype;
-
--- Components
--- Access Control - Median
--- Access Control - Driveway Closure
--- Access Control - Driveway Modification
--- Access Control - Hardened Centerline
--- Subcomponents
--- Protection Type - Car free
--- Protection Type - Concrete
--- Protection Type - Concrete and on-street parking
--- Protection Type - Concrete traffic bump
--- Protection Type - Concrete with landscape
--- Protection Type - Flex posts
--- Protection Type - Flex posts (City Post)
--- Protection Type - Flex posts with curb stops
--- Protection Type - Flex posts with on-street parking
--- Protection Type - Planters
--- Protection Type - Raised & behind curb
--- Protection Type - ZICLA Barriers
+	inserts_todo;

--- a/moped-database/recipes/copy_subcomponents_to_components.sql
+++ b/moped-database/recipes/copy_subcomponents_to_components.sql
@@ -1,12 +1,7 @@
--- Insert new tag to mark decommissioned components
-INSERT INTO moped_component_tags (name, type, slug) VALUES
-('', 'Decommissioned / Upgraded Component', 'decommissioned_upgraded_component');
-
--- Update existing component tag name to include 'component' in name
-UPDATE moped_component_tags SET name = '', type = 'Upgrades Existing Component', slug = 'upgrades_existing_component'
-WHERE slug = 'bikeways_performance_measure_upgrades_existing';
-
 -- Associate protection type subcomponents with Access Control components
+-- This is useful for batch inserting associations of multiple specific subcomponents 
+-- with multiple specific components.
+-- See https://github.com/cityofaustin/atd-moped/pull/1588
 -- The CTE produces all combinations of defined components and subcomponents IDs
 WITH
 	inserts_todo AS (


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/22248, Closes https://github.com/cityofaustin/atd-data-tech/issues/22232

This PR makes changes to component tags to make it easier to mark and filter out decommissioned components and also to be able to add protection type subcomponents like flex posts to some of the Access Control component types.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local 🙏

**Steps to test:**
1. Start up you local stack and then go to the data dictionary https://localhost:3000/moped/dev/lookups
2. Load the staging data dictionary to compare https://moped.austinmobility.io/moped/dev/lookups
3. Navigate to the component tags section and notice that the tag with type "Bikeways - Performance Measure" and name "Upgrades Existing" now only has name "Upgrades Existing Component"
4. Note that there is also a new component tag with type "Decommissioned / Upgraded Component"
5. Now, go to the components section of the dictionary and notice that these four components now list all protection type subcomponents as available:
   - Access Control - Median
   - Access Control - Driveway Closure
   - Access Control - Driveway Modification
   - Access Control - Hardened Centerline
6. Try adding these component tags and creating an Access Control component listed above with a protection type subcomponents

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
