### PR TITLE
Modify click-away behavior of advanced search dropdown to ignore clicks into simple search box

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -164,93 +164,98 @@ const Search = ({
   };
 
   return (
-    <div>
-      <Box mt={3}>
-        <Paper ref={divRef}>
-          <Grid container className={classes.searchBarContainer}>
-            <Grid item xs={12} md className={classes.gridSearchPadding}>
-              <SearchBar
-                searchFieldValue={searchFieldValue}
-                setSearchFieldValue={setSearchFieldValue}
-                handleSearchSubmission={handleSearchSubmission}
-                filters={filters}
-                setFilters={setFilters}
-                toggleAdvancedSearch={toggleAdvancedSearch}
-                advancedSearchAnchor={advancedSearchAnchor}
-                queryConfig={queryConfig}
-                isOr={isOr}
-                loading={loading}
-                filtersConfig={filtersConfig}
-                resetSimpleSearch={resetSimpleSearch}
-                setIsOr={setIsOr}
-                searchTerm={searchTerm}
-                setSearchParams={setSearchParams}
-                handleSnackbar={handleSnackbar}
-              />
-            </Grid>
-            <Grid item xs={12} md="auto" className={classes.downloadButtonGrid}>
-              <div>
-                {queryConfig.showExport && (
-                  <>
-                    <Hidden smUp>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        startIcon={<Icon>search</Icon>}
-                        onClick={handleSearchSubmission}
-                        sx={{ marginRight: theme.spacing(2) }}
-                      >
-                        Search
-                      </Button>
-                    </Hidden>
-                    <FormGroup sx={{ display: "inline" }}>
-                      <FormControlLabel
-                        control={
-                          <Switch
-                            checked={showMapView}
-                            onChange={handleMapToggle}
-                          />
-                        }
-                        label="Map"
-                      />
-                    </FormGroup>
-                    <Button
-                      disabled={
-                        (parentData?.[queryConfig.table] ?? []).length === 0
-                      }
-                      onClick={handleExportButtonClick}
-                      sx={{
-                        // Override startIcon margins to center icon when there is no "Download" text smDown
-                        "& .MuiButton-startIcon": {
-                          marginLeft: { xs: 0, sm: -theme.spacing(0.5) },
-                          marginRight: { xs: 0, sm: theme.spacing(1) },
-                        },
-                      }}
-                      startIcon={<SaveAltIcon />}
-                      variant="outlined"
-                      color="primary"
-                    >
-                      <Hidden smDown>Download</Hidden>
-                    </Button>
-                  </>
-                )}
-              </div>
-            </Grid>
-          </Grid>
-        </Paper>
-      </Box>
-      <Popper
-        id="advancedSearch"
-        open={Boolean(advancedSearchAnchor)}
-        anchorEl={advancedSearchAnchor}
-        onClose={handleAdvancedSearchClose}
-        placement={"bottom"}
-        className={classes.advancedSearchRoot}
-      >
-        {/* FYI: you cannot use a Select component inside the click away listener
+    <ClickAwayListener onClickAway={handleAdvancedSearchClose}>
+      {/* FYI: you cannot use a Select component inside the click away listener
         as discussed in this thread https://github.com/mui/material-ui/issues/25578 
         so we have opted to use Autocompletes instead*/}
-        <ClickAwayListener onClickAway={handleAdvancedSearchClose}>
+      <div>
+        <Box mt={3}>
+          <Paper ref={divRef}>
+            <Grid container className={classes.searchBarContainer}>
+              <Grid item xs={12} md className={classes.gridSearchPadding}>
+                <SearchBar
+                  searchFieldValue={searchFieldValue}
+                  setSearchFieldValue={setSearchFieldValue}
+                  handleSearchSubmission={handleSearchSubmission}
+                  filters={filters}
+                  setFilters={setFilters}
+                  toggleAdvancedSearch={toggleAdvancedSearch}
+                  advancedSearchAnchor={advancedSearchAnchor}
+                  queryConfig={queryConfig}
+                  isOr={isOr}
+                  loading={loading}
+                  filtersConfig={filtersConfig}
+                  resetSimpleSearch={resetSimpleSearch}
+                  setIsOr={setIsOr}
+                  searchTerm={searchTerm}
+                  setSearchParams={setSearchParams}
+                  handleSnackbar={handleSnackbar}
+                />
+              </Grid>
+              <Grid
+                item
+                xs={12}
+                md="auto"
+                className={classes.downloadButtonGrid}
+              >
+                <div>
+                  {queryConfig.showExport && (
+                    <>
+                      <Hidden smUp>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          startIcon={<Icon>search</Icon>}
+                          onClick={handleSearchSubmission}
+                          sx={{ marginRight: theme.spacing(2) }}
+                        >
+                          Search
+                        </Button>
+                      </Hidden>
+                      <FormGroup sx={{ display: "inline" }}>
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={showMapView}
+                              onChange={handleMapToggle}
+                            />
+                          }
+                          label="Map"
+                        />
+                      </FormGroup>
+                      <Button
+                        disabled={
+                          (parentData?.[queryConfig.table] ?? []).length === 0
+                        }
+                        onClick={handleExportButtonClick}
+                        sx={{
+                          // Override startIcon margins to center icon when there is no "Download" text smDown
+                          "& .MuiButton-startIcon": {
+                            marginLeft: { xs: 0, sm: -theme.spacing(0.5) },
+                            marginRight: { xs: 0, sm: theme.spacing(1) },
+                          },
+                        }}
+                        startIcon={<SaveAltIcon />}
+                        variant="outlined"
+                        color="primary"
+                      >
+                        <Hidden smDown>Download</Hidden>
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </Grid>
+            </Grid>
+          </Paper>
+        </Box>
+        <Popper
+          id="advancedSearch"
+          open={Boolean(advancedSearchAnchor)}
+          anchorEl={advancedSearchAnchor}
+          onClose={handleAdvancedSearchClose}
+          placement={"bottom"}
+          className={classes.advancedSearchRoot}
+        >
           <Paper className={classes.advancedSearchPaper}>
             <Filters
               setFilters={setFilters}
@@ -266,9 +271,9 @@ const Search = ({
               setSearchTerm={setSearchTerm}
             />
           </Paper>
-        </ClickAwayListener>
-      </Popper>
-    </div>
+        </Popper>
+      </div>
+    </ClickAwayListener>
   );
 };
 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/22694

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Deploy preview or local

**Steps to test:**
1. Go to the project list and enter "lamars" into the search box
2. Open the advanced search and add a row for "Status is Complete". Don't press apply yet.
3. Oops, you made a typo in the search box. Click into the search box and update "lamars" to "lamar", and notice that the advanced search dropdown did not collapse.
4. Add another advanced search or making any other changes, and then press "Apply" to apply the filters.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
