### PR TITLE
Fix missed update to new way initializeUserDBObject works

### DIFF
--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -260,7 +260,8 @@ export const UserProvider = ({ children }) => {
             // We must populate userDatabaseData if it's null otherwise the query will fail
             // when users are redirected to their last route after a forced logout
             // (see MainLayout.js and DashboardLayout.js for previous route restoration handling).
-            await initializeUserDBObject(session);
+            const userDBData = await initializeUserDBObject(session);
+            setSessionDatabaseData(userDBData);
           }
 
           setUser(session);

--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -190,17 +190,9 @@ export const UserProvider = ({ children }) => {
     setIsLoginLoading(true);
 
     try {
-      console.log("Loggin in with SSO...");
+      // Auth.federatedSignIn redirects the user so we set user state and local storage DB data after the redirect
+      // happens in the useEffect below that handles route restoration (initializeUserDBObject and setSessionDatabaseData).
       await Auth.federatedSignIn({ provider: "AzureAD" });
-
-      const session = await Auth.currentSession();
-      console.log("Logged in with SSO:", session);
-      const userDBData = await initializeUserDBObject(session);
-      console.log("User DB Data:", userDBData);
-      setSessionDatabaseData(userDBData);
-      setUser(session);
-
-      setIsLoginLoading(false);
     } catch (error) {
       console.error("Error getting user session on sign in: ", error);
       setUser(null);

--- a/moped-editor/src/auth/user.js
+++ b/moped-editor/src/auth/user.js
@@ -191,7 +191,7 @@ export const UserProvider = ({ children }) => {
 
     try {
       // Auth.federatedSignIn redirects the user so we set user state and local storage DB data after the redirect
-      // happens in the useEffect below that handles route restoration (initializeUserDBObject and setSessionDatabaseData).
+      // in the useEffect below that handles route restoration (initializeUserDBObject and setSessionDatabaseData).
       await Auth.federatedSignIn({ provider: "AzureAD" });
     } catch (error) {
       console.error("Error getting user session on sign in: ", error);


### PR DESCRIPTION
## Associated issues
This fixes a third place where the user DB row needs to be set. It also updates how we handle setting user state and local storage after the SSO redirect.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local if you want?

**Steps to test:**
1. Check this file to see that the other two `initializeUserDbObject` calls work this same way. They return the user data and then we set it in local storage. I just forgot to update this one.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
