### PR TITLE
Bump GraphQL engine image version to v2.48.16

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.48.15
+        image: hasura/graphql-engine:v2.48.16
         depends_on:
             - moped-pgsql
         expose:

--- a/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.48.15",
+            "image": "hasura/graphql-engine:v2.48.16",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.48.15",
+            "image": "hasura/graphql-engine:v2.48.16",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {


### PR DESCRIPTION

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27817

## Testing

* 👀 will do for the code, please review the diff.
* Please confirm the target image: https://hub.docker.com/layers/hasura/graphql-engine/v2.48.16/images/sha256-656e445987a45930978b30d1f8ab29f6a0b6d45a6bd9fba5ee470411605f47fd


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
