### PR TITLE
Handle expired refresh tokens

### DIFF
--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -135,8 +135,8 @@ export const initializeUserDBObject = async (session) => {
       const resData = await res.json();
 
       if (resData?.errors) {
-        console.error(resData.errors);
-        throw new Error("GraphQL errors occurred");
+        // Show error feedback in sign in form
+        throw new Error("Error fetching user data");
       }
 
       if (resData?.data?.moped_users) {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/24016

This PR handles an expired refresh token which lasts 30 days in production by forcing the user to log out and then log back in. I also made a change to await the fetching of the user's database data before proceeding to the previous view since the dashboard view and project summary view have queries that rely on the user id being populated.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**
1. Go to the deploy preview. If you are already signed in, sign out and then log in with one of the **Moped Test** users from our vault.
2. Go to the project list view, make sure you have a project link in view that you will click later, and then go work on something else for 60 minutes. ⏳
3. After an hour, come back to your tab that is on the project list view and click on a project link.
4. You should be logged out since the refresh token expiration is set to 60 minutes right now in our staging user pool.
5. Sign in again with the same test user and notice that you are being directed to the project details page of the link that you clicked on previously. This also tests that the user database local storage entry is populated since the summary query requires it to be defined to show whether you are following this project or not.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
