### PR TITLE
Update new project form to set same signal location description as the component form

### DIFF
--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -166,7 +166,7 @@ export const generateProjectComponent = (
 
   return {
     component_id: componentDef.component_id,
-    location_description: signalRecord.location_name.trim(),
+    location_description: `${signalRecord.signal_id}: ${signalRecord.location_name.trim()}`,
     feature_signals: {
       data: [signalRecord],
     },

--- a/moped-editor/src/utils/signalComponentHelpers.js
+++ b/moped-editor/src/utils/signalComponentHelpers.js
@@ -166,7 +166,7 @@ export const generateProjectComponent = (
 
   return {
     component_id: componentDef.component_id,
-    location_description: `${signalRecord.signal_id}: ${signalRecord.location_name.trim()}`,
+    location_description: `${signalRecord.signal_id}: ${signalRecord.location_name?.trim()}`,
     feature_signals: {
       data: [signalRecord],
     },

--- a/moped-editor/src/views/projects/newProjectView/NewProjectView.js
+++ b/moped-editor/src/views/projects/newProjectView/NewProjectView.js
@@ -9,11 +9,10 @@ import {
   ADD_PROJECT,
   PROJECT_FOLLOW,
 } from "src/queries/project";
-import { knackSignalRecordToFeatureSignalsRecord } from "src/utils/signalComponentHelpers";
+import { knackSignalRecordToFeatureSignalsRecord, generateProjectComponent } from "src/utils/signalComponentHelpers";
 
 import { useSessionDatabaseData } from "src/auth/user";
 
-import { generateProjectComponent } from "src/utils/signalComponentHelpers";
 
 /**
  * New Project View


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27235

## Testing
**URL to test:** 
https://deploy-preview-1812--atd-moped-main.netlify.app/moped/


**Steps to test:**

Create a new project using a signal asset. 
After creation, go to the map and click the details on the signal component. Look at the location description, it should be Signal ID: Signal Name. 

Compare to this project I created in staging: https://deploy-preview-1811--atd-moped-main.netlify.app/moped/projects/2215?tab=map&project_component_id=2978, The location description omits the signal ID. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
