### PR TITLE
Update should_sync_ecapris_statuses to false for projects without eCAPRIS IDs

### DIFF
--- a/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/down.sql
+++ b/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."moped_project" alter column "should_sync_ecapris_statuses" set default 'true';

--- a/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/up.sql
+++ b/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/up.sql
@@ -1,4 +1,10 @@
+-- use replica mode to disable triggers
+set session_replication_role = replica;
+
 -- should_sync_ecapris_statuses will default to false for projects without an eCAPRIS subproject id
 update moped_project set should_sync_ecapris_statuses = false where ecapris_subproject_id is null;
 
 alter table "public"."moped_project" alter column "should_sync_ecapris_statuses" set default 'false';
+
+-- reset the session replication role
+set session_replication_role = default;

--- a/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/up.sql
+++ b/moped-database/migrations/default/1750186599182_set_should_sync_ecapris_false/up.sql
@@ -1,0 +1,4 @@
+-- should_sync_ecapris_statuses will default to false for projects without an eCAPRIS subproject id
+update moped_project set should_sync_ecapris_statuses = false where ecapris_subproject_id is null;
+
+alter table "public"."moped_project" alter column "should_sync_ecapris_statuses" set default 'false';

--- a/moped-database/views/project_list_view.sql
+++ b/moped-database/views/project_list_view.sql
@@ -15,14 +15,8 @@ CREATE OR REPLACE VIEW project_list_view AS WITH project_person_list_lookup AS (
 funding_sources_lookup AS (
     SELECT
         mpf.project_id,
-        string_agg(
-            DISTINCT mfs.funding_source_name, ', '::text
-            ORDER BY mfs.funding_source_name
-        ) AS funding_source_name,
-        string_agg(
-            DISTINCT mfp.funding_program_name, ', '::text
-            ORDER BY mfp.funding_program_name
-        ) AS funding_program_names,
+        string_agg(DISTINCT mfs.funding_source_name, ', '::text ORDER BY mfs.funding_source_name) AS funding_source_name,
+        string_agg(DISTINCT mfp.funding_program_name, ', '::text ORDER BY mfp.funding_program_name) AS funding_program_names,
         string_agg(
             DISTINCT
             CASE
@@ -30,8 +24,7 @@ funding_sources_lookup AS (
                 WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
                 WHEN mfp.funding_program_name IS NOT null THEN mfp.funding_program_name
                 ELSE null::text
-            END, ', '::text
-            ORDER BY (
+            END, ', '::text ORDER BY (
                 CASE
                     WHEN mfs.funding_source_name IS NOT null AND mfp.funding_program_name IS NOT null THEN concat(mfs.funding_source_name, ' - ', mfp.funding_program_name)
                     WHEN mfs.funding_source_name IS NOT null THEN mfs.funding_source_name
@@ -168,10 +161,7 @@ min_estimated_phase_dates AS (
 project_component_work_types AS (
     SELECT
         mpc.project_id,
-        string_agg(
-            DISTINCT mwt.name, ', '::text
-            ORDER BY mwt.name
-        ) AS component_work_type_names
+        string_agg(DISTINCT mwt.name, ', '::text ORDER BY mwt.name) AS component_work_type_names
     FROM moped_proj_components mpc
     LEFT JOIN moped_proj_component_work_types mpcwt ON mpc.project_component_id = mpcwt.project_component_id
     LEFT JOIN moped_work_types mwt ON mpcwt.work_type_id = mwt.id


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/23041

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local

**Steps to test:**
1. Before applying migrations, start your local DB and find a project in `moped_projects` table without an `ecapris_subproject_id`. See that the `should_sync_ecapris_statuses = true`. Copy that project id to look up later
2. Apply migrations, now look up that project id and see that it now has `should_sync_ecapris_statuses = false`
3. New projects will default to `should_sync_ecapris_statuses = false`

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
