### PR TITLE
Add message to login page with link to service request form

### DIFF
--- a/moped-editor/src/layouts/DashboardLayout/NavBar/menuConfig.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/menuConfig.js
@@ -5,6 +5,9 @@ import ChatOutlinedIcon from "@mui/icons-material/ChatOutlined";
 import MapOutlinedIcon from "@mui/icons-material/MapOutlined";
 import BarChart from "@mui/icons-material/BarChart";
 
+export const serviceRequestLink =
+  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_399%22%3A%22Moped%22%7D";
+
 /**
  * Configuration for help menu items we iterate to render menu items in DropdownMenu and MobileDropdownMenu
  * @property {string} linkType - "internal" or "external" to determine how to render link
@@ -15,7 +18,7 @@ import BarChart from "@mui/icons-material/BarChart";
 export const helpItems = [
   {
     linkType: "external",
-    link: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_399%22%3A%22Moped%22%7D",
+    link: serviceRequestLink,
     title: "Contact support",
     Icon: <MailOutlineIcon fontSize="small" />,
   },

--- a/moped-editor/src/views/auth/LoginView.js
+++ b/moped-editor/src/views/auth/LoginView.js
@@ -15,6 +15,10 @@ import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import Page from "src/components/Page";
 import { useUser } from "src/auth/user";
 import SimpleDialog from "src/components/SimpleDialog";
+import ExternalLink from "src/components/ExternalLink";
+
+const serviceRequestLink =
+  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_399%22%3A%22Moped%22%7D";
 
 const LoginView = () => {
   const { login, loginSSO, isLoginLoading } = useUser();
@@ -180,6 +184,12 @@ const LoginView = () => {
               External user? Sign in{" "}
             </Typography>
             <SimpleDialog content={dialogContent} />
+          </Box>
+          <Box align="center" sx={{ pt: 2 }}>
+            <Typography display="inline" color="textSecondary" variant="body2">
+              Need access? Request{" "}
+              {<ExternalLink url={serviceRequestLink} text="here" />}.
+            </Typography>
           </Box>
         </Container>
       </Box>

--- a/moped-editor/src/views/auth/LoginView.js
+++ b/moped-editor/src/views/auth/LoginView.js
@@ -16,9 +16,8 @@ import Page from "src/components/Page";
 import { useUser } from "src/auth/user";
 import SimpleDialog from "src/components/SimpleDialog";
 import ExternalLink from "src/components/ExternalLink";
+import { serviceRequestLink } from "src/layouts/DashboardLayout/NavBar/menuConfig";
 
-const serviceRequestLink =
-  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_399%22%3A%22Moped%22%7D";
 
 const LoginView = () => {
   const { login, loginSSO, isLoginLoading } = useUser();

--- a/moped-editor/src/views/auth/LoginView.js
+++ b/moped-editor/src/views/auth/LoginView.js
@@ -16,8 +16,9 @@ import Page from "src/components/Page";
 import { useUser } from "src/auth/user";
 import SimpleDialog from "src/components/SimpleDialog";
 import ExternalLink from "src/components/ExternalLink";
-import { serviceRequestLink } from "src/layouts/DashboardLayout/NavBar/menuConfig";
 
+const serviceRequestLink =
+  "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22IT%20Support%20%E2%80%94%20Help%20with%20licenses%2C%20accounts%2C%20hardware%2C%20etc.%22%2C%22field_399%22%3A%22Moped%22%7D";
 
 const LoginView = () => {
   const { login, loginSSO, isLoginLoading } = useUser();


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27115

## Testing
**URL to test:** 

https://deploy-preview-1790--atd-moped-main.netlify.app/moped/session/signin

**Steps to test:**

Visit the deploy preview, do not log in. 

Click the link at the bottom and confirm the service request form fills out, with Moped as the product already selected. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test: "Sign out from the drop-down nav. Confirm there is a link to the service request form for requesting Moped access."
