### PR TITLE
Disable delete button in DeleteConfirmationModal when deleting

### DIFF
--- a/editor/src/views/dashboard/UserSavedViewsTable.jsx
+++ b/editor/src/views/dashboard/UserSavedViewsTable.jsx
@@ -114,7 +114,7 @@ const UserSavedViewsTable = ({ handleSnackbar }) => {
   });
 
   const [updateUserSavedView] = useMutation(UPDATE_USER_SAVED_VIEW);
-  const [deleteUserSavedView] = useMutation(DELETE_USER_SAVED_VIEW);
+  const [deleteUserSavedView, { loading: mutationPending }] = useMutation(DELETE_USER_SAVED_VIEW);
 
   // rows and rowModesModel used in DataGrid
   const [rows, setRows] = useState([]);
@@ -242,6 +242,7 @@ const UserSavedViewsTable = ({ handleSnackbar }) => {
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/dev/LookupsView/ComponentTagsTable.jsx
+++ b/editor/src/views/dev/LookupsView/ComponentTagsTable.jsx
@@ -121,7 +121,8 @@ const ComponentTagsTable = ({ canEdit, handleSnackbar, onScrollToTop }) => {
   });
 
   const [addComponentTag] = useMutation(ADD_COMPONENT_TAG);
-  const [updateComponentTag] = useMutation(UPDATE_COMPONENT_TAG);
+  const [updateComponentTag, { loading: mutationPending }] =
+    useMutation(UPDATE_COMPONENT_TAG);
 
   const tableRows = useMemo(
     () => transformDatabaseToGrid(data?.moped_component_tags),
@@ -353,6 +354,7 @@ const ComponentTagsTable = ({ canEdit, handleSnackbar, onScrollToTop }) => {
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
         confirmationText="Are you sure you want to remove this component tag? It will be hidden from the data dictionary and downstream views."
         actionButtonText="Remove"
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/dev/LookupsView/ProjectTagsTable.jsx
+++ b/editor/src/views/dev/LookupsView/ProjectTagsTable.jsx
@@ -121,7 +121,9 @@ const ProjectTagsTable = ({ canEdit, handleSnackbar, onScrollToTop }) => {
   });
 
   const [addProjectTagLookup] = useMutation(ADD_PROJECT_TAG_LOOKUP);
-  const [updateProjectTagLookup] = useMutation(UPDATE_PROJECT_TAG_LOOKUP);
+  const [updateProjectTagLookup, { loading: mutationPending }] = useMutation(
+    UPDATE_PROJECT_TAG_LOOKUP
+  );
 
   const tableRows = useMemo(
     () => transformDatabaseToGrid(data?.moped_tags),
@@ -348,6 +350,7 @@ const ProjectTagsTable = ({ canEdit, handleSnackbar, onScrollToTop }) => {
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
         confirmationText="Are you sure you want to remove this project tag? It will be hidden from the data dictionary and downstream views."
         actionButtonText="Remove"
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/projects/projectView/DeleteConfirmationModal.jsx
+++ b/editor/src/views/projects/projectView/DeleteConfirmationModal.jsx
@@ -19,6 +19,7 @@ import DeleteIcon from "@mui/icons-material/DeleteOutlined";
  * @param {string} additionalConfirmationText - Optional additional text to append to the default confirmation message
  * @param {string} actionButtonText - Optional custom text for the delete action button, defaults to "Delete"
  * @param {JSX.Element} actionButtonIcon - Optional custom icon for the delete action button, defaults to a delete icon
+ * @param {boolean} mutationPending - mutation loading status from delete mutation
  * @returns {JSX.Element}
  */
 const DeleteConfirmationModal = ({
@@ -31,6 +32,7 @@ const DeleteConfirmationModal = ({
   additionalConfirmationText,
   actionButtonText = "Delete",
   actionButtonIcon,
+  mutationPending,
 }) => {
   const handleDeleteClose = () => {
     setIsDeleteConfirmationOpen(false);
@@ -61,6 +63,7 @@ const DeleteConfirmationModal = ({
             color="primary"
             variant="contained"
             startIcon={ActionIcon}
+            disabled={mutationPending}
             onClick={() => {
               submitDelete();
               // closing the confirmation modal should happen after the delete mutation completes

--- a/editor/src/views/projects/projectView/ProjectFiles/ProjectFiles.jsx
+++ b/editor/src/views/projects/projectView/ProjectFiles/ProjectFiles.jsx
@@ -286,9 +286,9 @@ const ProjectFiles = ({ handleSnackbar }) => {
   const [updateProjectFileAttachment] = useMutation(
     PROJECT_FILE_ATTACHMENTS_UPDATE
   );
-  const [deleteProjectFileAttachment] = useMutation(
-    PROJECT_FILE_ATTACHMENTS_DELETE
-  );
+  const [deleteProjectFileAttachment, { loading: mutationPending }] =
+    useMutation(PROJECT_FILE_ATTACHMENTS_DELETE);
+
   const [createProjectFileAttachment] = useMutation(
     PROJECT_FILE_ATTACHMENTS_CREATE
   );
@@ -470,6 +470,7 @@ const ProjectFiles = ({ handleSnackbar }) => {
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
+++ b/editor/src/views/projects/projectView/ProjectFunding/FundingFile.jsx
@@ -47,11 +47,12 @@ const FundingFile = ({
     setAnchorElement(null);
   };
 
-  const [detachFundingFileAttachment] = useMutation(
-    isSyncedFromECapris
-      ? DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT
-      : DETACH_FILE_MOPED_FUNDING_ATTACHMENT
-  );
+  const [detachFundingFileAttachment, { loading: mutationPending }] =
+    useMutation(
+      isSyncedFromECapris
+        ? DETACH_FILE_ECAPRIS_FUNDING_ATTACHMENT
+        : DETACH_FILE_MOPED_FUNDING_ATTACHMENT
+    );
 
   const handleUnlinkFileAttachment = (id) => {
     detachFundingFileAttachment({
@@ -125,6 +126,7 @@ const FundingFile = ({
           submitDelete={() => handleUnlinkFileAttachment(fileRecordId)}
           isDeleteConfirmationOpen={isDeleteConfirmationOpen}
           setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+          mutationPending={mutationPending}
         />
       )}
     </Box>

--- a/editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectFunding/ProjectFundingTable.jsx
@@ -108,10 +108,13 @@ const ProjectFundingTable = ({
   /* Mutations for adding, editing, deleting funding records, and updating eCAPRIS sync status */
   const [addProjectFunding] = useMutation(ADD_PROJECT_FUNDING);
   const [updateProjectFunding] = useMutation(UPDATE_PROJECT_FUNDING);
-  const [deleteProjectFunding] = useMutation(DELETE_PROJECT_FUNDING);
-  const [deleteProjectFundingAndReattach] = useMutation(
-    DELETE_PROJECT_FUNDING_AND_REATTACH
+  const [deleteProjectFunding, { loading: mutationPending }] = useMutation(
+    DELETE_PROJECT_FUNDING
   );
+  const [
+    deleteProjectFundingAndReattach,
+    { loading: mutationPendingReattach },
+  ] = useMutation(DELETE_PROJECT_FUNDING_AND_REATTACH);
   const [updateShouldSyncECapris] = useMutation(
     PROJECT_UPDATE_ECAPRIS_FUNDING_SYNC
   );
@@ -556,6 +559,7 @@ const ProjectFundingTable = ({
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={mutationPending || mutationPendingReattach}
       />
       {eCaprisSubprojectId && (
         <SubprojectFundingModal

--- a/editor/src/views/projects/projectView/ProjectMilestones.jsx
+++ b/editor/src/views/projects/projectView/ProjectMilestones.jsx
@@ -210,7 +210,9 @@ const ProjectMilestones = ({
   const [updateProjectMilestone] = useMutation(
     UPDATE_PROJECT_MILESTONES_MUTATION
   );
-  const [deleteProjectMilestone] = useMutation(DELETE_PROJECT_MILESTONE);
+  const [deleteProjectMilestone, { loading: mutationPending }] = useMutation(
+    DELETE_PROJECT_MILESTONE
+  );
   const [addProjectMilestone] = useMutation(ADD_PROJECT_MILESTONE);
 
   // rows and rowModesModel used in DataGrid
@@ -493,6 +495,7 @@ const ProjectMilestones = ({
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/projects/projectView/ProjectNotes.jsx
+++ b/editor/src/views/projects/projectView/ProjectNotes.jsx
@@ -216,7 +216,7 @@ const ProjectNotes = ({
     },
   });
 
-  const [deleteExistingNote] = useMutation(DELETE_PROJECT_NOTE, {
+  const [deleteExistingNote, { loading: mutationPending }] = useMutation(DELETE_PROJECT_NOTE, {
     onCompleted() {
       refetch();
       if (isStatusEditModal) {
@@ -444,6 +444,7 @@ const ProjectNotes = ({
                 submitDelete={() => submitDeleteNote(deleteConfirmationId)}
                 isDeleteConfirmationOpen={isDeleteConfirmationOpen}
                 setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+                mutationPending={mutationPending}
               >
                 {displayNotes.map((note, i) => {
                   const isNotLastItem = i < displayNotes.length - 1;

--- a/editor/src/views/projects/projectView/ProjectPhases.jsx
+++ b/editor/src/views/projects/projectView/ProjectPhases.jsx
@@ -297,6 +297,7 @@ const ProjectPhases = ({
         submitDelete={handleDeleteClick(deleteConfirmationId)}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={deleteInProgress}
       />
       <CurrentPhaseDeleteModal
         isOpen={isDeleteCurrentConfirmationOpen}

--- a/editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectSummary/SubprojectsTable.jsx
@@ -179,7 +179,9 @@ const SubprojectsTable = ({
   );
 
   const [updateProjectSubproject] = useMutation(UPDATE_PROJECT_SUBPROJECT);
-  const [deleteProjectSubproject] = useMutation(DELETE_PROJECT_SUBPROJECT);
+  const [deleteProjectSubproject, { loading: mutationPending }] = useMutation(
+    DELETE_PROJECT_SUBPROJECT
+  );
 
   // rows and rowModesModel used in DataGrid
   const [rows, setRows] = useState([]);
@@ -421,6 +423,7 @@ const SubprojectsTable = ({
         }
         actionButtonText="Unlink"
         actionButtonIcon={<LinkOffIcon />}
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/projects/projectView/ProjectSummary/TagsSection.jsx
+++ b/editor/src/views/projects/projectView/ProjectSummary/TagsSection.jsx
@@ -37,7 +37,8 @@ const TagsSection = ({ projectId, handleSnackbar }) => {
   });
 
   const [addProjectTags] = useMutation(ADD_PROJECT_TAGS);
-  const [deleteProjectTag] = useMutation(DELETE_PROJECT_TAG);
+  const [deleteProjectTag, { loading: mutationPending }] =
+    useMutation(DELETE_PROJECT_TAG);
 
   if (error) console.error(error);
   if (loading || !data) return <CircularProgress />;
@@ -147,6 +148,7 @@ const TagsSection = ({ projectId, handleSnackbar }) => {
           submitDelete={() => handleTagDelete(deleteConfirmationId)}
           isDeleteConfirmationOpen={isDeleteConfirmationOpen}
           setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+          mutationPending={mutationPending}
         >
           <Grid2 container spacing={1}>
             {data.moped_proj_tags.map((tag) => (

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -319,7 +319,9 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
 
   const [insertProjectPersonnel] = useMutation(INSERT_PROJECT_PERSONNEL);
   const [updateProjectPersonnel] = useMutation(UPDATE_PROJECT_PERSONNEL);
-  const [deleteProjectPersonnel] = useMutation(DELETE_PROJECT_PERSONNEL);
+  const [deleteProjectPersonnel, { loading: mutationPending }] = useMutation(
+    DELETE_PROJECT_PERSONNEL
+  );
 
   const [rows, setRows] = useState([]);
   const [rowModesModel, setRowModesModel] = useState({});
@@ -616,6 +618,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         }}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={mutationPending}
       />
     </>
   );

--- a/editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectWorkActivity/ProjectWorkActivityTable.jsx
@@ -288,6 +288,7 @@ const ProjectWorkActivitiesTable = ({ handleSnackbar }) => {
         submitDelete={handleDeleteConfirmed}
         isDeleteConfirmationOpen={isDeleteConfirmationOpen}
         setIsDeleteConfirmationOpen={setIsDeleteConfirmationOpen}
+        mutationPending={deleteInProgress}
       />
     </>
   );


### PR DESCRIPTION
## Associated issues

http://github.com/cityofaustin/atd-data-tech/issues/28756

## Testing
**URL to test:** 

you will need to test locally until the parent branches are merged to main.

**Steps to test:**

Its a lot of creating records, throttling your connection and then deleting the record you just made. When the mutation is processing, the delete button should be disabled 

1. Delete a saved view. If you dont have one already, do an advanced search from the project list view. Save the view (the button to save a view is under the search input, on the left, after you have executed the search). Now go to the dashboard, click the saved views tab. Throttle your connection to slower and delete a saved view. 
2. Delete a component tag and a project tag. Go to the data dictionary and add a component tag. throttle, delete. Repeat for project tag. 
3. Project Funding files. Go to a project, add a file (add a "link to file" to make things easier). Now go to the funding tab and attach to a funding record. Use the detach menu to open the detach modal, throttle and detach. 
4. Project Files. On that same project, test deleting the file you added in 3. throttle and delete. 
5. Project Subprojects. From the project summary tab, add a subproject. Throttle and delete. 
6. Project Tags. From the summary tab, add a project tag. Now click the x on the tag to delete. I hope you remembered the throttle. 
7. Project Team members. Go to the team tab. Add a team member, throttle and then delete the record. 
8. Work Activities. Back on the funding tab, add a work activity. throttle, delete. 
9. Project notes. Add a note, throttle, delete 
10. Timeline tab. Test deleting a phase and a milestone. 
11. Thank you. 



---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
