### PR TITLE
adds subproject name to project summary ecapris funding dropdown

### DIFF
--- a/moped-database/metadata/databases/default/tables/public_ecapris_subproject_funding.yaml
+++ b/moped-database/metadata/databases/default/tables/public_ecapris_subproject_funding.yaml
@@ -12,42 +12,45 @@ select_permissions:
   - role: moped-admin
     permission:
       columns:
+        - app
+        - ecapris_subproject_id
         - fao_id
         - fdu
-        - id
-        - unit_long_name
         - fdu_status
-        - ecapris_subproject_id
-        - app
         - funding_program_id
         - funding_source_id
+        - id
+        - subproject_name
+        - unit_long_name
       filter: {}
     comment: ""
   - role: moped-editor
     permission:
       columns:
+        - app
+        - ecapris_subproject_id
         - fao_id
         - fdu
-        - id
-        - unit_long_name
         - fdu_status
-        - ecapris_subproject_id
-        - app
         - funding_program_id
         - funding_source_id
+        - id
+        - subproject_name
+        - unit_long_name
       filter: {}
     comment: ""
   - role: moped-viewer
     permission:
       columns:
+        - app
+        - ecapris_subproject_id
         - fao_id
         - fdu
-        - id
-        - unit_long_name
         - fdu_status
-        - ecapris_subproject_id
-        - app
         - funding_program_id
         - funding_source_id
+        - id
+        - subproject_name
+        - unit_long_name
       filter: {}
     comment: ""

--- a/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/down.sql
+++ b/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."ecapris_subproject_funding" add column "subproject_name" text
+--  null;

--- a/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/down.sql
+++ b/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/down.sql
@@ -1,4 +1,1 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."ecapris_subproject_funding" add column "subproject_name" text
---  null;
+alter table "public"."ecapris_subproject_funding" drop column "subproject_name";

--- a/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
+++ b/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
@@ -1,2 +1,1 @@
-alter table "public"."ecapris_subproject_funding" add column "subproject_name" text
- null;
+alter table "public"."ecapris_subproject_funding" add column "subproject_name" text not null;

--- a/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
+++ b/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."ecapris_subproject_funding" add column "subproject_name" text
+ null;

--- a/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
+++ b/moped-database/migrations/default/1776300831851_alter_table_public_ecapris_subproject_funding_add_column_subproject_name/up.sql
@@ -1,1 +1,2 @@
-alter table "public"."ecapris_subproject_funding" add column "subproject_name" text not null;
+alter table "public"."ecapris_subproject_funding" add column "subproject_name" text
+ null;

