### PR TITLE
Handle eCAPRIS sync activity in log when there is no eCAPRIS subproject id

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -94,6 +94,12 @@ export const formatProjectActivity = (change, lookupList) => {
     const newEcaprisId = changeData.new.ecapris_subproject_id;
     const oldEcaprisId = changeData.old.ecapris_subproject_id;
 
+    // If there is no eCAPRIS subproject ID set and syncing is enabled or disabled,
+    // return no icon or text so no activity row renders in ProjectActivityLog.
+    if (!newEcaprisId && !oldEcaprisId) {
+      return { changeIcon: null, changeText: null };
+    }
+
     // Sync enabled
     const isSyncEnabled = newSyncValue === true && oldSyncValue === false;
     if (isSyncEnabled) {

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -94,8 +94,9 @@ export const formatProjectActivity = (change, lookupList) => {
     const newEcaprisId = changeData.new.ecapris_subproject_id;
     const oldEcaprisId = changeData.old.ecapris_subproject_id;
 
-    // If there is no eCAPRIS subproject ID set and syncing is enabled or disabled,
-    // return no icon or text so no activity row renders in ProjectActivityLog.
+    // Skip rendering activity row when syncing state changes but no eCAPRIS ID is set.
+    // This edge case should only occur through direct database updates since the UI
+    // prevents updating should_sync_ecapris_statuses without an eCAPRIS ID.
     if (!newEcaprisId && !oldEcaprisId) {
       return { changeIcon: null, changeText: null };
     }


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/23350

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local

**Steps to test:**
1. Start your local stack and go to https://localhost:3000/moped/projects/3834 and notice that this project does not have an eCAPRIS subproject ID associated with it
2. Run the following statements on your local DB in your DB client:
```sql
-- Query the subproject id and sync status of the project
SELECT project_id, ecapris_subproject_id, should_sync_ecapris_statuses FROM moped_project
WHERE project_id = 3834;

-- Switch the sync column from TRUE to FALSE without changing the subproject id
UPDATE moped_project SET should_sync_ecapris_statuses = FALSE WHERE project_id = 3834;

-- Verify that the value has updated
SELECT project_id, ecapris_subproject_id, should_sync_ecapris_statuses FROM moped_project
WHERE project_id = 3834;
```
3. Now, go to the activity log of project 3834 (https://localhost:3000/moped/projects/3834?tab=activity_log) and notice that there is no row rendering for the update to the sync column when there is no eCAPRIS subproject id on the project. The latest update should still be `Synchronized this project with the Data Tracker`.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
