### PR TITLE
Update text labels in funding table and notes tab to outlined chips

### DIFF
--- a/moped-database/migrations/default/1778009019612_rename_moped_note_type/down.sql
+++ b/moped-database/migrations/default/1778009019612_rename_moped_note_type/down.sql
@@ -1,0 +1,3 @@
+UPDATE moped_note_types
+SET name = 'Synced from eCAPRIS'
+WHERE slug='ecapris_status_update';

--- a/moped-database/migrations/default/1778009019612_rename_moped_note_type/up.sql
+++ b/moped-database/migrations/default/1778009019612_rename_moped_note_type/up.sql
@@ -1,0 +1,3 @@
+UPDATE moped_note_types
+SET name = 'eCAPRIS'
+WHERE slug='ecapris_status_update';

--- a/moped-editor/src/components/SecondaryInformationChip.js
+++ b/moped-editor/src/components/SecondaryInformationChip.js
@@ -1,0 +1,18 @@
+import Chip from "@mui/material/Chip";
+
+/**
+ * chia fill this out
+ *
+ * @param {string} chipLabel - text displayed in chip
+ * @param {object} chipStyles - additional styles to apply to chip
+ */
+const SecondaryInformationChip = ({ chipLabel, chipStyles }) => (
+  <Chip
+    sx={{ height: "20px", ...chipStyles }}
+    label={chipLabel}
+    variant="outlined"
+    color="primary"
+  />
+);
+
+export default SecondaryInformationChip;

--- a/moped-editor/src/components/SecondaryInformationChip.js
+++ b/moped-editor/src/components/SecondaryInformationChip.js
@@ -1,8 +1,7 @@
 import Chip from "@mui/material/Chip";
 
 /**
- * chia fill this out
- *
+ * Shared component for secondary information
  * @param {string} chipLabel - text displayed in chip
  * @param {object} chipStyles - additional styles to apply to chip
  */