--- a/moped-editor/src/queries/funding.js
+++ b/moped-editor/src/queries/funding.js
@@ -40,6 +40,7 @@ export const COMBINED_FUNDING_QUERY = gql`
     }
     ecapris_subproject_funding(distinct_on: ecapris_subproject_id) {
       ecapris_subproject_id
+      subproject_name
     }
   }
 `;

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -144,6 +144,7 @@ export const SUMMARY_QUERY = gql`
     }
     ecapris_subproject_funding(distinct_on: ecapris_subproject_id) {
       ecapris_subproject_id
+      subproject_name
     }
   }
 `;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -111,7 +111,11 @@ const ProjectSummaryProjectECapris = ({
               value={selectedValue}
               sx={fieldSelectItem}
               options={options}
-              getOptionLabel={(e) => e?.["ecapris_subproject_id"] ?? ""}
+              getOptionLabel={(e) =>
+                e?.["ecapris_subproject_id"] && e?.["subproject_name"]
+                  ? `${e["ecapris_subproject_id"]} - ${e["subproject_name"]}`
+                  : ""
+              } // Display subproject name in dropdown to provide more context for user when selecting
               isOptionEqualToValue={(option, value) =>
                 option?.["ecapris_subproject_id"] ===
                 value?.["ecapris_subproject_id"]

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -134,7 +134,9 @@ const ProjectSummaryProjectECapris = ({
               value={selectedValue}
               sx={fieldSelectItem}
               options={options}
-              getOptionLabel={(e) => formatOptionLabel(e)}
+              getOptionLabel={(e) =>
+                e?.["ecapris_subproject_id"] ? formatOptionLabel(e) : ""
+              }
               isOptionEqualToValue={(option, value) =>
                 option?.["ecapris_subproject_id"] ===
                 value?.["ecapris_subproject_id"]

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -47,14 +47,13 @@ const ProjectSummaryProjectECapris = ({
   const userEmail = user?.idToken?.payload?.email;
 
   // Helper: find full option object by id and format option labels
-  const findOptionById = useCallback(
-    (id) => options?.find((o) => o?.ecapris_subproject_id === id),
-    [options]
-  );
-  const formatOptionLabel = (o) => {
-    if (!o) return "";
-    const id = o?.ecapris_subproject_id ?? "";
-    const name = o?.subproject_name ?? "";
+  const findOptionById = (id) =>
+    options?.find((option) => option?.ecapris_subproject_id === id);
+
+  const formatOptionLabel = (option) => {
+    if (!option) return "";
+    const id = option?.ecapris_subproject_id ?? "";
+    const name = option?.subproject_name ?? "";
     return name ? `${id} - ${name}` : id;
   };
 
@@ -76,23 +75,6 @@ const ProjectSummaryProjectECapris = ({
   const [clearECaprisId, { loading: clearLoading }] = useMutation(
     PROJECT_CLEAR_ECAPRIS_SUBPROJECT_ID
   );
-
-  // When entering edit mode, prefer the full option object from `options`
-  // so the Autocomplete can display both the id and the name if available.
-  useEffect(() => {
-    if (!editMode) return;
-
-    if (!eCaprisSubprojectId) {
-      setSelectedValue(null);
-      return;
-    }
-
-    setSelectedValue(
-      findOptionById(eCaprisSubprojectId) ?? {
-        ecapris_subproject_id: eCaprisSubprojectId,
-      }
-    );
-  }, [editMode, findOptionById, eCaprisSubprojectId]);
 
   const handleFieldClose = () => {
     setSelectedValue(initialValue);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -46,10 +46,11 @@ const ProjectSummaryProjectECapris = ({
   const { user } = useUser();
   const userEmail = user?.idToken?.payload?.email;
 
-  // Helper: find full option object by id and format option labels
+  // Find full option object by id and format option labels
   const findOptionById = (id) =>
     options?.find((option) => option?.ecapris_subproject_id === id);
 
+  // Format option label to include subproject name if available to provide more context for user when selecting an eCAPRIS subproject ID
   const formatOptionLabel = (option) => {
     if (!option) return "";
     const id = option?.ecapris_subproject_id ?? "";
@@ -58,9 +59,7 @@ const ProjectSummaryProjectECapris = ({
   };
 
   const initialValue = eCaprisSubprojectId
-    ? (findOptionById(eCaprisSubprojectId) ?? {
-        ecapris_subproject_id: eCaprisSubprojectId,
-      })
+    ? findOptionById(eCaprisSubprojectId)
     : null;
 
   const [editMode, setEditMode] = useState(false);
@@ -122,7 +121,7 @@ const ProjectSummaryProjectECapris = ({
               value={selectedValue}
               sx={fieldSelectItem}
               options={options}
-              getOptionLabel={(e) => formatOptionLabel(e)} // Display subproject name in dropdown to provide more context for user when selecting
+              getOptionLabel={(e) => formatOptionLabel(e)}
               isOptionEqualToValue={(option, value) =>
                 option?.["ecapris_subproject_id"] ===
                 value?.["ecapris_subproject_id"]

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";
@@ -47,7 +47,10 @@ const ProjectSummaryProjectECapris = ({
   const userEmail = user?.idToken?.payload?.email;
 
   // Helper: find full option object by id and format option labels
-  const findOptionById = (id) => options?.find((o) => o?.ecapris_subproject_id === id);
+  const findOptionById = useCallback(
+    (id) => options?.find((o) => o?.ecapris_subproject_id === id),
+    [options]
+  );
   const formatOptionLabel = (o) => {
     if (!o) return "";
     const id = o?.ecapris_subproject_id ?? "";
@@ -56,7 +59,9 @@ const ProjectSummaryProjectECapris = ({
   };
 
   const initialValue = eCaprisSubprojectId
-    ? findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId }
+    ? (findOptionById(eCaprisSubprojectId) ?? {
+        ecapris_subproject_id: eCaprisSubprojectId,
+      })
     : null;
 
   const [editMode, setEditMode] = useState(false);
@@ -82,8 +87,12 @@ const ProjectSummaryProjectECapris = ({
       return;
     }
 
-    setSelectedValue(findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId });
-  }, [editMode, options, eCaprisSubprojectId]);
+    setSelectedValue(
+      findOptionById(eCaprisSubprojectId) ?? {
+        ecapris_subproject_id: eCaprisSubprojectId,
+      }
+    );
+  }, [editMode, findOptionById, eCaprisSubprojectId]);
 
   const handleFieldClose = () => {
     setSelectedValue(initialValue);
@@ -189,7 +198,9 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               text={formatOptionLabel(
-                findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId }
+                findOptionById(eCaprisSubprojectId) ?? {
+                  ecapris_subproject_id: eCaprisSubprojectId,
+                }
               )}
               onClickEdit={() => {
                 if (disabled) return;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";
@@ -46,10 +46,17 @@ const ProjectSummaryProjectECapris = ({
   const { user } = useUser();
   const userEmail = user?.idToken?.payload?.email;
 
+  // Helper: find full option object by id and format option labels
+  const findOptionById = (id) => options?.find((o) => o?.ecapris_subproject_id === id);
+  const formatOptionLabel = (o) => {
+    if (!o) return "";
+    const id = o?.ecapris_subproject_id ?? "";
+    const name = o?.subproject_name ?? "";
+    return name ? `${id} - ${name}` : id;
+  };
+
   const initialValue = eCaprisSubprojectId
-    ? {
-        ecapris_subproject_id: eCaprisSubprojectId,
-      }
+    ? findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId }
     : null;
 
   const [editMode, setEditMode] = useState(false);
@@ -64,6 +71,19 @@ const ProjectSummaryProjectECapris = ({
   const [clearECaprisId, { loading: clearLoading }] = useMutation(
     PROJECT_CLEAR_ECAPRIS_SUBPROJECT_ID
   );
+
+  // When entering edit mode, prefer the full option object from `options`
+  // so the Autocomplete can display both the id and the name if available.
+  useEffect(() => {
+    if (!editMode) return;
+
+    if (!eCaprisSubprojectId) {
+      setSelectedValue(null);
+      return;
+    }
+
+    setSelectedValue(findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId });
+  }, [editMode, options, eCaprisSubprojectId]);
 
   const handleFieldClose = () => {
     setSelectedValue(initialValue);
@@ -111,11 +131,7 @@ const ProjectSummaryProjectECapris = ({
               value={selectedValue}
               sx={fieldSelectItem}
               options={options}
-              getOptionLabel={(e) =>
-                e?.["ecapris_subproject_id"] && e?.["subproject_name"]
-                  ? `${e["ecapris_subproject_id"]} - ${e["subproject_name"]}`
-                  : ""
-              } // Display subproject name in dropdown to provide more context for user when selecting
+              getOptionLabel={(e) => formatOptionLabel(e)} // Display subproject name in dropdown to provide more context for user when selecting
               isOptionEqualToValue={(option, value) =>
                 option?.["ecapris_subproject_id"] ===
                 value?.["ecapris_subproject_id"]
@@ -172,7 +188,9 @@ const ProjectSummaryProjectECapris = ({
             sx={!eCaprisSubprojectId ? { flex: 1 } : {}} // Grow hoverable input to fill space if missing eCAPRIS id & copy button
           >
             <ProjectSummaryLabel
-              text={eCaprisSubprojectId ? eCaprisSubprojectId : ""}
+              text={formatOptionLabel(
+                findOptionById(eCaprisSubprojectId) ?? { ecapris_subproject_id: eCaprisSubprojectId }
+              )}
               onClickEdit={() => {
                 if (disabled) return;
                 setEditMode(true);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -67,7 +67,6 @@ const ProjectSummaryProjectECapris = ({
   const { user } = useUser();
   const userEmail = user?.idToken?.payload?.email;
 
-  // Display subproject name in summary view if available
   const initialValue = eCaprisSubprojectId
     ? findOptionById(options, eCaprisSubprojectId)
     : null;
@@ -190,6 +189,7 @@ const ProjectSummaryProjectECapris = ({
             sx={!eCaprisSubprojectId ? { flex: 1 } : {}} // Grow hoverable input to fill space if missing eCAPRIS id & copy button
           >
             <ProjectSummaryLabel
+              // Display subproject name in summary view if available
               text={formatOptionLabel(
                 findOptionById(options, eCaprisSubprojectId) ?? {
                   ecapris_subproject_id: eCaprisSubprojectId,

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -27,6 +27,7 @@ export const findOptionById = (options, id) => {
   return options?.find((option) => option?.ecapris_subproject_id === id);
 };
 
+// Get option label for autocomplete display
 export const getOptionLabel = (option) => {
   return option
     ? `${option.ecapris_subproject_id} - ${option.subproject_name}`

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";
@@ -27,13 +27,21 @@ export const findOptionById = (options, id) => {
   return options?.find((option) => option?.ecapris_subproject_id === id);
 };
 
-// Format option label to include subproject name if available
-export const formatOptionLabel = (option) => {
-  if (!option) return "";
-  const id = option?.ecapris_subproject_id ?? "";
-  const name = option?.subproject_name ?? "";
-  return name ? `${id} - ${name}` : id;
-};
+// Memoized formatter to avoid recomputing labels repeatedly
+const useFormatOptionLabel = () =>
+  useMemo(() => {
+    const cache = new Map();
+    return (option) => {
+      if (!option) return "";
+      const id = option?.ecapris_subproject_id ?? "";
+      const name = option?.subproject_name ?? "";
+      const key = `${id}|${name}`;
+      if (cache.has(key)) return cache.get(key);
+      const label = name ? `${id} - ${name}` : id;
+      cache.set(key, label);
+      return label;
+    };
+  }, []);
 
 /**
  * ProjectSummaryProjectECapris Component
@@ -112,6 +120,8 @@ const ProjectSummaryProjectECapris = ({
         );
       });
   };
+
+  const formatOptionLabel = useFormatOptionLabel();
 
   return (
     <Grid2 size={12} sx={fieldGridItem}>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -68,7 +68,9 @@ const ProjectSummaryProjectECapris = ({
   const userEmail = user?.idToken?.payload?.email;
 
   const initialValue = eCaprisSubprojectId
-    ? findOptionById(options, eCaprisSubprojectId)
+    ? (findOptionById(options, eCaprisSubprojectId) ?? {
+        ecapris_subproject_id: eCaprisSubprojectId,
+      })
     : null;
 
   const [editMode, setEditMode] = useState(false);
@@ -190,11 +192,11 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               // Display subproject name in summary view if available
-              text={
-                formatOptionLabel(
-                  findOptionById(options, eCaprisSubprojectId)
-                ) ?? findOptionById(options, eCaprisSubprojectId)
-              }
+              text={formatOptionLabel(
+                findOptionById(options, eCaprisSubprojectId) ?? {
+                  ecapris_subproject_id: eCaprisSubprojectId,
+                }
+              )}
               onClickEdit={() => {
                 if (disabled) return;
                 setEditMode(true);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState, useEffect } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";
@@ -21,6 +21,19 @@ import {
   PROJECT_UPDATE_ECAPRIS_SUBPROJECT_ID,
   PROJECT_CLEAR_ECAPRIS_SUBPROJECT_ID,
 } from "src/queries/project";
+
+// Find full option object by id
+export const findOptionById = (options, id) => {
+  return options?.find((option) => option?.ecapris_subproject_id === id);
+};
+
+// Format option label to include subproject name if available
+export const formatOptionLabel = (option) => {
+  if (!option) return "";
+  const id = option?.ecapris_subproject_id ?? "";
+  const name = option?.subproject_name ?? "";
+  return name ? `${id} - ${name}` : id;
+};
 
 /**
  * ProjectSummaryProjectECapris Component
@@ -46,22 +59,9 @@ const ProjectSummaryProjectECapris = ({
   const { user } = useUser();
   const userEmail = user?.idToken?.payload?.email;
 
-  // Find full option object by id and format option labels
-  const findOptionById = useCallback((id) => {
-    return options?.find((option) => option?.ecapris_subproject_id === id);
-  }, [options]);
-
-  // Format option label to include subproject name if available
-  const formatOptionLabel = (option) => {
-    if (!option) return "";
-    const id = option?.ecapris_subproject_id ?? "";
-    const name = option?.subproject_name ?? "";
-    return name ? `${id} - ${name}` : id;
-  };
-
   // Display subproject name in summary view if available
   const initialValue = eCaprisSubprojectId
-    ? findOptionById(eCaprisSubprojectId)
+    ? findOptionById(options, eCaprisSubprojectId)
     : null;
 
   const [editMode, setEditMode] = useState(false);
@@ -181,7 +181,7 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               text={formatOptionLabel(
-                findOptionById(eCaprisSubprojectId) ?? {
+                findOptionById(options, eCaprisSubprojectId) ?? {
                   ecapris_subproject_id: eCaprisSubprojectId,
                 }
               )}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -181,7 +181,6 @@ const ProjectSummaryProjectECapris = ({
             sx={!eCaprisSubprojectId ? { flex: 1 } : {}} // Grow hoverable input to fill space if missing eCAPRIS id & copy button
           >
             <ProjectSummaryLabel
-              // Display subproject name in summary view if available
               text={eCaprisSubprojectId ? eCaprisSubprojectId : ""}
               onClickEdit={() => {
                 if (disabled) return;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";
@@ -47,8 +47,9 @@ const ProjectSummaryProjectECapris = ({
   const userEmail = user?.idToken?.payload?.email;
 
   // Find full option object by id and format option labels
-  const findOptionById = (id) =>
-    options?.find((option) => option?.ecapris_subproject_id === id);
+  const findOptionById = useCallback((id) => {
+    return options?.find((option) => option?.ecapris_subproject_id === id);
+  }, [options]);
 
   // Format option label to include subproject name if available
   const formatOptionLabel = (option) => {

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -27,21 +27,11 @@ export const findOptionById = (options, id) => {
   return options?.find((option) => option?.ecapris_subproject_id === id);
 };
 
-// Memoized formatter to avoid recomputing labels repeatedly
-const useFormatOptionLabel = () =>
-  useMemo(() => {
-    const cache = new Map();
-    return (option) => {
-      if (!option) return "";
-      const id = option?.ecapris_subproject_id ?? "";
-      const name = option?.subproject_name ?? "";
-      const key = `${id}|${name}`;
-      if (cache.has(key)) return cache.get(key);
-      const label = name ? `${id} - ${name}` : id;
-      cache.set(key, label);
-      return label;
-    };
-  }, []);
+export const getOptionLabel = (option) => {
+  return option
+    ? `${option.ecapris_subproject_id} - ${option.subproject_name}`
+    : "";
+};
 
 /**
  * ProjectSummaryProjectECapris Component
@@ -122,8 +112,6 @@ const ProjectSummaryProjectECapris = ({
       });
   };
 
-  const formatOptionLabel = useFormatOptionLabel();
-
   return (
     <Grid2 size={12} sx={fieldGridItem}>
       <Typography sx={fieldLabel}>eCAPRIS subproject ID</Typography>
@@ -135,7 +123,7 @@ const ProjectSummaryProjectECapris = ({
               sx={fieldSelectItem}
               options={options}
               getOptionLabel={(e) =>
-                e?.["ecapris_subproject_id"] ? formatOptionLabel(e) : ""
+                e?.["ecapris_subproject_id"] ? getOptionLabel(e) : ""
               }
               isOptionEqualToValue={(option, value) =>
                 option?.["ecapris_subproject_id"] ===
@@ -194,15 +182,7 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               // Display subproject name in summary view if available
-              text={
-                eCaprisSubprojectId
-                  ? formatOptionLabel(
-                      findOptionById(options, eCaprisSubprojectId) ?? {
-                        ecapris_subproject_id: eCaprisSubprojectId,
-                      }
-                    )
-                  : ""
-              }
+              text={eCaprisSubprojectId ? eCaprisSubprojectId : ""}
               onClickEdit={() => {
                 if (disabled) return;
                 setEditMode(true);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -58,6 +58,7 @@ const ProjectSummaryProjectECapris = ({
     return name ? `${id} - ${name}` : id;
   };
 
+  // Display subproject name in summary view if available
   const initialValue = eCaprisSubprojectId
     ? findOptionById(eCaprisSubprojectId)
     : null;

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -190,11 +190,11 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               // Display subproject name in summary view if available
-              text={formatOptionLabel(
-                findOptionById(options, eCaprisSubprojectId) ?? {
-                  ecapris_subproject_id: eCaprisSubprojectId,
-                }
-              )}
+              text={
+                formatOptionLabel(
+                  findOptionById(options, eCaprisSubprojectId)
+                ) ?? findOptionById(options, eCaprisSubprojectId)
+              }
               onClickEdit={() => {
                 if (disabled) return;
                 setEditMode(true);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -50,7 +50,7 @@ const ProjectSummaryProjectECapris = ({
   const findOptionById = (id) =>
     options?.find((option) => option?.ecapris_subproject_id === id);
 
-  // Format option label to include subproject name if available to provide more context for user when selecting an eCAPRIS subproject ID
+  // Format option label to include subproject name if available
   const formatOptionLabel = (option) => {
     if (!option) return "";
     const id = option?.ecapris_subproject_id ?? "";

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import ProjectSummaryIconButtons from "src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons";
 import ProjectSummaryLabel from "src/views/projects/projectView/ProjectSummary/ProjectSummaryLabel";
 import CopyTextButton from "src/components/CopyTextButton";

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -194,11 +194,15 @@ const ProjectSummaryProjectECapris = ({
           >
             <ProjectSummaryLabel
               // Display subproject name in summary view if available
-              text={formatOptionLabel(
-                findOptionById(options, eCaprisSubprojectId) ?? {
-                  ecapris_subproject_id: eCaprisSubprojectId,
-                }
-              )}
+              text={
+                eCaprisSubprojectId
+                  ? formatOptionLabel(
+                      findOptionById(options, eCaprisSubprojectId) ?? {
+                        ecapris_subproject_id: eCaprisSubprojectId,
+                      }
+                    )
+                  : ""
+              }
               onClickEdit={() => {
                 if (disabled) return;
                 setEditMode(true);

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectECapris.js
@@ -65,7 +65,7 @@ const ProjectSummaryProjectECapris = ({
     : null;
 
   const [editMode, setEditMode] = useState(false);
-  const [selectedValue, setSelectedValue] = useState(initialValue);
+  const [selectedValue, setSelectedValue] = useState(null);
   // Capture input value to include in service request if user encounters missing eCAPRIS subproject ID in options list
   const [inputValue, setInputValue] = useState("");
 
@@ -78,7 +78,7 @@ const ProjectSummaryProjectECapris = ({
   );
 
   const handleFieldClose = () => {
-    setSelectedValue(initialValue);
+    setSelectedValue(null);
     setInputValue("");
     setEditMode(false);
   };
@@ -103,7 +103,7 @@ const ProjectSummaryProjectECapris = ({
       })
       .catch((error) => {
         setEditMode(false);
-        setSelectedValue(initialValue);
+        setSelectedValue(null);
         handleSnackbar(
           true,
           "Error updating eCAPRIS subproject ID",
@@ -184,8 +184,9 @@ const ProjectSummaryProjectECapris = ({
             <ProjectSummaryLabel
               text={eCaprisSubprojectId ? eCaprisSubprojectId : ""}
               onClickEdit={() => {
-                if (disabled) return;
+                if (disabled || loading) return;
                 setEditMode(true);
+                setSelectedValue(initialValue);
               }}
               sxProp={disabled ? fieldLabelTextNoHover : fieldLabelText}
             />

--- a/moped-etl/ecapris-funding/ecapris_funding_sync.py
+++ b/moped-etl/ecapris-funding/ecapris_funding_sync.py
@@ -66,6 +66,7 @@ def main(args):
                 "updated_by_user_id": 1,
                 "fdu_status": record.get("fdu_status"),
                 "bond_year": record.get("bond_year"),
+                "subproject_name": record.get("sp_name"),
             }
         )
 

--- a/moped-etl/ecapris-funding/process/queries.py
+++ b/moped-etl/ecapris-funding/process/queries.py
@@ -16,7 +16,7 @@ GRAPHQL_QUERIES = {
     "project_funding_upsert": """
     mutation UpsertEcaprisFunding($objects: [ecapris_subproject_funding_insert_input!]!) {
         insert_ecapris_subproject_funding(objects: $objects, on_conflict: {constraint: ecapris_subproject_funding_fao_id_key, 
-        update_columns: [app, unit_long_name, subprogram, program, bond_year, ecapris_subproject_id, fdu_status]}) {
+        update_columns: [app, unit_long_name, subprogram, program, bond_year, subproject_name, ecapris_subproject_id, fdu_status]}) {
             returning {
                 fao_id
                 ecapris_subproject_id


### PR DESCRIPTION
## Associated issues
closes https://github.com/cityofaustin/atd-data-tech/issues/27565

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
local

**Steps to test:**
- run migrations
- run ETL script updates in `moped-etl\ecapris-funding`
- go to a project summary page, open the eCapris Subproject ID dropbox and note that the autocomplete now shows the eCapris Subproject ID followed by a dash and the subproject name
- select a new option and save to confirm the mutation runs properly

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test: "Select a eCAPRIS subproject id from the dropdown **that should show both id and subproject name in the options**, and check that you can copy and paste a link to the eCAPRIS subproject page in another browser tab." 