### PR TITLE
Attach new files to Moped funding records 

### DIFF
--- a/moped-database/metadata/databases/default/tables/public_combined_project_funding_view.yaml
+++ b/moped-database/metadata/databases/default/tables/public_combined_project_funding_view.yaml
@@ -12,6 +12,15 @@ array_relationships:
         remote_table:
           name: files_ecapris_funding
           schema: public
+  - name: moped_funding_files
+    using:
+      manual_configuration:
+        column_mapping:
+          original_id: entity_id
+        insertion_order: null
+        remote_table:
+          name: files_project_funding
+          schema: public
 select_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
+++ b/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
@@ -1,3 +1,52 @@
 table:
   name: files_project_funding
   schema: public
+insert_permissions:
+  - role: moped-admin
+    permission:
+      check: {}
+      columns:
+        - created_at
+        - entity_id
+        - file_id
+        - updated_at
+    comment: ""
+  - role: moped-editor
+    permission:
+      check: {}
+      columns:
+        - created_at
+        - entity_id
+        - file_id
+        - updated_at
+    comment: ""
+select_permissions:
+  - role: moped-admin
+    permission:
+      columns:
+        - created_at
+        - entity_id
+        - file_id
+        - id
+        - updated_at
+      filter: {}
+    comment: ""
+  - role: moped-editor
+    permission:
+      columns:
+        - created_at
+        - entity_id
+        - file_id
+        - id
+        - updated_at
+      filter: {}
+    comment: ""
+delete_permissions:
+  - role: moped-admin
+    permission:
+      filter: {}
+    comment: ""
+  - role: moped-editor
+    permission:
+      filter: {}
+    comment: ""

--- a/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
+++ b/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
@@ -1,0 +1,3 @@
+table:
+  name: files_project_funding
+  schema: public

--- a/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
+++ b/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
@@ -1,6 +1,10 @@
 table:
   name: files_project_funding
   schema: public
+object_relationships:
+  - name: moped_project_file
+    using:
+      foreign_key_constraint_on: file_id
 insert_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
+++ b/moped-database/metadata/databases/default/tables/public_files_project_funding.yaml
@@ -9,6 +9,9 @@ insert_permissions:
   - role: moped-admin
     permission:
       check: {}
+      set:
+        created_by_user_id: x-hasura-user-db-id
+        updated_by_user_id: x-hasura-user-db-id
       columns:
         - created_at
         - entity_id
@@ -18,6 +21,9 @@ insert_permissions:
   - role: moped-editor
     permission:
       check: {}
+      set:
+        created_by_user_id: x-hasura-user-db-id
+        updated_by_user_id: x-hasura-user-db-id
       columns:
         - created_at
         - entity_id

--- a/moped-database/metadata/databases/default/tables/public_moped_project_files.yaml
+++ b/moped-database/metadata/databases/default/tables/public_moped_project_files.yaml
@@ -16,6 +16,13 @@ array_relationships:
         table:
           name: files_ecapris_funding
           schema: public
+  - name: files_project_fundings
+    using:
+      foreign_key_constraint_on:
+        column: file_id
+        table:
+          name: files_project_funding
+          schema: public
 insert_permissions:
   - role: moped-admin
     permission:

--- a/moped-database/metadata/databases/default/tables/tables.yaml
+++ b/moped-database/metadata/databases/default/tables/tables.yaml
@@ -18,6 +18,7 @@
 - "!include public_features.yaml"
 - "!include public_features_council_districts.yaml"
 - "!include public_files_ecapris_funding.yaml"
+- "!include public_files_project_funding.yaml"
 - "!include public_layer_council_district.yaml"
 - "!include public_moped_activity_log.yaml"
 - "!include public_moped_component_tags.yaml"

--- a/moped-database/migrations/default/1776441267959_funding-file-attach/down.sql
+++ b/moped-database/migrations/default/1776441267959_funding-file-attach/down.sql
@@ -1,1 +1,1 @@
-DROP TABLE public.files_ecapris_funding;
+DROP TABLE public.files_project_funding;

--- a/moped-database/migrations/default/1776441267959_funding-file-attach/down.sql
+++ b/moped-database/migrations/default/1776441267959_funding-file-attach/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE public.files_ecapris_funding;

