### PR TITLE
Trim blank spaces from advanced search inputs

### DIFF
--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -285,7 +285,6 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
-    console.log(searchFieldValue, "search field val");
     const trimmedSearchFieldValue = searchFieldValue.trim();
     setSearchFieldValue(trimmedSearchFieldValue);
     setSearchTerm(trimmedSearchFieldValue);
@@ -298,7 +297,6 @@ const Filters = ({
       /* If we have advanced filters, set query state values and update search params */
       setSearchParams((prevSearchParams) => {
         const jsonParamString = JSON.stringify(filterParameters);
-        console.log(jsonParamString, "json");
         prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
         prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
         if (trimmedSearchFieldValue) {

--- a/moped-editor/src/components/GridTable/Filters.js
+++ b/moped-editor/src/components/GridTable/Filters.js
@@ -285,15 +285,20 @@ const Filters = ({
    * Applies the current local state and updates the parent's state
    */
   const handleApplyButtonClick = () => {
+    console.log(searchFieldValue, "search field val");
     const trimmedSearchFieldValue = searchFieldValue.trim();
     setSearchFieldValue(trimmedSearchFieldValue);
     setSearchTerm(trimmedSearchFieldValue);
 
     if (filterParameters.length > 0) {
+      // Trim white space from each advanced search filter value
+      filterParameters.forEach(
+        (filter) => (filter.value = filter.value.trim())
+      );
       /* If we have advanced filters, set query state values and update search params */
       setSearchParams((prevSearchParams) => {
         const jsonParamString = JSON.stringify(filterParameters);
-
+        console.log(jsonParamString, "json");
         prevSearchParams.set(advancedSearchFilterParamName, jsonParamString);
         prevSearchParams.set(advancedSearchIsOrParamName, isOrToggleValue);
         if (trimmedSearchFieldValue) {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/23129

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1616--atd-moped-main.netlify.app

**Steps to test:**
1. First test the behavior on [staging](https://moped.austinmobility.io/moped/projects). Open the advanced search on the projects page and select Full name as the field, and then type "        test    " in with a whole bunch of spaces before and after. See that you get zero results.
2. Also check the link in the url and see a whole bunch of +++ before and after your search value 
3. Now test this deploy preview, go to the projects list page and open the advanced search. Click on Full name and type "      test         " with a whole bunch of spaces before and after and see that now you get results. Open the advanced search again and see that your spaces were deleted. 
4. If you check the URL, you no longer have those +++++
5. Check combining w simple search, add different advanced search filters, etc


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Moved testing empty spaces into a simple search + advanced search test. "Trying adding blank spaces in the search inputs, and make sure they don't stay in the inputs or URL params." 
