### PR TITLE
Update funding amount inputs in the funding table to accurately reflect $0 and null values 

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -86,7 +86,7 @@ const OverrideFundingForm = ({
     setValue,
   } = useForm({
     defaultValues: {
-      funding_amount: fundingRecord.funding_amount ?? 0,
+      funding_amount: fundingRecord.funding_amount,
       description: fundingRecord.funding_description ?? "",
       should_use_ecapris_amount: fundingRecord?.should_use_ecapris_amount,
       funding_source_id: fundingRecord.fund_source?.funding_source_id,
@@ -300,6 +300,9 @@ const OverrideFundingForm = ({
               size="small"
               type="text"
               inputMode="numeric"
+              // the default value handler on the controlled text input Coerces falsey values to an empty string
+              // which is making 0 appear as an empty string. we do want null to be an empty string
+              valueHandler={(value) => (value === null ? "" : value)}
               onChangeHandler={amountOnChangeHandler}
               disabled={should_use_ecapris_amount}
               error={!!errors.funding_amount}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -204,7 +204,8 @@ const useColumns = ({
         field: "funding_amount",
         width: 100,
         editable: true,
-        valueFormatter: (value) => currencyFormatter.format(value),
+        valueFormatter: (value) =>
+          value === null ? null : currencyFormatter.format(value),
         renderEditCell: (props) => <DollarAmountIntegerField {...props} />,
         type: "currency",
       },

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -89,6 +89,11 @@ export const transformGridToDatabase = (gridRecord) => {
   const should_use_ecapris_amount =
     fdu_record_amount === Number(gridRecord.funding_amount);
 
+  // an empty string will throw an error, since the record expects an Int or null.
+  const funding_amount = Boolean(gridRecord.funding_amount)
+    ? gridRecord.funding_amount
+    : null;
+
   const {
     id,
     __typename,
@@ -117,5 +122,6 @@ export const transformGridToDatabase = (gridRecord) => {
     ecapris_funding_id,
     ecapris_subproject_id,
     should_use_ecapris_amount,
+    funding_amount,
   };
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -89,7 +89,7 @@ export const transformGridToDatabase = (gridRecord) => {
   const should_use_ecapris_amount =
     fdu_record_amount === Number(gridRecord.funding_amount);
 
-  // an empty string will throw an error, since the record expects an Int or null.
+  // the database expects the funding amount to be an Int or null. An empty string will result in an error, coerce to null
   const funding_amount = Boolean(gridRecord.funding_amount)
     ? gridRecord.funding_amount
     : null;

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
@@ -54,9 +54,11 @@ export const activityValidationSchema = yup.object().shape({
  * @param {object} field react-hook-form field object
  */
 export const amountOnChangeHandler = (value, field) => {
-  const handledValue = value
+  const integerValue = value
     ? removeNonIntegers(removeDecimalsAndTrailingNumbers(value))
     : null;
+  // if after removing non integers, we are only left we an empty string, handle as null
+  const handledValue = integerValue ? integerValue : null;
   field.onChange(handledValue);
 };
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/26463

The issue in which i am left to consider what is nothing, what is 0. 

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

While you can test via the [deploy preview](https://deploy-preview-1793--atd-moped-main.netlify.app/moped/projects), if you run locally with prod data, you will be able to inspect your database. 

**Steps to test:**

Choose a project with an eCAPRIS ID ex: https://localhost:3000/moped/projects/3221?tab=funding
If Sync is not turned on, turn on

1. Choose a record that has an amount. Click to edit and open the dialog, toggle to override the amount and change amount to 0. Save. 
2. see that the value in the table is $0. 
3. open that record to edit again, and now change the amount to an empty string
4. see that value is empty in the table. Test updating again to a number or to 0 again

Now test adding a manual record. 
1. add a record, do not pick an fdu. just pick a source or something .
2. add an amount in the amount input, delete it and leave blank. save. (this errors in prod)
3. edit the amount again, to 0. 
4. now test saving a number. 

 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
