### PR TITLE
Add tooltips to disabled note and funding buttons

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -271,7 +271,7 @@ const useColumns = ({
               <Tooltip
                 title={
                   row.is_synced_from_ecapris
-                    ? "Funding sources synced from eCAPRIS can't be deleted in Moped"
+                    ? "Switch off eCAPRIS sync to remove synced rows"
                     : null
                 }
               >

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -268,14 +268,25 @@ const useColumns = ({
               >
                 <EditOutlinedIcon />
               </IconButton>
-              <IconButton
-                aria-label="delete"
-                sx={{ color: "inherit", padding: "5px" }}
-                disabled={!!row.is_synced_from_ecapris}
-                onClick={handleDeleteOpen(id)}
+              <Tooltip
+                title={
+                  row.is_synced_from_ecapris
+                    ? "Funding sources synced from eCAPRIS can't be deleted in Moped"
+                    : null
+                }
               >
-                <DeleteOutlineIcon />
-              </IconButton>
+                <span>
+                  {/* Tooltip needs to listen to child element events, span is needed if button is disabled */}
+                  <IconButton
+                    aria-label="delete"
+                    sx={{ color: "inherit", padding: "5px" }}
+                    disabled={!!row.is_synced_from_ecapris}
+                    onClick={handleDeleteOpen(id)}
+                  >
+                    <DeleteOutlineIcon />
+                  </IconButton>
+                </span>
+              </Tooltip>
             </>
           ),
       },

--- a/moped-editor/src/views/projects/projectView/ProjectNotes.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes.js
@@ -129,7 +129,7 @@ const ProjectNotes = ({
   /** Get projectId from URL params if not passed down from ProjectSummaryStatusUpdate component
    * If component is being used in edit modal from dashboard get project id from props instead of url params.
    */
-  let { projectId: projectIdFromParam } = useParams();
+  const { projectId: projectIdFromParam } = useParams();
   const noteProjectId = isStatusEditModal ? projectId : projectIdFromParam;
 
   /* Use currentPhaseId if passed down from ProjectSummaryStatusUpdate component,

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -5,6 +5,7 @@ import {
   ListItemSecondaryAction,
   ListItemText,
   Typography,
+  Tooltip,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/DeleteOutlined";
 import EditIcon from "@mui/icons-material/EditOutlined";
@@ -116,29 +117,46 @@ const ProjectNotes = ({
             <SecondaryInformationChip chipLabel={note.note_type_name} />
           </Grid2>
           <Grid2>
-            <IconButton
-              edge="end"
-              aria-label="edit"
-              onClick={() => handleEditClick(noteIndex, note)}
-              size="small"
-              disabled={!isNoteEditable}
-              sx={editButtonStyles}
+            <Tooltip
+              title={
+                isNoteEditable ? null : "Only the author can edit this note"
+              }
             >
-              <EditIcon />
-            </IconButton>
+              <span>
+                {/* Tooltip needs to listen to child element events, span is needed if button is disabled */}
+                <IconButton
+                  edge="end"
+                  aria-label="edit"
+                  onClick={() => handleEditClick(noteIndex, note)}
+                  size="small"
+                  disabled={!isNoteEditable}
+                  sx={editButtonStyles}
+                >
+                  <EditIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
           </Grid2>
           <Grid2>
             {!isEditingNote && (
-              <IconButton
-                edge="end"
-                aria-label="delete"
-                onClick={() => handleDeleteOpen(note.original_id)}
-                size="small"
-                disabled={!isNoteEditable}
-                sx={editButtonStyles}
+              <Tooltip
+                title={
+                  isNoteEditable ? null : "Only the author can edit this note"
+                }
               >
-                <DeleteIcon />
-              </IconButton>
+                <span>
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => handleDeleteOpen(note.original_id)}
+                    size="small"
+                    disabled={!isNoteEditable}
+                    sx={editButtonStyles}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </span>
+              </Tooltip>
             )}
           </Grid2>
         </Grid2>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -141,7 +141,7 @@ const ProjectNotes = ({
             {!isEditingNote && (
               <Tooltip
                 title={
-                  isNoteEditable ? null : "Only the author can edit this note"
+                  isNoteEditable ? null : "Only the author can delete this note"
                 }
               >
                 <span>

--- a/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNotes/ProjectNote.js
@@ -53,13 +53,6 @@ const ProjectNotes = ({
   return (
     <ListItem alignItems="flex-start">
       <ListItemText
-        sx={
-          isNoteEditable
-            ? {
-                marginRight: "30px",
-              }
-            : {}
-        }
         secondaryTypographyProps={{
           sx: editButtonStyles,
         }}
@@ -119,7 +112,11 @@ const ProjectNotes = ({
           <Grid2>
             <Tooltip
               title={
-                isNoteEditable ? null : "Only the author can edit this note"
+                note.note_type_name === "eCAPRIS"
+                  ? "Status updates from eCAPRIS can't be edited in Moped"
+                  : isNoteEditable
+                    ? null
+                    : "Only the author can edit this note"
               }
             >
               <span>
@@ -141,7 +138,11 @@ const ProjectNotes = ({
             {!isEditingNote && (
               <Tooltip
                 title={
-                  isNoteEditable ? null : "Only the author can delete this note"
+                  note.note_type_name === "eCAPRIS"
+                    ? "Status updates from eCAPRIS can't be deleted in Moped"
+                    : isNoteEditable
+                      ? null
+                      : "Only the author can delete this note"
                 }
               >
                 <span>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28289

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

https://deploy-preview-1853--moped-main-and-prs.netlify.app/moped/projects

**Steps to test:**

Test the tooltips on the notes:
Navigate to a project with eCAPRIS status updates, for example: https://deploy-preview-1853--moped-main-and-prs.netlify.app/moped/projects/1746?tab=notes
Hover over the disabled edit icon on an eCAPRIS status update. Confirm the tooltip says "Status updates from eCAPRIS can't be edited in Moped"
Now hover over the disabled delete icon on the same update. Confirm the tooltip says "Status updates from eCAPRIS can't be deleted in Moped"

In this same project, there is a status update that I authored. Check the disabled icon tooltips: "Only the author can edit this note" and "Only the author can delete this note". 


Now test the tooltip on funding tables. Find a project with eCAPRIS funding records, for example: https://deploy-preview-1853--moped-main-and-prs.netlify.app/moped/projects/2224?tab=funding
Hover over the disabled delete icon button and confirm the tooltip says "Funding sources synced from eCAPRIS can't be deleted in Moped"


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [x] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
   - Updated existing test: "Go to a project with a "Status update" on the "Summary" tab that was added by another user. Verify that the edit and delete buttons are disabled **and show tooltips explaining why** on status updates in either the "Summary" or "Notes" tab. "
   - Updated existing test: "Now, delete all funding rows and turn on the "Sync from eCAPRIS" switch. You should see FDUs populate the table and be labeled as "eCAPRIS". **Notice that the delete icon is disabled and explains why.**"
