### PR TITLE
Move file attachment UI out of dialog

### DIFF
--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -96,7 +96,6 @@ const FundingFile = ({
         keepMounted
         open={menuOpen}
         onClose={handleMenuClose}
-        autoFocus={false}
         TransitionComponent={Fade}
         anchorOrigin={{
           vertical: "bottom",

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/material";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import { LinkOff } from "@mui/icons-material";
+import { useMutation } from "@apollo/client";
 import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
 import DeleteConfirmationModal from "src/views/projects/projectView/DeleteConfirmationModal";
 import {
@@ -17,11 +18,12 @@ import {
   DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
 } from "src/queries/project";
 
-const FundingFile = ({ file, isSyncedFromECapris }) => {
+const FundingFile = ({ file, isSyncedFromECapris, refetch, fileRecordId }) => {
   const [anchorElement, setAnchorElement] = useState(null);
-  const [detachConfirmationFileId, setDetachConfirmationFileId] =
-    useState(null);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] =
+    useState(false);
   const menuOpen = Boolean(anchorElement);
+
 
   const handleMenuOpen = (event) => {
     setAnchorElement(event.currentTarget);
@@ -44,13 +46,13 @@ const FundingFile = ({ file, isSyncedFromECapris }) => {
       },
     })
       .then(() => {
-        setDetachConfirmationFileId(null);
-        onClose();
-        handleSnackbar(true, "File attachment detached", "success");
+        setIsDeleteConfirmationOpen(null);
+        // handleSnackbar(true, "File attachment detached", "success");
       })
       .catch((error) => {
-        setDetachConfirmationFileId(null);
-        handleSnackbar(true, "Error detaching file attachment", "error", error);
+        setIsDeleteConfirmationOpen(null);
+        console.error(error);
+        // handleSnackbar(true, "Error detaching file attachment", "error", error);
       })
       .finally(() => {
         refetch();
@@ -93,7 +95,7 @@ const FundingFile = ({ file, isSyncedFromECapris }) => {
         }}
       >
         <MenuItem
-          onClick={() => console.log("unlink this file")}
+          onClick={() => setIsDeleteConfirmationOpen(true)}
           selected={false}
         >
           <ListItemIcon>
@@ -102,17 +104,15 @@ const FundingFile = ({ file, isSyncedFromECapris }) => {
           <ListItemText primary="Detach" />
         </MenuItem>
       </Menu>
-      {detachConfirmationFileId && (
+      {isDeleteConfirmationOpen && (
         <DeleteConfirmationModal
           type="file attachment"
           actionButtonText="Detach"
           additionalConfirmationText="This will not delete the file, only detach it from this funding record."
           actionButtonIcon={<LinkOff />}
-          submitDelete={() => handleUnlinkFileAttachment(file.id)}
-          isDeleteConfirmationOpen={detachConfirmationFileId === file.id}
-          setIsDeleteConfirmationOpen={(open) =>
-            setDetachConfirmationFileId(open ? file.id : null)
-          }
+          submitDelete={() => handleUnlinkFileAttachment(fileRecordId)}
+          isDeleteConfirmationOpen={isDeleteConfirmationOpen}
+          setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
         />
       )}
     </Box>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import {
   Box,
-  Fade, // do i need this actually
+  Fade,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -43,7 +43,7 @@ const FundingFile = ({ file }) => {
         <MoreHorizIcon />
       </IconButton>
       <Menu
-        id="fade-menu"
+        id="funding-file-action-menu"
         anchorEl={anchorElement}
         keepMounted
         open={menuOpen}
@@ -61,16 +61,9 @@ const FundingFile = ({ file }) => {
       >
         <MenuItem
           onClick={() => console.log("unlink this file")}
-          sx={(theme) => ({
-            minWidth: theme.spacing(14),
-          })}
           selected={false}
         >
-          <ListItemIcon
-            sx={(theme) => ({
-              minWidth: theme.spacing(2),
-            })}
-          >
+          <ListItemIcon>
             <LinkOff />
           </ListItemIcon>
           <ListItemText primary="Detach" />

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -18,6 +18,15 @@ import {
   DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
 } from "src/queries/project";
 
+/**
+ *
+ * @param {Object} file - File information object to pass into ProjectFileLink
+ * @param {Boolean} isSyncedFromECapris - if parent funding record is synced from eCAPRIS
+ * @param {Function} refetch - Provides a manual callback to update the Apollo cache
+ * @param {number} fileRecordId - files_project_funding id /  ecapris_subproject_funding id for record
+ * @param {Function} handleSnackbar - The function to handle feedback snackbar messages
+ * @returns {JSX.Element}
+ */
 const FundingFile = ({
   file,
   isSyncedFromECapris,

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -18,12 +18,17 @@ import {
   DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
 } from "src/queries/project";
 
-const FundingFile = ({ file, isSyncedFromECapris, refetch, fileRecordId }) => {
+const FundingFile = ({
+  file,
+  isSyncedFromECapris,
+  refetch,
+  fileRecordId,
+  handleSnackbar,
+}) => {
   const [anchorElement, setAnchorElement] = useState(null);
   const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] =
     useState(false);
   const menuOpen = Boolean(anchorElement);
-
 
   const handleMenuOpen = (event) => {
     setAnchorElement(event.currentTarget);
@@ -47,12 +52,11 @@ const FundingFile = ({ file, isSyncedFromECapris, refetch, fileRecordId }) => {
     })
       .then(() => {
         setIsDeleteConfirmationOpen(null);
-        // handleSnackbar(true, "File attachment detached", "success");
+        handleSnackbar(true, "File attachment detached", "success");
       })
       .catch((error) => {
         setIsDeleteConfirmationOpen(null);
-        console.error(error);
-        // handleSnackbar(true, "Error detaching file attachment", "error", error);
+        handleSnackbar(true, "Error detaching file attachment", "error", error);
       })
       .finally(() => {
         refetch();

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -60,11 +60,11 @@ const FundingFile = ({
       },
     })
       .then(() => {
-        setIsDeleteConfirmationOpen(null);
+        setIsDeleteConfirmationOpen(false);
         handleSnackbar(true, "File attachment detached", "success");
       })
       .catch((error) => {
-        setIsDeleteConfirmationOpen(null);
+        setIsDeleteConfirmationOpen(false);
         handleSnackbar(true, "Error detaching file attachment", "error", error);
       })
       .finally(() => {
@@ -91,7 +91,7 @@ const FundingFile = ({
         <MoreHorizIcon />
       </IconButton>
       <Menu
-        id="funding-file-action-menu"
+        id={`funding-file-action-menu-${fileRecordId}`}
         anchorEl={anchorElement}
         keepMounted
         open={menuOpen}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -11,9 +11,16 @@ import {
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import { LinkOff } from "@mui/icons-material";
 import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
+import DeleteConfirmationModal from "src/views/projects/projectView/DeleteConfirmationModal";
+import {
+  DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT,
+  DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
+} from "src/queries/project";
 
 const FundingFile = ({ file }) => {
   const [anchorElement, setAnchorElement] = useState(null);
+  const [detachConfirmationFileId, setDetachConfirmationFileId] =
+    useState(null);
   const menuOpen = Boolean(anchorElement);
 
   const handleMenuOpen = (event) => {
@@ -22,6 +29,32 @@ const FundingFile = ({ file }) => {
 
   const handleMenuClose = () => {
     setAnchorElement(null);
+  };
+
+  const [detachFundingFileAttachment] = useMutation(
+    isSyncedFromECapris
+      ? DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT
+      : DETACH_FILE_MOPED_FUNDING_ATTACHMENT
+  );
+
+  const handleUnlinkFileAttachment = (id) => {
+    detachFundingFileAttachment({
+      variables: {
+        id,
+      },
+    })
+      .then(() => {
+        setDetachConfirmationFileId(null);
+        onClose();
+        handleSnackbar(true, "File attachment detached", "success");
+      })
+      .catch((error) => {
+        setDetachConfirmationFileId(null);
+        handleSnackbar(true, "Error detaching file attachment", "error", error);
+      })
+      .finally(() => {
+        refetch();
+      });
   };
 
   return (
@@ -69,6 +102,19 @@ const FundingFile = ({ file }) => {
           <ListItemText primary="Detach" />
         </MenuItem>
       </Menu>
+      {detachConfirmationFileId && (
+        <DeleteConfirmationModal
+          type="file attachment"
+          actionButtonText="Detach"
+          additionalConfirmationText="This will not delete the file, only detach it from this funding record."
+          actionButtonIcon={<LinkOff />}
+          submitDelete={() => handleUnlinkFileAttachment(file.id)}
+          isDeleteConfirmationOpen={detachConfirmationFileId === file.id}
+          setIsDeleteConfirmationOpen={(open) =>
+            setDetachConfirmationFileId(open ? file.id : null)
+          }
+        />
+      )}
     </Box>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Box, IconButton } from "@mui/material";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
+
+const FundingFile = ({ file }) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+      }}
+    >
+      <ProjectFileLink
+        fileKey={file.file_key}
+        fileUrl={file.file_url}
+        fileName={file.file_name}
+        condensed
+        showNetworkPathStyles={false}
+      />
+      <IconButton onClick={() => console.log("open")}>
+        <MoreHorizIcon />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default FundingFile;

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -17,7 +17,7 @@ import {
   DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
 } from "src/queries/project";
 
-const FundingFile = ({ file }) => {
+const FundingFile = ({ file, isSyncedFromECapris }) => {
   const [anchorElement, setAnchorElement] = useState(null);
   const [detachConfirmationFileId, setDetachConfirmationFileId] =
     useState(null);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -1,9 +1,29 @@
-import React from "react";
-import { Box, IconButton } from "@mui/material";
+import React, { useState } from "react";
+import {
+  Box,
+  Fade, // do i need this actually
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import { LinkOff } from "@mui/icons-material";
 import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
 
 const FundingFile = ({ file }) => {
+  const [anchorElement, setAnchorElement] = useState(null);
+  const menuOpen = Boolean(anchorElement);
+
+  const handleMenuOpen = (event) => {
+    setAnchorElement(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorElement(null);
+  };
+
   return (
     <Box
       sx={{
@@ -19,9 +39,43 @@ const FundingFile = ({ file }) => {
         condensed
         showNetworkPathStyles={false}
       />
-      <IconButton onClick={() => console.log("open")}>
+      <IconButton onClick={handleMenuOpen}>
         <MoreHorizIcon />
       </IconButton>
+      <Menu
+        id="fade-menu"
+        anchorEl={anchorElement}
+        keepMounted
+        open={menuOpen}
+        onClose={handleMenuClose}
+        autoFocus={false}
+        TransitionComponent={Fade}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        <MenuItem
+          onClick={() => console.log("unlink this file")}
+          sx={(theme) => ({
+            minWidth: theme.spacing(14),
+          })}
+          selected={false}
+        >
+          <ListItemIcon
+            sx={(theme) => ({
+              minWidth: theme.spacing(2),
+            })}
+          >
+            <LinkOff />
+          </ListItemIcon>
+          <ListItemText primary="Detach" />
+        </MenuItem>
+      </Menu>
     </Box>
   );
 };

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -29,6 +29,7 @@ function AttachmentTabPanel(props) {
       style={{
         position: value === index ? "static" : "absolute",
         visibility: value === index ? "visible" : "hidden",
+        display: value === index ? "block" : "none",
         width: "100%",
       }}
       {...other}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -4,9 +4,7 @@ import { useMutation } from "@apollo/client";
 import { Box, Tabs, Tab } from "@mui/material";
 import {
   CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT,
-  DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT,
   CREATE_FILE_MOPED_FUNDING_ATTACHMENT,
-  DETACH_FILE_MOPED_FUNDING_ATTACHMENT,
   ATTACH_EXISTING_FILE_TO_ECAPRIS_FUNDING,
   ATTACH_EXISTING_FILE_TO_MOPED_FUNDING,
 } from "src/queries/project";
@@ -85,11 +83,6 @@ const ProjectFundingFilesAttachmentDialog = ({
       : ATTACH_EXISTING_FILE_TO_MOPED_FUNDING
   );
 
-  const [detachFundingFileAttachment] = useMutation(
-    isSyncedFromECapris
-      ? DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT
-      : DETACH_FILE_MOPED_FUNDING_ATTACHMENT
-  );
   const isLoading = addFileLoading || attachFileLoading;
 
   const filesAttachedToId = useMemo(() => {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -1,15 +1,7 @@
 import React, { useState, useMemo } from "react";
 import { useMutation } from "@apollo/client";
 
-import {
-  Box,
-  Divider,
-  IconButton,
-  Stack,
-  Tabs,
-  Tab,
-  Typography,
-} from "@mui/material";
+import { Box, Tabs, Tab } from "@mui/material";
 import {
   CREATE_FILE_ECAPRIS_FUNDING_ATTACHMENT,
   DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT,
@@ -20,9 +12,6 @@ import {
 } from "src/queries/project";
 
 import FileUploadSingle from "src/components/FileUpload/FileUploadSingle";
-import DeleteConfirmationModal from "src/views/projects/projectView/DeleteConfirmationModal";
-import { LinkOff } from "@mui/icons-material";
-import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
 import FormDialog from "src/components/FormDialog";
 import { useFileUploadForm } from "src/components/FileUpload/useFileUploadForm";
 import AttachExistingFileTable from "src/views/projects/projectView/ProjectFunding/AttachExistingFileTable";
@@ -102,8 +91,6 @@ const ProjectFundingFilesAttachmentDialog = ({
       : DETACH_FILE_MOPED_FUNDING_ATTACHMENT
   );
   const isLoading = addFileLoading || attachFileLoading;
-  const [detachConfirmationFileId, setDetachConfirmationFileId] =
-    useState(null);
 
   const filesAttachedToId = useMemo(() => {
     const filesType = isSyncedFromECapris
@@ -115,26 +102,6 @@ const ProjectFundingFilesAttachmentDialog = ({
 
     return filesAttachedToId ? filesAttachedToId : [];
   }, [fileAttachmentId, rows, isSyncedFromECapris]);
-
-  const handleUnlinkFileAttachment = (id) => {
-    detachFundingFileAttachment({
-      variables: {
-        id,
-      },
-    })
-      .then(() => {
-        setDetachConfirmationFileId(null);
-        onClose();
-        handleSnackbar(true, "File attachment detached", "success");
-      })
-      .catch((error) => {
-        setDetachConfirmationFileId(null);
-        handleSnackbar(true, "Error detaching file attachment", "error", error);
-      })
-      .finally(() => {
-        refetch();
-      });
-  };
 
   /* File upload form state and handlers */
   const handleClickSaveFile = (fileDataBundle) => {
@@ -277,65 +244,6 @@ const ProjectFundingFilesAttachmentDialog = ({
             attachedFiles={filesAttachedToId}
           />
         </AttachmentTabPanel>
-        <Box>
-          <Divider sx={{ marginY: 4 }} />
-          <Stack direction="column">
-            <Typography variant="h4" sx={{ mb: 1 }}>
-              Attached files
-            </Typography>
-
-            {filesAttachedToId.length > 0 ? (
-              filesAttachedToId.map((file) => {
-                if (!file) return null;
-                const fileDetails = file.moped_project_file;
-
-                return (
-                  <React.Fragment key={file.id}>
-                    <DeleteConfirmationModal
-                      type="file attachment"
-                      actionButtonText="Detach"
-                      additionalConfirmationText="This will not delete the file, only detach it from this funding record."
-                      actionButtonIcon={<LinkOff />}
-                      submitDelete={() => handleUnlinkFileAttachment(file.id)}
-                      isDeleteConfirmationOpen={
-                        detachConfirmationFileId === file.id
-                      }
-                      setIsDeleteConfirmationOpen={(open) =>
-                        setDetachConfirmationFileId(open ? file.id : null)
-                      }
-                    />
-                    <Stack
-                      direction="row"
-                      sx={{
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                      }}
-                      spacing={0.5}
-                    >
-                      <Box>
-                        <IconButton
-                          onClick={() => setDetachConfirmationFileId(file.id)}
-                          size="small"
-                        >
-                          <LinkOff />
-                        </IconButton>
-                      </Box>
-                      <Box sx={{ flex: 1 }}>
-                        <ProjectFileLink
-                          fileKey={fileDetails?.file_key}
-                          fileUrl={fileDetails?.file_url}
-                          fileName={fileDetails?.file_name}
-                        />
-                      </Box>
-                    </Stack>
-                  </React.Fragment>
-                );
-              })
-            ) : (
-              <Typography variant="body2">No files attached</Typography>
-            )}
-          </Stack>
-        </Box>
       </Box>
     </FormDialog>
   );

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingFilesAttachmentDialog.js
@@ -214,7 +214,7 @@ const ProjectFundingFilesAttachmentDialog = ({
       showDialogActions={true}
       dialogProps={{ maxWidth: "md" }}
     >
-      <Box sx={{ width: "100%", minHeight: "40vh" }}>
+      <Box sx={{ width: "100%" }}>
         <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
           <Tabs
             value={tabValue}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -370,6 +370,7 @@ const ProjectFundingTable = ({
     setOverrideFundingRecord,
     usingShiftKey,
     logUserEvent,
+    refetch,
   });
 
   const handleECaprisSwitch = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.js
@@ -371,6 +371,7 @@ const ProjectFundingTable = ({
     usingShiftKey,
     logUserEvent,
     refetch,
+    handleSnackbar
   });
 
   const handleECaprisSwitch = () => {

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -361,7 +361,13 @@ export const useColumns = ({
               {row?.[filesType].map((file_record) => {
                 const file = file_record.moped_project_file;
                 if (!file) return null;
-                return <FundingFile key={file.project_file_id} file={file} />;
+                return (
+                  <FundingFile
+                    key={file.project_file_id}
+                    file={file}
+                    isSyncedFromECapris={row.is_synced_from_ecapris}
+                  />
+                );
               })}
             </Stack>
           );

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Divider, Stack, IconButton } from "@mui/material";
+import { Box, Divider, Stack, IconButton } from "@mui/material";
 import LookupAutocompleteComponent from "src/components/DataGridPro/LookupAutocompleteComponent";
 import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import ViewOnlyTextField from "src/components/DataGridPro/ViewOnlyTextField";
@@ -16,6 +16,7 @@ import {
   isAmountOutOfRange,
   outOfRangeErrorMessage,
 } from "src/utils/numberFormatters";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
 /** Transforms database funding records to DataGrid rows with lookup objects to populate autocomplete components
  * @param {Array} fundingRecords - array of funding records from the database
@@ -353,7 +354,11 @@ export const useColumns = ({
             return;
           }
           return (
-            <Stack direction="column" spacing={0.5}>
+            <Stack
+              direction="column"
+              spacing={0.5}
+              divider={<Divider sx={{ my: 0.5 }} />}
+            >
               {row?.[filesType].map((file_record, index) => {
                 const file = file_record.moped_project_file;
 
@@ -361,14 +366,24 @@ export const useColumns = ({
 
                 return (
                   <React.Fragment key={file.project_file_id}>
-                    {index > 0 && <Divider sx={{ my: 0.5 }} />}
-                    <ProjectFileLink
-                      fileKey={file.file_key}
-                      fileUrl={file.file_url}
-                      fileName={file.file_name}
-                      condensed
-                      showNetworkPathStyles={false}
-                    />
+                    <Box
+                      sx={{
+                        display: "flex",
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                      }}
+                    >
+                      <ProjectFileLink
+                        fileKey={file.file_key}
+                        fileUrl={file.file_url}
+                        fileName={file.file_name}
+                        condensed
+                        showNetworkPathStyles={false}
+                      />
+                      <IconButton onClick={() => console.log("open")}>
+                        <MoreHorizIcon />
+                      </IconButton>
+                    </Box>
                   </React.Fragment>
                 );
               })}

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Box, Divider, Stack, IconButton } from "@mui/material";
+import { Divider, Stack, IconButton } from "@mui/material";
 import LookupAutocompleteComponent from "src/components/DataGridPro/LookupAutocompleteComponent";
 import DataGridTextField from "src/components/DataGridPro/DataGridTextField";
 import ViewOnlyTextField from "src/components/DataGridPro/ViewOnlyTextField";
@@ -9,14 +9,13 @@ import SecondaryInformationChip from "src/components/SecondaryInformationChip";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import AttachFileOutlinedIcon from "@mui/icons-material/AttachFileOutlined";
-import ProjectFileLink from "src/views/projects/projectView/ProjectFiles/ProjectFileLink";
 import DataGridActions from "src/components/DataGridPro/DataGridActions";
 import {
   currencyFormatter,
   isAmountOutOfRange,
   outOfRangeErrorMessage,
 } from "src/utils/numberFormatters";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import FundingFile from "src/views/projects/projectView/ProjectFunding/FundingFile";
 
 /** Transforms database funding records to DataGrid rows with lookup objects to populate autocomplete components
  * @param {Array} fundingRecords - array of funding records from the database
@@ -365,26 +364,27 @@ export const useColumns = ({
                 if (!file) return null;
 
                 return (
-                  <React.Fragment key={file.project_file_id}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexDirection: "row",
-                        justifyContent: "space-between",
-                      }}
-                    >
-                      <ProjectFileLink
-                        fileKey={file.file_key}
-                        fileUrl={file.file_url}
-                        fileName={file.file_name}
-                        condensed
-                        showNetworkPathStyles={false}
-                      />
-                      <IconButton onClick={() => console.log("open")}>
-                        <MoreHorizIcon />
-                      </IconButton>
-                    </Box>
-                  </React.Fragment>
+                  <FundingFile key={file.project_file_id} file={file} />
+                  // <React.Fragment key={file.project_file_id}>
+                  //   <Box
+                  //     sx={{
+                  //       display: "flex",
+                  //       flexDirection: "row",
+                  //       justifyContent: "space-between",
+                  //     }}
+                  //   >
+                  //     <ProjectFileLink
+                  //       fileKey={file.file_key}
+                  //       fileUrl={file.file_url}
+                  //       fileName={file.file_name}
+                  //       condensed
+                  //       showNetworkPathStyles={false}
+                  //     />
+                  //     <IconButton onClick={() => console.log("open")}>
+                  //       <MoreHorizIcon />
+                  //     </IconButton>
+                  //   </Box>
+                  // </React.Fragment>
                 );
               })}
             </Stack>

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -201,6 +201,7 @@ export const useColumns = ({
   setOverrideFundingRecord,
   usingShiftKey,
   logUserEvent,
+  handleSnackbar,
   refetch,
 }) =>
   useMemo(() => {
@@ -369,6 +370,7 @@ export const useColumns = ({
                     file={file}
                     isSyncedFromECapris={row.is_synced_from_ecapris}
                     refetch={refetch}
+                    handleSnackbar={handleSnackbar}
                   />
                 );
               })}
@@ -442,4 +444,5 @@ export const useColumns = ({
     usingShiftKey,
     logUserEvent,
     refetch,
+    handleSnackbar
   ]);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -363,29 +363,7 @@ export const useColumns = ({
 
                 if (!file) return null;
 
-                return (
-                  <FundingFile key={file.project_file_id} file={file} />
-                  // <React.Fragment key={file.project_file_id}>
-                  //   <Box
-                  //     sx={{
-                  //       display: "flex",
-                  //       flexDirection: "row",
-                  //       justifyContent: "space-between",
-                  //     }}
-                  //   >
-                  //     <ProjectFileLink
-                  //       fileKey={file.file_key}
-                  //       fileUrl={file.file_url}
-                  //       fileName={file.file_name}
-                  //       condensed
-                  //       showNetworkPathStyles={false}
-                  //     />
-                  //     <IconButton onClick={() => console.log("open")}>
-                  //       <MoreHorizIcon />
-                  //     </IconButton>
-                  //   </Box>
-                  // </React.Fragment>
-                );
+                return <FundingFile key={file.project_file_id} file={file} />;
               })}
             </Stack>
           );

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -201,6 +201,7 @@ export const useColumns = ({
   setOverrideFundingRecord,
   usingShiftKey,
   logUserEvent,
+  refetch,
 }) =>
   useMemo(() => {
     return [
@@ -364,8 +365,10 @@ export const useColumns = ({
                 return (
                   <FundingFile
                     key={file.project_file_id}
+                    fileRecordId={file_record.id}
                     file={file}
                     isSyncedFromECapris={row.is_synced_from_ecapris}
+                    refetch={refetch}
                   />
                 );
               })}
@@ -438,4 +441,5 @@ export const useColumns = ({
     setOverrideFundingRecord,
     usingShiftKey,
     logUserEvent,
+    refetch,
   ]);

--- a/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
+++ b/moped-editor/src/views/projects/projectView/ProjectFunding/helpers.js
@@ -358,11 +358,9 @@ export const useColumns = ({
               spacing={0.5}
               divider={<Divider sx={{ my: 0.5 }} />}
             >
-              {row?.[filesType].map((file_record, index) => {
+              {row?.[filesType].map((file_record) => {
                 const file = file_record.moped_project_file;
-
                 if (!file) return null;
-
                 return <FundingFile key={file.project_file_id} file={file} />;
               })}
             </Stack>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28525

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
locally, branching off of branches that branch

**Steps to test:**

Like in previous testing, we are going to start out by setting up a project with funding records and files. 

1. Start up your local stack with production data
2. Create a new project or go to an existing one
3. Go to the Funding tab and choosing an eCAPRIS subproject id like 10553.005 so that you will have an eCAPRIS funding row in your table
4. Manually add a row with a source and amount only then save it so you will have a Moped funding row in your table
5. Attach a file to each row, using the link to file option. The detach file section is no longer on the attach modal.
6. Add another file to one of the rows so you have multiple files on one row. 
7. Notice that your files now have the MoreHoriz icon right aligned in their same row. 
8. Click on the icon to open a Menu. The only option is "Detach"
9. Click Detach to launch the delete confirmation modal.
10. Detach the file. 

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
