### PR TITLE
Fix DataGridActions validation

### DIFF
--- a/editor/src/components/DataGridPro/DataGridActions.jsx
+++ b/editor/src/components/DataGridPro/DataGridActions.jsx
@@ -12,7 +12,10 @@ import {
   AttachFileOutlined as AttachFileOutlinedIcon,
 } from "@mui/icons-material";
 
-import { defaultEditColumnIconStyle } from "src/components/DataGridPro/utils/helpers.js";
+import {
+  defaultEditColumnIconStyle,
+  isEmpty,
+} from "src/components/DataGridPro/utils/helpers.js";
 
 /** Component for Data Grid table action buttons
  * @param {Number} id - Data Grid row id (same as project id)
@@ -57,7 +60,7 @@ const DataGridActions = ({
 
     for (const field of requiredFields) {
       const hasError = Boolean(editState[id]?.[field]?.error);
-      const hasValue = Boolean(editState[id]?.[field]?.value);
+      const hasValue = !isEmpty(editState[id]?.[field]?.value);
 
       if (hasError || !hasValue) {
         return false;

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -107,6 +107,7 @@ export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
   /**
    * Builds the onRowEditStop handler; see handleRowEditStop for events handled
    */
+  // TODO: Figure out why populating Name column make handleOnRowModesModelChange fire twice - first with view mode and then with edit mode
   const makeHandleRowEditStop = useCallback(
     ({ setRows, setRowModesModel }) =>
       (params, event) => {
@@ -120,21 +121,15 @@ export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
         if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
           const id = getRowId(params.row);
           markCanceled(id);
-          // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state and rowModesModel
+          // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state
           if (params.row.isNew) {
             setRows((prev) => prev.filter((row) => getRowId(row) !== id));
-            if (setRowModesModel) {
-              setRowModesModel((prev) => {
-                const { [id]: _, ...rest } = prev;
-                return rest;
-              });
-            }
-          } else if (setRowModesModel) {
-            setRowModesModel((prev) => ({
-              ...prev,
-              [id]: { mode: GridRowModes.View, ignoreModifications: true },
-            }));
           }
+          // Remove the row's entry from the rowModesModel to force out of edit mode
+          setRowModesModel((prev) => {
+            const { [id]: _, ...rest } = prev;
+            return rest;
+          });
         }
       },
     [getRowId, markCanceled]

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -107,7 +107,6 @@ export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
   /**
    * Builds the onRowEditStop handler; see handleRowEditStop for events handled
    */
-  // TODO: Figure out why populating Name column make handleOnRowModesModelChange fire twice - first with view mode and then with edit mode
   const makeHandleRowEditStop = useCallback(
     ({ setRows, setRowModesModel }) =>
       (params, event) => {
@@ -135,9 +134,26 @@ export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
     [getRowId, markCanceled]
   );
 
+  /**
+   * Build the model-change handler in the hook so it can reference canceled ids
+   */
+  const makeHandleRowModesModelChange = useCallback(
+    (setRowModesModel) => (newModel) => {
+      // Drop entries for rows that were just canceled
+      const filtered = Object.fromEntries(
+        Object.entries(newModel).filter(
+          ([id]) => !canceledRowIds.current.has(id)
+        )
+      );
+      setRowModesModel(filtered);
+    },
+    []
+  );
+
   return {
     wasCanceled,
     makeHandleCancelClick,
     makeHandleRowEditStop,
+    makeHandleRowModesModelChange,
   };
 };

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -21,10 +21,46 @@ export const handleRowEditStop = (rows, setRows) => (params, event) => {
   }
   if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
     if (params.row.isNew) {
+      event.defaultMuiPrevented = true;
       setRows(rows.filter((row) => row.id !== params.row.id));
     }
   }
 };
