### PR TITLE
Bump graphql-engine to v2.49.2

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.49.0
+        image: hasura/graphql-engine:v2.49.2
         depends_on:
             - moped-pgsql
         expose:

--- a/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.48.16",
+            "image": "hasura/graphql-engine:v2.49.2",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.49.0",
+            "image": "hasura/graphql-engine:v2.49.2",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/28802

## Testing

**Steps to test:**

* Spin up local dev, replicate some live data, try out the site
* Review the code, especially WRT the image being requested: [here](https://hub.docker.com/layers/hasura/graphql-engine/v2.49.2/images/sha256-122800e22107bee579610f7e3b266d33d347bff0935a84068ad8fb8a5ee78d06)

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
