### PR TITLE
Add moped to the project role link

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.js
@@ -147,7 +147,7 @@ const useColumns = ({
           <Box sx={{ fontWeight: 500 }}>
             Role{" "}
             <Link
-              href="data-dictionary#moped-project-roles"
+              href="/moped/data-dictionary#moped-project-roles"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/28337

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**

Go to a project's team tab (ex: https://deploy-preview-1845--moped-main-and-prs.netlify.app/moped/projects/2210?tab=team) and click the link to get to the data dictionary, the icon next to Role does it work?

I checked the [link](https://github.com/cityofaustin/atd-moped/blob/main/moped-editor/src/views/projects/projectView/ProjectComponents/RelatedComponentsListItem.js#L48) in the related components list item component to see if that works, and it does. 


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
