### PR TITLE
Fix activity log row render for deleted records

### DIFF
--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -26,7 +26,7 @@ export const formatComponentsActivity = (
   const componentText = {
     text: `${component} (#${componentID})`,
     style: "boldText",
-    link: componentLink
+    link: componentLink,
   };
   const phase = phaseList[change.record_data.event.data.new.phase_id];
   const subphase = subphaseList[change.record_data.event.data.new.subphase_id];
@@ -44,16 +44,13 @@ export const formatComponentsActivity = (
   if (change.description.length === 0) {
     return {
       changeIcon,
-      changeText: [
-        { text: "Added a component: ", style: null },
-        componentText,
-      ],
+      changeText: [{ text: "Added a component: ", style: null }, componentText],
     };
   }
 
   // delete an existing component
-  if (change.description[0].field === "is_deleted") {
-    const {link, ...simpleComponentText} = componentText;
+  if (change.description[0].fields.includes("is_deleted")) {
+    const { link, ...simpleComponentText } = componentText;
     if (change.record_data.event.data.new.is_deleted) {
       return {
         changeIcon,
@@ -71,10 +68,9 @@ export const formatComponentsActivity = (
         simpleComponentText,
       ],
     };
-
   }
 
-  if (change.description[0].field === "project_id") {
+  if (change.description[0].fields.includes("project_id")) {
     if (change.record_data.event.data.old.project_id === parseInt(projectId)) {
       // a component was moved from this project to another project
       return {

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -25,7 +25,7 @@ export const formatContractsActivity = (change) => {
   }
 
   // delete an existing work activity
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedFilesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFilesActivity.js
@@ -35,7 +35,7 @@ export const formatFilesActivity = (change) => {
   }
 
   // delete an existing file
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [{ text: "Deleted the file ", style: null }, fileText],

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -56,7 +56,7 @@ export const formatFundingActivity = (
     }
   }
   // delete an existing record
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     if (fundingSourceText) {
       return {
         changeIcon,

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -1,4 +1,4 @@
-import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
+import EventNoteOutlinedIcon from "@mui/icons-material/EventNoteOutlined";
 import { ProjectActivityLogTableMaps } from "src/views/projects/projectView/ProjectActivityLogTableMaps";
 
 export const formatMilestonesActivity = (change, milestoneList) => {
@@ -22,7 +22,7 @@ export const formatMilestonesActivity = (change, milestoneList) => {
   }
 
   // delete an existing milestone
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedNotesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedNotesActivity.js
@@ -22,7 +22,7 @@ export const formatNotesActivity = (change, entityList) => {
     };
   }
 
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedPersonnelActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPersonnelActivity.js
@@ -17,7 +17,7 @@ export const formatPersonnelActivity = (change, userList) => {
     };
   }
 
-  if (change.description[0].field === "user_id") {
+  if (change.description[0].fields.includes("user_id")) {
     return {
       changeIcon,
       changeText: [
@@ -30,7 +30,7 @@ export const formatPersonnelActivity = (change, userList) => {
   }
 
   // remove a person from the team
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [
@@ -42,23 +42,22 @@ export const formatPersonnelActivity = (change, userList) => {
   }
 
   // update the notes field
-  if (change.description[0].field === "notes")
-    return {
-    changeIcon,
-    changeText: [
-      { text: "Updated team member notes for " },
-      { text: userList[changeData.new.user_id], style: "boldText" },
-    ],
-  };
-
-  // the only other change that would be reflected here is adding or removing roles
-  else {
+  if (change.description[0].fields.includes("notes")) {
     return {
       changeIcon,
       changeText: [
-        { text: "Updated personnel role for "},
-        { text: userList[changeData.new.user_id], style: "boldText"},
-      ]
-    }
+        { text: "Updated team member notes for " },
+        { text: userList[changeData.new.user_id], style: "boldText" },
+      ],
+    };
+    // the only other change that would be reflected here is adding or removing roles
+  } else {
+    return {
+      changeIcon,
+      changeText: [
+        { text: "Updated personnel role for " },
+        { text: userList[changeData.new.user_id], style: "boldText" },
+      ],
+    };
   }
 };

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectTypesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectTypesActivity.js
@@ -22,7 +22,7 @@ export const formatProjectTypesActivity = (change, projectTypeList) => {
   }
 
   // delete an existing project type
-  if (change.description[0].field === "is_deleted") {
+  if (change.description[0].fields.includes("is_deleted")) {
     return {
       changeIcon,
       changeText: [


### PR DESCRIPTION
## Associated issues

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Deploy preview

**Steps to test:**
1. Delete the following project record types and check that they are correctly rendering as deleted (not showing `is_deleted`) in the UI
   - Component
   - Work activity
   - File
   - Funding
   - Milestone
   - Note
   - Team
   - Type (summary view) 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
