### PR TITLE
Switch Staging to ECS API endpoint

### DIFF
--- a/moped-editor/.env-cmdrc
+++ b/moped-editor/.env-cmdrc
@@ -55,7 +55,7 @@
     "REACT_APP_AWS_COGNITO_USER_POOL_ID": "us-east-1_U2dzkxfTv",
     "REACT_APP_AWS_COGNITO_APP_CLIENT_ID": "3u9n9373e37v603tbp25gs5fdc",
     "REACT_APP_HASURA_ENDPOINT": "https://moped-graphql-staging.austinmobility.io/v1/graphql",
-    "REACT_APP_API_ENDPOINT": "https://moped-api-staging.austinmobility.io",
+    "REACT_APP_API_ENDPOINT": "https://moped-user-file-api-staging.austinmobility.io",
     "REACT_APP_HASURA_ENV": "staging",
     "REACT_APP_AWS_CLOUDFRONT": "https://moped.austinmobility.io",
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_IN": "https://moped.austinmobility.io/moped/session/signin",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/21910

## Wait, not again, didn't we do this?

We were able to do all our testing of the PR based off a deploy preview, and I failed to include this one line prior to merge that would flip staging actually over to the new API. This change for staging will take effect on merger of this PR to `main`, I believe.

We'll see a second PR just like this one for production real soon.

## Testing

Freebie here, just take a look at the one-line-diff. Does it match the PR review section? 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
