### PR TITLE
Apply default override to all DataGridPro instances with `editMode="row"`

### DIFF
--- a/moped-editor/src/utils/dataGridHelpers.js
+++ b/moped-editor/src/utils/dataGridHelpers.js
@@ -1,1 +1,9 @@
+import { GridRowEditStopReasons } from "@mui/x-data-grid-pro";
+
 export const defaultEditColumnIconStyle = { fontSize: "24px" };
+
+export const handleRowEditStop = (params, event) => {
+  if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+    event.defaultMuiPrevented = true;
+  }
+};

--- a/moped-editor/src/views/dashboard/UserSavedViewsTable.js
+++ b/moped-editor/src/views/dashboard/UserSavedViewsTable.js
@@ -19,6 +19,7 @@ import DataGridActions from "src/components/DataGridPro/DataGridActions";
 import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import DeleteConfirmationModal from "../projects/projectView/DeleteConfirmationModal";
 import { FormattedDateString } from "src/utils/dateAndTime";
+import { handleRowEditStop } from "src/utils/dataGridPro";
 
 const requiredFields = ["description"];
 
@@ -250,6 +251,7 @@ const UserSavedViewsTable = ({ handleSnackbar }) => {
         onRowModesModelChange={handleRowModesModelChange}
         onProcessRowUpdateError={(error) => console.error}
         editMode="row"
+        onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
         hideFooter
         disableRowSelectionOnClick

--- a/moped-editor/src/views/dashboard/UserSavedViewsTable.js
+++ b/moped-editor/src/views/dashboard/UserSavedViewsTable.js
@@ -19,7 +19,7 @@ import DataGridActions from "src/components/DataGridPro/DataGridActions";
 import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import DeleteConfirmationModal from "../projects/projectView/DeleteConfirmationModal";
 import { FormattedDateString } from "src/utils/dateAndTime";
-import { handleRowEditStop } from "src/utils/dataGridPro";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const requiredFields = ["description"];
 

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -33,7 +33,7 @@ import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import ProjectFilesTypeSelect from "./ProjectFilesTypeSelect";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
-import { handleRowEditStop } from "src/utils/dataGridPro";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const useStyles = makeStyles(() => ({
   title: {

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -63,7 +63,7 @@ const useStyles = makeStyles(() => ({
 export const useFileTypeObject = (fileTypes) =>
   useMemo(
     () =>
-     fileTypes.reduce(
+      fileTypes.reduce(
         (obj, item) =>
           Object.assign(obj, {
             [item.id]: item.name,
@@ -89,7 +89,7 @@ const useColumns = ({
   handleDeleteOpen,
   validateFileInput,
   fileTypesLookup,
-  fileTypesObject
+  fileTypesObject,
 }) =>
   useMemo(() => {
     return [
@@ -335,7 +335,7 @@ const ProjectFiles = ({ handleSnackbar }) => {
   });
 
   const fileTypesLookup = data?.moped_file_types;
-  const fileTypesObject = useFileTypeObject(data?.moped_file_types || [])
+  const fileTypesObject = useFileTypeObject(data?.moped_file_types || []);
 
   useEffect(() => {
     if (data && data.moped_project_files.length > 0) {
@@ -461,7 +461,7 @@ const ProjectFiles = ({ handleSnackbar }) => {
     handleEditClick,
     validateFileInput,
     fileTypesLookup,
-    fileTypesObject
+    fileTypesObject,
   });
 
   // If no data or loading show progress circle

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -33,6 +33,7 @@ import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import ProjectFilesTypeSelect from "./ProjectFilesTypeSelect";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
+import { handleRowEditStop } from "src/utils/dataGridPro";
 
 const useStyles = makeStyles(() => ({
   title: {
@@ -478,6 +479,7 @@ const ProjectFiles = ({ handleSnackbar }) => {
           rows={rows}
           getRowId={(row) => row.project_file_id}
           editMode="row"
+          onRowEditStop={handleRowEditStop}
           rowModesModel={rowModesModel}
           onRowModesModelChange={handleRowModesModelChange}
           processRowUpdate={processRowUpdate}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -35,6 +35,7 @@ import dataGridProStyleOverrides from "src/styles/dataGridProStylesOverrides";
 import DeleteConfirmationModal from "../DeleteConfirmationModal";
 import { getLookupValueByID } from "src/components/DataGridPro/utils/helpers";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const useStyles = makeStyles((theme) => ({
   fieldGridItem: {
@@ -584,6 +585,7 @@ const ProjectFundingTable = ({ handleSnackbar }) => {
           getRowId={(row) => row.proj_funding_id}
           editMode="row"
           rowModesModel={rowModesModel}
+          onRowEditStop={handleRowEditStop}
           onRowModesModelChange={handleRowModesModelChange}
           processRowUpdate={processRowUpdate}
           onProcessRowUpdateError={(error) => console.error(error)}

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -25,7 +25,7 @@ import MilestoneTemplateModal from "./ProjectMilestones/MilestoneTemplateModal";
 import DataGridDateFieldEdit from "./ProjectMilestones/DataGridDateFieldEdit";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
-import { handleRowEditStop } from "src/utils/dataGridPro";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const useMilestoneNameLookup = (data) =>
   useMemo(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -25,6 +25,7 @@ import MilestoneTemplateModal from "./ProjectMilestones/MilestoneTemplateModal";
 import DataGridDateFieldEdit from "./ProjectMilestones/DataGridDateFieldEdit";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
+import { handleRowEditStop } from "src/utils/dataGridPro";
 
 const useMilestoneNameLookup = (data) =>
   useMemo(() => {
@@ -434,6 +435,7 @@ const ProjectMilestones = ({
         rows={rows}
         getRowId={(row) => row.project_milestone_id}
         editMode="row"
+        onRowEditStop={handleRowEditStop}
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}
         processRowUpdate={processRowUpdate}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -19,7 +19,7 @@ import {
   UPDATE_PROJECT_SUBPROJECT,
   DELETE_PROJECT_SUBPROJECT,
 } from "../../../../queries/subprojects";
-import { handleRowEditStop } from "src/utils/dataGridPro";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const requiredFields = ["project_name_full"];
 

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -19,6 +19,7 @@ import {
   UPDATE_PROJECT_SUBPROJECT,
   DELETE_PROJECT_SUBPROJECT,
 } from "../../../../queries/subprojects";
+import { handleRowEditStop } from "src/utils/dataGridPro";
 
 const requiredFields = ["project_name_full"];
 
@@ -287,6 +288,7 @@ const SubprojectsTable = ({
         slotProps={{ toolbar: { onClick: handleAddSubprojectClick } }}
         editMode="row"
         processRowUpdate={processRowUpdate}
+        onRowEditStop={handleRowEditStop}
         hideFooter
         disableRowSelectionOnClick
         localeText={{ noRowsLabel: "No subprojects to display" }}

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -29,6 +29,7 @@ import DeleteConfirmationModal from "../DeleteConfirmationModal";
 import ViewOnlyTextField from "src/components/DataGridPro/ViewOnlyTextField";
 import LookupAutocompleteComponent from "src/components/DataGridPro/LookupAutocompleteComponent";
 import { mopedUserAutocompleteProps } from "./utils";
+import { handleRowEditStop } from "src/utils/dataGridHelpers";
 
 const useStyles = makeStyles((theme) => ({
   infoIcon: {
@@ -411,12 +412,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     },
     []
   );
-
-  const handleRowEditStop = (params, event) => {
-    if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-      event.defaultMuiPrevented = true;
-    }
-  };
 
   const processRowUpdate = useCallback(
     (updatedRow, originalRow) => {


### PR DESCRIPTION
## Associated issues
Relates to https://github.com/cityofaustin/atd-data-tech/issues/20826 as a follow-on from #1600 

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added to existing test: "As you fill out fields, tab through them to make sure they are keyboard accessible and that choosing a dropdown option by pressing enter does not save the whole row." 
