### PR TITLE
Fix empty row that is added to table when ESCing out of adding new team member and subproject

### DIFF
--- a/moped-editor/src/utils/dataGridHelpers.js
+++ b/moped-editor/src/utils/dataGridHelpers.js
@@ -7,6 +7,7 @@ export const handleRowEditStop = (rows, setRows) => (params, event) => {
   if (params.reason === GridRowEditStopReasons.enterKeyDown) {
     event.defaultMuiPrevented = true;
   }
+  // Delete new row if user escapes out of edit mode
   if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
     if (params.row.isNew) {
       setRows(rows.filter((row) => row.id !== id));

--- a/moped-editor/src/utils/dataGridHelpers.js
+++ b/moped-editor/src/utils/dataGridHelpers.js
@@ -2,8 +2,14 @@ import { GridRowEditStopReasons } from "@mui/x-data-grid-pro";
 
 export const defaultEditColumnIconStyle = { fontSize: "24px" };
 
-export const handleRowEditStop = (params, event) => {
+export const handleRowEditStop = (rows, setRows) => (params, event) => {
+  const id = params.row.id;
   if (params.reason === GridRowEditStopReasons.enterKeyDown) {
     event.defaultMuiPrevented = true;
+  }
+  if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+    if (params.row.isNew) {
+      setRows(rows.filter((row) => row.id !== id));
+    }
   }
 };

--- a/moped-editor/src/views/dashboard/UserSavedViewsTable.js
+++ b/moped-editor/src/views/dashboard/UserSavedViewsTable.js
@@ -251,7 +251,7 @@ const UserSavedViewsTable = ({ handleSnackbar }) => {
         onRowModesModelChange={handleRowModesModelChange}
         onProcessRowUpdateError={(error) => console.error}
         editMode="row"
-        onRowEditStop={handleRowEditStop}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         processRowUpdate={processRowUpdate}
         hideFooter
         disableRowSelectionOnClick

--- a/moped-editor/src/views/projects/projectView/ProjectFiles.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFiles.js
@@ -473,7 +473,7 @@ const ProjectFiles = ({ handleSnackbar }) => {
           rows={rows}
           getRowId={(row) => row.project_file_id}
           editMode="row"
-          onRowEditStop={handleRowEditStop}
+          onRowEditStop={handleRowEditStop(rows, setRows)}
           rowModesModel={rowModesModel}
           onRowModesModelChange={handleRowModesModelChange}
           processRowUpdate={processRowUpdate}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -564,7 +564,7 @@ const ProjectFundingTable = ({ handleSnackbar, refetchProjectSummary }) => {
           getRowId={(row) => row.proj_funding_id}
           editMode="row"
           rowModesModel={rowModesModel}
-          onRowEditStop={handleRowEditStop}
+          onRowEditStop={handleRowEditStop(rows, setRows)}
           onRowModesModelChange={handleRowModesModelChange}
           processRowUpdate={processRowUpdate}
           onProcessRowUpdateError={(error) => console.error(error)}

--- a/moped-editor/src/views/projects/projectView/ProjectMilestones.js
+++ b/moped-editor/src/views/projects/projectView/ProjectMilestones.js
@@ -435,7 +435,7 @@ const ProjectMilestones = ({
         rows={rows}
         getRowId={(row) => row.project_milestone_id}
         editMode="row"
-        onRowEditStop={handleRowEditStop}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}
         processRowUpdate={processRowUpdate}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.js
@@ -288,7 +288,7 @@ const SubprojectsTable = ({
         slotProps={{ toolbar: { onClick: handleAddSubprojectClick } }}
         editMode="row"
         processRowUpdate={processRowUpdate}
-        onRowEditStop={handleRowEditStop}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         hideFooter
         disableRowSelectionOnClick
         localeText={{ noRowsLabel: "No subprojects to display" }}

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -575,7 +575,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         editMode="row"
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}
-        onRowEditStop={handleRowEditStop}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         onProcessRowUpdateError={(error) => {
           console.error("Unexpected error in processRowUpdate:", error);
         }}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/issues/assigned?issue=cityofaustin%7Catd-data-tech%7C22957

I fixed this bug for all our data grid tables, it was also happening in the milestones table.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Netlify

**Steps to test:**
1. Open staging and see what happens when you create a new row (in subprojects, team, or milestone tables) and then ESC, you are left with a weird empty row.
2. Now open the netlify link and test doing the same thing with these tables. Instead, the new row should be deleted when you press ESC.


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
