### PR TITLE
Adds Umami script helpers

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,30 @@
+# Privacy Policy
+
+## Analytics (Umami)
+
+We use **[Umami](https://umami.is)**, a privacy-focused analytics tool hosted on City of Austin infrastructure, to understand how our site is used. We do **not** use cookies for analytics. Not using cookies means we do not track or store information that could identify you across different sites or visits, which is important for protecting your privacy.
+
+**What we collect**
+
+- **Pages visited** — URL and page title
+- **Approximate location** — Country (and sometimes region or city), derived from IP address. We do **not** store your IP address in an identifiable form.
+- **Browser and device type** — e.g. Chrome, Safari, Windows, mobile
+- **Referrer** — The site or page you came from (or the previous page on our site)
+- **Optional interactions** — When we have added event tracking, we may record anonymous actions (e.g. use of a filter or button) with no personal data
+
+This information is **aggregated** and cannot be used to identify you. We use it to improve our content and services.
+
+**Where data is stored**
+
+Analytics data is stored on City of Austin systems (AWS). It is not sold or shared with third parties for advertising.
+
+**No cookie banner**
+
+Because Umami does not use cookies or collect personally identifiable information, we do not require cookie consent to run this analytics. However, we still think it's important to disclose our analytics practice for transparency with our stakeholders and users.
+
+---
+
+## References
+
+- [Umami: privacy and GDPR](https://umami.is/docs/faq)
+- [Umami privacy policy](https://umami.is/privacy)

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,7 +7,7 @@ We use **[Umami](https://umami.is)**, a privacy-focused analytics tool hosted on
 **What we collect**
 
 - **Pages visited** — URL and page title
-- **Approximate location** — Country (and sometimes region or city), derived from IP address. We do **not** store your IP address in an identifiable form.
+- **Approximate location** — Country (and sometimes region or city), derived from IP address. We do not store or harvest your IP address for tracking purposes.
 - **Browser and device type** — e.g. Chrome, Safari, Windows, mobile
 - **Referrer** — The site or page you came from (or the previous page on our site)
 - **Optional interactions** — When we have added event tracking, we may record anonymous actions (e.g. use of a filter or button) with no personal data

--- a/editor/.env.production
+++ b/editor/.env.production
@@ -10,3 +10,7 @@ VITE_AWS_COGNITO_DOMAIN=atd-moped-production.auth.us-east-1.amazoncognito.com
 VITE_KNACK_DATA_TRACKER_SIGNAL_VIEW=1483
 VITE_KNACK_DATA_TRACKER_APP_ID=5815f29f7f7252cc2ca91c4f
 VITE_KNACK_DATA_TRACKER_URL_BASE=https://mobility.austin.gov/moped/projects/
+VITE_UMAMI_SCRIPT_URL=https://umami.austinmobility.io/script.js
+VITE_UMAMI_WEBSITE_ID=ff41f9d2-8808-4380-b025-81c933ac3812
+VITE_UMAMI_DOMAINS=mobility.austin.gov
+VITE_UMAMI_TAG=production

--- a/editor/.env.staging
+++ b/editor/.env.staging
@@ -13,7 +13,7 @@ VITE_KNACK_DATA_TRACKER_URL_BASE=https://mobility.austin.gov/moped/projects/
 VITE_UMAMI_SCRIPT_URL=https://umami.austinmobility.io/script.js
 # Staging website ID — separate from production so local/staging/preview traffic is isolated.
 VITE_UMAMI_WEBSITE_ID=48c2ae18-3485-4f15-a608-039a60495943
-# Leave empty so deploy previews (*.netlify.app) and staging host both track.
-# Production still restricts via data-domains in .env.production.
-VITE_UMAMI_DOMAINS=
+# Do not set VITE_UMAMI_DOMAINS here — omitting it lets staging + deploy previews
+# (*.netlify.app) both track. Production still restricts via .env.production.
+# Setting VITE_UMAMI_DOMAINS="" can bake in literal quote characters and block all hosts.
 VITE_UMAMI_TAG=staging

--- a/editor/.env.staging
+++ b/editor/.env.staging
@@ -11,7 +11,9 @@ VITE_KNACK_DATA_TRACKER_SIGNAL_VIEW=1483
 VITE_KNACK_DATA_TRACKER_APP_ID=621958d0b5ab96001edcb4b1
 VITE_KNACK_DATA_TRACKER_URL_BASE=https://mobility.austin.gov/moped/projects/
 VITE_UMAMI_SCRIPT_URL=https://umami.austinmobility.io/script.js
-# Create a separate "Moped Editor (staging)" website in Umami for isolated test data.
+# Staging website ID — separate from production so local/staging/preview traffic is isolated.
 VITE_UMAMI_WEBSITE_ID=48c2ae18-3485-4f15-a608-039a60495943
-VITE_UMAMI_DOMAINS=moped.austinmobility.io
+# Leave empty so deploy previews (*.netlify.app) and staging host both track.
+# Production still restricts via data-domains in .env.production.
+VITE_UMAMI_DOMAINS=
 VITE_UMAMI_TAG=staging

--- a/editor/.env.staging
+++ b/editor/.env.staging
@@ -10,3 +10,8 @@ VITE_AWS_COGNITO_DOMAIN=atd-moped-staging.auth.us-east-1.amazoncognito.com
 VITE_KNACK_DATA_TRACKER_SIGNAL_VIEW=1483
 VITE_KNACK_DATA_TRACKER_APP_ID=621958d0b5ab96001edcb4b1
 VITE_KNACK_DATA_TRACKER_URL_BASE=https://mobility.austin.gov/moped/projects/
+VITE_UMAMI_SCRIPT_URL=https://umami.austinmobility.io/script.js
+# Create a separate "Moped Editor (staging)" website in Umami for isolated test data.
+VITE_UMAMI_WEBSITE_ID=48c2ae18-3485-4f15-a608-039a60495943
+VITE_UMAMI_DOMAINS=moped.austinmobility.io
+VITE_UMAMI_TAG=staging

--- a/editor/env_template
+++ b/editor/env_template
@@ -13,3 +13,8 @@ VITE_KNACK_DATA_TRACKER_URL_BASE=https://mobility.austin.gov/moped/projects/
 VITE_MUIX_LICENSE_KEY=Find in "Moped MUI X Pro License Key" entry
 VITE_NEARMAP_TOKEN=Find in "Moped Nearmap API Key" entry
 VITE_MAPBOX_TOKEN=Find in "Moped Mapbox API Key" entry
+VITE_UMAMI_SCRIPT_URL=https://umami.austinmobility.io/script.js
+# Use the staging website ID from Umami (not production). data-domains limits hits to localhost.
+VITE_UMAMI_WEBSITE_ID=
+VITE_UMAMI_DOMAINS=localhost
+VITE_UMAMI_TAG=local

--- a/editor/src/components/UmamiAnalytics.jsx
+++ b/editor/src/components/UmamiAnalytics.jsx
@@ -3,28 +3,63 @@ import { useEffect } from "react";
 // Fixed ID for the <script> tag in the DOM. Used to avoid injecting the tracker twice
 const SCRIPT_ELEMENT_ID = "umami-analytics";
 
+const LOG_PREFIX = "[umami]";
+
 /**
  * Loads the Umami tracker when script URL and website ID are configured.
  * Use per-environment VITE_UMAMI_* values so local/staging traffic does not
  * pollute production analytics (separate website IDs and/or data-domains).
  */
 const UmamiAnalytics = () => {
+  const appEnv = import.meta.env.VITE_APP_ENV;
   const scriptUrl = import.meta.env.VITE_UMAMI_SCRIPT_URL;
   const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
   const domains = import.meta.env.VITE_UMAMI_DOMAINS;
   const tag = import.meta.env.VITE_UMAMI_TAG; // Optional label for filtering in Umami
 
   useEffect(() => {
+    const hostname = window.location.hostname;
+
+    console.info(`${LOG_PREFIX} initializing`, {
+      appEnv,
+      hostname,
+      scriptUrl,
+      websiteId,
+      domains,
+      tag,
+    });
+
     if (!scriptUrl || !websiteId) {
+      console.warn(
+        `${LOG_PREFIX} tracker NOT loaded — missing ${
+          !scriptUrl ? "VITE_UMAMI_SCRIPT_URL" : "VITE_UMAMI_WEBSITE_ID"
+        }. Set it in the env file for this environment (${appEnv}).`
+      );
       return;
     }
 
     // Avoid injecting the tracker twice
     if (document.getElementById(SCRIPT_ELEMENT_ID)) {
+      console.debug(`${LOG_PREFIX} tracker already present, skipping injection`);
       return;
     }
 
-    // Create the <script> tag with the Umami tracker script.
+    // data-domains is a comma-delimited allowlist that Umami matches against
+    // window.location.hostname. If the current host isn't listed, the script
+    // loads but silently sends no events (common cause of "nothing on deploy
+    // previews", which run on *.netlify.app rather than the staging domain).
+    if (domains) {
+      const allowedHosts = domains.split(",").map((host) => host.trim());
+      if (!allowedHosts.includes(hostname)) {
+        console.warn(
+          `${LOG_PREFIX} current hostname "${hostname}" is NOT in data-domains [${allowedHosts.join(
+            ", "
+          )}]. Umami will load but will NOT send events. Add this hostname to VITE_UMAMI_DOMAINS (or clear it) to track here.`
+        );
+      }
+    }
+
+    // Creates the <script> tag with the Umami tracker script.
     // This should match the "Tracking code" in the Umami dashboard
     // ex: https://umami.austinmobility.io/websites/ff41f9d2-8808-4380-b025-81c933ac3812/settings
     const script = document.createElement("script");
@@ -41,8 +76,23 @@ const UmamiAnalytics = () => {
       script.setAttribute("data-tag", tag);
     }
 
+    script.addEventListener("load", () => {
+      console.info(
+        `${LOG_PREFIX} script loaded successfully from ${scriptUrl} (window.umami ${
+          typeof window.umami !== "undefined" ? "available" : "NOT available"
+        })`
+      );
+    });
+
+    script.addEventListener("error", () => {
+      console.error(
+        `${LOG_PREFIX} script FAILED to load from ${scriptUrl}. Check the URL, network, and any ad/tracker blockers.`
+      );
+    });
+
     document.head.appendChild(script);
-  }, [scriptUrl, websiteId, domains, tag]);
+    console.info(`${LOG_PREFIX} tracker script injected into <head>`);
+  }, [appEnv, scriptUrl, websiteId, domains, tag]);
 
   return null;
 };

--- a/editor/src/components/UmamiAnalytics.jsx
+++ b/editor/src/components/UmamiAnalytics.jsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+// Fixed ID for the <script> tag in the DOM. Used to avoid injecting the tracker twice
+const SCRIPT_ELEMENT_ID = "umami-analytics";
+
+/**
+ * Loads the Umami tracker when script URL and website ID are configured.
+ * Use per-environment VITE_UMAMI_* values so local/staging traffic does not
+ * pollute production analytics (separate website IDs and/or data-domains).
+ */
+const UmamiAnalytics = () => {
+  const scriptUrl = import.meta.env.VITE_UMAMI_SCRIPT_URL;
+  const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
+  const domains = import.meta.env.VITE_UMAMI_DOMAINS;
+  const tag = import.meta.env.VITE_UMAMI_TAG; // Optional label for filtering in Umami
+
+  useEffect(() => {
+    if (!scriptUrl || !websiteId) {
+      return;
+    }
+
+    // Avoid injecting the tracker twice
+    if (document.getElementById(SCRIPT_ELEMENT_ID)) {
+      return;
+    }
+
+    // Create the <script> tag with the Umami tracker script.
+    // This should match the "Tracking code" in the Umami dashboard
+    // ex: https://umami.austinmobility.io/websites/ff41f9d2-8808-4380-b025-81c933ac3812/settings
+    const script = document.createElement("script");
+    script.id = SCRIPT_ELEMENT_ID;
+    script.defer = true;
+    script.src = scriptUrl;
+    script.setAttribute("data-website-id", websiteId);
+
+    if (domains) {
+      script.setAttribute("data-domains", domains);
+    }
+
+    if (tag) {
+      script.setAttribute("data-tag", tag);
+    }
+
+    document.head.appendChild(script);
+  }, [scriptUrl, websiteId, domains, tag]);
+
+  return null;
+};
+
+export default UmamiAnalytics;

--- a/editor/src/components/UmamiAnalytics.jsx
+++ b/editor/src/components/UmamiAnalytics.jsx
@@ -3,60 +3,25 @@ import { useEffect } from "react";
 // Fixed ID for the <script> tag in the DOM. Used to avoid injecting the tracker twice
 const SCRIPT_ELEMENT_ID = "umami-analytics";
 
-const LOG_PREFIX = "[umami]";
-
 /**
  * Loads the Umami tracker when script URL and website ID are configured.
  * Use per-environment VITE_UMAMI_* values so local/staging traffic does not
  * pollute production analytics (separate website IDs and/or data-domains).
  */
 const UmamiAnalytics = () => {
-  const appEnv = import.meta.env.VITE_APP_ENV;
   const scriptUrl = import.meta.env.VITE_UMAMI_SCRIPT_URL;
   const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
   const domains = import.meta.env.VITE_UMAMI_DOMAINS;
-  const tag = import.meta.env.VITE_UMAMI_TAG; // Optional label for filtering in Umami
+  const tag = import.meta.env.VITE_UMAMI_TAG;
 
   useEffect(() => {
-    const hostname = window.location.hostname;
-
-    console.info(`${LOG_PREFIX} initializing`, {
-      appEnv,
-      hostname,
-      scriptUrl,
-      websiteId,
-      domains,
-      tag,
-    });
-
     if (!scriptUrl || !websiteId) {
-      console.warn(
-        `${LOG_PREFIX} tracker NOT loaded — missing ${
-          !scriptUrl ? "VITE_UMAMI_SCRIPT_URL" : "VITE_UMAMI_WEBSITE_ID"
-        }. Set it in the env file for this environment (${appEnv}).`
-      );
       return;
     }
 
     // Avoid injecting the tracker twice
     if (document.getElementById(SCRIPT_ELEMENT_ID)) {
-      console.debug(`${LOG_PREFIX} tracker already present, skipping injection`);
       return;
-    }
-
-    // data-domains is a comma-delimited allowlist that Umami matches against
-    // window.location.hostname. If the current host isn't listed, the script
-    // loads but silently sends no events (common cause of "nothing on deploy
-    // previews", which run on *.netlify.app rather than the staging domain).
-    if (domains) {
-      const allowedHosts = domains.split(",").map((host) => host.trim());
-      if (!allowedHosts.includes(hostname)) {
-        console.warn(
-          `${LOG_PREFIX} current hostname "${hostname}" is NOT in data-domains [${allowedHosts.join(
-            ", "
-          )}]. Umami will load but will NOT send events. Add this hostname to VITE_UMAMI_DOMAINS (or clear it) to track here.`
-        );
-      }
     }
 
     // Creates the <script> tag with the Umami tracker script.
@@ -76,23 +41,8 @@ const UmamiAnalytics = () => {
       script.setAttribute("data-tag", tag);
     }
 
-    script.addEventListener("load", () => {
-      console.info(
-        `${LOG_PREFIX} script loaded successfully from ${scriptUrl} (window.umami ${
-          typeof window.umami !== "undefined" ? "available" : "NOT available"
-        })`
-      );
-    });
-
-    script.addEventListener("error", () => {
-      console.error(
-        `${LOG_PREFIX} script FAILED to load from ${scriptUrl}. Check the URL, network, and any ad/tracker blockers.`
-      );
-    });
-
     document.head.appendChild(script);
-    console.info(`${LOG_PREFIX} tracker script injected into <head>`);
-  }, [appEnv, scriptUrl, websiteId, domains, tag]);
+  }, [scriptUrl, websiteId, domains, tag]);
 
   return null;
 };

