### PR TITLE
adds ability to save simple search as view

### DIFF
--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Box, Typography, Chip, Grid, Button, Tooltip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import {
@@ -120,15 +120,17 @@ const FiltersChips = ({
     setIsSaveViewModalOpen(true);
   };
 
+  /**
+   * Reenables the save view button when a new search term is applied
+   */
+  useEffect(() => {
+    setIsViewSaved(false);
+  }, [searchTerm]);
+
   return (
     <Box className={classes.filtersList}>
       <Typography className={classes.filtersText} component="span">
-        <Grid
-          container
-          display="flex"
-          justifyContent="flex-end"
-          spacing={0.5}
-        >
+        <Grid container display="flex" justifyContent="flex-end" spacing={0.5}>
           <Grid item>
             <Tooltip
               placement="bottom-start"

--- a/moped-editor/src/components/GridTable/FiltersChips.js
+++ b/moped-editor/src/components/GridTable/FiltersChips.js
@@ -39,6 +39,7 @@ const FiltersChips = ({
   setSearchParams,
   setIsOr,
   handleSnackbar,
+  searchTerm,
 }) => {
   const classes = useStyles();
 
@@ -191,6 +192,7 @@ const FiltersChips = ({
         filtersLabels={filtersLabels}
         setIsViewSaved={setIsViewSaved}
         handleSnackbar={handleSnackbar}
+        searchTerm={searchTerm}
       />
     </Box>
   );

--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -184,6 +184,7 @@ const Search = ({
                 filtersConfig={filtersConfig}
                 resetSimpleSearch={resetSimpleSearch}
                 setIsOr={setIsOr}
+                searchTerm={searchTerm}
                 setSearchParams={setSearchParams}
                 handleSnackbar={handleSnackbar}
               />

--- a/moped-editor/src/components/GridTable/SearchBar.js
+++ b/moped-editor/src/components/GridTable/SearchBar.js
@@ -69,7 +69,8 @@ const SearchBar = ({
   resetSimpleSearch,
   setSearchParams,
   setIsOr,
-  handleSnackbar
+  handleSnackbar,
+  searchTerm,
 }) => {
   const classes = useStyles();
 
@@ -165,7 +166,7 @@ const SearchBar = ({
         variant="outlined"
         value={searchFieldValue}
       />
-      {filterStateActive && !advancedSearchAnchor && (
+      {(filterStateActive || searchTerm) && !advancedSearchAnchor && (
         <FiltersChips
           filters={filters}
           setFilters={setFilters}
@@ -174,6 +175,7 @@ const SearchBar = ({
           isOr={isOr}
           setSearchParams={setSearchParams}
           handleSnackbar={handleSnackbar}
+          searchTerm={searchTerm}
         />
       )}
     </>

--- a/moped-editor/src/views/projects/projectsListView/components/SaveUserViewModal.js
+++ b/moped-editor/src/views/projects/projectsListView/components/SaveUserViewModal.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useMutation } from "@apollo/client";
 import { Dialog, DialogTitle, DialogContent, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
@@ -19,7 +19,7 @@ const SaveUserViewModal = ({
 
   let { pathname, search } = useLocation();
 
-  const getDefaultDescription = () => {
+  const defaultDescription = useMemo(() => {
     const filtersDescription = filtersLabels
       .map(
         (filter) =>
@@ -38,7 +38,7 @@ const SaveUserViewModal = ({
     } else {
       return "";
     }
-  };
+  }, [filtersLabels, searchTerm]);
 
   const onClose = () => {
     setIsSaveViewModalOpen(false);
@@ -84,7 +84,7 @@ const SaveUserViewModal = ({
       <DialogContent dividers={true}>
         <SaveUserViewForm
           onSave={onSaveViewClick}
-          description={() => getDefaultDescription()}
+          description={defaultDescription}
           loading={loading}
         />
       </DialogContent>

--- a/moped-editor/src/views/projects/projectsListView/components/SaveUserViewModal.js
+++ b/moped-editor/src/views/projects/projectsListView/components/SaveUserViewModal.js
@@ -13,17 +13,32 @@ const SaveUserViewModal = ({
   filtersLabels,
   setIsViewSaved,
   handleSnackbar,
+  searchTerm,
 }) => {
   const [saveView, { loading }] = useMutation(ADD_USER_SAVED_VIEW);
 
   let { pathname, search } = useLocation();
 
-  const defaultDescription = filtersLabels
-    .map(
-      (filter) =>
-        `${filter.filterLabel} ${filter.operatorLabel} ${filter.filterValue}`
-    )
-    .join(", ");
+  const getDefaultDescription = () => {
+    const filtersDescription = filtersLabels
+      .map(
+        (filter) =>
+          `${filter.filterLabel} ${filter.operatorLabel} ${filter.filterValue}`
+      )
+      .join(", ");
+
+    if (filtersDescription && searchTerm) {
+      return `${searchTerm} with ${filtersDescription}`;
+    }
+    if (filtersDescription && !searchTerm) {
+      return filtersDescription;
+    }
+    if (!filtersDescription && searchTerm) {
+      return searchTerm;
+    } else {
+      return "";
+    }
+  };
 
   const onClose = () => {
     setIsSaveViewModalOpen(false);
@@ -69,7 +84,7 @@ const SaveUserViewModal = ({
       <DialogContent dividers={true}>
         <SaveUserViewForm
           onSave={onSaveViewClick}
-          description={defaultDescription}
+          description={() => getDefaultDescription()}
           loading={loading}
         />
       </DialogContent>


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/22452

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1595--atd-moped-main.netlify.app/

**Steps to test:**
- go to project list view and execute a simple search
- the "save view" button should appear, click on it and note the description field is autopopulated with the search term
- save the view and confirm it appears in the saved views table and the link works
- go to project list view and execute a simple search, then add a filter (or vice versa)
- the "save view" button should appear, click on it and note the description field is autopopulated with the search term plus the filters applied
- save the view and confirm it appears in the saved views table and the link works

try out different combinations, adding a simple search and filters in different orders, removing one or the other, and saving the view. all combinations and orders should work!

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added new test, "Now, filter using only the simple search and make sure the "Save view" button appears so you can save a simple search term with or without advanced filters."  
