### PR TITLE
21884 update project summary check and x icons

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -41,11 +41,6 @@ const useStyles = makeStyles((theme) => ({
   fieldGridItem: {
     margin: theme.spacing(2),
   },
-  editIconConfirm: {
-    cursor: "pointer",
-    margin: ".25rem 0",
-    fontSize: "24px",
-  },
   fieldLabel: {
     width: "100%",
     color: theme.palette.text.secondary,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -224,6 +224,7 @@ const ProjectSummary = ({
               <Grid item xs={12}>
                 <ProjectSummaryProjectWebsite
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}
@@ -233,6 +234,7 @@ const ProjectSummary = ({
               <Grid item xs={12}>
                 <ProjectSummaryInterimID
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}
@@ -242,6 +244,7 @@ const ProjectSummary = ({
               <Grid item xs={12}>
                 <ProjectSummaryProjectECapris
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -161,11 +161,11 @@ const ProjectSummary = ({
                   updateMutation={PROJECT_UPDATE_LEAD}
                   tooltipText="Division, department, or organization responsible for successful project implementation"
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
-                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -178,11 +178,11 @@ const ProjectSummary = ({
                   updateMutation={PROJECT_UPDATE_SPONSOR}
                   tooltipText="Division, department, or organization who is the main contributor of funds for the project"
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
-                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -214,11 +214,11 @@ const ProjectSummary = ({
                   updateMutation={PROJECT_UPDATE_PUBLIC_PROCESS}
                   tooltipText="Current public phase of a project"
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
-                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -188,6 +188,7 @@ const ProjectSummary = ({
               <Grid item xs={12}>
                 <ProjectSummaryProjectPartners
                   projectId={projectId}
+                  loading={loading}
                   data={data}
                   refetch={refetch}
                   classes={classes}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -165,6 +165,7 @@ const ProjectSummary = ({
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
+                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -181,6 +182,7 @@ const ProjectSummary = ({
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
+                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -215,6 +217,7 @@ const ProjectSummary = ({
                   refetch={refetch}
                   classes={classes}
                   handleSnackbar={handleSnackbar}
+                  loading={loading}
                 />
               </Grid>
               <Grid item xs={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummary.js
@@ -33,16 +33,6 @@ const useStyles = makeStyles((theme) => ({
   fieldGridItem: {
     marginBottom: theme.spacing(3),
   },
-  editIconConfirm: {
-    cursor: "pointer",
-    margin: ".25rem 0",
-    fontSize: "24px",
-  },
-  editIconConfirmDisabled: {
-    margin: ".25rem 0",
-    fontSize: "24px",
-    color: theme.palette.text.secondary,
-  },
   fieldLabel: {
     width: "100%",
     color: theme.palette.text.secondary,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Grid, Box, Typography, Icon, TextField } from "@mui/material";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
-import { Autocomplete } from "@mui/material";
+import { Autocomplete, IconButton } from "@mui/material";
 
 import { useMutation } from "@apollo/client";
 
@@ -102,7 +102,7 @@ const ProjectSummaryAutocomplete = ({
               )}
               openOnFocus={true}
             ></Autocomplete>
-            <Icon className={classes.editIconConfirm} onClick={handleFieldSave}>
+            {/* <Icon className={classes.editIconConfirm} onClick={handleFieldSave}>
               check
             </Icon>
             <Icon
@@ -110,7 +110,20 @@ const ProjectSummaryAutocomplete = ({
               onClick={handleFieldClose}
             >
               close
-            </Icon>
+            </Icon> */}
+            <IconButton
+              size="large"
+              // disabled={!isDirty || loading}
+              type="submit"
+            >
+              <Icon>check</Icon>
+            </IconButton>
+            <IconButton size="large" 
+              // disabled={loading}
+              // onClick={handleCancel}
+            >
+              <Icon>close</Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -34,6 +34,7 @@ const ProjectSummaryAutocomplete = ({
   refetch,
   classes,
   handleSnackbar,
+  loading,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [fieldValue, setFieldValue] = useState(initialValue);
@@ -102,25 +103,19 @@ const ProjectSummaryAutocomplete = ({
               )}
               openOnFocus={true}
             ></Autocomplete>
-            {/* <Icon className={classes.editIconConfirm} onClick={handleFieldSave}>
-              check
-            </Icon>
-            <Icon
-              className={classes.editIconConfirm}
-              onClick={handleFieldClose}
-            >
-              close
-            </Icon> */}
             <IconButton
               size="large"
-              // disabled={!isDirty || loading}
-              type="submit"
+              disabled={
+                fieldValue?.[idColumn] === initialValue?.[idColumn] || loading
+              }
+              onClick={handleFieldSave}
             >
               <Icon>check</Icon>
             </IconButton>
-            <IconButton size="large" 
-              // disabled={loading}
-              // onClick={handleCancel}
+            <IconButton
+              size="large"
+              disabled={loading}
+              onClick={handleFieldClose}
             >
               <Icon>close</Icon>
             </IconButton>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -31,10 +31,10 @@ const ProjectSummaryAutocomplete = ({
   updateMutation,
   tooltipText,
   projectId,
+  loading,
   refetch,
   classes,
   handleSnackbar,
-  loading,
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [fieldValue, setFieldValue] = useState(initialValue);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { Grid, Box, Typography, Icon, TextField } from "@mui/material";
+import { Grid, Box, Typography, TextField } from "@mui/material";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
-import { Autocomplete, IconButton } from "@mui/material";
+import ProjectSummaryIconButtons from "./ProjectSummaryIconButtons";
+import { Autocomplete } from "@mui/material";
 
 import { useMutation } from "@apollo/client";
 
@@ -103,20 +104,12 @@ const ProjectSummaryAutocomplete = ({
               )}
               openOnFocus={true}
             ></Autocomplete>
-            <IconButton
-              disabled={
-                fieldValue?.[idColumn] === initialValue?.[idColumn] || loading
-              }
-              onClick={handleFieldSave}
-            >
-              <Icon>check</Icon>
-            </IconButton>
-            <IconButton
-              disabled={loading}
-              onClick={handleFieldClose}
-            >
-              <Icon>close</Icon>
-            </IconButton>
+            <ProjectSummaryIconButtons
+              handleSave={handleFieldSave}
+              handleClose={handleFieldClose}
+              disabledCondition={fieldValue?.[idColumn] === initialValue?.[idColumn]}
+              loading={loading}
+            />
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -104,7 +104,7 @@ const ProjectSummaryAutocomplete = ({
               openOnFocus={true}
             ></Autocomplete>
             <IconButton
-              size="large"
+              className={classes.editIconConfirm}
               disabled={
                 fieldValue?.[idColumn] === initialValue?.[idColumn] || loading
               }
@@ -113,7 +113,7 @@ const ProjectSummaryAutocomplete = ({
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              size="large"
+              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleFieldClose}
             >

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryAutocomplete.js
@@ -104,7 +104,6 @@ const ProjectSummaryAutocomplete = ({
               openOnFocus={true}
             ></Autocomplete>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={
                 fieldValue?.[idColumn] === initialValue?.[idColumn] || loading
               }
@@ -113,7 +112,6 @@ const ProjectSummaryAutocomplete = ({
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleFieldClose}
             >

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { IconButton, Icon } from "@mui/material";
+
+/**
+ * ProjectSummaryIconButtons Component
+ * @param {function} handleSave - Function to handle save action
+ * @param {function} handleClose - Function to handle close action
+ * @param {boolean} disabledCondition - Condition to disable the save button
+ * @param {boolean} loading - Loading state to disable buttons
+ * @returns {JSX.Element}
+ */
+const ProjectSummaryIconButtons = ({
+  handleSave,
+  handleClose,
+  disabledCondition,
+  loading,
+}) => {
+  return (
+    <>
+      <IconButton disabled={disabledCondition || loading} onClick={handleSave}>
+        <Icon>check</Icon>
+      </IconButton>
+      <IconButton onClick={handleClose}>
+        <Icon>close</Icon>
+      </IconButton>
+    </>
+  );
+};
+
+export default ProjectSummaryIconButtons;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
@@ -124,7 +124,6 @@ const ProjectSummaryInterimID = ({
               value={interimId ?? ""}
             />
             <IconButton
-              className={classes.editIconConfirm}
               disabled={
                 parseInt(originalValue) === parseInt(interimId) || loading
               }
@@ -133,7 +132,6 @@ const ProjectSummaryInterimID = ({
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleProjectInterimIdClose}
             >

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
-import { Box, Grid, Icon, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Grid,
+  Icon,
+  IconButton,
+  TextField,
+  Typography,
+} from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
 import {
@@ -24,6 +31,7 @@ import { useMutation } from "@apollo/client";
  */
 const ProjectSummaryInterimID = ({
   projectId,
+  loading,
   data,
   refetch,
   classes,
@@ -35,6 +43,8 @@ const ProjectSummaryInterimID = ({
   const [interimId, setInterimId] = useState(originalValue);
   const [updateProjectInterimId] = useMutation(PROJECT_UPDATE_INTERIM_ID);
   const [clearProjectInterimId] = useMutation(PROJECT_CLEAR_INTERIM_ID);
+  console.log(originalValue);
+  console.log(interimId);
 
   /**
    * Resets the project interim ID to original value
@@ -115,18 +125,22 @@ const ProjectSummaryInterimID = ({
               onChange={handleProjectInterimIdChange}
               value={interimId ?? ""}
             />
-            <Icon
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={
+                parseInt(originalValue) === parseInt(interimId) || loading
+              }
               onClick={handleProjectInterimIdSave}
             >
-              check
-            </Icon>
-            <Icon
+              <Icon>check</Icon>
+            </IconButton>
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={loading}
               onClick={handleProjectInterimIdClose}
             >
-              close
-            </Icon>
+              <Icon>close</Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
@@ -1,14 +1,8 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Grid,
-  Icon,
-  IconButton,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, TextField, Typography } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
+import ProjectSummaryIconButtons from "./ProjectSummaryIconButtons";
 import {
   removeDecimalsAndTrailingNumbers,
   removeNonIntegers,
@@ -123,20 +117,14 @@ const ProjectSummaryInterimID = ({
               onChange={handleProjectInterimIdChange}
               value={interimId ?? ""}
             />
-            <IconButton
-              disabled={
-                parseInt(originalValue) === parseInt(interimId) || loading
+            <ProjectSummaryIconButtons
+              handleSave={handleProjectInterimIdSave}
+              handleClose={handleProjectInterimIdClose}
+              disabledCondition={
+                parseInt(originalValue) === parseInt(interimId)
               }
-              onClick={handleProjectInterimIdSave}
-            >
-              <Icon>check</Icon>
-            </IconButton>
-            <IconButton
-              disabled={loading}
-              onClick={handleProjectInterimIdClose}
-            >
-              <Icon>close</Icon>
-            </IconButton>
+              loading={loading}
+            />
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryInterimID.js
@@ -43,8 +43,6 @@ const ProjectSummaryInterimID = ({
   const [interimId, setInterimId] = useState(originalValue);
   const [updateProjectInterimId] = useMutation(PROJECT_UPDATE_INTERIM_ID);
   const [clearProjectInterimId] = useMutation(PROJECT_CLEAR_INTERIM_ID);
-  console.log(originalValue);
-  console.log(interimId);
 
   /**
    * Resets the project interim ID to original value

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -156,14 +156,12 @@ const ProjectSummaryProjectECapris = ({
               value={eCapris}
             />
             <IconButton
-              className={classes.editIconConfirm}
               disabled={originalValue === eCapris || loading}
               onClick={handleProjectECaprisSave}
             >
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleProjectECaprisClose}
             >

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -90,15 +90,6 @@ const ProjectSummaryProjectECapris = ({
   const handleProjectECaprisSave = () => {
     const isEmpty = (eCapris ?? "").length === 0;
 
-    if (!isEmpty && !isValidECaprisId(eCapris)) {
-      handleSnackbar(
-        true,
-        `Invalid eCapris value: ${eCapris} must not contain letters and have exactly three digits after the decimal place. E.g., 12680.010.`,
-        "error"
-      );
-      return;
-    }
-
     (isEmpty
       ? clearProjectECapris({
           variables: {
@@ -155,11 +146,19 @@ const ProjectSummaryProjectECapris = ({
               label={null}
               onChange={handleProjectECaprisChange}
               value={eCapris}
+              error={!isValidECaprisId(eCapris)}
+              helperText={
+                !isValidECaprisId(eCapris)
+                  ? `eCapris value must contain no letters and have exactly three digits after the decimal place. E.g., 12680.010.`
+                  : null
+              }
             />
             <ProjectSummaryIconButtons
               handleSave={handleProjectECaprisSave}
               handleClose={handleProjectECaprisClose}
-              disabledCondition={originalValue === eCapris}
+              disabledCondition={
+                originalValue === eCapris || !isValidECaprisId(eCapris)
+              }
               loading={loading}
             />
           </>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Box, Grid, Icon, TextField, Typography } from "@mui/material";
+import { Box, Grid, Icon, IconButton, TextField, Typography } from "@mui/material";
 
 import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
@@ -47,6 +47,7 @@ const WrapperComponent = ({ children, noWrapper, classes }) =>
  */
 const ProjectSummaryProjectECapris = ({
   projectId,
+  loading,
   data,
   refetch,
   classes,
@@ -112,11 +113,7 @@ const ProjectSummaryProjectECapris = ({
     )
       .then(() => {
         setEditMode(false);
-        handleSnackbar(
-          true,
-          "eCAPRIS Subproject ID updated",
-          "success"
-        );
+        handleSnackbar(true, "eCAPRIS Subproject ID updated", "success");
       })
       .then(() => refetch())
       .catch((error) => {
@@ -158,18 +155,20 @@ const ProjectSummaryProjectECapris = ({
               onChange={handleProjectECaprisChange}
               value={eCapris}
             />
-            <Icon
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={originalValue === eCapris || loading}
               onClick={handleProjectECaprisSave}
             >
-              check
-            </Icon>
-            <Icon
+              <Icon>check</Icon>
+            </IconButton>
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={loading}
               onClick={handleProjectECaprisClose}
             >
-              close
-            </Icon>
+              <Icon>close</Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Box, Grid, Icon, IconButton, TextField, Typography } from "@mui/material";
+import { Box, Grid, TextField, Typography } from "@mui/material";
 
 import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
+import ProjectSummaryIconButtons from "./ProjectSummaryIconButtons";
 
 import {
   PROJECT_UPDATE_ECAPRIS_SUBPROJECT_ID,
@@ -155,18 +156,12 @@ const ProjectSummaryProjectECapris = ({
               onChange={handleProjectECaprisChange}
               value={eCapris}
             />
-            <IconButton
-              disabled={originalValue === eCapris || loading}
-              onClick={handleProjectECaprisSave}
-            >
-              <Icon>check</Icon>
-            </IconButton>
-            <IconButton
-              disabled={loading}
-              onClick={handleProjectECaprisClose}
-            >
-              <Icon>close</Icon>
-            </IconButton>
+            <ProjectSummaryIconButtons
+              handleSave={handleProjectECaprisSave}
+              handleClose={handleProjectECaprisClose}
+              disabledCondition={originalValue === eCapris}
+              loading={loading}
+            />
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -75,7 +75,12 @@ const ProjectSummaryProjectECapris = ({
     PROJECT_CLEAR_ECAPRIS_SUBPROJECT_ID
   );
 
-  const isValidECaprisId = (num) => /^[\d]*\.[0-9]{3}$/.test(num);
+  /**
+   * Validates the eCapris ID format or checks if it is empty so it can be cleared.
+   * The format should be a number with exactly three digits after the decimal point.
+   */
+  const isValidECaprisId = (num) =>
+    /^[\d]*\.[0-9]{3}$/.test(num) || !num?.length;
   /**
    * Resets the project website to original value
    */

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -159,7 +159,6 @@ const ProjectSummaryProjectPartners = ({
               ))}
             </Select>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={
                 JSON.stringify(originalEntities) ===
                   JSON.stringify(selectedEntities) || loading
@@ -169,7 +168,6 @@ const ProjectSummaryProjectPartners = ({
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleProjectPartnersClose}
             >

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -4,6 +4,7 @@ import {
   Checkbox,
   Grid,
   Icon,
+  IconButton,
   Input,
   ListItemText,
   MenuItem,
@@ -27,6 +28,7 @@ import { PROJECT_UPDATE_PARTNERS } from "../../../../queries/project";
  */
 const ProjectSummaryProjectPartners = ({
   projectId,
+  loading,
   data,
   refetch,
   classes,
@@ -156,18 +158,23 @@ const ProjectSummaryProjectPartners = ({
                 </MenuItem>
               ))}
             </Select>
-            <Icon
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={
+                JSON.stringify(originalEntities) ===
+                  JSON.stringify(selectedEntities) || loading
+              }
               onClick={handleProjectPartnersSave}
             >
-              check
-            </Icon>
-            <Icon
+              <Icon>check</Icon>
+            </IconButton>
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={loading}
               onClick={handleProjectPartnersClose}
             >
-              close
-            </Icon>
+              <Icon>close</Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectPartners.js
@@ -3,8 +3,6 @@ import {
   Box,
   Checkbox,
   Grid,
-  Icon,
-  IconButton,
   Input,
   ListItemText,
   MenuItem,
@@ -13,6 +11,7 @@ import {
 } from "@mui/material";
 
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
+import ProjectSummaryIconButtons from "./ProjectSummaryIconButtons";
 import { useMutation } from "@apollo/client";
 import { PROJECT_UPDATE_PARTNERS } from "../../../../queries/project";
 
@@ -158,21 +157,15 @@ const ProjectSummaryProjectPartners = ({
                 </MenuItem>
               ))}
             </Select>
-            <IconButton
-              disabled={
+            <ProjectSummaryIconButtons
+              handleSave={handleProjectPartnersSave}
+              handleClose={handleProjectPartnersClose}
+              disabledCondition={
                 JSON.stringify(originalEntities) ===
-                  JSON.stringify(selectedEntities) || loading
+                JSON.stringify(selectedEntities)
               }
-              onClick={handleProjectPartnersSave}
-            >
-              <Icon>check</Icon>
-            </IconButton>
-            <IconButton
-              disabled={loading}
-              onClick={handleProjectPartnersClose}
-            >
-              <Icon>close</Icon>
-            </IconButton>
+              loading={loading}
+            />
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
-import { Box, Grid, Icon, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Grid,
+  Icon,
+  IconButton,
+  TextField,
+  Typography,
+} from "@mui/material";
 
 import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
@@ -20,6 +27,7 @@ import { isValidUrl, makeUrlValid } from "src/utils/urls";
  */
 const ProjectSummaryProjectWebsite = ({
   projectId,
+  loading,
   data,
   refetch,
   classes,
@@ -101,22 +109,26 @@ const ProjectSummaryProjectWebsite = ({
               error={!isWebsiteValid}
               helperText={!isWebsiteValid ? "Website is not a valid URL" : null}
             />
-            <Icon
+            <IconButton
               className={
                 isWebsiteValid
                   ? classes.editIconConfirm
                   : classes.editIconConfirmDisabled
               }
+              disabled={
+                website === originalWebsite || !isWebsiteValid || loading
+              }
               onClick={handleProjectWebsiteSave}
             >
-              check
-            </Icon>
-            <Icon
+              <Icon>check</Icon>
+            </IconButton>
+            <IconButton
               className={classes.editIconConfirm}
+              disabled={loading}
               onClick={handleProjectWebsiteClose}
             >
-              close
-            </Icon>
+              <Icon>close</Icon>
+            </IconButton>
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -1,15 +1,9 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Grid,
-  Icon,
-  IconButton,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, TextField, Typography } from "@mui/material";
 
 import ExternalLink from "src/components/ExternalLink";
 import ProjectSummaryLabel from "./ProjectSummaryLabel";
+import ProjectSummaryIconButtons from "./ProjectSummaryIconButtons";
 
 import { PROJECT_UPDATE_WEBSITE } from "../../../../queries/project";
 import { useMutation } from "@apollo/client";
@@ -109,20 +103,12 @@ const ProjectSummaryProjectWebsite = ({
               error={!isWebsiteValid}
               helperText={!isWebsiteValid ? "Website is not a valid URL" : null}
             />
-            <IconButton
-              disabled={
-                website === originalWebsite || !isWebsiteValid || loading
-              }
-              onClick={handleProjectWebsiteSave}
-            >
-              <Icon>check</Icon>
-            </IconButton>
-            <IconButton
-              disabled={loading}
-              onClick={handleProjectWebsiteClose}
-            >
-              <Icon>close</Icon>
-            </IconButton>
+            <ProjectSummaryIconButtons
+              handleSave={handleProjectWebsiteSave}
+              handleClose={handleProjectWebsiteClose}
+              disabledCondition={website === originalWebsite || !isWebsiteValid}
+              loading={loading}
+            />
           </>
         )}
         {!editMode && (

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectWebsite.js
@@ -110,11 +110,6 @@ const ProjectSummaryProjectWebsite = ({
               helperText={!isWebsiteValid ? "Website is not a valid URL" : null}
             />
             <IconButton
-              className={
-                isWebsiteValid
-                  ? classes.editIconConfirm
-                  : classes.editIconConfirmDisabled
-              }
               disabled={
                 website === originalWebsite || !isWebsiteValid || loading
               }
@@ -123,7 +118,6 @@ const ProjectSummaryProjectWebsite = ({
               <Icon>check</Icon>
             </IconButton>
             <IconButton
-              className={classes.editIconConfirm}
               disabled={loading}
               onClick={handleProjectWebsiteClose}
             >


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/21884

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1617--atd-moped-main.netlify.app/

**Steps to test:**
- select a project
- click **project lead**, you should see a checkmark and an x icon button and the checkmark button should be disabled until you make or change the selected value
- click the x icon to confirm the change is canceled
- change the value and save the change, then click the field again to ensure the checkmark icon is disabled until you select a new value
- try doing the same thing without using a mouse by tabbing and shift tabbing through the options
- repeat the steps above for the remaining fields:
  - Sponsor
  - Partners
  - Public process
  - Website
  - Interim MPD (Access) ID
  - eCapris Subproject ID

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
