### PR TITLE
Update table dialog forms to disable save button on error

### DIFF
--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -58,6 +58,8 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
     resolver: yupResolver(validationSchema),
   });
 
+  const areFormErrors = Object.keys(errors).length > 0;
+
   const [isSignalProject] = watch(["isSignalProject"]);
 
   return (
@@ -211,7 +213,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
           success={success}
           buttonOptions={{
             type: "submit",
-            disabled: !isDirty || loading,
+            disabled: !isDirty || loading || areFormErrors,
           }}
         />
       </Box>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -45,7 +45,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
     handleSubmit,
     control,
     watch,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isValid },
   } = useForm({
     defaultValues: {
       projectName: null,
@@ -57,8 +57,6 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   const [isSignalProject] = watch(["isSignalProject"]);
 
@@ -213,7 +211,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
           success={success}
           buttonOptions={{
             type: "submit",
-            disabled: !isDirty || loading || areFormErrors,
+            disabled: !isDirty || !isValid || loading,
           }}
         />
       </Box>

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -85,7 +85,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
                   name="projectName"
                   control={control}
                   error={!!errors?.projectName}
-                  helperText={errors?.projectName?.message}
+                  helperText={errors?.projectName?.message || "Required"}
                   InputProps={{
                     disabled: loading,
                   }}
@@ -108,7 +108,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
                       textInputOptions={{
                         variant: "standard",
                         error: !!errors?.signal,
-                        helperText: errors?.signal?.message,
+                        helperText: errors?.signal?.message || "Required",
                         disabled: loading,
                       }}
                     />

--- a/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
+++ b/moped-editor/src/views/projects/newProjectView/DefineProjectForm.js
@@ -188,7 +188,7 @@ const DefineProjectForm = ({ handleSave, loading, success }) => {
                 size="small"
                 control={control}
                 error={!!errors?.description}
-                helperText={errors?.description?.message}
+                helperText={errors?.description?.message || "Required"}
                 InputProps={{
                   disabled: loading,
                 }}

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -110,14 +110,12 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
-    formState: { isDirty, errors },
+    formState: { isDirty, isValid, errors },
   } = useForm({
     defaultValues: initialFormValues ? initialFormValues : defaultFormValues,
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   // Get and format component and subcomponent options
   const { data: optionsData, error } = useQuery(GET_COMPONENTS_FORM_OPTIONS);
@@ -496,7 +494,7 @@ const ComponentForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={(!isDirty && !hasToggledPhaseSwitch) || areFormErrors}
+            disabled={(!isDirty && !hasToggledPhaseSwitch) || !isValid}
           >
             {hasGeometry ? "Save" : formButtonText}
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -278,6 +278,7 @@ const ComponentForm = ({
             control={control}
             autoFocus
             helperText="Required"
+            error={!!errors?.component}
             required={true}
           />
         </Grid2>

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
@@ -64,6 +64,7 @@ const MoveComponentForm = ({ onSave, component }) => {
             getOptionLabel={getOptionLabel}
             name="project"
             control={control}
+            error={!!errors?.project}
             autoFocus
             helperText="Required"
           />

--- a/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/MoveComponentForm.js
@@ -35,14 +35,13 @@ const MoveComponentForm = ({ onSave, component }) => {
   const {
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
     defaultValues: { project: null },
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
   const currentProjectId = component?.project_id;
-  const areFormErrors = Object.keys(errors).length > 0;
 
   // Get projects for autocomplete
   const { data, error } = useQuery(PROJECT_OPTIONS, {
@@ -84,7 +83,7 @@ const MoveComponentForm = ({ onSave, component }) => {
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={areFormErrors}
+            disabled={!isValid}
           >
             Move component
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -97,6 +97,8 @@ const OverrideFundingForm = ({
     mode: "onChange",
   });
 
+  const areFormErrors = Object.keys(errors).length > 0;
+
   const [should_use_ecapris_amount] = watch(["should_use_ecapris_amount"]);
 
   // if record is synced from ecapris and not yet manual, its first time overriding amount and description
@@ -332,7 +334,7 @@ const OverrideFundingForm = ({
             color="primary"
             type="submit"
             // Disable save button if editing and no changes made or mutation is loading
-            disabled={(!isNewOverride && !isDirty) || mutationState.loading}
+            disabled={(!isNewOverride && !isDirty) || mutationState.loading || areFormErrors}
           >
             Save
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/OverrideFundingForm.js
@@ -81,7 +81,7 @@ const OverrideFundingForm = ({
   const {
     handleSubmit,
     control,
-    formState: { isDirty, errors },
+    formState: { isDirty, isValid, errors },
     watch,
     setValue,
   } = useForm({
@@ -96,8 +96,6 @@ const OverrideFundingForm = ({
     resolver: yupResolver(validationSchema({ appropriatedFunding })),
     mode: "onChange",
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   const [should_use_ecapris_amount] = watch(["should_use_ecapris_amount"]);
 
@@ -334,7 +332,7 @@ const OverrideFundingForm = ({
             color="primary"
             type="submit"
             // Disable save button if editing and no changes made or mutation is loading
-            disabled={(!isNewOverride && !isDirty) || mutationState.loading || areFormErrors}
+            disabled={(!isNewOverride && !isDirty) || mutationState.loading || !isValid}
           >
             Save
           </Button>

--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -55,6 +55,8 @@ const ProjectNameForm = ({
     resolver: yupResolver(validationSchema),
   });
 
+  const areFormErrors = Object.keys(errors).length > 0;
+
   const handleSave = ({ projectName, projectSecondaryName }) => {
     updateProjectNames({
       variables: {
@@ -158,7 +160,7 @@ const ProjectNameForm = ({
           >
             <ProjectSummaryIconButtons
               handleClose={handleCancelClick}
-              disabledCondition={!isDirty}
+              disabledCondition={!isDirty || areFormErrors}
               loading={loading}
             />
           </Grid2>

--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -45,7 +45,7 @@ const ProjectNameForm = ({
   const {
     handleSubmit,
     control,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isValid },
   } = useForm({
     defaultValues: {
       projectName: originalName,
@@ -54,8 +54,6 @@ const ProjectNameForm = ({
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   const handleSave = ({ projectName, projectSecondaryName }) => {
     updateProjectNames({
@@ -160,7 +158,7 @@ const ProjectNameForm = ({
           >
             <ProjectSummaryIconButtons
               handleClose={handleCancelClick}
-              disabledCondition={!isDirty || areFormErrors}
+              disabledCondition={!isDirty || !isValid}
               loading={loading}
             />
           </Grid2>

--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -102,7 +102,7 @@ const ProjectNameForm = ({
               placeholder="Enter project name"
               control={control}
               error={!!errors?.projectName}
-              helperText={errors?.projectName?.message}
+              helperText={errors?.projectName?.message || "Required"}
               InputLabelProps={{
                 shrink: true,
               }}

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
@@ -237,7 +237,7 @@ const ProjectPhaseForm = ({
               control={control}
               error={!!formErrors?.phase_start}
             />
-            {!isCurrentPhase && (
+            {!isCurrentPhase && !formErrors?.phase_start &&(
               <FormHelperText>
                 Defaults to today (confirmed) if blank when marked as current
               </FormHelperText>

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
@@ -60,6 +60,7 @@ const ProjectPhaseForm = ({
   } = useForm({
     defaultValues,
     resolver: yupResolver(phaseValidationSchema),
+    mode: "onChange",
   });
 
   const subphases = useSubphases(watch("phase_id"), phases);
@@ -111,6 +112,8 @@ const ProjectPhaseForm = ({
       handleSnackbar,
     });
   };
+
+  const areFormErrors = Object.keys(formErrors).length > 0;
 
   /**
    * Defaults is_phase_start_confirmed to true if date is today or before
@@ -358,7 +361,7 @@ const ProjectPhaseForm = ({
             variant="contained"
             color="primary"
             type="submit"
-            disabled={!isDirty || mutationState.loading}
+            disabled={!isDirty || mutationState.loading || areFormErrors }
           >
             {mutationState.loading ? (
               <CircularProgress color="primary" size={20} />

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
@@ -195,11 +195,9 @@ const ProjectPhaseForm = ({
                 option?.phase_id === selectedOption?.phase_id
               }
               getOptionLabel={(option) => option?.phase_name || ""}
-              error={!!formErrors?.phase_id}
+              error={!!formErrors?.phase_id?.message}
+              helperText={formErrors?.phase_id?.message || "Required"}
             />
-            {formErrors?.phase_id && (
-              <FormHelperText>{formErrors.phase_id.message}</FormHelperText>
-            )}
           </FormControl>
         </Grid2>
         <Grid2 size={12}>
@@ -237,7 +235,7 @@ const ProjectPhaseForm = ({
               control={control}
               error={!!formErrors?.phase_start}
             />
-            {!isCurrentPhase && !formErrors?.phase_start &&(
+            {!isCurrentPhase && !formErrors?.phase_start && (
               <FormHelperText>
                 Defaults to today (confirmed) if blank when marked as current
               </FormHelperText>
@@ -342,7 +340,8 @@ const ProjectPhaseForm = ({
                 disabled={
                   isCurrentPhase ||
                   mutationState.loading ||
-                  (isNewPhase && !isDirty)
+                  (isNewPhase && !isDirty) ||
+                  !isValid
                 }
               >
                 {mutationState.loading ? (
@@ -359,7 +358,7 @@ const ProjectPhaseForm = ({
             variant="contained"
             color="primary"
             type="submit"
-            disabled={!isDirty || mutationState.loading || !isValid }
+            disabled={!isDirty || mutationState.loading || !isValid}
           >
             {mutationState.loading ? (
               <CircularProgress color="primary" size={20} />

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
@@ -63,6 +63,8 @@ const ProjectPhaseForm = ({
     mode: "onChange",
   });
 
+  const areFormErrors = Object.keys(formErrors).length > 0;
+
   const subphases = useSubphases(watch("phase_id"), phases);
 
   useResetDependentFieldOnParentFieldChange({
@@ -112,8 +114,6 @@ const ProjectPhaseForm = ({
       handleSnackbar,
     });
   };
-
-  const areFormErrors = Object.keys(formErrors).length > 0;
 
   /**
    * Defaults is_phase_start_confirmed to true if date is today or before

--- a/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectPhase/ProjectPhaseForm.js
@@ -56,14 +56,12 @@ const ProjectPhaseForm = ({
     control,
     watch,
     setValue,
-    formState: { isDirty, errors: formErrors },
+    formState: { isDirty, isValid, errors: formErrors },
   } = useForm({
     defaultValues,
     resolver: yupResolver(phaseValidationSchema),
     mode: "onChange",
   });
-
-  const areFormErrors = Object.keys(formErrors).length > 0;
 
   const subphases = useSubphases(watch("phase_id"), phases);
 
@@ -361,7 +359,7 @@ const ProjectPhaseForm = ({
             variant="contained"
             color="primary"
             type="submit"
-            disabled={!isDirty || mutationState.loading || areFormErrors }
+            disabled={!isDirty || mutationState.loading || !isValid }
           >
             {mutationState.loading ? (
               <CircularProgress color="primary" size={20} />

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -39,14 +39,12 @@ const ProjectSummaryProjectDescription = ({
     handleSubmit,
     control,
     setValue,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isValid },
   } = useForm({
     defaultValues: { description: originalDescription },
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   const [editMode, setEditMode] = useState(false);
 
@@ -134,7 +132,7 @@ const ProjectSummaryProjectDescription = ({
             />
             <ProjectSummaryIconButtons
               handleClose={handleCancel}
-              disabledCondition={!isDirty || areFormErrors}
+              disabledCondition={!isDirty || !isValid}
               loading={loading}
             />
           </>

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryProjectDescription.js
@@ -46,6 +46,8 @@ const ProjectSummaryProjectDescription = ({
     resolver: yupResolver(validationSchema),
   });
 
+  const areFormErrors = Object.keys(errors).length > 0;
+
   const [editMode, setEditMode] = useState(false);
 
   const [updateProjectDescription, { loading }] = useMutation(
@@ -132,7 +134,7 @@ const ProjectSummaryProjectDescription = ({
             />
             <ProjectSummaryIconButtons
               handleClose={handleCancel}
-              disabledCondition={!isDirty}
+              disabledCondition={!isDirty || areFormErrors}
               loading={loading}
             />
           </>

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
@@ -62,7 +62,7 @@ const ProjectWorkActivitiesForm = ({
   const {
     handleSubmit,
     control,
-    formState: { isDirty, errors: formErrors },
+    formState: { isDirty, isValid, errors: formErrors },
   } = useForm({
     defaultValues: {
       ...defaultValues,
@@ -70,8 +70,6 @@ const ProjectWorkActivitiesForm = ({
     resolver: yupResolver(activityValidationSchema),
     mode: "onChange",
   });
-
-  const areFormErrors = Object.keys(formErrors).length > 0;
 
   /** Formats array of task order objects into value prop of multiselect component */
   const taskOrderValueHandler = useCallback(
@@ -314,7 +312,7 @@ const ProjectWorkActivitiesForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={(!isDirty && !isNewActivity) || mutationState.loading || areFormErrors}
+            disabled={(!isDirty && !isNewActivity) || mutationState.loading || !isValid}
           >
             {mutationState.loading ? (
               <CircularProgress color="primary" size={20} />

--- a/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityForm.js
@@ -68,7 +68,10 @@ const ProjectWorkActivitiesForm = ({
       ...defaultValues,
     },
     resolver: yupResolver(activityValidationSchema),
+    mode: "onChange",
   });
+
+  const areFormErrors = Object.keys(formErrors).length > 0;
 
   /** Formats array of task order objects into value prop of multiselect component */
   const taskOrderValueHandler = useCallback(
@@ -311,7 +314,7 @@ const ProjectWorkActivitiesForm = ({
             color="primary"
             startIcon={<CheckCircle />}
             type="submit"
-            disabled={(!isDirty && !isNewActivity) || mutationState.loading}
+            disabled={(!isDirty && !isNewActivity) || mutationState.loading || areFormErrors}
           >
             {mutationState.loading ? (
               <CircularProgress color="primary" size={20} />

--- a/moped-editor/src/views/projects/projectsListView/components/SaveUserViewForm.js
+++ b/moped-editor/src/views/projects/projectsListView/components/SaveUserViewForm.js
@@ -17,14 +17,12 @@ const SaveUserViewForm = ({ onSave, description, loading }) => {
   const {
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
     defaultValues: { description: description },
     mode: "onChange",
     resolver: yupResolver(validationSchema),
   });
-
-  const areFormErrors = Object.keys(errors).length > 0;
 
   return (
     <ActivityMetrics eventName={"projects_saved_view"}>
@@ -61,7 +59,7 @@ const SaveUserViewForm = ({ onSave, description, loading }) => {
               color="primary"
               startIcon={<CheckCircle />}
               type="submit"
-              disabled={loading || areFormErrors}
+              disabled={loading || !isValid}
             >
               Save view
             </Button>


### PR DESCRIPTION
## Associated issues
closes https://github.com/cityofaustin/atd-data-tech/issues/27103

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1851--moped-main-and-prs.netlify.app/

**Steps to test:**

Check the following forms to confirm they disable the save/submit button on error:

- Project summary
  - ProjectNameForm
  - ProjectSummaryProjectDescription
- Map
  - ComponentForm
- Funding
  - OverrideFundingForm (edit a row with sync from eCapris selected)
  - ProjectWorkActivitiesForm
- Timeline
  - ProjectPhaseForm
- New project
  - DefineProjectForm

Finally, check `MoveComponentForm` to confirm it highlights errors on the project input field

Please let me know if you encounter any unexpected behavior!

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
