### PR TITLE
Add npm run lint to prod build and version bump for 3.9.0 release

### DIFF
--- a/editor/netlify.toml
+++ b/editor/netlify.toml
@@ -2,7 +2,7 @@
 [build]
   publish = "build"
   ignore = "/bin/false"
-  command = "npm run build:production"
+  command = "npm run lint && npm run build:production"
 
 # Redirect root to the app URL space, "/moped/"
 [[redirects]]

--- a/editor/package.json
+++ b/editor/package.json
@@ -2,7 +2,7 @@
   "name": "moped-editor",
   "author": "TPW Data & Technology Services",
   "license": "CC0-1.0",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Associated issues
None - just forgot to run `npm run lint` on production builds for catching errors in patches to prod. [More details here](https://austininnovation.slack.com/archives/CHZE6BC6L/p1781800167443189?thread_ts=1781799546.150959&cid=CHZE6BC6L)

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->

**Steps to test:**
1. No testing beyond reading the code. The intention is to run the lint script when building `production` branch too so we can prevent errors from reaching production in patches by failing the build

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
