### PR TITLE
Updates form buttons to be right of project name and secondary name

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -138,23 +138,13 @@ const ProjectNameForm = ({
               }}
             />
           </Grid2>
-          {/* Minimum width prevents icons from wrapping. */}
           <Grid2
-            container
-            direction="row"
-            sx={[
-              {
-                alignItems: "center",
-                alignContent: "center",
-              },
-              (theme) => ({
-                minWidth: theme.spacing(12),
-              }),
-            ]}
-            size={{
-              xs: 12,
-              lg: 1,
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: { xs: "flex-start", lg: "flex-end" },
             }}
+            size={{ xs: 12, lg: 1 }}
           >
             <ProjectSummaryIconButtons
               handleClose={handleCancelClick}

--- a/moped-editor/src/views/projects/projectView/ProjectNameForm.js
+++ b/moped-editor/src/views/projects/projectView/ProjectNameForm.js
@@ -87,10 +87,7 @@ const ProjectNameForm = ({
       >
         <Grid2 container spacing={2}>
           <Grid2
-            size={{
-              xs: 12,
-              lg: 6,
-            }}
+            size='grow'
           >
             <ControlledTextInput
               autoFocus
@@ -113,10 +110,7 @@ const ProjectNameForm = ({
             />
           </Grid2>
           <Grid2
-            size={{
-              xs: 12,
-              lg: 5,
-            }}
+            size='grow'
           >
             <ControlledTextInput
               variant="standard"
@@ -142,9 +136,8 @@ const ProjectNameForm = ({
             sx={{
               display: "flex",
               alignItems: "center",
-              justifyContent: { xs: "flex-start", lg: "flex-end" },
             }}
-            size={{ xs: 12, lg: 1 }}
+            size={{ xs: 12, lg: "auto" }}
           >
             <ProjectSummaryIconButtons
               handleClose={handleCancelClick}

--- a/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons.js
+++ b/moped-editor/src/views/projects/projectView/ProjectSummary/ProjectSummaryIconButtons.js
@@ -5,7 +5,7 @@ const iconButtonStyles = {
   width: 40,
   height: 40,
   flexShrink: 0,
-  alignSelf: "flex-start",
+  alignSelf: "center",
 };
 
 /**


### PR DESCRIPTION
## Associated issues

closes https://github.com/cityofaustin/atd-data-tech/issues/27519

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1860--moped-main-and-prs.netlify.app/

**Steps to test:**
- go to a project summary view page and click to edit the project name and/or secondary name
- the save and cancel buttons should now appear on the right side of the text inputs at desktop width
- set the aspect ratio to tablet size, the buttons should now display below the text inputs and be left justified

example screenshots of desktop and table view, respectively

<img width="1497" height="188" alt="Screenshot 2026-05-26 at 5 34 10 PM" src="https://github.com/user-attachments/assets/2229a443-beb1-493a-a140-c1929d10def1" />
<br />
<img width="513" height="660" alt="Screenshot 2026-05-26 at 5 33 32 PM" src="https://github.com/user-attachments/assets/c0cc9444-9469-4ceb-878f-569beeb518ff" />

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
