### PR TITLE
Update council_district_project_distribution_analytics view's buffer distance, dissolve behavior, and deleted-project support

### DIFF
--- a/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/down.sql
+++ b/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/down.sql
@@ -1,3 +1,6 @@
+DROP INDEX IF EXISTS idx_council_district_geom_2277;
+
+
 CREATE OR REPLACE VIEW council_district_project_distribution_analytics AS WITH area_project_buffers AS (
     SELECT
         projects.project_id,

--- a/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/down.sql
+++ b/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/down.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE VIEW council_district_project_distribution_analytics AS WITH area_project_buffers AS (
+    SELECT
+        projects.project_id,
+        st_buffer(st_transform(projects.geography::geometry, 2277), 33::double precision) AS buffer_geom
+    FROM project_geography AS projects
+    WHERE st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text])
+),
+
+area_district_aggregates AS (
+    SELECT
+        project_buffers.project_id,
+        districts.council_district AS council_district_id,
+        sum(st_area(st_intersection(project_buffers.buffer_geom, st_transform(districts.geography::geometry, 2277)))) AS total_area_in_district_sq_ft
+    FROM area_project_buffers AS project_buffers
+    INNER JOIN layer_council_district AS districts ON st_intersects(project_buffers.buffer_geom, st_transform(districts.geography::geometry, 2277))
+    GROUP BY project_buffers.project_id, districts.council_district
+),
+
+project_totals AS (
+    SELECT
+        area_district_aggregates.project_id,
+        sum(area_district_aggregates.total_area_in_district_sq_ft) AS total_area
+    FROM area_district_aggregates
+    GROUP BY area_district_aggregates.project_id
+)
+
+SELECT
+    ada.project_id,
+    ada.council_district_id AS district_id,
+    round((ada.total_area_in_district_sq_ft * 100::double precision / nullif(pt.total_area, 0::double precision))::numeric, 2) AS percentage_of_total
+FROM area_district_aggregates AS ada
+INNER JOIN project_totals AS pt ON ada.project_id = pt.project_id
+ORDER BY ada.project_id, ada.council_district_id;

--- a/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
+++ b/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
@@ -1,0 +1,43 @@
+-- Most recent migration: moped-database/migrations/default/1755539630397_add-project-district-analysis-m-views/up.sql
+
+CREATE OR REPLACE VIEW council_district_project_distribution_analytics AS WITH area_project_buffers AS (
+    SELECT
+        projects.project_id,
+        st_buffer(st_transform(projects.geography::geometry, 2277), 100::double precision) AS buffer_geom
+    FROM project_geography AS projects
+    WHERE st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text])
+),
+
+dissolved_project_buffers AS (
+    SELECT
+        area_project_buffers.project_id,
+        st_unaryunion(st_collect(area_project_buffers.buffer_geom)) AS dissolved_buffer_geom
+    FROM area_project_buffers
+    GROUP BY area_project_buffers.project_id
+),
+
+area_district_aggregates AS (
+    SELECT
+        project_buffers.project_id,
+        districts.council_district AS council_district_id,
+        sum(st_area(st_intersection(project_buffers.dissolved_buffer_geom, st_transform(districts.geography::geometry, 2277)))) AS total_area_in_district_sq_ft
+    FROM dissolved_project_buffers AS project_buffers
+    INNER JOIN layer_council_district AS districts ON st_intersects(project_buffers.dissolved_buffer_geom, st_transform(districts.geography::geometry, 2277))
+    GROUP BY project_buffers.project_id, districts.council_district
+),
+
+project_totals AS (
+    SELECT
+        area_district_aggregates.project_id,
+        sum(area_district_aggregates.total_area_in_district_sq_ft) AS total_area
+    FROM area_district_aggregates
+    GROUP BY area_district_aggregates.project_id
+)
+
+SELECT
+    ada.project_id,
+    ada.council_district_id AS district_id,
+    round((ada.total_area_in_district_sq_ft * 100::double precision / nullif(pt.total_area, 0::double precision))::numeric, 2) AS percentage_of_total
+FROM area_district_aggregates AS ada
+INNER JOIN project_totals AS pt ON ada.project_id = pt.project_id
+ORDER BY ada.project_id, ada.council_district_id;

