### PR TITLE
Update order of funding override dialog inputs to mirror inline form order and add status input to dialog

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -144,74 +144,6 @@ const OverrideFundingForm = ({
     <form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
       <Grid container spacing={2}>
         <Grid item xs={12}>
-          <Controller
-            name="should_use_ecapris_amount"
-            control={control}
-            render={({ field: { onChange, value } }) => (
-              <FormControlLabel
-                control={
-                  <Switch
-                    // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
-                    checked={!value}
-                    onChange={(e) => {
-                      // Check target value so we can restore previous amount if unchecking (if there is one)
-                      if (e.target.checked) {
-                        setValue(
-                          "funding_amount",
-                          fundingRecord.funding_amount ?? appropriatedFunding
-                        );
-                        onChange(false);
-                      } else {
-                        setValue("funding_amount", appropriatedFunding);
-                        onChange(true);
-                      }
-                    }}
-                  />
-                }
-                label="Override eCAPRIS appropriated amount"
-              />
-            )}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <FormControl fullWidth>
-            <ControlledTextInput
-              fullWidth
-              autoFocus
-              label="Amount"
-              name="funding_amount"
-              control={control}
-              size="small"
-              type="text"
-              inputMode="numeric"
-              onChangeHandler={amountOnChangeHandler}
-              disabled={should_use_ecapris_amount}
-            />
-            <FormHelperText>
-              eCAPRIS appropriated amount:{" "}
-              {currencyFormatter.format(appropriatedFunding)}
-            </FormHelperText>
-            {errors.funding_amount ? (
-              <FormHelperText error>
-                {errors.funding_amount?.message}
-              </FormHelperText>
-            ) : null}
-          </FormControl>
-        </Grid>
-        <Grid item xs={12}>
-          <FormControl fullWidth>
-            <ControlledTextInput
-              fullWidth
-              label="Description"
-              multiline
-              rows={2}
-              name="description"
-              control={control}
-              size="small"
-            />
-          </FormControl>
-        </Grid>
-        <Grid item xs={12}>
           <FormControl fullWidth>
             <ControlledAutocomplete
               control={control}
@@ -277,7 +209,75 @@ const OverrideFundingForm = ({
             </FormHelperText>
           </FormControl>
         </Grid>
+                <Grid item xs={12}>
+          <FormControl fullWidth>
+            <ControlledTextInput
+              fullWidth
+              label="Description"
+              multiline
+              rows={2}
+              name="description"
+              control={control}
+              size="small"
+            />
+          </FormControl>
+        </Grid>
       </Grid>
+        <Grid item xs={12}>
+          <Controller
+            name="should_use_ecapris_amount"
+            control={control}
+            render={({ field: { onChange, value } }) => (
+              <FormControlLabel
+                control={
+                  <Switch
+                    // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
+                    checked={!value}
+                    onChange={(e) => {
+                      // Check target value so we can restore previous amount if unchecking (if there is one)
+                      if (e.target.checked) {
+                        setValue(
+                          "funding_amount",
+                          fundingRecord.funding_amount ?? appropriatedFunding
+                        );
+                        onChange(false);
+                      } else {
+                        setValue("funding_amount", appropriatedFunding);
+                        onChange(true);
+                      }
+                    }}
+                  />
+                }
+                label="Override eCAPRIS appropriated amount"
+              />
+            )}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <FormControl fullWidth>
+            <ControlledTextInput
+              fullWidth
+              autoFocus
+              label="Amount"
+              name="funding_amount"
+              control={control}
+              size="small"
+              type="text"
+              inputMode="numeric"
+              onChangeHandler={amountOnChangeHandler}
+              disabled={should_use_ecapris_amount}
+            />
+            <FormHelperText>
+              eCAPRIS appropriated amount:{" "}
+              {currencyFormatter.format(appropriatedFunding)}
+            </FormHelperText>
+            {errors.funding_amount ? (
+              <FormHelperText error>
+                {errors.funding_amount?.message}
+              </FormHelperText>
+            ) : null}
+          </FormControl>
+        </Grid>
       <Grid container display="flex" justifyContent="flex-end">
         <Grid item sx={{ marginTop: 2, marginBottom: 2 }}>
           <Button

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -26,7 +26,9 @@ const validationSchema = ({ appropriatedFunding }) =>
       .number()
       .test(
         "lessThanAppropriated",
-        `Amount cannot exceed appropriated amount of ${currencyFormatter.format(appropriatedFunding)}`,
+        `Amount cannot exceed appropriated amount of ${currencyFormatter.format(
+          appropriatedFunding
+        )}`,
         function (value) {
           return value <= appropriatedFunding;
         }
@@ -209,7 +211,7 @@ const OverrideFundingForm = ({
             </FormHelperText>
           </FormControl>
         </Grid>
-                <Grid item xs={12}>
+        <Grid item xs={12}>
           <FormControl fullWidth>
             <ControlledTextInput
               fullWidth
@@ -223,61 +225,61 @@ const OverrideFundingForm = ({
           </FormControl>
         </Grid>
       </Grid>
-        <Grid item xs={12}>
-          <Controller
-            name="should_use_ecapris_amount"
-            control={control}
-            render={({ field: { onChange, value } }) => (
-              <FormControlLabel
-                control={
-                  <Switch
-                    // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
-                    checked={!value}
-                    onChange={(e) => {
-                      // Check target value so we can restore previous amount if unchecking (if there is one)
-                      if (e.target.checked) {
-                        setValue(
-                          "funding_amount",
-                          fundingRecord.funding_amount ?? appropriatedFunding
-                        );
-                        onChange(false);
-                      } else {
-                        setValue("funding_amount", appropriatedFunding);
-                        onChange(true);
-                      }
-                    }}
-                  />
-                }
-                label="Override eCAPRIS appropriated amount"
-              />
-            )}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <FormControl fullWidth>
-            <ControlledTextInput
-              fullWidth
-              autoFocus
-              label="Amount"
-              name="funding_amount"
-              control={control}
-              size="small"
-              type="text"
-              inputMode="numeric"
-              onChangeHandler={amountOnChangeHandler}
-              disabled={should_use_ecapris_amount}
+      <Grid item xs={12}>
+        <Controller
+          name="should_use_ecapris_amount"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <FormControlLabel
+              control={
+                <Switch
+                  // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
+                  checked={!value}
+                  onChange={(e) => {
+                    // Check target value so we can restore previous amount if unchecking (if there is one)
+                    if (e.target.checked) {
+                      setValue(
+                        "funding_amount",
+                        fundingRecord.funding_amount ?? appropriatedFunding
+                      );
+                      onChange(false);
+                    } else {
+                      setValue("funding_amount", appropriatedFunding);
+                      onChange(true);
+                    }
+                  }}
+                />
+              }
+              label="Override eCAPRIS appropriated amount"
             />
-            <FormHelperText>
-              eCAPRIS appropriated amount:{" "}
-              {currencyFormatter.format(appropriatedFunding)}
+          )}
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <FormControl fullWidth>
+          <ControlledTextInput
+            fullWidth
+            autoFocus
+            label="Amount"
+            name="funding_amount"
+            control={control}
+            size="small"
+            type="text"
+            inputMode="numeric"
+            onChangeHandler={amountOnChangeHandler}
+            disabled={should_use_ecapris_amount}
+          />
+          <FormHelperText>
+            eCAPRIS appropriated amount:{" "}
+            {currencyFormatter.format(appropriatedFunding)}
+          </FormHelperText>
+          {errors.funding_amount ? (
+            <FormHelperText error>
+              {errors.funding_amount?.message}
             </FormHelperText>
-            {errors.funding_amount ? (
-              <FormHelperText error>
-                {errors.funding_amount?.message}
-              </FormHelperText>
-            ) : null}
-          </FormControl>
-        </Grid>
+          ) : null}
+        </FormControl>
+      </Grid>
       <Grid container display="flex" justifyContent="flex-end">
         <Grid item sx={{ marginTop: 2, marginBottom: 2 }}>
           <Button

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -236,7 +236,7 @@ const OverrideFundingForm = ({
               filterOptions={filterOptions}
               getOptionLabel={(option) => option?.funding_status_name || ""}
               onChangeHandler={(fund_status, field) => {
-                return field.onChange(fund_status?.funding_status_id || null);
+                return field.onChange(fund_status?.funding_status_id || 1);
               }}
               isOptionEqualToValue={(option, selectedOption) =>
                 option.funding_status_id === selectedOption.funding_status_id

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -83,6 +83,7 @@ const OverrideFundingForm = ({
       should_use_ecapris_amount: fundingRecord?.should_use_ecapris_amount,
       funding_source_id: fundingRecord.fund_source?.funding_source_id,
       funding_program_id: fundingRecord.fund_program?.funding_program_id,
+      fund_status: fundingRecord.fund_status?.funding_status_id,
     },
     resolver: yupResolver(validationSchema({ appropriatedFunding })),
     mode: "onChange",
@@ -107,6 +108,7 @@ const OverrideFundingForm = ({
       data.should_use_ecapris_amount;
     transformedRecord.funding_source_id = data.funding_source_id;
     transformedRecord.funding_program_id = data.funding_program_id;
+    transformedRecord.funding_status_id = data.fund_status;
 
     const payload = isNewOverride
       ? {
@@ -224,61 +226,86 @@ const OverrideFundingForm = ({
             />
           </FormControl>
         </Grid>
-      </Grid>
-      <Grid item xs={12}>
-        <Controller
-          name="should_use_ecapris_amount"
-          control={control}
-          render={({ field: { onChange, value } }) => (
-            <FormControlLabel
-              control={
-                <Switch
-                  // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
-                  checked={!value}
-                  onChange={(e) => {
-                    // Check target value so we can restore previous amount if unchecking (if there is one)
-                    if (e.target.checked) {
-                      setValue(
-                        "funding_amount",
-                        fundingRecord.funding_amount ?? appropriatedFunding
-                      );
-                      onChange(false);
-                    } else {
-                      setValue("funding_amount", appropriatedFunding);
-                      onChange(true);
-                    }
-                  }}
-                />
+        <Grid item xs={12}>
+          <FormControl fullWidth>
+            <ControlledAutocomplete
+              control={control}
+              name="fund_status"
+              label="Status"
+              options={dataProjectFunding["moped_fund_status"]}
+              filterOptions={filterOptions}
+              getOptionLabel={(option) => option?.funding_status_name || ""}
+              onChangeHandler={(fund_status, field) => {
+                return field.onChange(fund_status?.funding_status_id || null);
+              }}
+              isOptionEqualToValue={(option, selectedOption) =>
+                option.funding_status_id === selectedOption.funding_status_id
               }
-              label="Override eCAPRIS appropriated amount"
+              valueHandler={(value) =>
+                value
+                  ? dataProjectFunding["moped_fund_status"].find(
+                      (s) => s.funding_status_id === value
+                    )
+                  : null
+              }
             />
-          )}
-        />
-      </Grid>
-      <Grid item xs={12}>
-        <FormControl fullWidth>
-          <ControlledTextInput
-            fullWidth
-            autoFocus
-            label="Amount"
-            name="funding_amount"
+          </FormControl>
+        </Grid>
+        <Grid item xs={12}>
+          <Controller
+            name="should_use_ecapris_amount"
             control={control}
-            size="small"
-            type="text"
-            inputMode="numeric"
-            onChangeHandler={amountOnChangeHandler}
-            disabled={should_use_ecapris_amount}
+            render={({ field: { onChange, value } }) => (
+              <FormControlLabel
+                control={
+                  <Switch
+                    // Invert value for switch so that "on" means we are overriding and NOT using eCAPRIS amount
+                    checked={!value}
+                    onChange={(e) => {
+                      // Check target value so we can restore previous amount if unchecking (if there is one)
+                      if (e.target.checked) {
+                        setValue(
+                          "funding_amount",
+                          fundingRecord.funding_amount ?? appropriatedFunding
+                        );
+                        onChange(false);
+                      } else {
+                        setValue("funding_amount", appropriatedFunding);
+                        onChange(true);
+                      }
+                    }}
+                  />
+                }
+                label="Override eCAPRIS appropriated amount"
+              />
+            )}
           />
-          <FormHelperText>
-            eCAPRIS appropriated amount:{" "}
-            {currencyFormatter.format(appropriatedFunding)}
-          </FormHelperText>
-          {errors.funding_amount ? (
-            <FormHelperText error>
-              {errors.funding_amount?.message}
+        </Grid>
+        <Grid item xs={12}>
+          <FormControl fullWidth>
+            <ControlledTextInput
+              fullWidth
+              autoFocus
+              label="Amount"
+              name="funding_amount"
+              control={control}
+              size="small"
+              type="text"
+              inputMode="numeric"
+              onChangeHandler={amountOnChangeHandler}
+              disabled={should_use_ecapris_amount}
+            />
+            <FormHelperText>
+              eCAPRIS appropriated amount:{" "}
+              {currencyFormatter.format(appropriatedFunding)}
             </FormHelperText>
-          ) : null}
-        </FormControl>
+            {errors.funding_amount ? (
+              <FormHelperText error>
+                {errors.funding_amount?.message}
+              </FormHelperText>
+            ) : null}
+          </FormControl>
+        </Grid>
       </Grid>
       <Grid container display="flex" justifyContent="flex-end">
         <Grid item sx={{ marginTop: 2, marginBottom: 2 }}>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/26863

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

You will have to test locally until the ecapris funding is in staging.

**Steps to test:**

Go to a record with an eCAPRIS ID. Toggle on sync from eCAPRIS if necessary. Here is a sample project
https://localhost:3000/moped/projects/3401?tab=funding

Click on a synced from eCAPRIS record to edit and open the override modal. 
Check that the order of the inputs now match top to bottom the left to right order of the table. 

Test updating the status and save your work. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test for testing override form: "Click the edit button and switch on the override amount. Try clearing the status and see that it defaults to "Tentative". Enter a custom amount and save. See that the table reflects your custom amount."
   - Updated existing test for testing inline (manual) form: "Fill out all fields except status and save the row - verify that you can't use a funding amount with a decimal or non-numeric characters and that you can typeahead FDUs using any part of the number and the unit name and that the status defaulted to "Tentative""
