### PR TITLE
Disable eCAPRIS Notes Filter

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -411,6 +411,10 @@ const ProjectNotes = ({
                   noteTypeId={type.id}
                   label={type.name}
                   key={type.slug}
+                  disableEcapris={
+                    type.slug === "ecapris_status_update" &&
+                    (!hasECaprisId || !shouldSyncFromECAPRIS)
+                  }
                 />
               ))}
             </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -411,10 +411,11 @@ const ProjectNotes = ({
                   noteTypeId={type.id}
                   label={type.name}
                   key={type.slug}
-                  disableEcapris={
+                  isDisabled={
                     type.slug === "ecapris_status_update" &&
                     (!hasECaprisId || !shouldSyncFromECAPRIS)
                   }
+                  disabledMessage="Enable eCAPRIS syncing to filter to eCAPRIS statuses"
                 />
               ))}
             </Grid>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
@@ -7,6 +7,8 @@ import { Button, Tooltip } from "@mui/material";
  * @param {function} setFilterNoteType - function to set the filter note type state
  * @param {string} filterNoteType - id for toggled note type
  * @param {string} label - button label
+ * @param {boolean} isDisabled - should the button be disabled
+ * @param {string} disabledMessage - message to render in tooltip if button is disabled
  * @return {JSX.Element}
  * @constructor
  */
@@ -15,23 +17,18 @@ const NoteTypeButton = ({
   setFilterNoteType,
   filterNoteType,
   label,
-  disableEcapris,
+  isDisabled,
+  disabledMessage,
 }) => {
   return (
-    <Tooltip
-      title={
-        disableEcapris
-          ? "Enable eCAPRIS syncing to filter to eCAPRIS statuses"
-          : ""
-      }
-    >
+    <Tooltip title={isDisabled ? disabledMessage : ""}>
       <span>
         <Button
           color="primary"
           sx={{ margin: 2 }}
           variant={filterNoteType === noteTypeId ? "contained" : "outlined"}
           onClick={() => setFilterNoteType(noteTypeId)}
-          disabled={disableEcapris}
+          disabled={isDisabled}
         >
           {label}
         </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import { Button, Tooltip } from "@mui/material";
 
 /**
  * Defines the NoteTypeButton with a toggle style-change behavior.
@@ -15,15 +15,29 @@ const NoteTypeButton = ({
   setFilterNoteType,
   filterNoteType,
   label,
-}) => (
-  <Button
-    color="primary"
-    sx={{ margin: 2 }}
-    variant={filterNoteType === noteTypeId ? "contained" : "outlined"}
-    onClick={() => setFilterNoteType(noteTypeId)}
-  >
-    {label}
-  </Button>
-);
+  disableEcapris,
+}) => {
+  return (
+    <Tooltip
+      title={
+        disableEcapris
+          ? "Enable eCAPRIS syncing to filter to eCAPRIS statuses"
+          : ""
+      }
+    >
+      <span>
+        <Button
+          color="primary"
+          sx={{ margin: 2 }}
+          variant={filterNoteType === noteTypeId ? "contained" : "outlined"}
+          onClick={() => setFilterNoteType(noteTypeId)}
+          disabled={disableEcapris}
+        >
+          {label}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};
 
 export default NoteTypeButton;

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/NoteTypeButton.js
@@ -3,7 +3,7 @@ import { Button, Tooltip } from "@mui/material";
 /**
  * Defines the NoteTypeButton with a toggle style-change behavior.
  * @param {Object} props
- * @param {number} noteTypeId - id of note type for button
+ * @param {number} noteTypeId - id of note type for buttClickon
  * @param {function} setFilterNoteType - function to set the filter note type state
  * @param {string} filterNoteType - id for toggled note type
  * @param {string} label - button label
@@ -21,6 +21,8 @@ const NoteTypeButton = ({
   disabledMessage,
 }) => {
   return (
+    // Disabled buttons dont trigger user interactions so the tooltip
+    // wont show unless button is wrapped in a span https://v5.mui.com/material-ui/react-tooltip/#disabled-elements
     <Tooltip title={isDisabled ? disabledMessage : ""}>
       <span>
         <Button


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/22702

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local

**Steps to test:**
1. Use prod replica data so you can actually see projects that have eCAPRIS statuses
2. Go to the Notes tab of a project that has an eCAPRIS id (For example: https://localhost:3000/moped/projects/3248?tab=notes). Use the toggle button to turn off eCAPRIS syncing
3. See that the "Synced from eCAPRIS" filter button gets disabled and has a tooltip when you hover
4. Turn the syncing toggle back on and see that you can now see and filter to eCAPRIS statuses
5. Test removing the eCAPRIS id from the summary or funding page, then return to the Notes tab and see that the button is disabled again

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
