### PR TITLE
Update milestone activity log config to show "milestone" instead of "id"

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -1,5 +1,5 @@
 import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
-import { ProjectActivityLogTableMaps } from "../../views/projects/projectView/ProjectActivityLogTableMaps";
+import { ProjectActivityLogTableMaps } from "src/views/projects/projectView/ProjectActivityLogTableMaps";
 
 export const formatMilestonesActivity = (change, milestoneList) => {
   const entryMap = ProjectActivityLogTableMaps["moped_proj_milestones"];

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -137,7 +137,7 @@ export const ProjectActivityLogTableMaps = {
         label: "project ID",
       },
       milestone_id: {
-        label: "id",
+        label: "milestone",
       },
       project_milestone_id: {
         label: "ID",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19761

A very snacky snackoo

## Testing
**Steps to test:**

compare the first activity here
https://deploy-preview-1590--atd-moped-main.netlify.app/moped/projects/1924?tab=activity_log

to 

https://moped.austinmobility.io/moped/projects/1924?tab=activity_log


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
