### PR TITLE
Show eCapris status syncing updates in project activity log

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Before you begin, make sure you have the following installed on your system:
 
      ```bash
      ./hasura_cluster start_only
-     ./run_migrations
+     hasura migrate apply
      ./hasura-cluster start
 
      ```

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -145,7 +145,7 @@ export const formatProjectActivity = (change, lookupList) => {
         changeIcon,
         changeText: [
           {
-            text: "Updated eCAPRIS subproject statuses sync for ",
+            text: "Updated eCAPRIS subproject ID and statuses sync from ",
             style: null,
           },
           { text: oldEcaprisId, style: "boldText" },

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -69,8 +69,9 @@ export const formatProjectActivity = (change, lookupList) => {
   // is if the primary and secondary names have both been updated
   const updatedFullName = changes.length > 1;
 
-  // the field that was changed in the activity
-  const changedField = change.description[0].field;
+  // Get the changed fields from the description
+  const fields = change.description[0]?.fields || [];
+  const changedField = fields[0];
 
   if (!changedField) {
     return {

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -70,8 +70,8 @@ export const formatProjectActivity = (change, lookupList) => {
   const updatedFullName = changes.length > 1;
 
   // Get the changed fields from the description
-  const fields = change.description[0]?.fields || [];
-  const changedField = fields[0];
+  const changedFields = change.description[0]?.fields || [];
+  const changedField = changedFields[0];
 
   if (!changedField) {
     return {
@@ -81,8 +81,10 @@ export const formatProjectActivity = (change, lookupList) => {
   }
 
   // Check for eCAPRIS-related field changes using the fields array
-  const hasEcaprisSyncChange = fields.includes("should_sync_ecapris_statuses");
-  const hasEcaprisIdChange = fields.includes("ecapris_subproject_id");
+  const hasEcaprisSyncChange = changedFields.includes(
+    "should_sync_ecapris_statuses"
+  );
+  const hasEcaprisIdChange = changedFields.includes("ecapris_subproject_id");
   const hasEcaprisSyncAndIdChanges = hasEcaprisSyncChange && hasEcaprisIdChange;
 
   // Handle eCAPRIS sync changes (only sync field changed)

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -80,8 +80,13 @@ export const formatProjectActivity = (change, lookupList) => {
     };
   }
 
-  // Special handling for eCAPRIS sync changes
-  if (changedField === "should_sync_ecapris_statuses") {
+  // Check for eCAPRIS-related field changes using the fields array
+  const hasEcaprisSyncChange = fields.includes("should_sync_ecapris_statuses");
+  const hasEcaprisIdChange = fields.includes("ecapris_subproject_id");
+  const hasEcaprisSyncAndIdChanges = hasEcaprisSyncChange && hasEcaprisIdChange;
+
+  // Handle eCAPRIS sync changes (only sync field changed)
+  if (hasEcaprisSyncChange && !hasEcaprisIdChange) {
     const newSyncValue = changeData.new.should_sync_ecapris_statuses;
     const oldSyncValue = changeData.old.should_sync_ecapris_statuses;
     const newEcaprisId = changeData.new.ecapris_subproject_id;
@@ -120,8 +125,8 @@ export const formatProjectActivity = (change, lookupList) => {
     }
   }
 
-  // Special handling for eCAPRIS subproject ID changes when sync is enabled
-  if (changedField === "ecapris_subproject_id") {
+  // Handle eCAPRIS ID changes when sync is enabled (only ID field changed)
+  if (hasEcaprisIdChange && !hasEcaprisSyncChange) {
     const syncEnabled = changeData.new.should_sync_ecapris_statuses;
     const oldEcaprisId = changeData.old.ecapris_subproject_id;
     const newEcaprisId = changeData.new.ecapris_subproject_id;
@@ -149,16 +154,8 @@ export const formatProjectActivity = (change, lookupList) => {
     }
   }
 
-  // Handle cases where both fields are changed in the same update
-  // Check if both should_sync_ecapris_statuses and ecapris_subproject_id changed
-  const syncChanged =
-    changeData.new.should_sync_ecapris_statuses !==
-    changeData.old.should_sync_ecapris_statuses;
-  const ecaprisIdChanged =
-    changeData.new.ecapris_subproject_id !==
-    changeData.old.ecapris_subproject_id;
-
-  if (syncChanged && ecaprisIdChanged) {
+  // Handle cases where both eCAPRIS fields changed in the same update
+  if (hasEcaprisSyncAndIdChanges) {
     const newSyncValue = changeData.new.should_sync_ecapris_statuses;
     const newEcaprisId = changeData.new.ecapris_subproject_id;
     const oldEcaprisId = changeData.old.ecapris_subproject_id;

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -142,44 +142,26 @@ const usePrepareActivityData = (activityData) =>
           // otherwise compare the old record to the new record to find the field that was updated
           const newData = outputEvent.record_data.event.data.new;
           const oldData = outputEvent.record_data.event.data.old;
-          let changedField = "";
           let changedFields = [];
 
           Object.keys(newData).forEach((key) => {
             if (!!newData[key] && typeof newData[key] === "object") {
               if (!isEqual(newData[key], oldData[key])) {
                 changedFields.push(key);
-                if (!changedField) changedField = key;
               }
             } else if (
               newData[key] !== oldData[key] &&
               !CHANGE_FIELDS_TO_IGNORE.includes(key)
             ) {
               changedFields.push(key);
-              if (!changedField) changedField = key;
             }
           });
-
-          // Special handling for eCAPRIS fields - if both changed, prioritize the combination
-          const ecaprisFields = [
-            "should_sync_ecapris_statuses",
-            "ecapris_subproject_id",
-          ];
-          const ecaprisFieldsChanged = ecaprisFields.filter((field) =>
-            changedFields.includes(field)
-          );
-
-          if (ecaprisFieldsChanged.length > 1) {
-            // Both eCAPRIS fields changed, use a special field name to indicate this
-            changedField = "ecapris_sync_and_id";
-          }
 
           outputEvent.description = [
             {
               new: newData,
               old: oldData,
-              field: changedField,
-              changedFields: changedFields, // Add all changed fields for reference
+              fields: changedFields, // Use fields array
             },
           ];
         }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLogTableMaps.js
@@ -11,6 +11,9 @@ export const ProjectActivityLogTableMaps = {
       ecapris_subproject_id: {
         label: "eCAPRIS subproject ID",
       },
+      should_sync_ecapris_statuses: {
+        label: "eCAPRIS status sync",
+      },
       current_status: {
         label: "current status",
       },
@@ -72,11 +75,11 @@ export const ProjectActivityLogTableMaps = {
         label: "is retired",
       },
       project_name_secondary: {
-        label: "secondary project name"
+        label: "secondary project name",
       },
       project_name_full: {
-        label: "full project name"
-      }
+        label: "full project name",
+      },
     },
   },
   moped_proj_entities: {
@@ -336,11 +339,11 @@ export const ProjectActivityLogTableMaps = {
         label: "subphase",
       },
       is_phase_start_confirmed: {
-        label: "start date confirmation"
+        label: "start date confirmation",
       },
       is_phase_end_confirmed: {
-        label: "end date confirmation"
-      }
+        label: "end date confirmation",
+      },
     },
   },
   moped_proj_components: {
@@ -378,17 +381,17 @@ export const ProjectActivityLogTableMaps = {
       },
       // we don't render these audit fields in the activity log UI
       created_at: {
-        label: "creation date"
+        label: "creation date",
       },
       created_by_user_id: {
-        label: "created by user"
+        label: "created by user",
       },
       updated_at: {
-        label: "update date"
+        label: "update date",
       },
       updated_by_user_id: {
-        label: "updated by user"
-      }
+        label: "updated by user",
+      },
     },
   },
   moped_project_files: {
@@ -480,12 +483,11 @@ export const ProjectActivityLogTableMaps = {
       project_id: {
         label: "project ID",
       },
-      
 
-      // The following two pairs fields represent the same conceptual idea, however, 
+      // The following two pairs fields represent the same conceptual idea, however,
       // the first pair were the original names of the fields and the second pair
       // are names we later migrated to for these columns. Both need to be defined
-      // as part of this object to support activity log records which contain the 
+      // as part of this object to support activity log records which contain the
       // older field names.
 
       // original field names
@@ -503,7 +505,6 @@ export const ProjectActivityLogTableMaps = {
       created_by_user_id: {
         label: "added by",
       },
-      
 
       funding_source_id: {
         label: "source",


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/22431

![Screenshot 2025-06-27 at 12 58 29 PM](https://github.com/user-attachments/assets/a9d4ba71-60a8-45a5-a580-c20e53ea9952)

Note: It's not in scope here, but I'd recommend a follow-up issue to make it so that Activity Log data automatically refreshes instead of having to manually refresh to see updates in the tab. cc/ @mddilley 

## Testing
Will have to test locally since this is a branch off a branch.

**Steps to test:**
- Go to any project
- On the summary page...
  - a. If the project has an eCAPRIS Subproject ID, delete it. Check the Activity tab and refresh the page (this is needed to requery the activity log data). You should see a new activity log entry that says the ID was removed and the sync was disabled.  
  - b. If the project doesn't have an eCAPRIS Subject ID, add one (ex: 7333.001). Check the Activity tab and refresh the page (this is needed to requery the activity log data). You should see a new activity log entry that says the ID was set and sync was enabled.
- Now do the opposite from the step above. If you did A, go ahead and add a Subproject ID and follow B above. If you did B, delete the Subproject ID you added and follow A above. You should now have tested both adding and removing a Subproject ID and checked how those actions are displayed in the activity log.
- Now, with a subproject ID added, go to the Notes tab and disable the sync from eCapris. Check the activity log tab, refresh the page, and confirm the activity of Disabled eCapris sync is displayed. On Notes, toggle it back on, go back to Activity tab, refresh, and confirm the activity of Enabled eCapris sync.
- Now, with sync enabled, go back to the Summary page and change the subproject ID (ex: 2231.292). In the Activity tab, you should see that sync was updated from the old subproject ID to the new one.
- Now, with sync disabled, change the subproject ID on the Summary tab and you should see an Activity Log item that says the subproject ID was added and sync status was automatically enabled.


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