--- a/moped-database/migrations/default/1776441267959_funding-file-attach/up.sql
+++ b/moped-database/migrations/default/1776441267959_funding-file-attach/up.sql
@@ -1,7 +1,7 @@
 -- Create join table to link Moped projects, moped project funding rows, and Moped project files
 CREATE TABLE public.files_project_funding (
     id SERIAL PRIMARY KEY,
-    project_id int4 NOT NULL REFERENCES public.moped_project(project_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    entity_id int4 NOT NULL REFERENCES public.moped_proj_funding(proj_funding_id) ON DELETE RESTRICT ON UPDATE CASCADE,
     file_id int4 NOT NULL REFERENCES public.moped_project_files(project_file_id) ON DELETE RESTRICT ON UPDATE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -9,8 +9,8 @@ CREATE TABLE public.files_project_funding (
     updated_by_user_id int4 NOT NULL REFERENCES moped_users (user_id) ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
-COMMENT ON TABLE public.files_project_funding IS 'Join table to link Moped projects, Moped funding rows, and Moped project files to create funding file attachments.';
-COMMENT ON COLUMN public.files_project_funding.project_id IS 'References the Moped project to which the file attachment belongs.';
+COMMENT ON TABLE public.files_project_funding IS 'Join table to link Moped funding rows and Moped project files to create funding file attachments.';
+COMMENT ON COLUMN public.files_project_funding.entity_id IS 'References the Moped project funding record to which the file attachment belongs.';
 COMMENT ON COLUMN public.files_project_funding.file_id IS 'References the file that is attached to the moped funding row.';
 COMMENT ON COLUMN public.files_project_funding.created_at IS 'Timestamp for when the record was created.';
 COMMENT ON COLUMN public.files_project_funding.updated_at IS 'Timestamp for when the record was last updated.';

--- a/moped-database/migrations/default/1776441267959_funding-file-attach/up.sql
+++ b/moped-database/migrations/default/1776441267959_funding-file-attach/up.sql
@@ -1,0 +1,18 @@
+-- Create join table to link Moped projects, moped project funding rows, and Moped project files
+CREATE TABLE public.files_project_funding (
+    id SERIAL PRIMARY KEY,
+    project_id int4 NOT NULL REFERENCES public.moped_project(project_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    file_id int4 NOT NULL REFERENCES public.moped_project_files(project_file_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by_user_id int4 NOT NULL REFERENCES moped_users (user_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    updated_by_user_id int4 NOT NULL REFERENCES moped_users (user_id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE public.files_project_funding IS 'Join table to link Moped projects, Moped funding rows, and Moped project files to create funding file attachments.';
+COMMENT ON COLUMN public.files_project_funding.project_id IS 'References the Moped project to which the file attachment belongs.';
+COMMENT ON COLUMN public.files_project_funding.file_id IS 'References the file that is attached to the moped funding row.';
+COMMENT ON COLUMN public.files_project_funding.created_at IS 'Timestamp for when the record was created.';
+COMMENT ON COLUMN public.files_project_funding.updated_at IS 'Timestamp for when the record was last updated.';
+COMMENT ON COLUMN public.files_project_funding.created_by_user_id IS 'References the user who created the file attachment record.';
+COMMENT ON COLUMN public.files_project_funding.updated_by_user_id IS 'References the user who last updated the file attachment record.';

--- a/moped-editor/src/queries/funding.js
+++ b/moped-editor/src/queries/funding.js
@@ -33,6 +33,14 @@ export const COMBINED_FUNDING_QUERY = gql`
           file_name
         }
       }
+      moped_funding_files {
+        moped_project_file {
+          project_file_id
+          file_url
+          file_key
+          file_name
+        }
+      }
     }
     moped_fund_sources(where: { is_deleted: { _eq: false } }) {
       funding_source_id

--- a/moped-editor/src/queries/project.js
+++ b/moped-editor/src/queries/project.js
@@ -738,6 +738,36 @@ export const DELETE_FILE_ECAPRIS_FUNDING_ATTACHMENT = gql`
   }
 `;
 
+export const CREATE_FILE_MOPED_FUNDING_ATTACHMENT = gql`
+  mutation InsertFileWithMopedFundingConnection(
+    $object: moped_project_files_insert_input!
+  ) {
+    insert_moped_project_files_one(object: $object) {
+      project_file_id
+      files_project_fundings {
+        id
+      }
+    }
+  }
+`;
+
+export const DELETE_FILE_MOPED_FUNDING_ATTACHMENT = gql`
+  mutation DeleteFileProjectFunding(
+    $fileId: Int!
+    $entityId: Int!
+  ) {
+    delete_files_project_funding(
+      where: {
+        file_id: { _eq: $fileId }
+        entity_id: { _eq: $entityId }
+      }
+    ) {
+      affected_rows
+    }
+  }
+`;
+
+
 export const PROJECT_ARCHIVE = gql`
   mutation ArchiveMopedProject($projectId: Int!) {
     update_moped_project(

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -36,7 +36,10 @@ const ProjectFundingFilesAttachmentDialog = ({
   dataLookups,
   rows,
 }) => {
-  const fundingRecord = rows.find((row) => row.id === fileAttachmentId); // should i memoize this
+  const fundingRecord = useMemo(
+    () => rows.find((row) => row.id === fileAttachmentId),
+    [rows, fileAttachmentId]
+  );
   const isSyncedFromECapris = fundingRecord.is_synced_from_ecapris;
   const [addFundingFileAttachment] = useMutation(
     isSyncedFromECapris

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -53,12 +53,12 @@ const ProjectFundingFilesAttachmentDialog = ({
     useState(null);
 
   const filesAttachedToId = useMemo(() => {
-    const filename = isSyncedFromECapris
+    const filesType  = isSyncedFromECapris
       ? "ecapris_funding_files"
       : "moped_funding_files";
     const filesAttachedToId = rows
       .find((row) => row.id === fileAttachmentId)
-      ?.[filename].map((file_record) => file_record.moped_project_file);
+      ?.[filesType].map((file_record) => file_record.moped_project_file);
 
     return filesAttachedToId ? filesAttachedToId : [];
   }, [fileAttachmentId, rows]);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -37,7 +37,6 @@ const ProjectFundingFilesAttachmentDialog = ({
   rows,
 }) => {
   const fundingRecord = rows.find((row) => row.id === fileAttachmentId); // should i memoize this
-  console.log(fundingRecord);
   const isSyncedFromECapris = fundingRecord.is_synced_from_ecapris;
   const [addFundingFileAttachment] = useMutation(
     isSyncedFromECapris
@@ -65,7 +64,6 @@ const ProjectFundingFilesAttachmentDialog = ({
 
   const handleClickSaveFile = (fileDataBundle) => {
     const entityId = fundingRecord?.proj_funding_id;
-    console.log(entityId);
     const fileConnectionData = isSyncedFromECapris
       ? {
           files_ecapris_fundings: {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -53,11 +53,12 @@ const ProjectFundingFilesAttachmentDialog = ({
     useState(null);
 
   const filesAttachedToId = useMemo(() => {
+    const filename = isSyncedFromECapris
+      ? "ecapris_funding_files"
+      : "moped_funding_files";
     const filesAttachedToId = rows
       .find((row) => row.id === fileAttachmentId)
-      ?.ecapris_funding_files.map(
-        (file_record) => file_record.moped_project_file
-      );
+      ?.[filename].map((file_record) => file_record.moped_project_file);
 
     return filesAttachedToId ? filesAttachedToId : [];
   }, [fileAttachmentId, rows]);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -5,6 +5,8 @@ import { Box, Divider, IconButton, Typography, Stack } from "@mui/material";
 import {
   CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT,
   DELETE_FILE_ECAPRIS_FUNDING_ATTACHMENT,
+  CREATE_FILE_MOPED_FUNDING_ATTACHMENT,
+  DELETE_FILE_MOPED_FUNDING_ATTACHMENT,
 } from "src/queries/project";
 
 import FileUploadDialogSingle from "src/components/FileUpload/FileUploadDialogSingle";
@@ -34,11 +36,18 @@ const ProjectFundingFilesAttachmentDialog = ({
   dataLookups,
   rows,
 }) => {
+  const fundingRecord = rows.find((row) => row.id === fileAttachmentId); // should i memoize this
+  console.log(fundingRecord);
+  const isSyncedFromECapris = fundingRecord.is_synced_from_ecapris;
   const [addFundingFileAttachment] = useMutation(
-    CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT
+    isSyncedFromECapris
+      ? CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT
+      : CREATE_FILE_MOPED_FUNDING_ATTACHMENT
   );
   const [detachFundingFileAttachment] = useMutation(
-    DELETE_FILE_ECAPRIS_FUNDING_ATTACHMENT
+    isSyncedFromECapris
+      ? DELETE_FILE_ECAPRIS_FUNDING_ATTACHMENT
+      : DELETE_FILE_MOPED_FUNDING_ATTACHMENT
   );
   const [detachConfirmationFileId, setDetachConfirmationFileId] =
     useState(null);
@@ -54,8 +63,24 @@ const ProjectFundingFilesAttachmentDialog = ({
   }, [fileAttachmentId, rows]);
 
   const handleClickSaveFile = (fileDataBundle) => {
-    const fundingRecord = rows.find((row) => row.id === fileAttachmentId);
     const entityId = fundingRecord?.proj_funding_id;
+    console.log(entityId);
+    const fileConnectionData = isSyncedFromECapris
+      ? {
+          files_ecapris_fundings: {
+            data: {
+              project_id: projectId,
+              entity_id: entityId,
+            },
+          },
+        }
+      : {
+          files_project_fundings: {
+            data: {
+              entity_id: entityId,
+            },
+          },
+        };
 
     addFundingFileAttachment({
       variables: {
@@ -67,12 +92,7 @@ const ProjectFundingFilesAttachmentDialog = ({
           file_key: fileDataBundle?.key,
           file_size: fileDataBundle?.file?.fileSize ?? 0,
           file_url: fileDataBundle?.url,
-          files_ecapris_fundings: {
-            data: {
-              project_id: projectId,
-              entity_id: entityId,
-            },
-          },
+          ...fileConnectionData,
         },
       },
     })

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -60,7 +60,7 @@ const ProjectFundingFilesAttachmentDialog = ({
       ?.[filesType].map((file_record) => file_record.moped_project_file);
 
     return filesAttachedToId ? filesAttachedToId : [];
-  }, [fileAttachmentId, rows]);
+  }, [fileAttachmentId, rows, isSyncedFromECapris]);
 
   const handleClickSaveFile = (fileDataBundle) => {
     const entityId = fundingRecord?.proj_funding_id;

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -52,7 +52,7 @@ const ProjectFundingFilesAttachmentDialog = ({
     useState(null);
 
   const filesAttachedToId = useMemo(() => {
-    const filesType  = isSyncedFromECapris
+    const filesType = isSyncedFromECapris
       ? "ecapris_funding_files"
       : "moped_funding_files";
     const filesAttachedToId = rows

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -40,7 +40,7 @@ const ProjectFundingFilesAttachmentDialog = ({
     () => rows.find((row) => row.id === fileAttachmentId),
     [rows, fileAttachmentId]
   );
-  const isSyncedFromECapris = fundingRecord.is_synced_from_ecapris;
+  const isSyncedFromECapris = fundingRecord?.is_synced_from_ecapris ?? false;
   const [addFundingFileAttachment] = useMutation(
     isSyncedFromECapris
       ? CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -216,7 +216,6 @@ const ProjectFundingTable = ({
         isNew: true,
         proj_funding_id: id,
         is_manual: true,
-        ecapris_funding_files: [],
       },
       ...oldRows,
     ]);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -320,9 +320,12 @@ export const useColumns = ({
         editable: false,
         sortable: false,
         renderCell: ({ row }) => {
+          const filesType = row.is_synced_from_ecapris
+            ? "ecapris_funding_files"
+            : "moped_funding_files";
           return (
             <Stack direction="column" spacing={0.5}>
-              {row.ecapris_funding_files.map((file_record, index) => {
+              {row?.[filesType].map((file_record, index) => {
                 const file = file_record.moped_project_file;
 
                 if (!file) return null;

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -323,6 +323,9 @@ export const useColumns = ({
           const filesType = row.is_synced_from_ecapris
             ? "ecapris_funding_files"
             : "moped_funding_files";
+          if (!row?.[filesType]) {
+            return;
+          }
           return (
             <Stack direction="column" spacing={0.5}>
               {row?.[filesType].map((file_record, index) => {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -368,6 +368,7 @@ export const useColumns = ({
               handleDeleteOpen={handleDeleteOpen}
               handleSaveClick={handleSaveClick}
               handleEditClick={handleEditClick}
+              handleFileAttachmentClick={handleFileAttachmentClick}
               editDisabled={row.is_synced_from_ecapris}
               deleteDisabled={row.is_synced_from_ecapris}
             />


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27483

## Testing
**URL to test:** 
test locally, use prod data

**Steps to test:**

This PR builds off of the work in https://github.com/cityofaustin/atd-moped/pull/1820

1. Open a project (or create a new one)
2. Navigate to the funding table. Select an eCAPRIS subproject id like `10553.009`
3. Like the previous PR, you see funding rows, paperclip icons and Files column. 
4. Now either add another funding row (not imported from eCAPRIS) or edit an existing row so the record is not synced from eCAPRIS.

5. Click the paperclip to open the attachment dialog. 
6. Toggle the link to file switch and enter a name, type, description and a drive path or link. 

7. You can see the file in the files column of this table, also go to the Files tab and see it there as well. 

8. use your db client to confirm that this record is in the correct table.

```sql
select * from files_project_funding fpf 
```

9. Click the paperclip to open the attached files dialog again. Now unlink the file. 
The file is still on the Files tab but is no longer on the funding table. 




---
#### Ship list
- [ ] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Added items to launch checklist in https://github.com/cityofaustin/atd-moped/pull/1820
