### PR TITLE
Enhance local orchestration script and adjust volume for postgres 18

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     moped-pgsql:
         image: "atddocker/postgis:unified-db"
         volumes:
-            - moped-db-vol:/var/lib/postgresql/data
+            - moped-db-vol:/var/lib/postgresql
         expose:
             - 5432
         ports:

--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -286,6 +286,37 @@ function show_banner() {
   echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -";
 }
 
+function help() {
+  cat <<'HELP_EOM'
+Usage: ./hasura-cluster [options] <command> [args]
+
+Options:
+  -h, --help              Show this help message and exit
+  -j, --use-any-snapshot  Use most recent local snapshot during replicate
+
+Commands:
+  start [compose_file]    Start cluster and run migrations/metadata/seeds
+  start_only [compose_file]
+                          Start cluster without running migrations
+  stop                    Stop cluster and remove volumes
+  restart                 Stop and start cluster (with migrations)
+  reload                  Stop and start cluster (without migrations)
+  status                  Show Hasura health and version
+  follow                  Follow logs for all services
+  console                 Open Hasura console
+  setenv <local|staging|production>
+                          Switch hasura config environment
+  prune                   Remove Docker volumes named moped*
+  replicate               Copy production DB into local DB and apply metadata
+  help                    Show this help message
+
+Examples:
+  ./hasura-cluster setenv local
+  ./hasura-cluster start
+  ./hasura-cluster replicate --use-any-snapshot
+HELP_EOM
+}
+
 function __check_export_complete() {
   local file_path="$1"
   local last_line=$(tail -n 3 "$file_path" | head -n 1)
@@ -351,6 +382,10 @@ use_any_snapshot=false
 # Process named arguments
 while (( "$#" )); do
   case "$1" in
+    -h|--help)
+      positional_args=("help")
+      shift
+      ;;
     -j|--use-any-snapshot)
       use_any_snapshot=true
       shift
@@ -366,7 +401,7 @@ done
 #
 # Let's make sure docker is running...
 #
-if [[ "$(__get_docker_running)" != "TRUE" ]]; then
+if [[ "${positional_args[0]}" != "help" ]] && [[ "$(__get_docker_running)" != "TRUE" ]]; then
     show_banner "${positional_args[0]}" && echo "Docker is not running. Please start docker on your computer"
   exit;
 fi;

--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -32,6 +32,8 @@ function __set_postgresql_image() {
 }
 
 HIDE_HASURA_KIT_BANNER="FALSE";
+HASURA_CLUSTER_VERBOSE="FALSE";
+HASURA_CLUSTER_LOG_FOLLOW_PID="";
 __set_postgresql_image; # into HASURA_CLUSTER_POSTGRES_IMAGE
 
 
@@ -94,6 +96,31 @@ function __wait_server_ready() {
   echo "[λ] Hasura server ready!                    ✅";
 }
 
+function __start_log_passthrough() {
+  local compose_file="$1"
+  if [[ "${HASURA_CLUSTER_VERBOSE}" != "TRUE" ]]; then
+    return
+  fi
+
+  echo "Verbose mode enabled: streaming container output during startup..."
+  if [[ "${compose_file}" = "" ]]; then
+    docker compose -f docker-compose.yml logs --follow --tail=50 &
+  else
+    docker compose -f "${compose_file}" logs --follow --tail=50 &
+  fi
+  HASURA_CLUSTER_LOG_FOLLOW_PID=$!
+}
+
+function __stop_log_passthrough() {
+  if [[ "${HASURA_CLUSTER_LOG_FOLLOW_PID}" = "" ]]; then
+    return
+  fi
+
+  kill "${HASURA_CLUSTER_LOG_FOLLOW_PID}" &> /dev/null || true
+  wait "${HASURA_CLUSTER_LOG_FOLLOW_PID}" 2> /dev/null || true
+  HASURA_CLUSTER_LOG_FOLLOW_PID="";
+}
+
 
 #
 # Waits until the local hasura server is ready
@@ -143,6 +170,7 @@ function run_migration() {
 function start_only() {
   __get_platform;
   START_MODE=$1;
+  __start_log_passthrough "${START_MODE}";
   if [[ "${START_MODE}" = "" ]]; then
     docker compose -f docker-compose.yml up -d;
   else
@@ -151,6 +179,7 @@ function start_only() {
 
   echo "Checking the Hasura server is ready...";
   __wait_server_ready;
+  __stop_log_passthrough;
 }
 
 #
@@ -292,6 +321,7 @@ Usage: ./hasura-cluster [options] <command> [args]
 
 Options:
   -h, --help              Show this help message and exit
+  -v, --verbose           Stream container logs during startup
   -j, --use-any-snapshot  Use most recent local snapshot during replicate
 
 Commands:
@@ -386,6 +416,10 @@ while (( "$#" )); do
       positional_args=("help")
       shift
       ;;
+    -v|--verbose)
+      HASURA_CLUSTER_VERBOSE="TRUE"
+      shift
+      ;;
     -j|--use-any-snapshot)
       use_any_snapshot=true
       shift
@@ -397,6 +431,8 @@ while (( "$#" )); do
       ;;
   esac
 done
+
+trap __stop_log_passthrough EXIT
 
 #
 # Let's make sure docker is running...

--- a/moped-database/hasura-cluster
+++ b/moped-database/hasura-cluster
@@ -349,9 +349,12 @@ HELP_EOM
 
 function __check_export_complete() {
   local file_path="$1"
-  local last_line=$(tail -n 3 "$file_path" | head -n 1)
-  
-  if [[ "$last_line" == *"PostgreSQL database dump complete"* ]]; then
+  local end_of_file
+  end_of_file=$(tail -n 20 "$file_path")
+
+  # New pg_dump output can include additional trailer lines (for example
+  # "\unrestrict <token>") after the completion marker.
+  if [[ "$end_of_file" == *"PostgreSQL database dump complete"* ]]; then
     # echo "PostgreSQL database export is complete."
     return 0
   else


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28059

## Testing

If you have a problem with during testing or down the road with this orchestration script, please reach out. It's hard to reproduce the problem once you have it fixed on your machine, and it's possible that I may have to make adjustments. Big thanks to @roseeichelmann for her help verifying that things worked for her this morning.

* Spin down the moped db if it's running
* Check out this branch
* `docker compose pull moped-pgsql`
  * you should see it pull a new version of the DB image
* `./hasura-cluster -h` ✨ 
* `./hasura-cluster start`
* `./hasura-cluster stop`
* `./hasura-cluster replicate`

Everything feel normal?

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
