### PR TITLE
Patch v3.51 into main: Update Nearmap API key

### DIFF
--- a/moped-editor/.env-cmdrc
+++ b/moped-editor/.env-cmdrc
@@ -10,7 +10,6 @@
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_OUT": "https://localhost:3000/moped/session/signin",
     "REACT_APP_AWS_COGNITO_DOMAIN": "atd-moped-staging.auth.us-east-1.amazoncognito.com",
     "REACT_APP_MAPBOX_TOKEN": "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNraWV4dHR0ZjAwNnYyd3FwYjFoNHduaDcifQ.--3vRm2KHq1gh5K_L0pqtA",
-    "REACT_APP_NEARMAP_TOKEN": "NWE1ZTA1YTYtOTg4Yy00ZGNhLWFjMzYtMmYxOTI2M2UyODRk",
     "REACT_APP_KNACK_DATA_TRACKER_SIGNAL_VIEW": 1483,
     "REACT_APP_KNACK_DATA_TRACKER_APP_ID": "621958d0b5ab96001edcb4b1",
     "REACT_APP_KNACK_DATA_TRACKER_URL_BASE": "https://mobility.austin.gov/moped/projects/"
@@ -26,7 +25,6 @@
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_OUT": "https://moped-test.austinmobility.io/moped/session/signin",
     "REACT_APP_AWS_COGNITO_DOMAIN": "atd-moped-staging.auth.us-east-1.amazoncognito.com",
     "REACT_APP_MAPBOX_TOKEN": "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNraWV4dHR0ZjAwNnYyd3FwYjFoNHduaDcifQ.--3vRm2KHq1gh5K_L0pqtA",
-    "REACT_APP_NEARMAP_TOKEN": "NWE1ZTA1YTYtOTg4Yy00ZGNhLWFjMzYtMmYxOTI2M2UyODRk",
     "REACT_APP_KNACK_DATA_TRACKER_SIGNAL_VIEW": 1483,
     "REACT_APP_KNACK_DATA_TRACKER_APP_ID": "621958d0b5ab96001edcb4b1",
     "REACT_APP_KNACK_DATA_TRACKER_URL_BASE": "https://mobility.austin.gov/moped/projects/"
@@ -42,7 +40,6 @@
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_OUT": "https://moped.austinmobility.io/moped/session/signin",
     "REACT_APP_AWS_COGNITO_DOMAIN": "atd-moped-staging.auth.us-east-1.amazoncognito.com",
     "REACT_APP_MAPBOX_TOKEN": "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNraWV4dHR0ZjAwNnYyd3FwYjFoNHduaDcifQ.--3vRm2KHq1gh5K_L0pqtA",
-    "REACT_APP_NEARMAP_TOKEN": "NWE1ZTA1YTYtOTg4Yy00ZGNhLWFjMzYtMmYxOTI2M2UyODRk",
     "REACT_APP_KNACK_DATA_TRACKER_SIGNAL_VIEW": 1483,
     "REACT_APP_KNACK_DATA_TRACKER_APP_ID": "621958d0b5ab96001edcb4b1",
     "REACT_APP_KNACK_DATA_TRACKER_URL_BASE": "https://mobility.austin.gov/moped/projects/"
@@ -58,7 +55,6 @@
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_OUT": "https://moped.austinmobility.io/moped/session/signin",
     "REACT_APP_AWS_COGNITO_DOMAIN": "atd-moped-staging.auth.us-east-1.amazoncognito.com",
     "REACT_APP_MAPBOX_TOKEN": "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNraWV4dHR0ZjAwNnYyd3FwYjFoNHduaDcifQ.--3vRm2KHq1gh5K_L0pqtA",
-    "REACT_APP_NEARMAP_TOKEN": "NWE1ZTA1YTYtOTg4Yy00ZGNhLWFjMzYtMmYxOTI2M2UyODRk",
     "REACT_APP_KNACK_DATA_TRACKER_SIGNAL_VIEW": 1483,
     "REACT_APP_KNACK_DATA_TRACKER_APP_ID": "621958d0b5ab96001edcb4b1",
     "REACT_APP_KNACK_DATA_TRACKER_URL_BASE": "https://mobility.austin.gov/moped/projects/"
