### PR TITLE
Patch v2.37.1

### DIFF
--- a/.github/workflows/etl_ecapris_statuses_docker.yml
+++ b/.github/workflows/etl_ecapris_statuses_docker.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: atddocker/atd-moped-etl-ecapris-statuses:${{ github.ref_name }}
           context: ./moped-etl/ecapris-statuses

--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.47.0
+        image: hasura/graphql-engine:v2.48.0
         depends_on:
             - moped-pgsql
         expose:

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.37.0",
+  "version": "2.37.1",
   "homepage": "/moped",
   "private": false,
   "repository": {


### PR DESCRIPTION
## Associated issues
This patch moves the fix to build the eCapris ETL image only for linux/amd64 instead of multi-architecture into production.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
n/a

**Steps to test:**
None, this workflow works in main (https://github.com/cityofaustin/atd-moped/actions/runs/15195189629) - it just needs to get to production

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
