### PR TITLE
Prevent out of range error in dollar fields

### DIFF
--- a/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
+++ b/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
@@ -65,7 +65,8 @@ const LookupAutocompleteComponent = ({
           id,
           field: field.fieldName,
           value: field.setFieldValue(newValue),
-          debounceMs: 200
+          // multiple fields being updated and potentially validated, debounce helps prevent race conditions
+          debounceMs: 100
         });
       });
     }

--- a/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
+++ b/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
@@ -52,23 +52,21 @@ const LookupAutocompleteComponent = ({
     }
   }, [open, refetch]);
 
-  const handleChange = (event, newValue) => {
-    apiRef.current.setEditCellValue({
+  const handleChange = async (event, newValue) => {
+    await apiRef.current.setEditCellValue({
       id,
       field,
       value: newValue,
     });
 
     if (dependentFieldsArray && dependentFieldsArray.length > 0) {
-      dependentFieldsArray.forEach((field) => {
-        apiRef.current.setEditCellValue({
+      for (const field of dependentFieldsArray) {
+        await apiRef.current.setEditCellValue({
           id,
           field: field.fieldName,
           value: field.setFieldValue(newValue),
-          // multiple fields being updated and potentially validated, debounce helps prevent race conditions
-          debounceMs: 100
         });
-      });
+      }
     }
   };
 

--- a/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
+++ b/moped-editor/src/components/DataGridPro/LookupAutocompleteComponent.js
@@ -65,6 +65,7 @@ const LookupAutocompleteComponent = ({
           id,
           field: field.fieldName,
           value: field.setFieldValue(newValue),
+          debounceMs: 200
         });
       });
     }

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -24,3 +24,5 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
  * @return {String} Number string with only 0-9 integer characters
  */
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
+
+export const isAmountOutOfRange = number => number >= 2_147_483_647;

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -25,4 +25,5 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
  */
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
 
+// check if number exceeds the maximum number that can be saved in the db
 export const isAmountOutOfRange = (number) => number >= 2_147_483_647;

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -25,4 +25,4 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
  */
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
 
-export const isAmountOutOfRange = number => number >= 2_147_483_647;
+export const isAmountOutOfRange = (number) => number >= 2_147_483_647;

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -26,6 +26,7 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
 
 export const INT_4_MAX = 2_147_483_647;
+export const outOfRangeErrorMessage = "Amount is out of range";
 
 // check if number exceeds the maximum number that can be saved in the db
 export const isAmountOutOfRange = (number) => {

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -25,5 +25,7 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
  */
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
 
+export const INT_4_MAX = 2_147_483_647
+
 // check if number exceeds the maximum number that can be saved in the db
-export const isAmountOutOfRange = (number) => number >= 2_147_483_647;
+export const isAmountOutOfRange = (number) => number >= INT_4_MAX;

--- a/moped-editor/src/utils/numberFormatters.js
+++ b/moped-editor/src/utils/numberFormatters.js
@@ -25,7 +25,12 @@ export const removeDecimalsAndTrailingNumbers = (number) =>
  */
 export const removeNonIntegers = (number) => number.replace(/[^0-9]/g, "");
 
-export const INT_4_MAX = 2_147_483_647
+export const INT_4_MAX = 2_147_483_647;
 
 // check if number exceeds the maximum number that can be saved in the db
-export const isAmountOutOfRange = (number) => number >= INT_4_MAX;
+export const isAmountOutOfRange = (number) => {
+  if (number === null) {
+    return false;
+  }
+  return Number(number) >= INT_4_MAX;
+};

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -3,6 +3,7 @@ import { TextField } from "@mui/material";
 import {
   removeDecimalsAndTrailingNumbers,
   removeNonIntegers,
+  isAmountOutOfRange,
 } from "src/utils/numberFormatters";
 import { useGridApiContext } from "@mui/x-data-grid-pro";
 
@@ -14,9 +15,11 @@ import { useGridApiContext } from "@mui/x-data-grid-pro";
  * @param {String} field - name of field
  * @return {JSX.Element}
  */
-const DollarAmountIntegerField = ({ id, value, field, hasFocus }) => {
+const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
   const apiRef = useGridApiContext();
   const ref = React.useRef(null);
+
+  console.log(error)
 
   React.useEffect(() => {
     if (hasFocus) {
@@ -24,7 +27,7 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus }) => {
     }
   }, [hasFocus]);
 
-  const handleChange = (event, newValue) => {
+  const handleChange = (event) => {
     const { value: inputValue } = event.target;
 
     // First, remove decimal point and trailing characters onChange to handle pasted numbers
@@ -43,7 +46,7 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus }) => {
   return (
     <TextField
       variant="standard"
-      style={{ width: "80px" }}
+      style={{ minWidth: "80px" }}
       id="funding_amount"
       inputRef={ref}
       name="funding_amount"
@@ -51,6 +54,8 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus }) => {
       inputMode="numeric"
       value={value ?? ""}
       onChange={handleChange}
+      error={error}
+      helperText={isAmountOutOfRange(value) ?  "Value is out of range" : null}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -19,8 +19,6 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
   const apiRef = useGridApiContext();
   const ref = React.useRef(null);
 
-  console.log(error)
-
   React.useEffect(() => {
     if (hasFocus) {
       ref.current.focus();
@@ -55,7 +53,7 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
       value={value ?? ""}
       onChange={handleChange}
       error={error}
-      helperText={isAmountOutOfRange(value) ?  "Value is out of range" : null}
+      helperText={error ? "Value is out of range" : null}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -3,7 +3,6 @@ import { TextField } from "@mui/material";
 import {
   removeDecimalsAndTrailingNumbers,
   removeNonIntegers,
-  isAmountOutOfRange,
 } from "src/utils/numberFormatters";
 import { useGridApiContext } from "@mui/x-data-grid-pro";
 

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -14,7 +14,7 @@ import { useGridApiContext } from "@mui/x-data-grid-pro";
  * @param {String} field - name of field
  * @return {JSX.Element}
  */
-const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
+const DollarAmountIntegerField = (props, { id, value, field, hasFocus, error }) => {
   const apiRef = useGridApiContext();
   const ref = React.useRef(null);
 
@@ -24,14 +24,19 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
     }
   }, [hasFocus]);
 
-  const handleChange = (event) => {
+  console.log(id, value, field, props);
+
+  const handleChange = (event, newValue) => {
     const { value: inputValue } = event.target;
+    console.log(newValue);
 
     // First, remove decimal point and trailing characters onChange to handle pasted numbers
     const valueWithoutDecimals = removeDecimalsAndTrailingNumbers(inputValue);
 
     // Then, remove all non-integers
     const valueWithIntegersOnly = removeNonIntegers(valueWithoutDecimals);
+
+    console.log(apiRef)
 
     apiRef.current.setEditCellValue({
       id,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -14,7 +14,7 @@ import { useGridApiContext } from "@mui/x-data-grid-pro";
  * @param {String} field - name of field
  * @return {JSX.Element}
  */
-const DollarAmountIntegerField = (props, { id, value, field, hasFocus, error }) => {
+const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
   const apiRef = useGridApiContext();
   const ref = React.useRef(null);
 
@@ -24,19 +24,13 @@ const DollarAmountIntegerField = (props, { id, value, field, hasFocus, error }) 
     }
   }, [hasFocus]);
 
-  console.log(id, value, field, props);
-
-  const handleChange = (event, newValue) => {
+  const handleChange = (event) => {
     const { value: inputValue } = event.target;
-    console.log(newValue);
-
     // First, remove decimal point and trailing characters onChange to handle pasted numbers
     const valueWithoutDecimals = removeDecimalsAndTrailingNumbers(inputValue);
 
     // Then, remove all non-integers
     const valueWithIntegersOnly = removeNonIntegers(valueWithoutDecimals);
-
-    console.log(apiRef)
 
     apiRef.current.setEditCellValue({
       id,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/DollarAmountIntegerField.js
@@ -12,9 +12,19 @@ import { useGridApiContext } from "@mui/x-data-grid-pro";
  * @param {Integer} id - Data Grid row id
  * @param {String} value - field value
  * @param {String} field - name of field
+ * @param {Boolean} hasFocus - if field hasFocus
+ * @param {Boolean} error - if input validation failed
+ * @param {String} errorMessage - error message text from input validation
  * @return {JSX.Element}
  */
-const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
+const DollarAmountIntegerField = ({
+  id,
+  value,
+  field,
+  hasFocus,
+  error,
+  errorMessage,
+}) => {
   const apiRef = useGridApiContext();
   const ref = React.useRef(null);
 
@@ -51,7 +61,7 @@ const DollarAmountIntegerField = ({ id, value, field, hasFocus, error }) => {
       value={value ?? ""}
       onChange={handleChange}
       error={error}
-      helperText={error ? "Value is out of range" : null}
+      helperText={error ? errorMessage : null}
     />
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -52,6 +52,7 @@ import {
   transformGridToDatabase,
 } from "src/views/projects/projectView/ProjectFunding/helpers";
 import { useLogUserEvent } from "src/utils/userEvents";
+import { isAmountOutOfRange } from "src/utils/numberFormatters";
 
 // object to pass to the Fund column's LookupAutocomplete component
 const fduAutocompleteProps = {
@@ -205,6 +206,10 @@ const useColumns = ({
         field: "funding_amount",
         width: 100,
         editable: true,
+        preProcessEditCellProps: (params) => ({
+          ...params.props,
+          error: isAmountOutOfRange(params.props.value),
+        }),
         valueFormatter: (value) =>
           value === null ? null : currencyFormatter.format(value),
         renderEditCell: (props) => <DollarAmountIntegerField {...props} />,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -206,10 +206,15 @@ const useColumns = ({
         field: "funding_amount",
         width: 100,
         editable: true,
-        preProcessEditCellProps: (params) => ({
-          ...params.props,
-          error: isAmountOutOfRange(params.props.value),
-        }),
+        preProcessEditCellProps: (params) => {
+          console.log(params, params.props.value);
+          if (params.hasRowChanged) {
+            return {
+              ...params.props,
+              error: isAmountOutOfRange(params.props.value),
+            };
+          }
+        },
         valueFormatter: (value) =>
           value === null ? null : currencyFormatter.format(value),
         renderEditCell: (props) => <DollarAmountIntegerField {...props} />,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -52,7 +52,10 @@ import {
   transformGridToDatabase,
 } from "src/views/projects/projectView/ProjectFunding/helpers";
 import { useLogUserEvent } from "src/utils/userEvents";
-import { isAmountOutOfRange } from "src/utils/numberFormatters";
+import {
+  isAmountOutOfRange,
+  outOfRangeErrorMessage,
+} from "src/utils/numberFormatters";
 
 // object to pass to the Fund column's LookupAutocomplete component
 const fduAutocompleteProps = {
@@ -210,6 +213,7 @@ const useColumns = ({
           return {
             ...params.props,
             error: isAmountOutOfRange(params.props.value),
+            errorMessage: outOfRangeErrorMessage,
           };
         },
         valueFormatter: (value) =>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -207,13 +207,10 @@ const useColumns = ({
         width: 100,
         editable: true,
         preProcessEditCellProps: (params) => {
-          console.log(params, params.props.value);
-          if (params.hasRowChanged) {
-            return {
-              ...params.props,
-              error: isAmountOutOfRange(params.props.value),
-            };
-          }
+          return {
+            ...params.props,
+            error: isAmountOutOfRange(params.props.value),
+          };
         },
         valueFormatter: (value) =>
           value === null ? null : currencyFormatter.format(value),

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
@@ -220,7 +220,13 @@ const ProjectWorkActivitiesForm = ({
               control={control}
               onChangeHandler={amountOnChangeHandler}
               size="small"
+              error={formErrors.contract_amount}
             />
+            {formErrors?.contract_amount && (
+              <FormHelperText>
+                {formErrors.contract_amount.message}
+              </FormHelperText>
+            )}
           </FormControl>
         </Grid2>
         <Grid2 size={12}>

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
@@ -203,6 +203,7 @@ const ProjectWorkActivitiesForm = ({
               name="work_assignment_id"
               control={control}
               size="small"
+              error={!!formErrors?.work_assignment_id}
             />
             {formErrors?.work_assignment_id && (
               <FormHelperText>
@@ -212,7 +213,7 @@ const ProjectWorkActivitiesForm = ({
           </FormControl>
         </Grid2>
         <Grid2 size={12}>
-          <FormControl fullWidth>
+          <FormControl fullWidth error={!!formErrors?.contract_amount}>
             <ControlledTextInput
               fullWidth
               label="Amount"
@@ -220,7 +221,7 @@ const ProjectWorkActivitiesForm = ({
               control={control}
               onChangeHandler={amountOnChangeHandler}
               size="small"
-              error={formErrors.contract_amount}
+              error={!!formErrors?.contract_amount}
             />
             {formErrors?.contract_amount && (
               <FormHelperText>
@@ -256,6 +257,7 @@ const ProjectWorkActivitiesForm = ({
               name="description"
               control={control}
               size="small"
+              error={!!formErrors.description}
             />
             {formErrors?.description && (
               <FormHelperText>{formErrors.description.message}</FormHelperText>

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
@@ -36,7 +36,10 @@ export const activityValidationSchema = yup.object().shape({
     .string()
     .max(500, "Must be less than 500 characters")
     .nullable(),
-  contract_amount: yup.number().nullable(),
+  contract_amount: yup
+    .number()
+    .max(2_147_483_647, "Amount is out of range")
+    .nullable(),
   status_id: yup.number().required(),
   status_note: yup
     .string()

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
@@ -38,7 +38,7 @@ export const activityValidationSchema = yup.object().shape({
     .nullable(),
   contract_amount: yup
     .number()
-    .max(2_147_483_647, "Amount is out of range")
+    .max(2_147_483_647, "Amount is out of range") // max number an int can be in the db
     .nullable(),
   status_id: yup.number().required(),
   status_note: yup

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
@@ -3,6 +3,7 @@ import * as yup from "yup";
 import {
   removeDecimalsAndTrailingNumbers,
   removeNonIntegers,
+  INT_4_MAX,
 } from "src/utils/numberFormatters";
 
 export const IMPLEMENTATION_WORKGROUP_OPTIONS = [
@@ -38,7 +39,7 @@ export const activityValidationSchema = yup.object().shape({
     .nullable(),
   contract_amount: yup
     .number()
-    .max(2_147_483_647, "Amount is out of range") // max number an int can be in the db
+    .max(INT_4_MAX, "Amount is out of range") // max number an int can be in the db
     .nullable(),
   status_id: yup.number().required(),
   status_note: yup

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/utils/form.js
@@ -4,6 +4,7 @@ import {
   removeDecimalsAndTrailingNumbers,
   removeNonIntegers,
   INT_4_MAX,
+  outOfRangeErrorMessage,
 } from "src/utils/numberFormatters";
 
 export const IMPLEMENTATION_WORKGROUP_OPTIONS = [
@@ -39,7 +40,7 @@ export const activityValidationSchema = yup.object().shape({
     .nullable(),
   contract_amount: yup
     .number()
-    .max(INT_4_MAX, "Amount is out of range") // max number an int can be in the db
+    .max(INT_4_MAX, outOfRangeErrorMessage)
     .nullable(),
   status_id: yup.number().required(),
   status_note: yup


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/27326


<details>
<summary>My rationale when trying to squeeze this in, before getting more feedback</summary>
I picked up this snackoo yesterday thinking I could potentially squeeze into the release today, but I am not sure and think it might need some UX feedback. 

The bug is that numbers larger than 2,147,183,647 cant be saved in the db because they are too big and we get a `DataError: integer out of range`. I thought about changing the column type in the db, but the issue says to handel it on the front end. 

We strip decimal places and letters from the DollarAmountIntegerField without any feedback, but reducing huge numbers to their upper limit without any indication to the user why felt weird to me. So I instead am checking the field on the funding table and then indicating an error on the field if the number is too big. 

And for the work activities table I updated the yup resolver. But I am not sure if this is the behavior we want. At least it prevents the mutation from crashing. 
</details>


## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

https://deploy-preview-1826--atd-moped-main.netlify.app/moped/projects/2207?tab=funding

**Steps to test:**

Add a new funding record. Try to input a giant number as the amount like 10,000,000,000 and see that you cant save the record. 

Do the same for the work activities table amount. 



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Removed note from script  