+
+/**
+ * Returns a handleCancelClick handler that prevents processRowUpdate from firing
+ * when canceling drafts or edits on a row
+ * @param {Array} rows - The current rows state
+ * @param {Function} setRows - The rows state setter
+ * @param {Object} rowModesModel - The current row modes model
+ * @param {Function} setRowModesModel - The row modes model state setter
+ * @param {Function} getRowId - Function to get the row's id field, defaults to row.id
+ * @returns {Function} - A handleCancelClick handler
+ */
+export const handleCancelClick =
+  (
+    rows,
+    setRows,
+    rowModesModel,
+    setRowModesModel,
+    getRowId = (row) => row.id
+  ) =>
+  (id) =>
+  () => {
+    const editedRow = rows.find((row) => getRowId(row) === id);
+    if (editedRow?.isNew) {
+      setRows((prev) => prev.filter((row) => getRowId(row) !== id));
+      setRowModesModel((prev) => {
+        const { [id]: _, ...rest } = prev;
+        return rest;
+      });
+    } else {
+      setRowModesModel((prev) => ({
+        ...prev,
+        [id]: { mode: GridRowModes.View, ignoreModifications: true },
+      }));
+    }
+  };
 
 /**
  * Uses the rowModesModel to determine if any row is currently in edit mode
@@ -33,5 +69,9 @@ export const handleRowEditStop = (rows, setRows) => (params, event) => {
  * @param {Object} rowModesModel - The row modes model from the DataGrid
  * @returns {boolean} - True if any row is in edit mode, false otherwise
  */
-export const getIsEditMode = (rowModesModel) =>
-  Object.values(rowModesModel).some((m) => m?.mode === GridRowModes.Edit);
+export const getIsEditMode = (rowModesModel) => {
+  console.log(rowModesModel);
+  return Object.values(rowModesModel).some(
+    (m) => m?.mode === GridRowModes.Edit
+  );
+};

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -11,54 +11,27 @@ export const defaultEditColumnIconStyle = { fontSize: "24px" };
  * @param {Function} setRows - The rows state setter
  * @returns {Function} - A DataGrid `onRowEditStop` event handler
  */
-export const handleRowEditStop = (rows, setRows) => (params, event) => {
-  if (params.reason === GridRowEditStopReasons.rowFocusOut) {
-    event.defaultMuiPrevented = true;
-    return;
-  }
-  if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-    event.defaultMuiPrevented = true;
-  }
-  if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
-    if (params.row.isNew) {
+export const handleRowEditStop =
+  (rows, setRows, setRowModesModel) => (params, event) => {
+    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
       event.defaultMuiPrevented = true;
-      setRows(rows.filter((row) => row.id !== params.row.id));
+      return;
     }
-  }
-};
-
-/**
- * Returns a handleCancelClick handler that prevents processRowUpdate from firing
- * when canceling drafts or edits on a row
- * @param {Array} rows - The current rows state
- * @param {Function} setRows - The rows state setter
- * @param {Object} rowModesModel - The current row modes model
- * @param {Function} setRowModesModel - The row modes model state setter
- * @param {Function} getRowId - Function to get the row's id field, defaults to row.id
- * @returns {Function} - A handleCancelClick handler
- */
-export const handleCancelClick =
-  (
-    rows,
-    setRows,
-    rowModesModel,
-    setRowModesModel,
-    getRowId = (row) => row.id
-  ) =>
-  (id) =>
-  () => {
-    const editedRow = rows.find((row) => getRowId(row) === id);
-    if (editedRow?.isNew) {
-      setRows((prev) => prev.filter((row) => getRowId(row) !== id));
-      setRowModesModel((prev) => {
-        const { [id]: _, ...rest } = prev;
-        return rest;
-      });
-    } else {
-      setRowModesModel((prev) => ({
-        ...prev,
-        [id]: { mode: GridRowModes.View, ignoreModifications: true },
-      }));
+    if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+      event.defaultMuiPrevented = true;
+    }
+    if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+      if (params.row.isNew) {
+        const rowIdToRemove = params.row.id;
+        setRows((prevRows) =>
+          prevRows.filter((row) => row.id !== rowIdToRemove)
+        );
+        setRowModesModel((prevRowModesModel) => {
+          const { [rowIdToRemove]: _, ...rest } = prevRowModesModel;
+          return rest;
+        });
+        event.defaultMuiPrevented = true;
+      }
     }
   };
 
@@ -69,9 +42,5 @@ export const handleCancelClick =
  * @param {Object} rowModesModel - The row modes model from the DataGrid
  * @returns {boolean} - True if any row is in edit mode, false otherwise
  */