--- a/moped-editor/src/views/dev/LookupsView/ComponentTagsTable.js
+++ b/moped-editor/src/views/dev/LookupsView/ComponentTagsTable.js
@@ -263,8 +263,8 @@ const ComponentTagsTable = ({ canEdit, handleSnackbar, onScrollToTop }) => {
       variables: {
         id: updatedRow.id,
         set: {
-          name: mutationData.name ?? null,
-          type: mutationData.type ?? null,
+          name: mutationData.name || null,
+          type: mutationData.type || null,
           slug: mutationData.slug,
         },
       },

--- a/moped-editor/src/views/dev/LookupsView/ComponentTagsTable.js
+++ b/moped-editor/src/views/dev/LookupsView/ComponentTagsTable.js
@@ -28,7 +28,7 @@ import {
 } from "./componentTagsHelpers";
 import { createRecordKeyHash } from "src/utils/urls";
 
-const requiredFields = ["name", "type", "slug"];
+const requiredFields = ["slug"];
 
 const useColumns = ({
   rowModesModel,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -2,7 +2,6 @@ import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import isEqual from "lodash.isequal";
 
-// Material
 import {
   Button,
   FormControlLabel,
@@ -46,6 +45,7 @@ import {
   getIsEditMode,
   handleRowEditStop,
 } from "src/components/DataGridPro/utils/helpers.js";
+import SecondaryInformationChip from "src/components/SecondaryInformationChip";
 import OverrideFundingDialog from "src/views/projects/projectView/ProjectFunding/OverrideFundingDialog";
 import {
   transformDatabaseToGrid,
@@ -98,12 +98,16 @@ const useColumns = ({
       {
         headerName: "FDU",
         field: "fdu",
-        width: 200,
+        width: 225,
         editable: true,
         renderCell: ({ row, value }) =>
           row.is_synced_from_ecapris ? (
             <>
               <span>{value?.fdu}</span>
+              <SecondaryInformationChip
+                chipLabel="eCAPRIS"
+                chipStyles={{ marginLeft: "8px" }}
+              />
               <Typography
                 variant="body2"
                 sx={{

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -9,7 +9,6 @@ import {
   Switch,
   Tooltip,
   IconButton,
-  Typography,
 } from "@mui/material";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -108,15 +108,6 @@ const useColumns = ({
                 chipLabel="eCAPRIS"
                 chipStyles={{ marginLeft: "8px" }}
               />
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "primary.main",
-                  fontWeight: 500,
-                }}
-              >
-                SYNCED FROM ECAPRIS
-              </Typography>
             </>
           ) : (
             value?.fdu

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -394,11 +394,6 @@ const ProjectNotes = ({
           size={12}
         >
           <Grid2>
-            <FormControlLabel
-              sx={{ margin: 2 }}
-              label="Show"
-              control={<span />}
-            />
             <NoteTypeButton
               filterNoteType={filterNoteType}
               setFilterNoteType={setFilterNoteType}

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -100,52 +100,50 @@ const ProjectNotes = ({
         }
         secondary={secondary}
       />
-      {
-        <ListItemSecondaryAction
-          sx={{
-            top: 0,
-            marginTop: 3,
-          }}
-        >
-          <Grid2 container spacing={0.5}>
-            <Grid2
-              sx={{
-                alignItems: "center",
-                display: "flex",
-                marginRight: theme.spacing(1),
-              }}
+      <ListItemSecondaryAction
+        sx={{
+          top: 0,
+          marginTop: 3,
+        }}
+      >
+        <Grid2 container spacing={0.5}>
+          <Grid2
+            sx={{
+              alignItems: "center",
+              display: "flex",
+              marginRight: theme.spacing(1),
+            }}
+          >
+            <SecondaryInformationChip chipLabel={note.note_type_name} />
+          </Grid2>
+          <Grid2>
+            <IconButton
+              edge="end"
+              aria-label="edit"
+              onClick={() => handleEditClick(noteIndex, note)}
+              size="small"
+              disabled={!isNoteEditable}
+              sx={editButtonStyles}
             >
-              <SecondaryInformationChip chipLabel={note.note_type_name} />
-            </Grid2>
-            <Grid2>
+              <EditIcon />
+            </IconButton>
+          </Grid2>
+          <Grid2>
+            {!isEditingNote && (
               <IconButton
                 edge="end"
-                aria-label="edit"
-                onClick={() => handleEditClick(noteIndex, note)}
+                aria-label="delete"
+                onClick={() => handleDeleteOpen(note.original_id)}
                 size="small"
                 disabled={!isNoteEditable}
                 sx={editButtonStyles}
               >
-                <EditIcon />
+                <DeleteIcon />
               </IconButton>
-            </Grid2>
-            <Grid2>
-              {!isEditingNote && (
-                <IconButton
-                  edge="end"
-                  aria-label="delete"
-                  onClick={() => handleDeleteOpen(note.original_id)}
-                  size="small"
-                  disabled={!isNoteEditable}
-                  sx={editButtonStyles}
-                >
-                  <DeleteIcon />
-                </IconButton>
-              )}
-            </Grid2>
+            )}
           </Grid2>
-        </ListItemSecondaryAction>
-      }
+        </Grid2>
+      </ListItemSecondaryAction>
     </ListItem>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -10,6 +10,7 @@ import DeleteIcon from "@mui/icons-material/DeleteOutlined";
 import EditIcon from "@mui/icons-material/EditOutlined";
 
 import ProjectStatusBadge from "src/views/projects/projectView/ProjectStatusBadge";
+import SecondaryInformationChip from "src/components/SecondaryInformationChip";
 
 import "src/views/projects/projectView/ProjectNotes/ProjectNotes.css";
 
@@ -21,6 +22,9 @@ import theme from "src/theme";
 
 const editButtonStyles = {
   color: theme.palette.text.primary,
+  "&.Mui-disabled": {
+    color: theme.palette.text.secondary,
+  },
 };
 
 /**
@@ -81,19 +85,6 @@ const ProjectNotes = ({
                 note.created_at
               )} ${makeHourAndMinutesFromTimeStampTZ(note.created_at)}`}
             </Typography>
-            <Typography
-              component={"span"}
-              sx={{
-                display: "inline",
-                marginLeft: "12px",
-                color: theme.palette.primary.main,
-                textTransform: "uppercase",
-                fontSize: ".875rem",
-                fontWeight: 500,
-              }}
-            >
-              {note.note_type_name}
-            </Typography>
             <Typography component={"span"}>
               {/* only show note's status badge if the note has a phase_id */}
               {phaseKey && phaseName && (
@@ -109,39 +100,48 @@ const ProjectNotes = ({
         }
         secondary={secondary}
       />
-      {isNoteEditable && (
-        <ListItemSecondaryAction
-          sx={{
-            top: 0,
-            marginTop: 3,
-          }}
-        >
-          <Grid2 container spacing={0.5}>
-            <Grid2>
-              <IconButton
-                edge="end"
-                aria-label="edit"
-                onClick={() => handleEditClick(noteIndex, note)}
-                size="small"
-              >
-                <EditIcon sx={editButtonStyles} />
-              </IconButton>
-            </Grid2>
-            <Grid2>
-              {!isEditingNote && (
+      {
+        <>
+          <ListItemSecondaryAction
+            sx={{
+              top: 0,
+              marginTop: 3,
+            }}
+          >
+            <Grid2 container spacing={0.5}>
+              <Grid2 sx={{ alignItems: "center", display: "flex" }}>
+                <SecondaryInformationChip chipLabel={note.note_type_name} />
+              </Grid2>
+              <Grid2>
                 <IconButton
                   edge="end"
-                  aria-label="delete"
-                  onClick={() => handleDeleteOpen(note.original_id)}
+                  aria-label="edit"
+                  onClick={() => handleEditClick(noteIndex, note)}
                   size="small"
+                  disabled={!isNoteEditable}
+                  sx={editButtonStyles}
                 >
-                  <DeleteIcon sx={editButtonStyles} />
+                  <EditIcon />
                 </IconButton>
-              )}
+              </Grid2>
+              <Grid2>
+                {!isEditingNote && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => handleDeleteOpen(note.original_id)}
+                    size="small"
+                    disabled={!isNoteEditable}
+                    sx={editButtonStyles}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                )}
+              </Grid2>
             </Grid2>
-          </Grid2>
-        </ListItemSecondaryAction>
-      )}
+          </ListItemSecondaryAction>
+        </>
+      }
     </ListItem>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -49,7 +49,6 @@ const ProjectNotes = ({
 }) => {
   const phaseKey = note.phase_key;
   const phaseName = note.phase_name;
-
   return (
     <ListItem alignItems="flex-start">
       <ListItemText

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -101,46 +101,50 @@ const ProjectNotes = ({
         secondary={secondary}
       />
       {
-        <>
-          <ListItemSecondaryAction
-            sx={{
-              top: 0,
-              marginTop: 3,
-            }}
-          >
-            <Grid2 container spacing={0.5}>
-              <Grid2 sx={{ alignItems: "center", display: "flex" }}>
-                <SecondaryInformationChip chipLabel={note.note_type_name} />
-              </Grid2>
-              <Grid2>
+        <ListItemSecondaryAction
+          sx={{
+            top: 0,
+            marginTop: 3,
+          }}
+        >
+          <Grid2 container spacing={0.5}>
+            <Grid2
+              sx={{
+                alignItems: "center",
+                display: "flex",
+                marginRight: theme.spacing(1),
+              }}
+            >
+              <SecondaryInformationChip chipLabel={note.note_type_name} />
+            </Grid2>
+            <Grid2>
+              <IconButton
+                edge="end"
+                aria-label="edit"
+                onClick={() => handleEditClick(noteIndex, note)}
+                size="small"
+                disabled={!isNoteEditable}
+                sx={editButtonStyles}
+              >
+                <EditIcon />
+              </IconButton>
+            </Grid2>
+            <Grid2>
+              {!isEditingNote && (
                 <IconButton
                   edge="end"
-                  aria-label="edit"
-                  onClick={() => handleEditClick(noteIndex, note)}
+                  aria-label="delete"
+                  onClick={() => handleDeleteOpen(note.original_id)}
                   size="small"
                   disabled={!isNoteEditable}
                   sx={editButtonStyles}
                 >
-                  <EditIcon />
+                  <DeleteIcon />
                 </IconButton>
-              </Grid2>
-              <Grid2>
-                {!isEditingNote && (
-                  <IconButton
-                    edge="end"
-                    aria-label="delete"
-                    onClick={() => handleDeleteOpen(note.original_id)}
-                    size="small"
-                    disabled={!isNoteEditable}
-                    sx={editButtonStyles}
-                  >
-                    <DeleteIcon />
-                  </IconButton>
-                )}
-              </Grid2>
+              )}
             </Grid2>
-          </ListItemSecondaryAction>
-        </>
+          </Grid2>
+        </ListItemSecondaryAction>
       }
     </ListItem>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -23,7 +23,7 @@ import theme from "src/theme";
 const editButtonStyles = {
   color: theme.palette.text.primary,
   "&.Mui-disabled": {
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.disabled,
   },
 };
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28146
and sneaking in: https://github.com/cityofaustin/atd-data-tech/issues/28275

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

local so you can see the new project note type 

**Steps to test:**

using prod data, spin up and apply migrations

Go to a project with an eCAPRIS subproject id, ex: https://localhost:3000/moped/projects/3061?tab=funding
Turn on "sync from ecapris" if not already on. Records from eCAPRIS now have the chip label instead of the text.

Navigate to the notes tab for that project. 
See that the options to filter notes are ALL / INTERNAL NOTE / STATUS UPDATE / ECAPRIS. There is no label "show" before the options.
The note type is shown in the chip, to the left of the edit/delete controls.
The edit and delete icons are visible, but disabled if you are not the author of the note. 
Add a note to see the clickable icons. 


- I am also tacking on a fix for an unrelated bug. 
https://localhost:3000/moped/data-dictionary#moped-component-tags
go to the component tags table, add a new tag. You should be able to add a tag with only a slug, leaving name and type empty. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test: "Go to a project with a "Status update" on the "Summary" tab that was added by another user. Verify that the **edit and delete buttons are disabled** on the that status update on either the "Summary" or "Notes" tab." 
