### PR TITLE
Update data dictionary route

### DIFF
--- a/moped-editor/src/auth/rolesBasedRules.js
+++ b/moped-editor/src/auth/rolesBasedRules.js
@@ -19,6 +19,7 @@ const readOnlyStaticRules = [
   "404:visit",
   "all:visit",
   "style:visit",
+  "dictionary:visit",
   "projects-map:visit",
 ];
 

--- a/moped-editor/src/layouts/DashboardLayout/NavBar/menuConfig.js
+++ b/moped-editor/src/layouts/DashboardLayout/NavBar/menuConfig.js
@@ -42,7 +42,7 @@ export const helpItems = [
   },
   {
     linkType: "internal",
-    link: "/moped/dev/lookups",
+    link: "/moped/data-dictionary",
     title: "Data dictionary",
     Icon: <MenuBookOutlined fontSize="small" />,
   },

--- a/moped-editor/src/routes.js
+++ b/moped-editor/src/routes.js
@@ -75,9 +75,14 @@ export const routes = [
         element: <DeviasStyleView />,
       },
       {
-        path: "dev/lookups",
-        action: "style:visit",
+        path: "data-dictionary",
+        action: "dictionary:visit",
         element: <LookupsView />,
+      },
+      {
+        path: "dev/lookups",
+        action: "dictionary:visit",
+        element: <Navigate to="/moped/data-dictionary" />,
       },
       {
         path: "views/signal-projects",

--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -144,7 +144,7 @@ const useColumns = ({
           <Box sx={{ fontWeight: 500 }}>
             Role{" "}
             <Link
-              href="dev/lookups#moped-project_roles"
+              href="data-dictionary#moped-project-roles"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27533

## Testing

**Steps to test:**

Visit: https://deploy-preview-1813--atd-moped-main.netlify.app/moped/data-dictionary
Visit: https://deploy-preview-1813--atd-moped-main.netlify.app/moped/dev/lookups and confirm that it reroutes you

Use the menu to navigate to the data dictionary, check the route is updated. 
Visit a projects team table and click on the ? icon next to roles. It [will not scroll you to the correct section](https://github.com/cityofaustin/atd-data-tech/issues/27762), but confirm it takes you to the new data dictionary route. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
