### PR TITLE
Release Party: Bump local development version of `graphql-engine` to `v2.48.5`

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.48.4
+        image: hasura/graphql-engine:v2.48.5
         depends_on:
             - moped-pgsql
         expose:


### PR DESCRIPTION
This PR is part of the Moped release today, documented here: https://github.com/cityofaustin/atd-data-tech/issues/24389. 

Merging this PR will bump local development's version of `graphql-engine` to remain aligned to the versions in production and staging. This PR is to be merged during the release party when @mddilley gives the 👍 

This PR is in lieu of pushing on `main`, it seems just a little bit more right to do it this way.