### PR TITLE
replaces map toggle with icon button group

### DIFF
--- a/moped-editor/src/components/GridTable/Search.js
+++ b/moped-editor/src/components/GridTable/Search.js
@@ -161,7 +161,10 @@ const Search = ({
 
   const handleMapToggle = (event, view) => {
     if (view === null) {
-      // If no view is selected, do nothing
+      // If no view is selected, do nothing. This is necessary because the ToggleButtonGroup
+      // will call this function with `null` when the user clicks on the currently selected button.
+      // This behavior is associated with the `exclusive` prop of the ToggleButtonGroup, see
+      // https://v5.mui.com/material-ui/api/toggle-button-group/#toggle-button-group-prop-onChange
       return;
     }
     setShowMapView(view === "map");


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/22304

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1625--atd-moped-main.netlify.app/

**Steps to test:**
- go to the project list view, it should default to list view
- click the map button, the view should change to map view and show `map=true` in the url path
- click the list button, the view should return to list view and show `map=false` in the url path
- try toggling back and forth to make sure there are no state conflicts
- try viewing the project list view page in different dimensions to make sure the formatting aligns with the formatting in production

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated exist test to say "Remove any filters applied to the project list view. Click the map view toggle button on from the project list view and make sure the map view loads."
