### PR TITLE
Trigger component form validation when toggling phase switch

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectComponents/ComponentForm.js
@@ -110,6 +110,7 @@ const ComponentForm = ({
     control,
     watch,
     setValue,
+    trigger,
     formState: { isDirty, isValid, errors },
   } = useForm({
     defaultValues: initialFormValues ? initialFormValues : defaultFormValues,
@@ -410,6 +411,7 @@ const ComponentForm = ({
                 onChange={() => {
                   setUseComponentPhase(!useComponentPhase);
                   setHasToggledPhaseSwitch(true);
+                  trigger();
                 }}
                 name="useComponentPhase"
                 color="primary"


### PR DESCRIPTION
## Associated issues
None - just a small bug fix to be able to clear component phase info by turning off the toggle switch

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
Deploy preview or local

**Steps to test:**
1. Go to the deploy preview or run locally and go to an existing project
2. Create or edit a component and add a component phase then save
3. Now, open the same component's attribute edit form
4. Turn the "Use component phase" toggle off and you should see the "Save" button turn active and blue
5. Save and see that the phase is now removed from the component

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