--- a/editor/src/config.js
+++ b/editor/src/config.js
@@ -4,6 +4,12 @@ const config = {
     APP_HASURA_ENDPOINT: import.meta.env.VITE_HASURA_ENDPOINT,
     APP_API_ENDPOINT: import.meta.env.VITE_API_ENDPOINT,
   },
+  umami: {
+    SCRIPT_URL: import.meta.env.VITE_UMAMI_SCRIPT_URL,
+    WEBSITE_ID: import.meta.env.VITE_UMAMI_WEBSITE_ID,
+    DOMAINS: import.meta.env.VITE_UMAMI_DOMAINS,
+    TAG: import.meta.env.VITE_UMAMI_TAG,
+  },
   cognito: {
     APP_CLIENT_ID: import.meta.env.VITE_AWS_COGNITO_APP_CLIENT_ID,
     DOMAIN: import.meta.env.VITE_AWS_COGNITO_DOMAIN,

--- a/editor/src/index.jsx
+++ b/editor/src/index.jsx
@@ -8,6 +8,7 @@ import App from "./App";
 import { Amplify, Hub } from "aws-amplify";
 
 import config from "./config";
+import UmamiAnalytics from "src/components/UmamiAnalytics";
 
 // https://aws-amplify.github.io/docs/js/hub
 Hub.listen(/.*/, ({ channel, payload }) =>
@@ -49,6 +50,7 @@ Amplify.configure({
 
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>
+    <UmamiAnalytics />
     <UserProvider>
       <App />
     </UserProvider>

--- a/editor/src/layouts/DashboardLayout/Footer.jsx
+++ b/editor/src/layouts/DashboardLayout/Footer.jsx
@@ -7,8 +7,12 @@ const Footer = () => {
   return (
     <Box
       sx={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
         paddingTop: 1,
         paddingLeft: 4,
+        paddingRight: 4,
         paddingBottom: 2,
       }}
     >
@@ -17,6 +21,25 @@ const Footer = () => {
         <ExternalLink
           text={`v${pckg.version}`}
           url="https://github.com/cityofaustin/atd-moped/releases/latest"
+          linkColor="inherit"
+        />
+        <Typography
+          variant="caption"
+          color="textSecondary"
+          sx={{ marginLeft: 1.5 }}
+        >
+          <ExternalLink
+            text="Privacy Policy"
+            url="https://github.com/cityofaustin/atd-moped/blob/main/PRIVACY.md"
+            linkColor="inherit"
+          />
+        </Typography>
+      </Typography>
+      <Typography variant="caption" color="textSecondary">
+        Built by{" "}
+        <ExternalLink
+          text="Data & Technology Services"
+          url="https://austinmobility.io"
           linkColor="inherit"
         />
       </Typography>

--- a/editor/src/utils/umami.js
+++ b/editor/src/utils/umami.js
@@ -1,0 +1,19 @@
+/**
+ * Track a custom Umami event when the tracker is loaded.
+ * Safe to call before the script finishes loading (no-op).
+ *
+ * @param {string} eventName
+ * @param {Record<string, string | number | boolean>} [eventData]
+ */
+export const trackUmamiEvent = (eventName, eventData) => {
+  if (typeof window === "undefined" || typeof window.umami?.track !== "function") {
+    return;
+  }
+
+  if (eventData) {
+    window.umami.track(eventName, eventData);
+    return;
+  }
+
+  window.umami.track(eventName);
+};


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/27712

- Adds Umami analytics to the Moped Editor with per-environment config (`VITE_UMAMI_*`), using separate website IDs so production stays isolated from staging/local/preview traffic
- Production restricts tracking to `mobility.austin.gov`. Staging omits `data-domains` so staging and Netlify deploy previews both track to the staging website
- Adds `PRIVACY.md` documenting analytics practices and updates the app footer with Privacy Policy + Built by Data & Technology Services links (VZE-style)

These two infrastructure PRs enable this implementation in Moped:
- https://github.com/cityofaustin/umami-analytics/pull/1
- https://github.com/cityofaustin/dts-services-haproxy/pull/11

## Testing
**URL to test:** 

- https://umami.austinmobility.io/websites/48c2ae18-3485-4f15-a608-039a60495943
- https://deploy-preview-1894--moped-main-and-prs.netlify.app/moped/projects

**Steps to test:**

1. Log into Umami (credentials in 1PW) and go to this dashboard for `Moped Editor - STAGING`: https://umami.austinmobility.io/websites/48c2ae18-3485-4f15-a608-039a60495943
    - Check the recent Visits and View counts as a baseline for comparison.
2. Go to the deploy preview Projects List: https://deploy-preview-1894--moped-main-and-prs.netlify.app/moped/projects
    - Then select any project details to navigate to. Take note of the project id or URL path
3. Go back to Umami, refresh, and note if the Views counter goes up. Also check under Pages, select the URL tab.   
    - Review to see if the project you selected is listed or its counter has increased.
5. Go to the Website Settings for `Moped Editor - STAGING` by clicking the "Edit" button in the top right corner or just go to https://umami.austinmobility.io/websites/48c2ae18-3485-4f15-a608-039a60495943/settings
    - Scroll to the bottom to "Reset" the data so the next tester has a blank slate, or to clarify if your testing steps worked and repeat if necessary.
6. Note the Footer on any page. Click the Privacy Policy link. 
    - It should take you to a Github repo 404 that will be resolved once the PRIVACY.md gets merged to `main`.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [x] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- ~[ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable~