-export const getIsEditMode = (rowModesModel) => {
-  console.log(rowModesModel);
-  return Object.values(rowModesModel).some(
-    (m) => m?.mode === GridRowModes.Edit
-  );
-};
+export const getIsEditMode = (rowModesModel) =>
+  Object.values(rowModesModel).some((m) => m?.mode === GridRowModes.Edit);

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -1,3 +1,4 @@
+import { useCallback, useRef } from "react";
 import { GridRowEditStopReasons, GridRowModes } from "@mui/x-data-grid-pro";
 
 export const defaultEditColumnIconStyle = { fontSize: "24px" };
@@ -50,3 +51,98 @@ export const handleRowEditStop = (rows, setRows) => (params, event) => {
  */
 export const getIsEditMode = (rowModesModel) =>
   Object.values(rowModesModel).some((m) => m?.mode === GridRowModes.Edit);
+
+/**
+ * Custom hook to contain workaround fix for bug described in https://github.com/mui/mui-x/issues/21766
+ * Handles issue where canceling an edit on a row does not properly prevent the subsequent processRowUpdate from executing.
+ * So, we track the ids of canceled rows and check those ids during processRowUpdate to skip mutation.
+ */
+export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
+  // Track canceled row IDs so we can check in processRowUpdate if a row's edit was canceled
+  // and skip mutations for those rows
+  const canceledRowIds = useRef(new Set());
+
+  /**
+   * Call at the start of processRowUpdate to skip mutation if marked as canceled
+   */
+  const wasCanceled = useCallback((id) => {
+    if (canceledRowIds.current.has(id)) {
+      canceledRowIds.current.delete(id);
+      return true;
+    }
+    return false;
+  }, []);
+
+  /**
+   * Mark row as canceled by id
+   */
+  const markCanceled = useCallback((id) => {
+    canceledRowIds.current.add(id);
+  }, []);
+
+  /**
+   * Make cancel handler that marks rows as canceled and updates row and rowModesModel state
+   */
+  const makeHandleCancelClick = useCallback(
+    ({ setRows, setRowModesModel }) =>
+      (id) =>
+      () => {
+        markCanceled(id);
+        // Remove the row's entry from the rowModesModel to force out of edit mode
+        setRowModesModel((prev) => {
+          const { [id]: _, ...rest } = prev;
+          return rest;
+        });
+        // If the row is new, remove it from the rows state
+        setRows((prev) => {
+          const editedRow = prev.find((row) => getRowId(row) === id);
+          return editedRow?.isNew
+            ? prev.filter((row) => getRowId(row) !== id)
+            : prev;
+        });
+      },
+    [getRowId, markCanceled]
+  );
+
+  /**
+   * Builds the onRowEditStop handler; see handleRowEditStop for events handled
+   */
+  const makeHandleRowEditStop = useCallback(
+    ({ setRows, setRowModesModel }) =>
+      (params, event) => {
+        if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+          event.defaultMuiPrevented = true;
+          return;
+        }
+        if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+          event.defaultMuiPrevented = true;
+        }
+        if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+          const id = getRowId(params.row);
+          markCanceled(id);
+          // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state and rowModesModel
+          if (params.row.isNew) {
+            setRows((prev) => prev.filter((row) => getRowId(row) !== id));
+            if (setRowModesModel) {
+              setRowModesModel((prev) => {
+                const { [id]: _, ...rest } = prev;
+                return rest;
+              });
+            }
+          } else if (setRowModesModel) {
+            setRowModesModel((prev) => ({
+              ...prev,
+              [id]: { mode: GridRowModes.View, ignoreModifications: true },
+            }));
+          }
+        }
+      },
+    [getRowId, markCanceled]
+  );
+
+  return {
+    wasCanceled,
+    makeHandleCancelClick,
+    makeHandleRowEditStop,
+  };
+};

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -83,72 +83,63 @@ export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
   /**
    * Make cancel handler that marks rows as canceled and updates row and rowModesModel state
    */