--- a/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
+++ b/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
@@ -43,3 +43,7 @@ SELECT
 FROM area_district_aggregates AS ada
 INNER JOIN project_totals AS pt ON ada.project_id = pt.project_id
 ORDER BY ada.project_id, ada.council_district_id;
+
+
+CREATE INDEX IF NOT EXISTS idx_council_district_geom_2277
+ON layer_council_district USING gist (st_transform(geography::geometry, 2277));

--- a/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
+++ b/moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
@@ -5,7 +5,9 @@ CREATE OR REPLACE VIEW council_district_project_distribution_analytics AS WITH a
         projects.project_id,
         st_buffer(st_transform(projects.geography::geometry, 2277), 100::double precision) AS buffer_geom
     FROM project_geography AS projects
-    WHERE st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text])
+    INNER JOIN moped_project AS mp ON projects.project_id = mp.project_id
+    WHERE mp.is_deleted = false
+        AND st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text])
 ),
 
 dissolved_project_buffers AS (

--- a/moped-database/views/council_district_project_distribution_analytics.sql
+++ b/moped-database/views/council_district_project_distribution_analytics.sql
@@ -1,20 +1,29 @@
--- Most recent migration: moped-database/migrations/default/1755539630397_add-project-district-analysis-m-views/up.sql
+-- Most recent migration: moped-database/migrations/default/1758551918596_adjust-projects-per-district-view/up.sql
 
 CREATE OR REPLACE VIEW council_district_project_distribution_analytics AS WITH area_project_buffers AS (
     SELECT
         projects.project_id,
-        st_buffer(st_transform(projects.geography::geometry, 2277), 33::double precision) AS buffer_geom
+        st_buffer(st_transform(projects.geography::geometry, 2277), 100::double precision) AS buffer_geom
     FROM project_geography projects
-    WHERE st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text])
+    JOIN moped_project mp ON projects.project_id = mp.project_id
+    WHERE mp.is_deleted = false AND (st_geometrytype(projects.geography::geometry) = any(ARRAY['ST_MultiPoint'::text, 'ST_MultiLineString'::text]))
+),
+
+dissolved_project_buffers AS (
+    SELECT
+        area_project_buffers.project_id,
+        st_unaryunion(st_collect(area_project_buffers.buffer_geom)) AS dissolved_buffer_geom
+    FROM area_project_buffers
+    GROUP BY area_project_buffers.project_id
 ),
 
 area_district_aggregates AS (
     SELECT
         project_buffers.project_id,
         districts.council_district AS council_district_id,
-        sum(st_area(st_intersection(project_buffers.buffer_geom, st_transform(districts.geography::geometry, 2277)))) AS total_area_in_district_sq_ft
-    FROM area_project_buffers project_buffers
-    JOIN layer_council_district districts ON st_intersects(project_buffers.buffer_geom, st_transform(districts.geography::geometry, 2277))
+        sum(st_area(st_intersection(project_buffers.dissolved_buffer_geom, st_transform(districts.geography::geometry, 2277)))) AS total_area_in_district_sq_ft
+    FROM dissolved_project_buffers project_buffers
+    JOIN layer_council_district districts ON st_intersects(project_buffers.dissolved_buffer_geom, st_transform(districts.geography::geometry, 2277))
     GROUP BY project_buffers.project_id, districts.council_district
 ),
 


### PR DESCRIPTION
# Associated issues

This PR hopes to close https://github.com/cityofaustin/atd-data-tech/issues/24669. 

# Testing (partially borrowed from PR 1652)

* Replicate some live data into your local database and then apply the migration in this feature branch.
* Connect to your database and open the view `council_district_project_distribution_analytics`.
* I hand-calculated project 22's results in QGIS, and I got 27.10% for one and 72.90%. Are these figures close to what you see in the table? 
  * They don't have to match exactly -- i have made no attempt to align the resolution of the buffers or how it handles end-caps. Close enough works here.
* If you want, please feel free to spot check other projects.

* Take a look at the code. Do you see:
  * An inner join in the first CTE to remove soft-deleted projects?
  * The view dissolves the buffers created from the line segments and points in the second, new CTE?
  * An update to a buffering distance of 100 feet in the first CTE?

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
