### PR TITLE
Fix global search results transparency bug

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -275,7 +275,7 @@ const NavigationSearchInput = ({ input404Class }) => {
             // inherit the position from the modifiers and dont reset to 0
             style={{ position: "fixed", top: "unset", left: "unset" }}
             // disablePortal=true ensures the popper wont slip behind the material tables
-            disablePortal
+            // disablePortal
             modifiers={[]}
             className={clsx(
               input404Class ? classes.searchPopper404 : classes.searchPopper,

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/NavigationSearchInput.js
@@ -274,8 +274,6 @@ const NavigationSearchInput = ({ input404Class }) => {
             placement="bottom-start"
             // inherit the position from the modifiers and dont reset to 0
             style={{ position: "fixed", top: "unset", left: "unset" }}
-            // disablePortal=true ensures the popper wont slip behind the material tables
-            // disablePortal
             modifiers={[]}
             className={clsx(
               input404Class ? classes.searchPopper404 : classes.searchPopper,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/24400

My best theory is that [making the app bar static](https://github.com/cityofaustin/atd-moped/pull/1655/files#diff-38d34c5c659b6eb0b9c9d27aa1ba057817e68762881bb2572a4e9cef8449e093R75) undid the need for our portal-disabling workaround for the Popper component that is further down in the app bar tree.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**
1. Use the global search to search for something like "test" or a project id
2. Check that you can't see the table or view below the dropdown options through them in:
   - the project list view
   - the dashboard
   - the data dictionary
   - a project page

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