-  const makeHandleCancelClick = useCallback(
+  const makeHandleCancelClick =
     ({ setRows, setRowModesModel }) =>
-      (id) =>
-      () => {
+    (id) =>
+    () => {
+      markCanceled(id);
+      // Remove the row's entry from the rowModesModel to force out of edit mode
+      setRowModesModel((prev) => {
+        const { [id]: _, ...rest } = prev;
+        return rest;
+      });
+      // If the row is new, remove it from the rows state
+      setRows((prev) => {
+        const editedRow = prev.find((row) => getRowId(row) === id);
+        return editedRow?.isNew
+          ? prev.filter((row) => getRowId(row) !== id)
+          : prev;
+      });
+    };
+
+  /**
+   * Builds the onRowEditStop handler; see handleRowEditStop for events handled
+   */
+  const makeHandleRowEditStop =
+    ({ setRows, setRowModesModel }) =>
+    (params, event) => {
+      if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+        event.defaultMuiPrevented = true;
+        return;
+      }
+      if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+        event.defaultMuiPrevented = true;
+      }
+      if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+        const id = getRowId(params.row);
         markCanceled(id);
+        // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state
+        if (params.row.isNew) {
+          setRows((prev) => prev.filter((row) => getRowId(row) !== id));
+        }
         // Remove the row's entry from the rowModesModel to force out of edit mode
         setRowModesModel((prev) => {
           const { [id]: _, ...rest } = prev;
           return rest;
         });
-        // If the row is new, remove it from the rows state
-        setRows((prev) => {
-          const editedRow = prev.find((row) => getRowId(row) === id);
-          return editedRow?.isNew
-            ? prev.filter((row) => getRowId(row) !== id)
-            : prev;
-        });
-      },
-    [getRowId, markCanceled]
-  );
-
-  /**
-   * Builds the onRowEditStop handler; see handleRowEditStop for events handled
-   */
-  const makeHandleRowEditStop = useCallback(
-    ({ setRows, setRowModesModel }) =>
-      (params, event) => {
-        if (params.reason === GridRowEditStopReasons.rowFocusOut) {
-          event.defaultMuiPrevented = true;
-          return;
-        }
-        if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-          event.defaultMuiPrevented = true;
-        }
-        if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
-          const id = getRowId(params.row);
-          markCanceled(id);
-          // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state
-          if (params.row.isNew) {
-            setRows((prev) => prev.filter((row) => getRowId(row) !== id));
-          }
-          // Remove the row's entry from the rowModesModel to force out of edit mode
-          setRowModesModel((prev) => {
-            const { [id]: _, ...rest } = prev;
-            return rest;
-          });
-        }
-      },
-    [getRowId, markCanceled]
-  );
+      }
+    };
 
   /**
    * Build the model-change handler in the hook so it can reference canceled ids
    */
-  const makeHandleRowModesModelChange = useCallback(
-    (setRowModesModel) => (newModel) => {
-      // Drop entries for rows that were just canceled
-      const filtered = Object.fromEntries(
-        Object.entries(newModel).filter(
-          ([id]) => !canceledRowIds.current.has(id)
-        )
-      );
-      setRowModesModel(filtered);
-    },
-    []
-  );
+  const makeHandleRowModesModelChange = (setRowModesModel) => (newModel) => {
+    // Drop entries for rows that were just canceled
+    const filtered = Object.fromEntries(
+      Object.entries(newModel).filter(([id]) => !canceledRowIds.current.has(id))
+    );
+    setRowModesModel(filtered);
+  };
 
   return {
     wasCanceled,

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -3,6 +3,21 @@ import { GridRowEditStopReasons, GridRowModes } from "@mui/x-data-grid-pro";
 export const defaultEditColumnIconStyle = { fontSize: "24px" };
 
 /**
+ * Checks if a DataGrid inline edit input is empty to initialize validation state
+ * as invalid; an empty required field is not valid no matter the data type
+ * @param {string|object|array|number|boolean|null|undefined} value - value of input
+ * @returns
+ */
+export const isEmpty = (value) => {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim() === "";
+  // Check for array first since it is also an object
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
+  return false;
+};
+
+/**
  * Custom event handler for the DataGrid `onRowEditStop` event that:
  * 1. Prevents saving on Enter key press
  * 2. Prevents saving on click-away

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -11,29 +11,20 @@ export const defaultEditColumnIconStyle = { fontSize: "24px" };
  * @param {Function} setRows - The rows state setter
  * @returns {Function} - A DataGrid `onRowEditStop` event handler
  */
-export const handleRowEditStop =
-  (rows, setRows, setRowModesModel) => (params, event) => {
-    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
-      event.defaultMuiPrevented = true;
-      return;
+export const handleRowEditStop = (rows, setRows) => (params, event) => {
+  if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+    event.defaultMuiPrevented = true;
+    return;
+  }
+  if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+    event.defaultMuiPrevented = true;
+  }
+  if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+    if (params.row.isNew) {
+      setRows(rows.filter((row) => row.id !== params.row.id));
     }
-    if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-      event.defaultMuiPrevented = true;
-    }
-    if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
-      if (params.row.isNew) {
-        const rowIdToRemove = params.row.id;
-        setRows((prevRows) =>
-          prevRows.filter((row) => row.id !== rowIdToRemove)
-        );
-        setRowModesModel((prevRowModesModel) => {
-          const { [rowIdToRemove]: _, ...rest } = prevRowModesModel;
-          return rest;
-        });
-        event.defaultMuiPrevented = true;
-      }
-    }
-  };
+  }
+};
 
 /**
  * Uses the rowModesModel to determine if any row is currently in edit mode

--- a/editor/src/components/DataGridPro/utils/helpers.js
+++ b/editor/src/components/DataGridPro/utils/helpers.js
@@ -1,4 +1,3 @@
-import { useCallback, useRef } from "react";
 import { GridRowEditStopReasons, GridRowModes } from "@mui/x-data-grid-pro";
 
 export const defaultEditColumnIconStyle = { fontSize: "24px" };
@@ -6,14 +5,18 @@ export const defaultEditColumnIconStyle = { fontSize: "24px" };
 /**
  * Checks if a DataGrid inline edit input is empty to initialize validation state
  * as invalid; an empty required field is not valid no matter the data type
- * @param {string|object|array|number|boolean|null|undefined} value - value of input
+ * @param {string|object|array|date|number|boolean|null|undefined} value - value of input
  * @returns
  */
 export const isEmpty = (value) => {
-  if (value == null) return true;
+  if (value === null || value === undefined) return true;
+  // Strings
   if (typeof value === "string") return value.trim() === "";
-  // Check for array first since it is also an object
+  // Number (excluding NaN)
+  if (typeof value === "number") return Number.isNaN(value);
+  // Check for array and date first since they are also objects
   if (Array.isArray(value)) return value.length === 0;
+  if (value instanceof Date) return Number.isNaN(value.getTime());
   if (typeof value === "object") return Object.keys(value).length === 0;
   return false;
 };