@@ -74,7 +70,6 @@
     "REACT_APP_AWS_COGNITO_REDIRECT_SIGN_OUT": "https://mobility.austin.gov/moped/session/signin",
     "REACT_APP_AWS_COGNITO_DOMAIN": "atd-moped-production.auth.us-east-1.amazoncognito.com",
     "REACT_APP_MAPBOX_TOKEN": "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNraWV4dHR0ZjAwNnYyd3FwYjFoNHduaDcifQ.--3vRm2KHq1gh5K_L0pqtA",
-    "REACT_APP_NEARMAP_TOKEN": "NWE1ZTA1YTYtOTg4Yy00ZGNhLWFjMzYtMmYxOTI2M2UyODRk",
     "REACT_APP_KNACK_DATA_TRACKER_SIGNAL_VIEW": 1483,
     "REACT_APP_KNACK_DATA_TRACKER_APP_ID": "5815f29f7f7252cc2ca91c4f",
     "REACT_APP_KNACK_DATA_TRACKER_URL_BASE": "https://mobility.austin.gov/moped/projects/"

--- a/moped-editor/README.md
+++ b/moped-editor/README.md
@@ -8,7 +8,7 @@ Web application for interacting with Moped data.
 
 2. Follow [steps](https://github.com/cityofaustin/atd-moped/tree/main/moped-database#readme) to start the Moped database.
 
-3. Copy the environment variables template and fill in the values from the DTS password store. You will see the [MUI X Missing license key warning](https://v7.mui.com/x/introduction/licensing/#1-missing-license-key) without the MUI X environment variable.
+3. Copy the environment variables template and fill in the values from the DTS password store. You will see the [MUI X Missing license key warning](https://v7.mui.com/x/introduction/licensing/#1-missing-license-key) without the MUI X environment variable. Nearmap aerial tiles will not be available without secret set in local environment.
 
 ```shell
 cp env_template .env

--- a/moped-editor/env_template
+++ b/moped-editor/env_template
@@ -1,1 +1,2 @@
 REACT_APP_MUIX_LICENSE_KEY=Find in "Moped MUI X Pro License Key" entry
+REACT_APP_NEARMAP_TOKEN=Find in "Moped Nearmap API Key" entry

--- a/moped-editor/package.json
+++ b/moped-editor/package.json
@@ -2,7 +2,7 @@
   "name": "atd-moped-editor",
   "author": "ATD Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "homepage": "/moped",
   "private": false,
   "repository": {

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/mapSettings.js
@@ -1,5 +1,5 @@
 const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
-// This API key is managed by CTM. Contact help desk for maintenance and troubleshooting.
+// This API key is managed by ATS. Contact help desk for maintenance and troubleshooting.
 const NEARMAP_KEY = process.env.REACT_APP_NEARMAP_TOKEN;
 
 // minimum map zoom to display selectable features, and


### PR DESCRIPTION
## Associated issues
Part of https://github.com/cityofaustin/atd-data-tech/issues/26997 but also to get Nearmap aerials working againPart of https://github.com/cityofaustin/atd-data-tech/issues/26997 but also to get Nearmap aerials working again

I cherry-picked the same commit from https://github.com/cityofaustin/atd-moped/pull/1837 so this change makes its way into `main`.


## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Local (wish we could test from the deploy preview but Nearmap doesn't support wildcards in allow lists)

**Steps to test:**
1. Pull the latest from `main` and merge into this branch (I forgot that there is a fix to the local stack in `main` that is needed to spin this up successfully. Wanted to avoid bundling everything in `main` into this patch which is a small change)
2. Update your local `.env` with the updated secret (Moped Nearmap API Key (VITE_NEARMAP_TOKEN)) in our password manager
3. Spin up the local stack and go check out the Nearmap aerials working by seeing the beautiful Wishbone Bridge ✨

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~