### PR TITLE
Update documentation link icon button to navigate on click in any part of the button

### DIFF
--- a/moped-editor/src/components/DocumentationIconLink.js
+++ b/moped-editor/src/components/DocumentationIconLink.js
@@ -19,20 +19,20 @@ const DocumentationIconLink = ({
   iconButtonSx = {},
 }) => (
   <Tooltip title={tooltipText}>
-    <IconButton sx={iconButtonSx} color="inherit" size={size}>
-      <Link
-        component={RouterLink}
-        to={documentationLink}
-        target="_blank"
-        underline="none"
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
+    <Link
+      component={RouterLink}
+      to={documentationLink}
+      target="_blank"
+      underline="none"
+      sx={{
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
+      <IconButton sx={iconButtonSx} color="inherit" size={size}>
         <MenuBookOutlined sx={{ color: "text.secondary" }} fontSize="small" />
-      </Link>
-    </IconButton>
+      </IconButton>
+    </Link>
   </Tooltip>
 );
 

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/NewComponentToolbar.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/NewComponentToolbar.js
@@ -37,7 +37,7 @@ const NewComponentToolbar = ({
           >
             New Component
           </Button>
-          <Box>
+          <Box sx={{ display: "flex" }}>
             <IconButton
               onClick={() => setAreSettingsOpen(!areSettingsOpen)}
               aria-label="settings"


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27511

The snackiest snackoo. 

## Testing
**URL to test:** 

https://deploy-preview-1803--atd-moped-main.netlify.app/moped/projects/2210?tab=map

**Steps to test:**

Click the link above, and hover over the button. Click in the shaded hover area, but not the actual icon. The documentation opens in a new tab!

<img width="302" height="195" alt="Screenshot 2026-03-24 at 4 28 02 PM" src="https://github.com/user-attachments/assets/47cd730b-29b2-40cc-ad62-cba59dbead21" />



Compare to here: 
https://moped.austinmobility.io/moped/projects/1957?tab=map



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
