### PR TITLE
Update activity log to handle old and new Hasura event schema when creating fields list

### DIFF
--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedComponentsActivity.js
@@ -134,7 +134,7 @@ export const formatComponentsActivity = (
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    if (newRecord?.[field] !== oldRecord?.[field]) {
       if (CHANGE_FIELDS_TO_IGNORE.includes(field)) {
         return;
       }

--- a/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedContractsActivity.js
@@ -51,12 +51,12 @@ export const formatContractsActivity = (change) => {
   Object.keys(newRecord).forEach((field) => {
     // typeof(null) resolves as "object", check that field is not null before checking if object
     // task orders are in arrays
-    if (!!newRecord[field] && typeof newRecord[field] === "object") {
-      if (!isEqual(newRecord[field], oldRecord[field])) {
+    if (!!newRecord?.[field] && typeof newRecord?.[field] === "object") {
+      if (!isEqual(newRecord?.[field], oldRecord?.[field])) {
         changes.push(entryMap.fields[field]?.label);
       }
     } else if (
-      newRecord[field] !== oldRecord[field] &&
+      newRecord?.[field] !== oldRecord?.[field] &&
       !fieldsToSkip.includes(field)
     ) {
       changes.push(entryMap.fields[field]?.label);

--- a/moped-editor/src/utils/activityLogFormatters/mopedFilesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFilesActivity.js
@@ -55,7 +55,7 @@ export const formatFilesActivity = (change) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    if (newRecord?.[field] !== oldRecord?.[field]) {
       if (CHANGE_FIELDS_TO_IGNORE.includes(field)) {
         return;
       }

--- a/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedFundingActivity.js
@@ -88,12 +88,12 @@ export const formatFundingActivity = (
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
     // typeof(null) === "object", check that field is not null before checking if object
-    if (!!newRecord[field] && typeof newRecord[field] === "object") {
-      if (!isEqual(newRecord[field], oldRecord[field])) {
+    if (!!newRecord?.[field] && typeof newRecord?.[field] === "object") {
+      if (!isEqual(newRecord?.[field], oldRecord?.[field])) {
         changes.push(entryMap.fields[field]?.label);
       }
     } else if (
-      newRecord[field] !== oldRecord[field] &&
+      newRecord?.[field] !== oldRecord?.[field] &&
       !fieldsToSkip.includes(field)
     ) {
       changes.push(entryMap.fields[field]?.label);

--- a/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedMilestonesActivity.js
@@ -48,7 +48,7 @@ export const formatMilestonesActivity = (change, milestoneList) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    if (newRecord?.[field] !== oldRecord?.[field]) {
       // filter out fields that are not listed in the activity log table maps to prevent
       // automated field updates (created at, updated at, etc.) from entering the array
       if (!!entryMap.fields[field]) {

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -38,7 +38,7 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
   let changes = [];
 
   // if the record has been deleted that supersedes any other changes
-  if (newRecord["is_deleted"] === true) {
+  if (newRecord?.["is_deleted"] === true) {
     return {
       changeIcon,
       changeText: [

--- a/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedPhasesActivity.js
@@ -52,7 +52,7 @@ export const formatPhasesActivity = (change, phaseList, subphaseList) => {
 
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
-    if (newRecord[field] !== oldRecord[field]) {
+    if (newRecord?.[field] !== oldRecord?.[field]) {
       // filter out fields that are not listed in the activity log table maps to prevent
       // automated field updates (created at, updated at, etc.) from entering the array
       if (!!entryMap.fields[field]) {

--- a/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
+++ b/moped-editor/src/utils/activityLogFormatters/mopedProjectActivity.js
@@ -53,12 +53,12 @@ export const formatProjectActivity = (change, lookupList) => {
   // loop through fields to check for differences, push label onto changes Array
   Object.keys(newRecord).forEach((field) => {
     // typeof(null) === "object", check that field is not null before checking if object
-    if (!!newRecord[field] && typeof newRecord[field] === "object") {
-      if (!isEqual(newRecord[field], oldRecord[field])) {
+    if (!!newRecord?.[field] && typeof newRecord?.[field] === "object") {
+      if (!isEqual(newRecord?.[field], oldRecord?.[field])) {
         changes.push(entryMap.fields[field]?.label);
       }
     } else if (
-      newRecord[field] !== oldRecord[field] &&
+      newRecord?.[field] !== oldRecord?.[field] &&
       !fieldsToSkip.includes(field)
     ) {
       changes.push(entryMap.fields[field]?.label);

--- a/moped-editor/src/utils/activityLogHelpers.js
+++ b/moped-editor/src/utils/activityLogHelpers.js
@@ -23,7 +23,7 @@ export const formatActivityLogEntry = (change, lookupData, projectId) => {
     case "moped_project":
       // if the user is changing the public process status id field,
       // provide the publicProcessStatusList lookup object
-      if (change?.description[0]?.field === "public_process_status_id") {
+      if (change?.description[0]?.fields.includes("public_process_status_id")) {
         return formatProjectActivity(
           change,
           lookupData.publicProcessStatusList

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -125,8 +125,8 @@ const CHANGE_FIELDS_TO_IGNORE = ["updated_by_user_id", "updated_at"];
  * {
  *   "new": true,
  *   "old": false,
- *   "fields": ["completed"]
- *}
+ *   "fields": ["completed", "is_deleted", ...]
+ * }
  * @param {Array} eventList - The data object as provided by apollo
  * @returns {Array}
  */

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -121,6 +121,12 @@ const CHANGE_FIELDS_TO_IGNORE = ["updated_by_user_id", "updated_at"];
 /**
  * Updates the description field with newData and oldData
  * Makes sure the project creation event is the last in the returned Array
+ * The formatters expect the following object shape:
+ * {
+ *   "new": true,
+ *   "old": false,
+ *   "fields": ["completed"]
+ *}
  * @param {Array} eventList - The data object as provided by apollo
  * @returns {Array}
  */
@@ -135,13 +141,6 @@ const usePrepareActivityData = (activityData) =>
       let outputEvent = { ...event };
       // if the description includes "newSchema", we need to manually find the difference in the update
       if (event.description[0]?.newSchema) {
-        if (
-          event.record_type === "moped_proj_milestones" &&
-          (event.activity_id !== "42c0c12f-8c4f-4da1-8860-41ea3a2515e1" ||
-            event.activity_id !== "42c0c12f-8c4f-4da1-8860-41ea3a2515e1")
-        ) {
-          console.log("new schema", event);
-        }
         // if event is an INSERT there is no previous record to compare to
         if (event.operation_type === "INSERT") {
           outputEvent.description = [];
@@ -185,11 +184,6 @@ const usePrepareActivityData = (activityData) =>
             fields: changedFields, // Extract from old schema's field-by-field tracking
           },
         ];
-        console.log("old schema", event, {
-          new: newData,
-          old: oldData,
-          fields: changedFields, // Extract from old schema's field-by-field tracking
-        });
       }
       outputList.push(outputEvent);
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -119,15 +119,21 @@ const useLookupTables = (data) =>
 const CHANGE_FIELDS_TO_IGNORE = ["updated_by_user_id", "updated_at"];
 
 /**
- * Updates the description field with newData and oldData
- * Makes sure the project creation event is the last in the returned Array
- * The formatters expect the following object shape:
- * {
- *   "new": true,
- *   "old": false,
+ * Formats the activity log data for display in the project activity log.
+ * For our old schema, it extracts the changed fields from the description array.
+ * For the new schema, it compares the old and new record data to find the changed fields.
+ * It returns an array of formatted activity log entries.
+ *
+ * The formatters expect the following description object shape when handling updated records:
+ * event.description = [{
+ *   "new": {...the new record data},
+ *   "old": {...the old record data},
  *   "fields": ["completed", "is_deleted", ...]
- * }
- * @param {Array} eventList - The data object as provided by apollo
+ * }]
+ * The formatters expect the following description object shape when handling inserted records:
+ * event.description = []
+ *
+ * @param {Array} activityData - The data object as provided by apollo
  * @returns {Array}
  */
 const usePrepareActivityData = (activityData) =>
@@ -185,7 +191,7 @@ const usePrepareActivityData = (activityData) =>
             {
               new: newData,
               old: oldData,
-              fields: changedFields, // Extract from old schema's field-by-field tracking
+              fields: changedFields, // Extracted from old schema's field-by-field tracking
             },
           ];
         }

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -135,6 +135,13 @@ const usePrepareActivityData = (activityData) =>
       let outputEvent = { ...event };
       // if the description includes "newSchema", we need to manually find the difference in the update
       if (event.description[0]?.newSchema) {
+        if (
+          event.record_type === "moped_proj_milestones" &&
+          (event.activity_id !== "42c0c12f-8c4f-4da1-8860-41ea3a2515e1" ||
+            event.activity_id !== "42c0c12f-8c4f-4da1-8860-41ea3a2515e1")
+        ) {
+          console.log("new schema", event);
+        }
         // if event is an INSERT there is no previous record to compare to
         if (event.operation_type === "INSERT") {
           outputEvent.description = [];
@@ -165,6 +172,24 @@ const usePrepareActivityData = (activityData) =>
             },
           ];
         }
+      } else {
+        // Handle old schema - extract changed fields from description array
+        const changedFields = event.description.map((change) => change.field);
+        const newData = outputEvent.record_data.event.data.new;
+        const oldData = outputEvent.record_data.event.data.old;
+
+        outputEvent.description = [
+          {
+            new: newData,
+            old: oldData,
+            fields: changedFields, // Extract from old schema's field-by-field tracking
+          },
+        ];
+        console.log("old schema", event, {
+          new: newData,
+          old: oldData,
+          fields: changedFields, // Extract from old schema's field-by-field tracking
+        });
       }
       outputList.push(outputEvent);
 

--- a/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectActivityLog.js
@@ -172,18 +172,23 @@ const usePrepareActivityData = (activityData) =>
           ];
         }
       } else {
-        // Handle old schema - extract changed fields from description array
-        const changedFields = event.description.map((change) => change.field);
-        const newData = outputEvent.record_data.event.data.new;
-        const oldData = outputEvent.record_data.event.data.old;
+        // if event is an INSERT there is no previous record to compare to
+        if (event.operation_type === "INSERT") {
+          outputEvent.description = [];
+        } else {
+          // Handle old schema - extract changed fields from description array
+          const changedFields = event.description.map((change) => change.field);
+          const newData = outputEvent.record_data.event.data.new;
+          const oldData = outputEvent.record_data.event.data.old;
 
-        outputEvent.description = [
-          {
-            new: newData,
-            old: oldData,
-            fields: changedFields, // Extract from old schema's field-by-field tracking
-          },
-        ];
+          outputEvent.description = [
+            {
+              new: newData,
+              old: oldData,
+              fields: changedFields, // Extract from old schema's field-by-field tracking
+            },
+          ];
+        }
       }
       outputList.push(outputEvent);
 


### PR DESCRIPTION
## Associated issues
No issue related. This is to patch up how our current activity log code handles the old Hasura event schema.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local please so that you can look at a project that uses the old schema

**Steps to test:**
1. Go to https://localhost:3000/moped/projects/232?tab=activity_log and make sure that the activity log loads. This shows that the activity log works with the old event schema.
2. Expand the collapsible section below and see a full page screenshot of a project where I created, edited, and deleted all project record types. This shows that the code is working with the new event schema.
3. I don't want to create a bunch of duplicate work so I am good with y'all trusting the screenshot. You can test if you like.

<details>

<summary>Expand me!</summary>

**Moving a component from one project to another**
<img width="1417" height="70" alt="Screenshot 2025-07-31 at 3 47 25 PM" src="https://github.com/user-attachments/assets/f6334d96-0977-4ce1-b8ae-373f61786b00" />

**The rest of the events**
<img width="3360" height="8222" alt="screencapture-localhost-3000-moped-projects-3899-2025-07-31-15_53_04" src="https://github.com/user-attachments/assets/4f527650-c40c-4edd-9de1-f04ee66789e7" />

</details>

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
