### PR TITLE
Fix local activity logging

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             - HASURA_GRAPHQL_CONSOLE_ASSETS_DIR=/srv/console-assets
             - MOPED_API_ACTIONS_URL=http://localhost:5000/actions
             - MOPED_API_EVENTS_URL=http://localhost:5000/events
-            - HASURA_ENDPOINT=http://localhost:8082/v1/graphql
+            - HASURA_ENDPOINT=http://localhost:8080/v1/graphql
             - MOPED_API_APIKEY=DuMmyApiKeyHFVOVto19otC1wX6sP2N0VSKrCD70L10B7Sm525ZR6L672i2F79M9!
             - 'HASURA_GRAPHQL_JWT_SECRET={"type":"RS256","jwk_url": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_U2dzkxfTv/.well-known/jwks.json","claims_format": "stringified_json"}'
             - HASURA_GRAPHQL_ADMIN_SECRET=hasurapassword


### PR DESCRIPTION
## Associated issues
None, just patching a regression in the activity log that I introduced in https://github.com/cityofaustin/atd-moped/pull/1782. This did not impact our staging or production activity logging.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local 🙏 

**Steps to test:**
1. Spin up your local stack, create a new project, and check the activity log to make sure you see two initial events
2. Make more edits and see that they are tracked in the activity log

#### Before
<img width="1506" height="330" alt="Screenshot 2026-04-27 at 2 09 50 PM" src="https://github.com/user-attachments/assets/58e1f212-af83-4792-a19b-5401af7c0466" />

#### After
<img width="1506" height="408" alt="Screenshot 2026-04-27 at 2 12 07 PM" src="https://github.com/user-attachments/assets/ecccedad-86bd-4a5f-8727-87e9ff295dea" />

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
