### PR TITLE
Update ExternalLink component text overflow in condensed mode

### DIFF
--- a/editor/src/components/ExternalLink.jsx
+++ b/editor/src/components/ExternalLink.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
@@ -40,12 +40,14 @@ const ExternalLink = ({
   const displayText = friendlyText || text || url;
 
   return (
-    <span
+    <Box
+      component="span"
       onClick={(e) => {
         if (stopPropagation) {
           e.stopPropagation();
         }
       }}
+      sx={{ overflow: "hidden", minWidth: 0 }}
     >
       <Link
         href={url}
@@ -68,7 +70,7 @@ const ExternalLink = ({
           />
         )}
       </Link>
-    </span>
+    </Box>
   );
 };
 

--- a/editor/src/views/projects/projectView/ProjectFiles/ProjectFileLink.jsx
+++ b/editor/src/views/projects/projectView/ProjectFiles/ProjectFileLink.jsx
@@ -59,7 +59,6 @@ const ProjectFileLink = ({
             overflow: "hidden",
             display: "block",
             textOverflow: "ellipsis",
-            ...(condensed && { minWidth: 0 }),
           },
           noWrap: condensed,
           title: fileUrl,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29295

## Testing
**URL to test:** 
<!---
deploy-preview-[pr-number]--atd-moped-main.netlify.app/moped/
--->
https://deploy-preview-1893--moped-main-and-prs.netlify.app/moped/

**Steps to test:**
1. Go to this [project funding table in the staging app](https://moped.austinmobility.io/moped/projects/2232?tab=funding)
   - Grab the divider in the headers between **Amount** and **Files** and drag it to the left to decrease the width
   - See that the file name does not truncate and does not show ellipses like the network path attachment below it
   - See that the menu button to detach the file falls out of the viewable width
2. Go to this [project funding table in the deploy preview](https://deploy-preview-1893--moped-main-and-prs.netlify.app/moped/projects/2232?tab=funding)
   - Grab the divider in the headers between **Amount** and **Files** and drag it to the left to decrease the width
   - See that the file name truncates and shows ellipses just like the network path attachment below it
   - See that the menu button to detach the file remains visible in the width of the column
3. You can also check for regressions in external links in the following places
   - fallback error component 
      - easiest way to see this is go to an invalid advanced search like [this one in the deploy preview](https://deploy-preview-1893--moped-main-and-prs.netlify.app/moped/projects?filters=%5B%7B%22field%22%3A%22current_phases%22%2C%22operator%22%3A%22string_equals_case_insensitive%22%2C%22value%22%3A%22Design%22%7D%5D&isOr=false)  and [this one in staging](https://moped.austinmobility.io/moped/projects?filters=%5B%7B%22field%22%3A%22current_phases%22%2C%22operator%22%3A%22string_equals_case_insensitive%22%2C%22value%22%3A%22Design%22%7D%5D&isOr=false)
   - version number link in the footer
   - link to the DTS service request form on the login page
   - editing the eCAPRIS subproject id to an invalid number like 112.001 and seeing the link shown in the autocomplete dropdown
   - project summary website
   - project summary "View in Data Tracker" link
   - project work activity table work order link column

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