@@ -51,100 +54,3 @@ export const handleRowEditStop = (rows, setRows) => (params, event) => {
  */
 export const getIsEditMode = (rowModesModel) =>
   Object.values(rowModesModel).some((m) => m?.mode === GridRowModes.Edit);
-
-/**
- * Custom hook to contain workaround fix for bug described in https://github.com/mui/mui-x/issues/21766
- * Handles issue where canceling an edit on a row does not properly prevent the subsequent processRowUpdate from executing.
- * So, we track the ids of canceled rows and check those ids during processRowUpdate to skip mutation.
- */
-export const useCanceledRowFix = ({ getRowId = (row) => row.id } = {}) => {
-  // Track canceled row IDs so we can check in processRowUpdate if a row's edit was canceled
-  // and skip mutations for those rows
-  const canceledRowIds = useRef(new Set());
-
-  /**
-   * Call at the start of processRowUpdate to skip mutation if marked as canceled
-   */
-  const wasCanceled = useCallback((id) => {
-    if (canceledRowIds.current.has(id)) {
-      canceledRowIds.current.delete(id);
-      return true;
-    }
-    return false;
-  }, []);
-
-  /**
-   * Mark row as canceled by id
-   */
-  const markCanceled = useCallback((id) => {
-    canceledRowIds.current.add(id);
-  }, []);
-
-  /**
-   * Make cancel handler that marks rows as canceled and updates row and rowModesModel state
-   */
-  const makeHandleCancelClick =
-    ({ setRows, setRowModesModel }) =>
-    (id) =>
-    () => {
-      markCanceled(id);
-      // Remove the row's entry from the rowModesModel to force out of edit mode
-      setRowModesModel((prev) => {
-        const { [id]: _, ...rest } = prev;
-        return rest;
-      });
-      // If the row is new, remove it from the rows state
-      setRows((prev) => {
-        const editedRow = prev.find((row) => getRowId(row) === id);
-        return editedRow?.isNew
-          ? prev.filter((row) => getRowId(row) !== id)
-          : prev;
-      });
-    };
-
-  /**
-   * Builds the onRowEditStop handler; see handleRowEditStop for events handled
-   */
-  const makeHandleRowEditStop =
-    ({ setRows, setRowModesModel }) =>
-    (params, event) => {
-      if (params.reason === GridRowEditStopReasons.rowFocusOut) {
-        event.defaultMuiPrevented = true;
-        return;
-      }
-      if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-        event.defaultMuiPrevented = true;
-      }
-      if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
-        const id = getRowId(params.row);
-        markCanceled(id);
-        // Same as in makeHandleCancelClick: if the row is new, remove it from the rows state
-        if (params.row.isNew) {
-          setRows((prev) => prev.filter((row) => getRowId(row) !== id));
-        }
-        // Remove the row's entry from the rowModesModel to force out of edit mode
-        setRowModesModel((prev) => {
-          const { [id]: _, ...rest } = prev;
-          return rest;
-        });
-      }
-    };
-
-  /**
-   * Build the model-change handler in the hook so it can reference canceled ids
-   */
-  const makeHandleRowModesModelChange = (setRowModesModel) => (newModel) => {
-    // Drop entries for rows that were just canceled
-    const filtered = Object.fromEntries(
-      Object.entries(newModel).filter(([id]) => !canceledRowIds.current.has(id))
-    );
-    setRowModesModel(filtered);
-  };
-
-  return {
-    wasCanceled,
-    makeHandleCancelClick,
-    makeHandleRowEditStop,
-    makeHandleRowModesModelChange,
-  };
-};

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import isEqual from "lodash.isequal";
 import { v4 as uuidv4 } from "uuid";
 
