### PR TITLE
Bump graphql-engine to 2.49.5

### DIFF
--- a/moped-database/docker-compose.yml
+++ b/moped-database/docker-compose.yml
@@ -1,7 +1,7 @@
 # Architecture Independent Docker Stack Components for Moped Development Environment
 services:
     hasura:
-        image: hasura/graphql-engine:v2.49.4
+        image: hasura/graphql-engine:v2.49.5
         depends_on:
             - moped-pgsql
         expose:

--- a/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/production.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.49.4",
+            "image": "hasura/graphql-engine:v2.49.5",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
+++ b/moped-database/ecs_task_definitions/staging.graphql-engine.ecs-td.json
@@ -28,7 +28,7 @@
                 "startPeriod": 15,
                 "timeout": 5
             },
-            "image": "hasura/graphql-engine:v2.49.4",
+            "image": "hasura/graphql-engine:v2.49.5",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29398

## Testing

**Steps to test:**

* Spin up local dev, replicate some live data, try out the site
* Review the code, especially WRT the image being requested: [here](https://hub.docker.com/layers/hasura/graphql-engine/v2.49.5/images/sha256-f01554205e5547f56a312dd470ce94d266287c465504e97d0b1f32573a221e7e)


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Product manager checked [DB view dependencies](https://atd-dts.gitbook.io/moped-documentation/product-management/updating-the-arcgis-online-components-database-view)
- [ ] Product manager checked if any columns in views used by the Power BI dataflow were added, deleted, or renamed
- [ ] Product manager added to [QA test script](https://docs.google.com/spreadsheets/d/1n_O6MLh9cwwPf57HUM394Ea-z9uuoEV1-QW4axNZXLE/edit#) if applicable