@@ -558,6 +558,10 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     }
   };
 
+  const handleOnRowModesModelChange = (newModel) => {
+    setRowModesModel(newModel);
+  };
+
   return (
     <>
       <MopedDataGridInlineEdit
@@ -568,7 +572,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         loading={loading || !data}
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
-        onRowModesModelChange={setRowModesModel}
+        onRowModesModelChange={handleOnRowModesModelChange}
         onRowEditStop={makeHandleRowEditStop({ setRows, setRowModesModel })}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -26,6 +26,7 @@ import { mopedUserAutocompleteProps } from "./utils";
 import {
   getIsEditMode,
   handleRowEditStop,
+  makeHandleCancelClick,
 } from "src/components/DataGridPro/utils/helpers.js";
 
 const useWorkgroupLookup = (data) =>
@@ -387,18 +388,26 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     [rowModesModel]
   );
 
-  const handleCancelClick = useCallback(
-    (id) => () => {
-      setRowModesModel({
-        ...rowModesModel,
-        [id]: { mode: GridRowModes.View, ignoreModifications: true },
-      });
-      const editedRow = rows.find((row) => row.project_personnel_id === id);
-      if (editedRow.isNew) {
-        setRows(rows.filter((row) => row.id !== id));
-      }
-    },
-    [rowModesModel, rows]
+  // const handleCancelClick = useCallback(
+  //   (id) => () => {
+  //     setRowModesModel({
+  //       ...rowModesModel,
+  //       [id]: { mode: GridRowModes.View, ignoreModifications: true },
+  //     });
+  //     const editedRow = rows.find((row) => row.project_personnel_id === id);
+  //     if (editedRow.isNew) {
+  //       setRows(rows.filter((row) => row.id !== id));
+  //     }
+  //   },
+  //   [rowModesModel, rows]
+  // );
+
+  const handleCancelClick = makeHandleCancelClick(
+    rows,
+    setRows,
+    rowModesModel,
+    setRowModesModel,
+    (row) => row.project_personnel_id
   );
 
   const handleDeleteOpen = useCallback(

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -411,7 +411,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     (updatedRow, originalRow) => {
       const rowId = updatedRow.project_personnel_id;
       if (wasCanceled(rowId)) {
-        console.log("skipping mutation for cancelled row:", rowId);
         return originalRow; // Return original row to skip mutation
       }
 

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -26,7 +26,6 @@ import { mopedUserAutocompleteProps } from "./utils";
 import {
   getIsEditMode,
   handleRowEditStop,
-  makeHandleCancelClick,
 } from "src/components/DataGridPro/utils/helpers.js";
 
 const useWorkgroupLookup = (data) =>
@@ -388,26 +387,18 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     [rowModesModel]
   );
 
-  // const handleCancelClick = useCallback(
-  //   (id) => () => {
-  //     setRowModesModel({
-  //       ...rowModesModel,
-  //       [id]: { mode: GridRowModes.View, ignoreModifications: true },
-  //     });
-  //     const editedRow = rows.find((row) => row.project_personnel_id === id);
-  //     if (editedRow.isNew) {
-  //       setRows(rows.filter((row) => row.id !== id));
-  //     }
-  //   },
-  //   [rowModesModel, rows]
-  // );
-
-  const handleCancelClick = makeHandleCancelClick(
-    rows,
-    setRows,
-    rowModesModel,
-    setRowModesModel,
-    (row) => row.project_personnel_id
+  const handleCancelClick = useCallback(
+    (id) => () => {
+      setRowModesModel({
+        ...rowModesModel,
+        [id]: { mode: GridRowModes.View, ignoreModifications: true },
+      });
+      const editedRow = rows.find((row) => row.project_personnel_id === id);
+      if (editedRow.isNew) {
+        setRows(rows.filter((row) => row.id !== id));
+      }
+    },
+    [rowModesModel, rows]
   );
 
   const handleDeleteOpen = useCallback(
@@ -579,7 +570,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
         onRowModesModelChange={setRowModesModel}
-        onRowEditStop={handleRowEditStop(rows, setRows)}
+        onRowEditStop={handleRowEditStop(rows, setRows, setRowModesModel)}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}
         toolbar

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import isEqual from "lodash.isequal";
 import { v4 as uuidv4 } from "uuid";
 
@@ -25,7 +25,7 @@ import LookupAutocompleteComponent from "src/components/DataGridPro/LookupAutoco
 import { mopedUserAutocompleteProps } from "./utils";
 import {
   getIsEditMode,
-  handleRowEditStop,
+  useCanceledRowFix,
 } from "src/components/DataGridPro/utils/helpers.js";
 
 const useWorkgroupLookup = (data) =>
@@ -387,19 +387,12 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     [rowModesModel]
   );
 
-  const handleCancelClick = useCallback(
-    (id) => () => {
-      setRowModesModel({
-        ...rowModesModel,
-        [id]: { mode: GridRowModes.View, ignoreModifications: true },
-      });
-      const editedRow = rows.find((row) => row.project_personnel_id === id);
-      if (editedRow.isNew) {
-        setRows(rows.filter((row) => row.id !== id));
-      }
-    },
-    [rowModesModel, rows]
-  );
+  const { wasCanceled, makeHandleCancelClick, makeHandleRowEditStop } =
+    useCanceledRowFix();
+  const handleCancelClick = makeHandleCancelClick({
+    setRows,
+    setRowModesModel,
+  });
 
   const handleDeleteOpen = useCallback(
     (id) => () => {
@@ -411,6 +404,12 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
 
   const processRowUpdate = useCallback(
     (updatedRow, originalRow) => {
+      const rowId = updatedRow.id;
+      if (wasCanceled(rowId)) {
+        console.log("skipping mutation for cancelled row:", rowId);
+        return originalRow; // Return original row to skip mutation
+      }
+
       let userId;
 
       const userObject = data.moped_users.find((user) => {
@@ -535,6 +534,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
       projectId,
       refetch,
       handleSnackbar,
+      wasCanceled,
     ]
   );
 
@@ -569,7 +569,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
         onRowModesModelChange={setRowModesModel}
-        onRowEditStop={handleRowEditStop(rows, setRows)}
+        onRowEditStop={makeHandleRowEditStop({ setRows, setRowModesModel })}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}
         toolbar

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -387,8 +387,13 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     [rowModesModel]
   );
 
-  const { wasCanceled, makeHandleCancelClick, makeHandleRowEditStop } =
-    useCanceledRowFix();
+  const {
+    wasCanceled,
+    makeHandleCancelClick,
+    makeHandleRowEditStop,
+    makeHandleRowModesModelChange,
+  } = useCanceledRowFix({ getRowId: (row) => row.project_personnel_id });
+
   const handleCancelClick = makeHandleCancelClick({
     setRows,
     setRowModesModel,
@@ -404,7 +409,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
 
   const processRowUpdate = useCallback(
     (updatedRow, originalRow) => {
-      const rowId = updatedRow.id;
+      const rowId = updatedRow.project_personnel_id;
       if (wasCanceled(rowId)) {
         console.log("skipping mutation for cancelled row:", rowId);
         return originalRow; // Return original row to skip mutation
@@ -558,10 +563,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     }
   };
 
-  const handleOnRowModesModelChange = (newModel) => {
-    setRowModesModel(newModel);
-  };
-
   return (
     <>
       <MopedDataGridInlineEdit
@@ -572,7 +573,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         loading={loading || !data}
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
-        onRowModesModelChange={handleOnRowModesModelChange}
+        onRowModesModelChange={makeHandleRowModesModelChange(setRowModesModel)}
         onRowEditStop={makeHandleRowEditStop({ setRows, setRowModesModel })}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -431,7 +431,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
           "Invalid user data, user not found:",
           updatedRow.moped_user
         );
-        throw new Error("Invalid user data");
       }
 
       // normalize the updatedRow and originalRow
@@ -570,7 +569,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
         onRowModesModelChange={setRowModesModel}
-        onRowEditStop={handleRowEditStop(rows, setRows, setRowModesModel)}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}
         toolbar

--- a/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
+++ b/editor/src/views/projects/projectView/ProjectTeam/ProjectTeamTable.jsx
@@ -25,7 +25,7 @@ import LookupAutocompleteComponent from "src/components/DataGridPro/LookupAutoco
 import { mopedUserAutocompleteProps } from "./utils";
 import {
   getIsEditMode,
-  useCanceledRowFix,
+  handleRowEditStop,
 } from "src/components/DataGridPro/utils/helpers.js";
 
 const useWorkgroupLookup = (data) =>
@@ -387,17 +387,19 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
     [rowModesModel]
   );
 
-  const {
-    wasCanceled,
-    makeHandleCancelClick,
-    makeHandleRowEditStop,
-    makeHandleRowModesModelChange,
-  } = useCanceledRowFix({ getRowId: (row) => row.project_personnel_id });
-
-  const handleCancelClick = makeHandleCancelClick({
-    setRows,
-    setRowModesModel,
-  });
+  const handleCancelClick = useCallback(
+    (id) => () => {
+      setRowModesModel({
+        ...rowModesModel,
+        [id]: { mode: GridRowModes.View, ignoreModifications: true },
+      });
+      const editedRow = rows.find((row) => row.project_personnel_id === id);
+      if (editedRow.isNew) {
+        setRows(rows.filter((row) => row.id !== id));
+      }
+    },
+    [rowModesModel, rows]
+  );
 
   const handleDeleteOpen = useCallback(
     (id) => () => {
@@ -409,11 +411,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
 
   const processRowUpdate = useCallback(
     (updatedRow, originalRow) => {
-      const rowId = updatedRow.project_personnel_id;
-      if (wasCanceled(rowId)) {
-        return originalRow; // Return original row to skip mutation
-      }
-
       let userId;
 
       const userObject = data.moped_users.find((user) => {
@@ -434,6 +431,7 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
           "Invalid user data, user not found:",
           updatedRow.moped_user
         );
+        throw new Error("Invalid user data");
       }
 
       // normalize the updatedRow and originalRow
@@ -538,7 +536,6 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
       projectId,
       refetch,
       handleSnackbar,
-      wasCanceled,
     ]
   );
 
@@ -572,8 +569,8 @@ const ProjectTeamTable = ({ projectId, handleSnackbar }) => {
         loading={loading || !data}
         getRowId={getRowIdMemoized}
         rowModesModel={rowModesModel}
-        onRowModesModelChange={makeHandleRowModesModelChange(setRowModesModel)}
-        onRowEditStop={makeHandleRowEditStop({ setRows, setRowModesModel })}
+        onRowModesModelChange={setRowModesModel}
+        onRowEditStop={handleRowEditStop(rows, setRows)}
         processRowUpdate={processRowUpdate}
         onCellKeyDown={checkIfShiftKey}
         toolbar


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29305

This PR fixes a bug in the validation of inputs in DataGridPro tables with edit functionality.

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1883--moped-main-and-prs.netlify.app/moped/projects/ or local

**Steps to test:**
1. Go to the project team table in staging https://moped.austinmobility.io/moped/projects/1928?tab=team
2. Open your dev tools to watch the JS console output
3. Create a new row, select two roles and leave the other two inputs empty, and then try to save
4. See the error logged
5. Repeat using this branch by testing in the deploy preview or local instance and see that the save (check) button remains disabled until you fill in the required fields

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
